### PR TITLE
Add exit code to Runtime.Send() and rationalize the interface down to one send method.

### DIFF
--- a/actors/builtin/cron/cron_actor.go
+++ b/actors/builtin/cron/cron_actor.go
@@ -32,12 +32,8 @@ func (a *CronActor) EpochTick(rt vmr.Runtime) *vmr.EmptyReturn {
 	// a.Entries is basically a static registry for now, loaded
 	// in the interpreter static registry.
 	for _, entry := range a.Entries {
-		rt.SendCatchingErrors(vmr.InvocInput{
-			To:     entry.ToAddr,
-			Method: entry.MethodNum,
-			Params: nil,
-			Value:  abi.TokenAmount(0),
-		})
+		_, _ = rt.Send(entry.ToAddr, entry.MethodNum, nil, abi.TokenAmount(0))
+		// Any error and return value are ignored.
 	}
 
 	return &vmr.EmptyReturn{}

--- a/actors/builtin/init/init_actor.go
+++ b/actors/builtin/init/init_actor.go
@@ -84,8 +84,9 @@ func (a *InitActor) Exec(rt Runtime, execCodeID abi.ActorCodeID, constructorPara
 	// Create an empty actor.
 	rt.CreateActor(execCodeID, idAddr)
 
-	// Invoke constructor. If construction fails, the error should propagate and cause Exec to fail too.
-	rt.Send(idAddr, builtin.MethodConstructor, constructorParams, rt.ValueReceived())
+	// Invoke constructor.
+	_, code := rt.Send(idAddr, builtin.MethodConstructor, constructorParams, rt.ValueReceived())
+	vmr.RequireSuccess(rt, code, "constructor failed")
 
 	return &ExecReturn{idAddr, uniqueAddress}
 }

--- a/actors/builtin/multisig/multisig_actor.go
+++ b/actors/builtin/multisig/multisig_actor.go
@@ -263,12 +263,14 @@ func (a *MultiSigActor) _rtApproveTransactionOrAbort(rt vmr.Runtime, txnID TxnID
 		}
 
 		// A sufficient number of approvals have arrived and sufficient funds have been unlocked: relay the message and delete from pending queue.
-		rt.Send(
+		_, code := rt.Send(
 			txn.To,
 			txn.Method,
 			txn.Params,
 			txn.Value,
 		)
+		// The exit code is explicitly ignored. It's ok for the subcall to fail.
+		_ = code
 		a._rtDeletePendingTransaction(rt, txnID)
 	}
 }

--- a/actors/builtin/storage_market/storage_market_actor.go
+++ b/actors/builtin/storage_market/storage_market_actor.go
@@ -69,8 +69,10 @@ func (a *StorageMarketActor) WithdrawBalance(rt Runtime, entryAddr addr.Address,
 
 	UpdateRelease(rt, h, st)
 
-	rt.SendFunds(builtin.BurntFundsActorAddr, amountSlashedTotal)
-	rt.SendFunds(recipientAddr, amountExtracted)
+	_, code := rt.Send(builtin.BurntFundsActorAddr, builtin.MethodSend, nil, amountSlashedTotal)
+	vmr.RequireSuccess(rt, code, "failed to burn slashed funds")
+	_, code = rt.Send(recipientAddr, builtin.MethodSend, nil, amountExtracted)
+	vmr.RequireSuccess(rt, code, "failed to send funds")
 	return &vmr.EmptyReturn{}
 }
 
@@ -148,7 +150,8 @@ func (a *StorageMarketActor) PublishStorageDeals(rt Runtime, newStorageDeals []S
 
 	UpdateRelease(rt, h, st)
 
-	rt.SendFunds(builtin.BurntFundsActorAddr, amountSlashedTotal)
+	_, code := rt.Send(builtin.BurntFundsActorAddr, builtin.MethodSend, nil, amountSlashedTotal)
+	vmr.RequireSuccess(rt, code, "failed to burn funds")
 	return &vmr.EmptyReturn{}
 }
 
@@ -335,7 +338,8 @@ func (a *StorageMarketActor) OnEpochTickEnd(rt Runtime) *vmr.EmptyReturn {
 
 	UpdateRelease(rt, h, st)
 
-	rt.SendFunds(builtin.BurntFundsActorAddr, amountSlashedTotal)
+	_, code := rt.Send(builtin.BurntFundsActorAddr, builtin.MethodSend, nil, amountSlashedTotal)
+	vmr.RequireSuccess(rt, code, "failed to burn funds")
 	return &vmr.EmptyReturn{}
 }
 

--- a/actors/runtime/exitcode/reserved.go
+++ b/actors/runtime/exitcode/reserved.go
@@ -1,5 +1,7 @@
 package exitcode
 
+import "strconv"
+
 type ExitCode int64
 
 func (x ExitCode) IsSuccess() bool {
@@ -8,6 +10,11 @@ func (x ExitCode) IsSuccess() bool {
 
 func (x ExitCode) IsError() bool {
 	return !x.IsSuccess()
+}
+
+// Implement error to trigger Go compiler checking of exit code return values.
+func (x ExitCode) Error() string {
+	return strconv.FormatInt(int64(x), 10)
 }
 
 const (

--- a/actors/runtime/runtime.go
+++ b/actors/runtime/runtime.go
@@ -61,15 +61,9 @@ type Runtime interface {
 	// functions, and should be used for any function whose computation is expensive.
 	Compute(ComputeFunctionID, args []interface{}) interface{}
 
-	// Sends a message to another actor.
+	// Sends a message to another actor, returning the exit code and return value envelope.
 	// If the invoked method does not return successfully, this caller will be aborted too.
-	Send(toAddr addr.Address, methodNum abi.MethodNum, params abi.MethodParams, value abi.TokenAmount) SendReturn
-	SendQuery(toAddr addr.Address, methodNum abi.MethodNum, params abi.MethodParams) SendReturn
-	SendFunds(toAddr addr.Address, value abi.TokenAmount)
-
-	// Sends a message to another actor, trapping an unsuccessful execution.
-	// This may only be invoked by the singleton Cron actor.
-	SendCatchingErrors(input InvocInput) (ret SendReturn, exitCode exitcode.ExitCode)
+	Send(toAddr addr.Address, methodNum abi.MethodNum, params abi.MethodParams, value abi.TokenAmount) (SendReturn, exitcode.ExitCode)
 
 	// Computes an address for a new actor. The returned address is intended to uniquely refer to
 	// the actor even in the event of a chain re-org (whereas an ID-address might refer to a
@@ -123,13 +117,6 @@ type SendReturn interface {
 type TraceSpan interface {
 	// Ends the span
 	End()
-}
-
-type InvocInput struct {
-	To     addr.Address
-	Method abi.MethodNum
-	Params abi.MethodParams
-	Value  abi.TokenAmount
 }
 
 type ActorStateHandle interface {


### PR DESCRIPTION
This is mostly a mechanical change, preserving the existing semantics, with the exception of the multisig actor. The final multisig approval will now succeed even if the message that is sent fails.

Closes #20