### PR TITLE
Add network name to runtime. Move shared builtin code to builtin.

### DIFF
--- a/actors/builtin/init/init_actor.go
+++ b/actors/builtin/init/init_actor.go
@@ -52,7 +52,7 @@ func (a *InitActor) Constructor(rt Runtime) *vmr.EmptyReturn {
 	rt.State().Transaction(&st, func() interface{} {
 		st.AddressMap = map[addr.Address]abi.ActorID{} // TODO HAMT
 		st.NextID = abi.ActorID(builtin.FirstNonSingletonActorId)
-		st.NetworkName = vmr.NetworkName()
+		st.NetworkName = rt.NetworkName()
 		return nil
 	})
 	return &vmr.EmptyReturn{}
@@ -95,7 +95,7 @@ func (a *InitActor) Exec(rt Runtime, execCodeID cid.Cid, constructorParams abi.M
 
 	// Invoke constructor.
 	_, code := rt.Send(idAddr, builtin.MethodConstructor, constructorParams, rt.ValueReceived())
-	vmr.RequireSuccess(rt, code, "constructor failed")
+	builtin.RequireSuccess(rt, code, "constructor failed")
 
 	return &ExecReturn{idAddr, uniqueAddress}
 }

--- a/actors/builtin/reward/reward_actor.go
+++ b/actors/builtin/reward/reward_actor.go
@@ -107,7 +107,7 @@ func (a *RewardActor) WithdrawReward(rt vmr.Runtime) *vmr.EmptyReturn {
 	}).(abi.TokenAmount)
 
 	_, code := rt.Send(ownerAddr, builtin.MethodSend, nil, withdrawableReward)
-	vmr.RequireSuccess(rt, code, "failed to send funds to owner")
+	builtin.RequireSuccess(rt, code, "failed to send funds to owner")
 	return &vmr.EmptyReturn{}
 }
 
@@ -141,7 +141,7 @@ func (a *RewardActor) AwardBlockReward(
 			serde.MustSerializeParams(miner),
 			abi.TokenAmount(rewardToGarnish),
 		)
-		vmr.RequireSuccess(rt, code, "failed to add balance to power actor")
+		builtin.RequireSuccess(rt, code, "failed to add balance to power actor")
 	}
 
 	var st RewardActorState

--- a/actors/builtin/storage_market/storage_market_actor.go
+++ b/actors/builtin/storage_market/storage_market_actor.go
@@ -37,7 +37,7 @@ func (a *StorageMarketActor) WithdrawBalance(rt Runtime, entryAddr addr.Address,
 		rt.Abort(exitcode.ErrIllegalArgument, "negative amount %v", amountRequested)
 	}
 
-	recipientAddr := vmr.RT_MinerEntry_ValidateCaller_DetermineFundsLocation(rt, entryAddr, vmr.MinerEntrySpec_MinerOrSignable)
+	recipientAddr := builtin.RT_MinerEntry_ValidateCaller_DetermineFundsLocation(rt, entryAddr, builtin.MinerEntrySpec_MinerOrSignable)
 
 	var amountExtracted abi.TokenAmount
 	var st StorageMarketActorState
@@ -61,16 +61,16 @@ func (a *StorageMarketActor) WithdrawBalance(rt Runtime, entryAddr addr.Address,
 	})
 
 	_, code := rt.Send(builtin.BurntFundsActorAddr, builtin.MethodSend, nil, amountSlashedTotal)
-	vmr.RequireSuccess(rt, code, "failed to burn slashed funds")
+	builtin.RequireSuccess(rt, code, "failed to burn slashed funds")
 	_, code = rt.Send(recipientAddr, builtin.MethodSend, nil, amountExtracted)
-	vmr.RequireSuccess(rt, code, "failed to send funds")
+	builtin.RequireSuccess(rt, code, "failed to send funds")
 	return &vmr.EmptyReturn{}
 }
 
 // Deposits the specified amount into the balance held in escrow.
 // Note: the amount is included implicitly in the message.
 func (a *StorageMarketActor) AddBalance(rt Runtime, entryAddr addr.Address) *vmr.EmptyReturn {
-	vmr.RT_MinerEntry_ValidateCaller_DetermineFundsLocation(rt, entryAddr, vmr.MinerEntrySpec_MinerOrSignable)
+	builtin.RT_MinerEntry_ValidateCaller_DetermineFundsLocation(rt, entryAddr, builtin.MinerEntrySpec_MinerOrSignable)
 
 	var st StorageMarketActorState
 	rt.State().Transaction(&st, func() interface{} {
@@ -143,7 +143,7 @@ func (a *StorageMarketActor) PublishStorageDeals(rt Runtime, newStorageDeals []S
 	})
 
 	_, code := rt.Send(builtin.BurntFundsActorAddr, builtin.MethodSend, nil, amountSlashedTotal)
-	vmr.RequireSuccess(rt, code, "failed to burn funds")
+	builtin.RequireSuccess(rt, code, "failed to burn funds")
 	return &vmr.EmptyReturn{}
 }
 
@@ -342,7 +342,7 @@ func (a *StorageMarketActor) OnEpochTickEnd(rt Runtime) *vmr.EmptyReturn {
 	})
 
 	_, code := rt.Send(builtin.BurntFundsActorAddr, builtin.MethodSend, nil, amountSlashedTotal)
-	vmr.RequireSuccess(rt, code, "failed to burn funds")
+	builtin.RequireSuccess(rt, code, "failed to burn funds")
 	return &vmr.EmptyReturn{}
 }
 

--- a/actors/builtin/storage_power/storage_power_actor.go
+++ b/actors/builtin/storage_power/storage_power_actor.go
@@ -43,7 +43,7 @@ type StoragePowerActor struct{}
 ////////////////////////////////////////////////////////////////////////////////
 
 func (a *StoragePowerActor) AddBalance(rt Runtime, minerAddr addr.Address) *vmr.EmptyReturn {
-	vmr.RT_MinerEntry_ValidateCaller_DetermineFundsLocation(rt, minerAddr, vmr.MinerEntrySpec_MinerOnly)
+	builtin.RT_MinerEntry_ValidateCaller_DetermineFundsLocation(rt, minerAddr, builtin.MinerEntrySpec_MinerOnly)
 
 	msgValue := rt.ValueReceived()
 
@@ -64,7 +64,7 @@ func (a *StoragePowerActor) WithdrawBalance(rt Runtime, minerAddr addr.Address, 
 		rt.Abort(exitcode.ErrIllegalArgument, "negative withdrawal %v", amountRequested)
 	}
 
-	recipientAddr := vmr.RT_MinerEntry_ValidateCaller_DetermineFundsLocation(rt, minerAddr, vmr.MinerEntrySpec_MinerOnly)
+	recipientAddr := builtin.RT_MinerEntry_ValidateCaller_DetermineFundsLocation(rt, minerAddr, builtin.MinerEntrySpec_MinerOnly)
 
 	var amountExtracted abi.TokenAmount
 	var st StoragePowerActorState
@@ -81,7 +81,7 @@ func (a *StoragePowerActor) WithdrawBalance(rt Runtime, minerAddr addr.Address, 
 	})
 
 	_, code := rt.Send(recipientAddr, builtin.MethodSend, nil, amountExtracted)
-	vmr.RequireSuccess(rt, code, "failed to send funds")
+	builtin.RequireSuccess(rt, code, "failed to send funds")
 	return &vmr.EmptyReturn{}
 }
 
@@ -106,7 +106,7 @@ func (a *StoragePowerActor) CreateMiner(rt Runtime, workerAddr addr.Address, sec
 		),
 		abi.NewTokenAmount(0),
 	)
-	vmr.RequireSuccess(rt, code, "failed to init new actor")
+	builtin.RequireSuccess(rt, code, "failed to init new actor")
 	var addresses initact.ExecReturn
 	autil.AssertNoError(ret.Into(addresses))
 
@@ -146,7 +146,7 @@ func (a *StoragePowerActor) DeleteMiner(rt Runtime, minerAddr addr.Address) *vmr
 		rt.AbortStateMsg("Deletion requested for miner with power still remaining")
 	}
 
-	ownerAddr, workerAddr := vmr.RT_GetMinerAccountsAssert(rt, minerAddr)
+	ownerAddr, workerAddr := builtin.RT_GetMinerAccountsAssert(rt, minerAddr)
 	rt.ValidateImmediateCallerIs(ownerAddr, workerAddr)
 
 	a._rtDeleteMinerActor(rt, minerAddr)
@@ -312,7 +312,7 @@ func (a *StoragePowerActor) ReportConsensusFault(rt Runtime, blockHeader1, block
 
 	// reward slasher
 	_, code := rt.Send(slasherAddr, builtin.MethodSend, nil, amountToSlasher)
-	vmr.RequireSuccess(rt, code, "failed to reward slasher")
+	builtin.RequireSuccess(rt, code, "failed to reward slasher")
 
 	// burn the rest of pledge collateral
 	// delete miner from power table
@@ -388,7 +388,7 @@ func (a *StoragePowerActor) _rtInitiateNewSurprisePoStChallenges(rt Runtime) {
 			nil,
 			abi.NewTokenAmount(0),
 		)
-		vmr.RequireSuccess(rt, code, "failed to challenge miner")
+		builtin.RequireSuccess(rt, code, "failed to challenge miner")
 	}
 }
 
@@ -419,7 +419,7 @@ func (a *StoragePowerActor) _rtProcessDeferredCronEvents(rt Runtime) {
 			),
 			abi.NewTokenAmount(0),
 		)
-		vmr.RequireSuccess(rt, code, "failed to defer cron event")
+		builtin.RequireSuccess(rt, code, "failed to defer cron event")
 	}
 }
 
@@ -438,7 +438,7 @@ func (a *StoragePowerActor) _rtSlashPledgeCollateral(rt Runtime, minerAddr addr.
 	}).(abi.TokenAmount)
 
 	_, code := rt.Send(builtin.BurntFundsActorAddr, builtin.MethodSend, nil, amountSlashed)
-	vmr.RequireSuccess(rt, code, "failed to burn funds")
+	builtin.RequireSuccess(rt, code, "failed to burn funds")
 }
 
 func (a *StoragePowerActor) _rtDeleteMinerActor(rt Runtime, minerAddr addr.Address) {
@@ -464,8 +464,8 @@ func (a *StoragePowerActor) _rtDeleteMinerActor(rt Runtime, minerAddr addr.Addre
 		serde.MustSerializeParams(),
 		abi.NewTokenAmount(0),
 	)
-	vmr.RequireSuccess(rt, code, "failed to delete miner actor")
+	builtin.RequireSuccess(rt, code, "failed to delete miner actor")
 
 	_, code = rt.Send(builtin.BurntFundsActorAddr, builtin.MethodSend, nil, amountSlashed)
-	vmr.RequireSuccess(rt, code, "failed to burn funds")
+	builtin.RequireSuccess(rt, code, "failed to burn funds")
 }

--- a/actors/runtime/runtime.go
+++ b/actors/runtime/runtime.go
@@ -16,6 +16,9 @@ import (
 // Runtime is the VM's internal runtime object.
 // this is everything that is accessible to actors, beyond parameters.
 type Runtime interface {
+	// The network name, e.g. "mainnet".
+	NetworkName() string
+
 	// The current chain epoch number. The genesis block has epoch zero.
 	CurrEpoch() abi.ChainEpoch
 


### PR DESCRIPTION
This breaks the dependency of runtime on builtin.