### PR TITLE
simplify sector state

### DIFF
--- a/actors/builtin/methods.go
+++ b/actors/builtin/methods.go
@@ -69,8 +69,7 @@ const (
 	Method_StorageMarketActor_PublishStorageDeals
 
 	// Internal mechanism events
-	Method_StorageMarketActor_OnMinerSectorPreCommit_VerifyDealsOrAbort
-	Method_StorageMarketActor_OnMinerSectorProveCommit_VerifyDealsOrAbort
+	Method_StorageMarketActor_VerifyDealsOnSectorProveCommit
 	Method_StorageMarketActor_OnMinerSectorsTerminate
 
 	// State queries

--- a/actors/builtin/storage_miner/storage_miner_actor_state.go
+++ b/actors/builtin/storage_miner/storage_miner_actor_state.go
@@ -15,10 +15,10 @@ import (
 // Balance of a StorageMinerActor should equal exactly the sum of PreCommit deposits
 // that are not yet returned or burned.
 type StorageMinerActorState struct {
-	PreCommittedSectors PreCommittedSectorsAMT 
-	Sectors    SectorsAMT
-	FaultSet SectorNumberSetHAMT // TODO bitfield
-	ProvingSet cid.Cid
+	PreCommittedSectors PreCommittedSectorsAMT // PreCommitted Sectors
+	Sectors    SectorsAMT // Proven Sectors can be Active or in TemporaryFault
+	FaultSet SectorNumberSetHAMT // TODO bitfield of Sectors in TemporaryFault
+	ProvingSet cid.Cid // cid of SectorsAMT - sectors in FaultSet
 
 	PoStState  MinerPoStState
 	Info       MinerInfo
@@ -71,11 +71,11 @@ type SectorPreCommitOnChainInfo struct {
 }
 
 type SectorOnChainInfo struct {
-	Info                  SectorPreCommitInfo // Also contains Expiration field.
-	ActivationEpoch       abi.ChainEpoch
+	Info                  SectorPreCommitInfo
+	ActivationEpoch       abi.ChainEpoch // Epoch at which SectorProveCommit is accepted
 	DeclaredFaultEpoch    abi.ChainEpoch // -1 if not currently declared faulted.
 	DeclaredFaultDuration abi.ChainEpoch // -1 if not currently declared faulted.
-	DealWeight            abi.DealWeight
+	DealWeight            abi.DealWeight // integral of active deals over sector lifetime, 0 if CommittedCapacity sector
 }
 
 type SectorPreCommitInfo struct {
@@ -83,7 +83,7 @@ type SectorPreCommitInfo struct {
 	SealedCID    abi.SealedSectorCID // CommR
 	SealEpoch    abi.ChainEpoch
 	DealIDs      abi.DealIDs
-	Expiration   abi.ChainEpoch
+	Expiration   abi.ChainEpoch // Sector Expiration
 }
 
 type SectorProveCommitInfo struct {

--- a/actors/builtin/storage_miner/storage_miner_actor_state.go
+++ b/actors/builtin/storage_miner/storage_miner_actor_state.go
@@ -3,6 +3,7 @@ package storage_miner
 import (
 	"io"
 
+	cid "github.com/ipfs/go-cid"
 	addr "github.com/filecoin-project/go-address"
 	peer "github.com/libp2p/go-libp2p-core/peer"
 
@@ -14,9 +15,12 @@ import (
 // Balance of a StorageMinerActor should equal exactly the sum of PreCommit deposits
 // that are not yet returned or burned.
 type StorageMinerActorState struct {
+	PreCommittedSectors PreCommittedSectorsAMT 
 	Sectors    SectorsAMT
+	FaultSet SectorNumberSetHAMT // TODO bitfield
+	ProvingSet cid.Cid
+
 	PoStState  MinerPoStState
-	ProvingSet SectorNumberSetHAMT
 	Info       MinerInfo
 }
 
@@ -60,23 +64,18 @@ func (mps *MinerPoStState) Is_DetectedFault() bool {
 	return mps.NumConsecutiveFailures > 0
 }
 
-type SectorState int64
-
-const (
-	PreCommit SectorState = iota
-	Active
-	TemporaryFault
-)
+type SectorPreCommitOnChainInfo struct {
+	Info SectorPreCommitInfo
+	PreCommitDeposit abi.TokenAmount
+	PreCommitEpoch abi.ChainEpoch
+}
 
 type SectorOnChainInfo struct {
-	State                 SectorState
 	Info                  SectorPreCommitInfo // Also contains Expiration field.
-	PreCommitDeposit      abi.TokenAmount
-	PreCommitEpoch        abi.ChainEpoch
-	ActivationEpoch       abi.ChainEpoch // -1 if still in PreCommit state.
+	ActivationEpoch       abi.ChainEpoch
 	DeclaredFaultEpoch    abi.ChainEpoch // -1 if not currently declared faulted.
 	DeclaredFaultDuration abi.ChainEpoch // -1 if not currently declared faulted.
-	DealWeight            abi.DealWeight // -1 if not yet validated with StorageMarketActor.
+	DealWeight            abi.DealWeight
 }
 
 type SectorPreCommitInfo struct {
@@ -89,14 +88,12 @@ type SectorPreCommitInfo struct {
 
 type SectorProveCommitInfo struct {
 	SectorNumber     abi.SectorNumber
-	RegisteredProof  abi.RegisteredProof
 	Proof            abi.SealProof
-	InteractiveEpoch abi.ChainEpoch
-	Expiration       abi.ChainEpoch
 }
 
 // TODO AMT
 type SectorsAMT map[abi.SectorNumber]SectorOnChainInfo
+type PreCommittedSectorsAMT map[abi.SectorNumber]SectorPreCommitOnChainInfo
 
 // TODO HAMT
 type SectorNumberSetHAMT map[abi.SectorNumber]bool
@@ -179,24 +176,30 @@ func (st *StorageMinerActorState) _getStorageWeightDescsForSectors(sectorNumbers
 	return ret
 }
 
-func (x *SectorOnChainInfo) Is_TemporaryFault() bool {
-	ret := (x.State == TemporaryFault)
-	if ret {
-		Assert(x.DeclaredFaultEpoch != epochUndefined)
-		Assert(x.DeclaredFaultDuration != epochUndefined)
+func (st *StorageMinerActorState) IsSectorInTemporaryFault(sectorNumber abi.SectorNumber) bool {
+	checkSector, found := st.Sectors[sectorNumber]
+	if !found {
+		return false
 	}
+	_, ret := st.FaultSet[sectorNumber]
+	Assert(checkSector.DeclaredFaultEpoch != epochUndefined)
+	Assert(checkSector.DeclaredFaultDuration != epochUndefined)
+	return ret
+}
+
+func (st *StorageMinerActorState) GetCurrentProvingSet() cid.Cid {
+	// Current ProvingSet is a snapshot of the Sectors AMT subtracting sectors in the FaultSet
+	var ret cid.Cid
 	return ret
 }
 
 // Must be significantly larger than DeclaredFaultEpoch, since otherwise it may be possible
 // to declare faults adaptively in order to exempt challenged sectors.
 func (x *SectorOnChainInfo) EffectiveFaultBeginEpoch() abi.ChainEpoch {
-	Assert(x.Is_TemporaryFault())
 	return x.DeclaredFaultEpoch + indices.StorageMining_DeclaredFaultEffectiveDelay()
 }
 
 func (x *SectorOnChainInfo) EffectiveFaultEndEpoch() abi.ChainEpoch {
-	Assert(x.Is_TemporaryFault())
 	return x.EffectiveFaultBeginEpoch() + x.DeclaredFaultDuration
 }
 

--- a/actors/runtime/indices/indices.go
+++ b/actors/runtime/indices/indices.go
@@ -366,6 +366,12 @@ func StorageMining_SpcLookbackSeal() abi.ChainEpoch {
 	return StorageMining_Finality() // should be approximately the same as finality
 }
 
+func StorageMining_SpcLookbackSealLimit() abi.ChainEpoch {
+	PARAM_FINISH()
+	return 0
+}
+
+
 func StorageMining_MaxSealTime32GiBWinStackedSDR() abi.ChainEpoch {
 	PARAM_FINISH()
 	MAX_SEAL_TIME_32GIB_WIN_STACKED_SDR := abi.ChainEpoch(1) // TODO: Change to a dictionary with RegisteredProofs as the key.

--- a/actors/runtime/indices/indices.go
+++ b/actors/runtime/indices/indices.go
@@ -366,12 +366,6 @@ func StorageMining_SpcLookbackSeal() abi.ChainEpoch {
 	return StorageMining_Finality() // should be approximately the same as finality
 }
 
-func StorageMining_SpcLookbackSealLimit() abi.ChainEpoch {
-	PARAM_FINISH()
-	return 0
-}
-
-
 func StorageMining_MaxSealTime32GiBWinStackedSDR() abi.ChainEpoch {
 	PARAM_FINISH()
 	MAX_SEAL_TIME_32GIB_WIN_STACKED_SDR := abi.ChainEpoch(1) // TODO: Change to a dictionary with RegisteredProofs as the key.


### PR DESCRIPTION
Simplify sector state with the following changes:
- [x] Active, TemporaryFault, and PreCommit still exists as concept but removed SectorState field from MinerActorState
- [x] Introduce PreCommittedSectorsAMT to keep track of PreCommit sectors
- [x] SectorAMT contains all Active and TemporaryFault sectors
- [x] TemporaryFault sectors are stored in FaultSet
- [x] ProvingSet is a snapshot of the current SectorAMT subtracting sectors in the FaultSet. It is a pointer to the root of SectorAMT
- [x] ProvingSet is updated at ProveCommit (assume sector gaining power at ProveCommit)and OnSurprisePoStChallenge. Lotus does this slightly differently and likely needs some changes but this ties to the discussion of when a sector gains power and ElectionPoSt.
- [x] Remove deal verification at PreCommit and only do that at ProveCommit, better separation of concerns and they are doing the same deal checks
- [x] VerifyDealsOnSectorProveCommit returns DealWeight upon successful verification to reduce one inter actor round trip
- [x] Remove unnecessary fields in PreCommitInfo and ProveCommitInfo
- [x] Add SectorPreCommitOnChainInfo to reduce onchain footprint as PreCommit related info can be discarded after ProveCommit
- [x] A sector is only in TemporaryFault state (hence in the FaultSet) after EffectiveFaultBeginEpoch() and not at DeclareTemporaryFault

TODO:
- [ ] align on power and update ProvingSet when HAMT/AMT are in place

cc @jzimmerman @sternhenri 