### PR TITLE
First implementation of mock runtime and construction unit tests for the multisig actor

### DIFF
--- a/actors/builtin/multisig/multisig_actor.go
+++ b/actors/builtin/multisig/multisig_actor.go
@@ -47,17 +47,18 @@ func (a *MultiSigActor) Constructor(rt vmr.Runtime, params *ConstructorParams) *
 		signers = append(signers, a)
 	}
 
-	var st MultiSigActorState
-	rt.State().Transaction(&st, func() interface{} {
+	rt.State().Construct(func() vmr.CBORMarshaler {
+		var st MultiSigActorState
 		st.Signers = signers
 		st.NumApprovalsThreshold = params.NumApprovalsThreshold
 		st.PendingTxns = autil.EmptyHAMT
+		st.InitialBalance = abi.NewTokenAmount(0)
 		if params.UnlockDuration != 0 {
-			st.UnlockDuration = params.UnlockDuration
 			st.InitialBalance = rt.ValueReceived()
+			st.UnlockDuration = params.UnlockDuration
 			st.StartEpoch = rt.CurrEpoch()
 		}
-		return nil
+		return &st
 	})
 	return &vmr.EmptyReturn{}
 }

--- a/actors/builtin/multisig/multisig_test.go
+++ b/actors/builtin/multisig/multisig_test.go
@@ -38,7 +38,7 @@ func TestConstruction(t *testing.T) {
 		rt.Verify()
 
 		var st multisig.MultiSigActorState
-		rt.GetState(&st)
+		rt.Readonly(&st)
 		assert.Equal(t, params.Signers, st.Signers)
 		assert.Equal(t, params.NumApprovalsThreshold, st.NumApprovalsThreshold)
 		assert.Equal(t, abi.NewTokenAmount(0), st.InitialBalance)
@@ -61,7 +61,7 @@ func TestConstruction(t *testing.T) {
 		rt.Verify()
 
 		var st multisig.MultiSigActorState
-		rt.GetState(&st)
+		rt.Readonly(&st)
 		assert.Equal(t, params.Signers, st.Signers)
 		assert.Equal(t, params.NumApprovalsThreshold, st.NumApprovalsThreshold)
 		assert.Equal(t, abi.NewTokenAmount(0), st.InitialBalance)

--- a/actors/builtin/multisig/multisig_test.go
+++ b/actors/builtin/multisig/multisig_test.go
@@ -1,0 +1,80 @@
+package multisig_test
+
+import (
+	"context"
+	"testing"
+
+	addr "github.com/filecoin-project/go-address"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/specs-actors/actors/builtin"
+	"github.com/filecoin-project/specs-actors/actors/builtin/multisig"
+	"github.com/filecoin-project/specs-actors/actors/runtime"
+	"github.com/filecoin-project/specs-actors/support/mock"
+)
+
+func TestConstruction(t *testing.T) {
+	actor := multisig.MultiSigActor{}
+
+	receiver := newAddr(t, 100)
+	anne := newAddr(t, 101)
+	bob := newAddr(t, 102)
+	charlie := newAddr(t, 103)
+
+	builder := mock.NewBuilder(context.Background(), t, receiver).WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID)
+
+	t.Run("simple construction", func(t *testing.T) {
+		rt := builder.Build()
+		params := multisig.ConstructorParams{
+			Signers:               []addr.Address{anne, bob, charlie},
+			NumApprovalsThreshold: 2,
+			UnlockDuration:        0,
+		}
+
+		rt.ExpectValidateCallerAddr(builtin.InitActorAddr)
+		ret := actor.Constructor(rt, &params)
+		assert.Equal(t, runtime.EmptyReturn{}, *ret)
+		rt.Verify()
+
+		var st multisig.MultiSigActorState
+		rt.GetState(&st)
+		assert.Equal(t, params.Signers, st.Signers)
+		assert.Equal(t, params.NumApprovalsThreshold, st.NumApprovalsThreshold)
+		assert.Equal(t, abi.NewTokenAmount(0), st.InitialBalance)
+		assert.Equal(t, abi.ChainEpoch(0), st.UnlockDuration)
+		assert.Equal(t, abi.ChainEpoch(0), st.StartEpoch)
+		//txns := adt.NewMap(rt.Store(), st.PendingTxns)
+		// TODO: assert transactions is empty
+	})
+
+	t.Run("construction with vesting", func(t *testing.T) {
+		rt := builder.WithEpoch(1234).Build()
+		params := multisig.ConstructorParams{
+			Signers:               []addr.Address{anne, bob, charlie},
+			NumApprovalsThreshold: 3,
+			UnlockDuration:        100,
+		}
+		rt.ExpectValidateCallerAddr(builtin.InitActorAddr)
+		ret := actor.Constructor(rt, &params)
+		assert.Equal(t, runtime.EmptyReturn{}, *ret)
+		rt.Verify()
+
+		var st multisig.MultiSigActorState
+		rt.GetState(&st)
+		assert.Equal(t, params.Signers, st.Signers)
+		assert.Equal(t, params.NumApprovalsThreshold, st.NumApprovalsThreshold)
+		assert.Equal(t, abi.NewTokenAmount(0), st.InitialBalance)
+		assert.Equal(t, abi.ChainEpoch(100), st.UnlockDuration)
+		assert.Equal(t, abi.ChainEpoch(1234), st.StartEpoch)
+		// assert no transactions
+	})
+}
+
+func newAddr(t *testing.T, id uint64) addr.Address {
+	address, err := addr.NewIDAddress(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return address
+}

--- a/actors/runtime/exitcode/reserved.go
+++ b/actors/runtime/exitcode/reserved.go
@@ -55,16 +55,16 @@ const (
 	// Indicates an invalid argument passed to a runtime method.
 	SysErrorIllegalArgument = ExitCode(10)
 
-	// MethodSubcallError is returned when an actor method's Send call has
-	// returned with a failure error code (and the Send call did not specify
-	// to ignore errors).
-	SysErrorSubcallAbort = ExitCode(11)
+	// Indicates  an object failed to de/serialize for storage.
+	SysErrSerialization = ExitCode(11)
 
 	// Reserved exit codes, do not use.
 	SysErrorReserved1 = ExitCode(12)
 	SysErrorReserved2 = ExitCode(13)
 	SysErrorReserved3 = ExitCode(14)
-	SysErrorReserved4 = ExitCode(15)
+
+	// Indicates something broken within the VM.
+	SysErrInternal = ExitCode(15)
 )
 
 // The initial range of exit codes is reserved for system errors.

--- a/actors/runtime/runtime.go
+++ b/actors/runtime/runtime.go
@@ -127,17 +127,16 @@ type TraceSpan interface {
 	End()
 }
 
-// ReadonlyStateHandle provides read-only access to an actor's state object.
-type ReadonlyStateHandle interface {
+// StateHandle provides mutable, exclusive access to actor state.
+type StateHandle interface {
+	// Construct initializes the state object.
+	// This is only valid in a constructor function and when the state has not yet been initialized.
+	Construct(f func() CBORMarshaler)
+
 	// Readonly loads a readonly copy of the state into the argument.
 	//
 	// Any modification to the state is illegal and will result in an abort.
 	Readonly(obj CBORUnmarshaler)
-}
-
-// StateHandle provides mutable, exclusive access to actor state.
-type StateHandle interface {
-	ReadonlyStateHandle
 
 	// Transaction loads a mutable version of the state into the `obj` argument and protects
 	// the execution from side effects (including message send).

--- a/actors/util/assert.go
+++ b/actors/util/assert.go
@@ -15,7 +15,9 @@ func Assert(b bool) {
 }
 
 func AssertNoError(e error) {
-	AssertMsg(e == nil, fmt.Sprintf("%v", e))
+	if e != nil {
+		panic(e.Error())
+	}
 }
 
 // Indicating behavior not yet specified, and may require other spec changes.

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/ipfs/go-hamt-ipld v0.0.14
 	github.com/libp2p/go-libp2p-core v0.3.0
 	github.com/multiformats/go-multihash v0.0.10
+	github.com/stretchr/testify v1.4.0
 	github.com/whyrusleeping/cbor-gen v0.0.0-20200122015334-52eaf73beaf5
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
 )

--- a/support/mock/builder.go
+++ b/support/mock/builder.go
@@ -1,0 +1,74 @@
+package mock
+
+import (
+	"context"
+	"testing"
+
+	addr "github.com/filecoin-project/go-address"
+	cid "github.com/ipfs/go-cid"
+
+	"github.com/filecoin-project/specs-actors/actors/abi"
+)
+
+// Build for fluent initialization of a mock runtime.
+type RuntimeBuilder struct {
+	rt *Runtime
+}
+
+// Initializes a new builder with a receiving actor address.
+func NewBuilder(ctx context.Context, t *testing.T, receiver addr.Address) *RuntimeBuilder {
+	m := &Runtime{
+		ctx:                      ctx,
+		epoch:                    0,
+		receiver:                 receiver,
+		caller:                   addr.Address{},
+		callerType:               cid.Undef,
+		miner:                    addr.Address{},
+
+		state:                    cid.Undef,
+		store:                    make(map[cid.Cid][]byte),
+
+		balance:                  abi.NewTokenAmount(0),
+		valueReceived:            abi.NewTokenAmount(0),
+
+		t:                        t,
+		expectValidateCallerAny:  false,
+		expectValidateCallerAddr: nil,
+		expectValidateCallerType: nil,
+	}
+	return &RuntimeBuilder{m}
+}
+
+// Builds a new runtime object with the configured values.
+func (b *RuntimeBuilder) Build() *Runtime {
+	cpy := *b.rt
+
+	// Deep copy the mutable values.
+	cpy.store = make(map[cid.Cid][]byte)
+	for k, v := range b.rt.store {
+		cpy.store[k] = v
+	}
+	return &cpy
+}
+
+func (b *RuntimeBuilder) WithEpoch(epoch abi.ChainEpoch) *RuntimeBuilder {
+	b.rt.epoch = epoch
+	return b
+}
+
+func (b *RuntimeBuilder) WithCaller(address addr.Address, code cid.Cid) *RuntimeBuilder {
+	b.rt.caller = address
+	b.rt.callerType = code
+	return b
+}
+
+func (b *RuntimeBuilder) WithMiner(miner addr.Address) *RuntimeBuilder {
+	b.rt.miner = miner
+	return b
+}
+
+func (b *RuntimeBuilder) WithBalance(balance, received abi.TokenAmount) *RuntimeBuilder {
+	b.rt.balance = balance
+	b.rt.valueReceived = received
+	return b
+}

--- a/support/mock/mockrt.go
+++ b/support/mock/mockrt.go
@@ -1,0 +1,326 @@
+package mock
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	addr "github.com/filecoin-project/go-address"
+	cid "github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+
+	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/specs-actors/actors/runtime"
+	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	"github.com/filecoin-project/specs-actors/actors/runtime/indices"
+	"github.com/filecoin-project/specs-actors/actors/util/adt"
+)
+
+// A mock runtime for unit testing of actors in isolation.
+// The mock allows direct specification of the runtime context as observable by an actor, supports
+// the storage interface, and mocks out side-effect-inducing calls.
+type Runtime struct {
+	// Execution context
+	ctx        context.Context
+	epoch      abi.ChainEpoch
+	receiver   addr.Address
+	caller     addr.Address
+	callerType cid.Cid
+	miner      addr.Address
+	valueReceived abi.TokenAmount
+
+	// Actor state
+	state         cid.Cid
+	balance       abi.TokenAmount
+
+	// VM implementation
+	store         map[cid.Cid][]byte
+	inTransaction bool
+
+	// Expectations
+	t                        *testing.T
+	expectValidateCallerAny  bool
+	expectValidateCallerAddr []addr.Address
+	expectValidateCallerType []cid.Cid
+}
+
+var _ runtime.Runtime = &Runtime{}
+var _ runtime.StateHandle = &Runtime{}
+
+var cidBuilder = cid.V1Builder{
+	Codec:    cid.DagCBOR,
+	MhType:   mh.SHA2_256,
+	MhLength: 0, // default
+}
+
+///// Implementation of the runtime API /////
+
+func (rt *Runtime) CurrEpoch() abi.ChainEpoch {
+	return rt.epoch
+}
+
+func (rt *Runtime) CurrReceiver() addr.Address {
+	return rt.receiver
+}
+
+func (rt *Runtime) ImmediateCaller() addr.Address {
+	return rt.caller
+}
+
+func (rt *Runtime) ValidateImmediateCallerAcceptAny() {
+	if !rt.expectValidateCallerAny {
+		rt.t.Fatalf("unexpected validate-caller-any")
+	}
+	rt.expectValidateCallerAny = false
+}
+
+func (rt *Runtime) ValidateImmediateCallerIs(addrs ...addr.Address) {
+	// Check and clear expectations.
+	if len(rt.expectValidateCallerAddr) == 0 {
+		rt.t.Errorf("unexpected validate caller addrs")
+		return
+	}
+	if !reflect.DeepEqual(rt.expectValidateCallerAddr, addrs) {
+		rt.t.Errorf("unexpected validate caller addrs %v, expected %v", addrs, rt.expectValidateCallerAddr)
+		return
+	}
+	defer func() {
+		rt.expectValidateCallerAddr = []addr.Address{}
+	}()
+
+	// Implement method.
+	for _, expected := range addrs {
+		if rt.caller == expected {
+			return
+		}
+	}
+	rt.Abort(exitcode.ErrForbidden, "caller address %v forbidden, allowed: %v", rt.caller, addrs)
+}
+
+func (rt *Runtime) ValidateImmediateCallerType(types ...cid.Cid) {
+	// Check and clear expectations.
+	if len(rt.expectValidateCallerType) == 0 {
+		rt.t.Errorf("unexpected validate caller code")
+	}
+	if !reflect.DeepEqual(rt.expectValidateCallerType, types) {
+		rt.t.Errorf("unexpected validate caller code %v, expected %v", types, rt.expectValidateCallerType)
+	}
+	defer func() {
+		rt.expectValidateCallerType = []cid.Cid{}
+	}()
+
+	// Implement method.
+	for _, expected := range types {
+		if rt.callerType == expected {
+			return
+		}
+	}
+	rt.Abort(exitcode.ErrForbidden, "caller type %v forbidden, allowed: %v", rt.callerType, types)
+}
+
+func (rt *Runtime) ToplevelBlockWinner() addr.Address {
+	return rt.miner
+}
+
+func (rt *Runtime) CurrentBalance() abi.TokenAmount {
+	return rt.balance
+}
+
+func (rt *Runtime) ValueReceived() abi.TokenAmount {
+	return rt.valueReceived
+}
+
+func (rt *Runtime) GetActorCodeID(addr addr.Address) (ret cid.Cid, ok bool) {
+	panic("implement me")
+}
+
+func (rt *Runtime) GetRandomness(epoch abi.ChainEpoch) abi.RandomnessSeed {
+	panic("implement me")
+}
+
+func (rt *Runtime) State() runtime.StateHandle {
+	return rt
+}
+
+func (rt *Runtime) IpldGet(c cid.Cid, o runtime.CBORUnmarshaler) bool {
+	data, found := rt.store[c]
+	if found {
+		err := o.UnmarshalCBOR(bytes.NewReader(data))
+		if err != nil {
+			rt.Abort(exitcode.SysErrSerialization, err.Error())
+		}
+	}
+	return found
+}
+
+func (rt *Runtime) IpldPut(o runtime.CBORMarshaler) cid.Cid {
+	r := bytes.Buffer{}
+	err := o.MarshalCBOR(&r)
+	if err != nil {
+		rt.Abort(exitcode.SysErrSerialization, err.Error())
+	}
+	data := r.Bytes()
+	key, err := cidBuilder.Sum(data)
+	rt.store[key] = data
+	return key
+}
+
+func (rt *Runtime) Send(toAddr addr.Address, methodNum abi.MethodNum, params abi.MethodParams, value abi.TokenAmount) (runtime.SendReturn, exitcode.ExitCode) {
+	if rt.inTransaction {
+		rt.Abort(exitcode.SysErrorIllegalActor, "side-effect within transaction")
+	}
+	panic("implement me")
+}
+
+func (rt *Runtime) NewActorAddress() addr.Address {
+	panic("implement me")
+}
+
+func (rt *Runtime) CreateActor(codeId cid.Cid, address addr.Address) {
+	if rt.inTransaction {
+		rt.Abort(exitcode.SysErrorIllegalActor, "side-effect within transaction")
+	}
+	panic("implement me")
+}
+
+func (rt *Runtime) DeleteActor(address addr.Address) {
+	if rt.inTransaction {
+		rt.Abort(exitcode.SysErrorIllegalActor, "side-effect within transaction")
+	}
+	panic("implement me")
+}
+
+func (rt *Runtime) CurrIndices() indices.Indices {
+	panic("implement me")
+}
+
+func (rt *Runtime) Abort(errExitCode exitcode.ExitCode, msg string, args ...interface{}) {
+	panic(abort{errExitCode, fmt.Sprintf(msg, args...)})
+}
+
+func (rt *Runtime) AbortStateMsg(msg string) {
+	rt.Abort(exitcode.ErrPlaceholder, msg)
+}
+
+func (rt *Runtime) Syscalls() runtime.Syscalls {
+	panic("implement me")
+}
+
+func (rt *Runtime) Context() context.Context {
+	return rt.ctx
+}
+
+func (rt *Runtime) StartSpan(name string) runtime.TraceSpan {
+	return &TraceSpan{}
+}
+
+///// State handle implementation /////
+
+func (rt *Runtime) Construct(f func() runtime.CBORMarshaler) {
+	if rt.state.Defined() {
+		rt.Abort(exitcode.SysErrorIllegalActor, "state already constructed")
+	}
+	st := f()
+	rt.state = rt.IpldPut(st)
+}
+
+func (rt *Runtime) Readonly(st runtime.CBORUnmarshaler) {
+	found := rt.IpldGet(rt.state, st)
+	if !found {
+		rt.Abort(exitcode.SysErrInternal, "actor state not found: %v", rt.state)
+	}
+}
+
+func (rt *Runtime) Transaction(st runtime.CBORer, f func() interface{}) interface{} {
+	if rt.inTransaction {
+		rt.Abort(exitcode.SysErrorIllegalActor, "nested transaction")
+	}
+	rt.Readonly(st)
+	rt.inTransaction = true
+	ret := f()
+	rt.state = rt.IpldPut(st)
+	rt.inTransaction = false
+	return ret
+}
+
+///// Trace span implementation /////
+
+type TraceSpan struct {
+}
+
+func (t TraceSpan) End() {
+	// no-op
+}
+
+type abort struct {
+	code exitcode.ExitCode
+	msg  string
+}
+
+///// Inspection facilities /////
+
+func (rt *Runtime) StateRoot() cid.Cid {
+	return rt.state
+}
+
+func (rt *Runtime) GetState(o runtime.CBORUnmarshaler) {
+	rt.IpldGet(rt.state, o)
+}
+
+func (rt *Runtime) Store() adt.Store {
+	return adt.AsStore(rt)
+}
+
+///// Mocking facilities /////
+
+func (rt *Runtime) ExpectValidateCallerAny() {
+	rt.expectValidateCallerAny = true
+}
+
+func (rt *Runtime) ExpectValidateCallerAddr(addrs ...addr.Address) {
+	rt.expectValidateCallerAddr = addrs[:]
+}
+
+func (rt *Runtime) ExpectValidateCallerType(types ...cid.Cid) {
+	rt.expectValidateCallerType = types[:]
+}
+
+// Verifies that expected calls were received, and resets all expectations.
+func (rt *Runtime) Verify() {
+	if rt.expectValidateCallerAny {
+		rt.t.Error("expected ValidateCallerAny, not received")
+	}
+	if len(rt.expectValidateCallerAddr) > 0 {
+		rt.t.Errorf("expected ValidateCallerAddr %v, not received", rt.expectValidateCallerAddr)
+	}
+	if len(rt.expectValidateCallerType) > 0 {
+		rt.t.Errorf("expected ValidateCallerType %v, not received", rt.expectValidateCallerType)
+	}
+
+	rt.Reset()
+}
+
+// Resets expectations
+func (rt *Runtime) Reset() {
+	rt.expectValidateCallerAny = false
+	rt.expectValidateCallerAddr = nil
+	rt.expectValidateCallerType = nil
+}
+
+// Calls f() expecting it to invoke Runtime.Abort() with a specified exit code.
+func (rt *Runtime) ExpectAbort(expected exitcode.ExitCode, f func()) {
+	defer func() {
+		r := recover()
+		a, ok := r.(abort)
+		if !ok {
+			panic(r)
+		}
+		if a.code != expected {
+			rt.t.Errorf("abort expected code %v, got %v %s", expected, a.code, a.msg)
+		}
+	}()
+	f()
+	rt.t.Errorf("expected abort with code %v but call succeeded", expected)
+}

--- a/support/mock/mockrt.go
+++ b/support/mock/mockrt.go
@@ -23,17 +23,17 @@ import (
 // the storage interface, and mocks out side-effect-inducing calls.
 type Runtime struct {
 	// Execution context
-	ctx        context.Context
-	epoch      abi.ChainEpoch
-	receiver   addr.Address
-	caller     addr.Address
-	callerType cid.Cid
-	miner      addr.Address
+	ctx           context.Context
+	epoch         abi.ChainEpoch
+	receiver      addr.Address
+	caller        addr.Address
+	callerType    cid.Cid
+	miner         addr.Address
 	valueReceived abi.TokenAmount
 
 	// Actor state
-	state         cid.Cid
-	balance       abi.TokenAmount
+	state   cid.Cid
+	balance abi.TokenAmount
 
 	// VM implementation
 	store         map[cid.Cid][]byte
@@ -163,6 +163,9 @@ func (rt *Runtime) IpldPut(o runtime.CBORMarshaler) cid.Cid {
 	}
 	data := r.Bytes()
 	key, err := cidBuilder.Sum(data)
+	if err != nil {
+		rt.Abort(exitcode.SysErrSerialization, err.Error())
+	}
 	rt.store[key] = data
 	return key
 }


### PR DESCRIPTION
The test exposed a bug in the constructor failing to initialize a bigint value.

This is based on #45, which must land first.