### PR TITLE
Replace all exported method return types with structures

### DIFF
--- a/actors/abi/deal.go
+++ b/actors/abi/deal.go
@@ -1,8 +1,10 @@
 package abi
 
+import "math/big"
+
 type DealID int64
 type DealIDs struct {
 	Items []DealID
 }
 
-type DealWeight int64 // should be BigInt
+type DealWeight *big.Int

--- a/actors/abi/piece.go
+++ b/actors/abi/piece.go
@@ -33,7 +33,3 @@ type PieceInfo struct {
 	Size     int64 // Size in nodes. For BLS12-381 (capacity 254 bits), must be >= 16. (16 * 8 = 128)
 	PieceCID PieceCID
 }
-
-type PieceInfos struct {
-	Items []PieceInfo
-}

--- a/actors/builtin/account/account_actor.go
+++ b/actors/builtin/account/account_actor.go
@@ -6,14 +6,12 @@ import (
 	vmr "github.com/filecoin-project/specs-actors/actors/runtime"
 )
 
-type InvocOutput = vmr.InvocOutput
-
 type AccountActor struct{}
 
-func (a *AccountActor) Constructor(rt vmr.Runtime) InvocOutput {
+func (a *AccountActor) Constructor(rt vmr.Runtime) *vmr.EmptyReturn {
 	// TODO: set the pubkey address here from parameters
 	rt.ValidateImmediateCallerIs(builtin.SystemActorAddr)
-	return InvocOutput{}
+	return &vmr.EmptyReturn{}
 }
 
 type AccountActorState struct {

--- a/actors/builtin/cron/cron_actor.go
+++ b/actors/builtin/cron/cron_actor.go
@@ -2,6 +2,7 @@ package cron
 
 import (
 	addr "github.com/filecoin-project/go-address"
+
 	abi "github.com/filecoin-project/specs-actors/actors/abi"
 	builtin "github.com/filecoin-project/specs-actors/actors/builtin"
 	vmr "github.com/filecoin-project/specs-actors/actors/runtime"
@@ -19,13 +20,13 @@ type CronTableEntry struct {
 	MethodNum abi.MethodNum
 }
 
-func (a *CronActor) Constructor(rt vmr.Runtime) vmr.InvocOutput {
+func (a *CronActor) Constructor(rt vmr.Runtime) *vmr.EmptyReturn {
 	// Nothing. intentionally left blank.
 	rt.ValidateImmediateCallerIs(builtin.SystemActorAddr)
-	return vmr.InvocOutput{}
+	return &vmr.EmptyReturn{}
 }
 
-func (a *CronActor) EpochTick(rt vmr.Runtime) vmr.InvocOutput {
+func (a *CronActor) EpochTick(rt vmr.Runtime) *vmr.EmptyReturn {
 	rt.ValidateImmediateCallerIs(builtin.SystemActorAddr)
 
 	// a.Entries is basically a static registry for now, loaded
@@ -39,5 +40,5 @@ func (a *CronActor) EpochTick(rt vmr.Runtime) vmr.InvocOutput {
 		})
 	}
 
-	return vmr.InvocOutput{}
+	return &vmr.EmptyReturn{}
 }

--- a/actors/builtin/reward/reward_actor.go
+++ b/actors/builtin/reward/reward_actor.go
@@ -12,9 +12,6 @@ import (
 	cid "github.com/ipfs/go-cid"
 )
 
-type InvocOutput = vmr.InvocOutput
-type Runtime = vmr.Runtime
-
 var TODO = autil.TODO
 
 type VestingFunction int64
@@ -91,13 +88,14 @@ func (st *RewardActorState) _withdrawReward(rt vmr.Runtime, ownerAddr addr.Addre
 
 type RewardActor struct{}
 
-func (a *RewardActor) Constructor(rt vmr.Runtime) InvocOutput {
+func (a *RewardActor) Constructor(rt vmr.Runtime) *vmr.EmptyReturn {
 	rt.ValidateImmediateCallerIs(builtin.SystemActorAddr)
 	// initialize Reward Map with investor accounts
-	panic("TODO")
+	autil.IMPL_FINISH()
+	return &vmr.EmptyReturn{}
 }
 
-func (a *RewardActor) State(rt Runtime) (vmr.ActorStateHandle, RewardActorState) {
+func (a *RewardActor) State(rt vmr.Runtime) (vmr.ActorStateHandle, RewardActorState) {
 	h := rt.AcquireState()
 	stateCID := cid.Cid(h.Take())
 	var state RewardActorState
@@ -107,7 +105,7 @@ func (a *RewardActor) State(rt Runtime) (vmr.ActorStateHandle, RewardActorState)
 	return h, state
 }
 
-func (a *RewardActor) WithdrawReward(rt vmr.Runtime) {
+func (a *RewardActor) WithdrawReward(rt vmr.Runtime) *vmr.EmptyReturn {
 	rt.ValidateImmediateCallerType(builtin.CallerTypesSignable...)
 	ownerAddr := rt.ImmediateCaller()
 
@@ -118,6 +116,7 @@ func (a *RewardActor) WithdrawReward(rt vmr.Runtime) {
 	UpdateReleaseRewardActorState(rt, h, st)
 
 	rt.SendFunds(ownerAddr, withdrawableReward)
+	return &vmr.EmptyReturn{}
 }
 
 func (a *RewardActor) AwardBlockReward(
@@ -126,7 +125,7 @@ func (a *RewardActor) AwardBlockReward(
 	penalty abi.TokenAmount,
 	minerNominalPower abi.StoragePower,
 	currPledge abi.TokenAmount,
-) {
+) *vmr.EmptyReturn {
 	rt.ValidateImmediateCallerIs(builtin.SystemActorAddr)
 
 	inds := rt.CurrIndices()
@@ -168,9 +167,10 @@ func (a *RewardActor) AwardBlockReward(
 		st.RewardMap[miner] = rewards
 	}
 	UpdateReleaseRewardActorState(rt, h, st)
+	return &vmr.EmptyReturn{}
 }
 
-func UpdateReleaseRewardActorState(rt Runtime, h vmr.ActorStateHandle, st RewardActorState) {
+func UpdateReleaseRewardActorState(rt vmr.Runtime, h vmr.ActorStateHandle, st RewardActorState) {
 	newCID := abi.ActorSubstateCID(rt.IpldPut(&st))
 	h.UpdateRelease(newCID)
 }

--- a/actors/builtin/storage_market/storage_market_actor_boilerplate.go
+++ b/actors/builtin/storage_market/storage_market_actor_boilerplate.go
@@ -17,7 +17,6 @@ type DealIDQueue = autil.DealIDQueue
 // workaround due to the lack of generics support in Go.
 ////////////////////////////////////////////////////////////////////////////////
 
-type InvocOutput = vmr.InvocOutput
 type Runtime = vmr.Runtime
 type Bytes = abi.Bytes
 

--- a/actors/builtin/storage_miner/storage_miner_actor_boilerplate.go
+++ b/actors/builtin/storage_miner/storage_miner_actor_boilerplate.go
@@ -19,7 +19,6 @@ var RT_ConfirmFundsReceiptOrAbort_RefundRemainder = vmr.RT_ConfirmFundsReceiptOr
 // workaround due to the lack of generics support in Go.
 ////////////////////////////////////////////////////////////////////////////////
 
-type InvocOutput = vmr.InvocOutput
 type Runtime = vmr.Runtime
 
 var Assert = autil.Assert

--- a/actors/builtin/storage_miner/storage_miner_actor_state.go
+++ b/actors/builtin/storage_miner/storage_miner_actor_state.go
@@ -67,7 +67,7 @@ type SectorOnChainInfo struct {
 	ActivationEpoch       abi.ChainEpoch // -1 if still in PreCommit state.
 	DeclaredFaultEpoch    abi.ChainEpoch // -1 if not currently declared faulted.
 	DeclaredFaultDuration abi.ChainEpoch // -1 if not currently declared faulted.
-	DealWeight            big.Int        // -1 if not yet validated with StorageMarketActor.
+	DealWeight            *big.Int        // -1 if not yet validated with StorageMarketActor.
 }
 
 type SectorPreCommitInfo struct {

--- a/actors/builtin/storage_power/storage_power_actor_boilerplate.go
+++ b/actors/builtin/storage_power/storage_power_actor_boilerplate.go
@@ -1,7 +1,7 @@
 package storage_power
 
 import (
-	"github.com/filecoin-project/specs-actors/actors/abi"
+	abi "github.com/filecoin-project/specs-actors/actors/abi"
 	vmr "github.com/filecoin-project/specs-actors/actors/runtime"
 	autil "github.com/filecoin-project/specs-actors/actors/util"
 )
@@ -12,8 +12,6 @@ type SectorTerminationType = autil.SectorTermination
 
 var SectorTerminationType_NormalExpiration = autil.NormalExpiration
 
-var RT_MinerEntry_ValidateCaller_DetermineFundsLocation = vmr.RT_MinerEntry_ValidateCaller_DetermineFundsLocation
-
 ////////////////////////////////////////////////////////////////////////////////
 // Boilerplate
 //
@@ -22,7 +20,6 @@ var RT_MinerEntry_ValidateCaller_DetermineFundsLocation = vmr.RT_MinerEntry_Vali
 // workaround due to the lack of generics support in Go.
 ////////////////////////////////////////////////////////////////////////////////
 
-type InvocOutput = vmr.InvocOutput
 type Runtime = vmr.Runtime
 
 var Assert = autil.Assert

--- a/actors/runtime/params.go
+++ b/actors/runtime/params.go
@@ -1,0 +1,33 @@
+package runtime
+
+import (
+	"fmt"
+	cbg "github.com/whyrusleeping/cbor-gen"
+	"io"
+)
+
+type EmptyReturn struct{}
+
+var _ cbg.CBORMarshaler = (*EmptyReturn)(nil)
+// 0x80 is empty list (major type 4 with zero length)
+// 0xa0 is empty map (major type 5 with zero length)
+// This is encoded with empty-list since we use tuple-encoding for everything.
+const emptyListEncoded = 0x80
+
+
+func (EmptyReturn) MarshalCBOR(w io.Writer) error {
+	_, err := w.Write([]byte{emptyListEncoded})
+	return err
+}
+
+func (EmptyReturn) UnmarshalCBOR(r io.Reader) error {
+	buf := make([]byte, 1)
+	_, err := r.Read(buf)
+	if err != nil {
+		return err
+	}
+	if buf[0] != emptyListEncoded {
+		return fmt.Errorf("invalid empty return %x", buf[0])
+	}
+	return nil
+}

--- a/actors/runtime/runtime_util.go
+++ b/actors/runtime/runtime_util.go
@@ -1,10 +1,9 @@
 package runtime
 
 import (
-	"bytes"
 	"context"
-	"github.com/ipfs/go-cid"
-	"github.com/ipfs/go-hamt-ipld"
+	cid "github.com/ipfs/go-cid"
+	hamt "github.com/ipfs/go-hamt-ipld"
 
 	addr "github.com/filecoin-project/go-address"
 	abi "github.com/filecoin-project/specs-actors/actors/abi"
@@ -43,16 +42,8 @@ func RT_Address_Is_StorageMiner(rt Runtime, minerAddr addr.Address) bool {
 }
 
 func RT_GetMinerAccountsAssert(rt Runtime, minerAddr addr.Address) (ownerAddr addr.Address, workerAddr addr.Address) {
-	raw := rt.SendQuery(minerAddr, builtin.Method_StorageMinerActor_GetOwnerAddr, nil)
-	r := bytes.NewReader(raw)
-	err := ownerAddr.UnmarshalCBOR(r)
-	autil.AssertNoError(err)
-
-	raw = rt.SendQuery(minerAddr, builtin.Method_StorageMinerActor_GetWorkerAddr, nil)
-	r = bytes.NewReader(raw)
-	err = workerAddr.UnmarshalCBOR(r)
-	autil.AssertNoError(err)
-
+	autil.AssertNoError(rt.SendQuery(minerAddr, builtin.Method_StorageMinerActor_GetOwnerAddr, nil).Into(ownerAddr))
+	autil.AssertNoError(rt.SendQuery(minerAddr, builtin.Method_StorageMinerActor_GetWorkerAddr, nil).Into(workerAddr))
 	return
 }
 

--- a/actors/util/actor_util.go
+++ b/actors/util/actor_util.go
@@ -78,7 +78,7 @@ type MinerEventSetHAMT []MinerEvent
 type SectorStorageWeightDesc struct {
 	SectorSize abi.SectorSize
 	Duration   abi.ChainEpoch
-	DealWeight big.Int
+	DealWeight *big.Int
 }
 
 type SectorTermination int64

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,5 @@ require (
 	github.com/ipfs/go-hamt-ipld v0.0.14
 	github.com/libp2p/go-libp2p-core v0.3.0
 	github.com/multiformats/go-multihash v0.0.10
+	github.com/whyrusleeping/cbor-gen v0.0.0-20191216205031-b047b6acb3c0
 )


### PR DESCRIPTION
This is part of getting the exports to have a consistent type signature for method dispatch. These structures should be cbor-encoded for on-chain representation in a follow-up.

[We have already added params structs for the mutlisig actor, other actors are still to come]