### PR TITLE
build: Makefile correctly generates cbor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GO_BIN ?= go
 GOLINT ?= golangci-lint
 
-all: build lint gen test tidy
+all: build lint test tidy
 .PHONY: all
 
 build:
@@ -21,6 +21,7 @@ lint:
 .PHONY: lint
 
 gen:
+	find ./ -type f -name 'cbor_gen.go' -exec rm {} +
 	$(GO_BIN) run ./gen/gen.go
 .PHONY: gen
 


### PR DESCRIPTION
- initially if the generated cbor code didin't complie a developer would
need to manually remove it before running `make gen`, now that happens
automatically.