### PR TITLE
Implement NewEmptyMap, Map.CollectKeys and fix ForEach.

### DIFF
--- a/actors/abi/big/int.go
+++ b/actors/abi/big/int.go
@@ -38,6 +38,12 @@ func FromString(s string) (Int, error) {
 	return Int{v}, nil
 }
 
+func (bi Int) Copy() Int {
+	cpy := Int{}
+	cpy.Int.Set(bi.Int)
+	return cpy
+}
+
 func Mul(a, b Int) Int {
 	return Int{big.NewInt(0).Mul(a.Int, b.Int)}
 }

--- a/actors/builtin/multisig/multisig_actor_state.go
+++ b/actors/builtin/multisig/multisig_actor_state.go
@@ -55,7 +55,7 @@ func (st *MultiSigActorState) _hasAvailable(currBalance abi.TokenAmount, amountT
 }
 
 func (as *MultiSigActorState) getPendingTransaction(s adt.Store, txnID TxnID) (MultiSigTransaction, error) {
-	hm := adt.NewMap(s, as.PendingTxns)
+	hm := adt.AsMap(s, as.PendingTxns)
 
 	var out MultiSigTransaction
 	found, err := hm.Get(txnID, &out)
@@ -71,7 +71,7 @@ func (as *MultiSigActorState) getPendingTransaction(s adt.Store, txnID TxnID) (M
 }
 
 func (as *MultiSigActorState) putPendingTransaction(s adt.Store, txnID TxnID, txn MultiSigTransaction) error {
-	hm := adt.NewMap(s, as.PendingTxns)
+	hm := adt.AsMap(s, as.PendingTxns)
 
 	if err := hm.Put(txnID, &txn); err != nil {
 		return errors.Wrapf(err, "failed to write transaction")
@@ -82,7 +82,7 @@ func (as *MultiSigActorState) putPendingTransaction(s adt.Store, txnID TxnID, tx
 }
 
 func (as *MultiSigActorState) deletePendingTransaction(s adt.Store, txnID TxnID) error {
-	hm := adt.NewMap(s, as.PendingTxns)
+	hm := adt.AsMap(s, as.PendingTxns)
 
 	if err := hm.Delete(txnID); err != nil {
 		return errors.Wrapf(err, "failed to delete transaction")

--- a/actors/builtin/multisig/multisig_test.go
+++ b/actors/builtin/multisig/multisig_test.go
@@ -6,11 +6,13 @@ import (
 
 	addr "github.com/filecoin-project/go-address"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/builtin/multisig"
 	"github.com/filecoin-project/specs-actors/actors/runtime"
+	"github.com/filecoin-project/specs-actors/actors/util/adt"
 	"github.com/filecoin-project/specs-actors/support/mock"
 )
 
@@ -44,8 +46,10 @@ func TestConstruction(t *testing.T) {
 		assert.Equal(t, abi.NewTokenAmount(0), st.InitialBalance)
 		assert.Equal(t, abi.ChainEpoch(0), st.UnlockDuration)
 		assert.Equal(t, abi.ChainEpoch(0), st.StartEpoch)
-		//txns := adt.NewMap(rt.Store(), st.PendingTxns)
-		// TODO: assert transactions is empty
+		txns := adt.AsMap(rt.Store(), st.PendingTxns)
+		keys, err := txns.CollectKeys()
+		require.NoError(t, err)
+		assert.Empty(t, keys)
 	})
 
 	t.Run("construction with vesting", func(t *testing.T) {

--- a/actors/builtin/storage_power/storage_power_actor.go
+++ b/actors/builtin/storage_power/storage_power_actor.go
@@ -385,17 +385,24 @@ func (a *StoragePowerActor) OnEpochTickEnd(rt Runtime) *vmr.EmptyReturn {
 
 func (a *StoragePowerActor) Constructor(rt Runtime) *vmr.EmptyReturn {
 	rt.ValidateImmediateCallerIs(builtin.SystemActorAddr)
-	var st StoragePowerActorState
-	rt.State().Transaction(&st, func() interface{} {
+
+
+	rt.State().Construct(func() vmr.CBORMarshaler {
+		emptyMap, err := adt.MakeEmptyMap(adt.AsStore(rt))
+		if err != nil {
+			rt.Abort(exitcode.ErrIllegalState, "failed to create empty map: %v", err)
+		}
+
+		var st StoragePowerActorState
 		st.TotalNetworkPower = abi.NewStoragePower(0)
-		st.PowerTable = autil.EmptyHAMT
+		st.PowerTable = emptyMap.Root()
 		st.EscrowTable = autil.BalanceTableHAMT_Empty()
 		st.CachedDeferredCronEvents = MinerEventsHAMT_Empty()
 		st.PoStDetectedFaultMiners = autil.MinerSetHAMT_Empty()
-		st.ClaimedPower = autil.EmptyHAMT
-		st.NominalPower = autil.EmptyHAMT
+		st.ClaimedPower = emptyMap.Root()
+		st.NominalPower = emptyMap.Root()
 		st.NumMinersMeetingMinPower = 0
-		return nil
+		return &st
 	})
 	return &vmr.EmptyReturn{}
 }

--- a/actors/util/actor_util.go
+++ b/actors/util/actor_util.go
@@ -1,25 +1,10 @@
 package util
 
 import (
-	"context"
-
 	addr "github.com/filecoin-project/go-address"
+
 	abi "github.com/filecoin-project/specs-actors/actors/abi"
-	cid "github.com/ipfs/go-cid"
-	hamt "github.com/ipfs/go-hamt-ipld"
 )
-
-func init() {
-	cst := hamt.NewCborStore()
-	nd := hamt.NewNode(cst)
-	emptyHAMT, err := cst.Put(context.Background(), nd)
-	if err != nil {
-		panic(err)
-	}
-	EmptyHAMT = emptyHAMT
-}
-
-var EmptyHAMT cid.Cid
 
 type BalanceTableHAMT map[addr.Address]abi.TokenAmount
 
@@ -185,17 +170,7 @@ func IntToDealIDHAMT_Empty() IntToDealIDHAMT {
 	panic("")
 }
 
-func DealIDSetHAMT_Empty() DealIDSetHAMT {
-	IMPL_FINISH()
-	panic("")
-}
-
 func MinerSetHAMT_Empty() MinerSetHAMT {
-	IMPL_FINISH()
-	panic("")
-}
-
-func ActorIDSetHAMT_Empty() ActorIDSetHAMT {
 	IMPL_FINISH()
 	panic("")
 }

--- a/actors/util/adt/map.go
+++ b/actors/util/adt/map.go
@@ -1,11 +1,13 @@
 package adt
 
 import (
+	"bytes"
 	"context"
 
 	cid "github.com/ipfs/go-cid"
 	hamt "github.com/ipfs/go-hamt-ipld"
 	errors "github.com/pkg/errors"
+	cbg "github.com/whyrusleeping/cbor-gen"
 
 	vmr "github.com/filecoin-project/specs-actors/actors/runtime"
 )
@@ -27,12 +29,20 @@ type Map struct {
 	store Store
 }
 
-// NewMap creates a new HAMT with root `r` and store `s`.
-func NewMap(s Store, r cid.Cid) *Map {
+// AsMap interprets a store as a HAMT-based map with root `r`.
+func AsMap(s Store, r cid.Cid) *Map {
 	return &Map{
 		root:  r,
 		store: s,
 	}
+}
+
+// Creates a new map backed by an empty HAMT and flushes it to the store.
+func MakeEmptyMap(s Store) (*Map, error) {
+	nd := hamt.NewNode(s)
+	newMap := AsMap(s, cid.Undef)
+	err := newMap.write(nd)
+	return newMap, err
 }
 
 // Root return the root cid of HAMT.
@@ -42,33 +52,27 @@ func (h *Map) Root() cid.Cid {
 
 // Put adds value `v` with key `k` to the hamt store.
 func (h *Map) Put(k Keyer, v vmr.CBORMarshaler) error {
-	oldRoot, err := hamt.LoadNode(h.store.Context(), h.store, h.root)
+	root, err := hamt.LoadNode(h.store.Context(), h.store, h.root)
 	if err != nil {
 		return errors.Wrapf(err, "Map Put failed to load node %v", h.root)
 	}
-	if err := oldRoot.Set(h.store.Context(), k.Key(), v); err != nil {
+	if err = root.Set(h.store.Context(), k.Key(), v); err != nil {
 		return errors.Wrapf(err, "Map Put failed set in node %v with key %v value %v", h.root, k.Key(), v)
 	}
-	if err := oldRoot.Flush(h.store.Context()); err != nil {
+	if err = root.Flush(h.store.Context()); err != nil {
 		return errors.Wrapf(err, "Map Put failed to flush node %v : %v", h.root, err)
 	}
 
-	// update the root
-	newRoot, err := h.store.Put(h.store.Context(), oldRoot)
-	if err != nil {
-		return errors.Wrapf(err, "Map Put failed to persist changes to store %s", h.root)
-	}
-	h.root = newRoot
-	return nil
+	return h.write(root)
 }
 
 // Get puts the value at `k` into `out`.
 func (h *Map) Get(k Keyer, out vmr.CBORUnmarshaler) (bool, error) {
-	oldRoot, err := hamt.LoadNode(h.store.Context(), h.store, h.root)
+	root, err := hamt.LoadNode(h.store.Context(), h.store, h.root)
 	if err != nil {
 		return false, errors.Wrapf(err, "Map Get failed to load node %v", h.root)
 	}
-	if err := oldRoot.Find(h.store.Context(), k.Key(), out); err != nil {
+	if err := root.Find(h.store.Context(), k.Key(), out); err != nil {
 		if err == hamt.ErrNotFound {
 			return false, nil
 		}
@@ -79,35 +83,56 @@ func (h *Map) Get(k Keyer, out vmr.CBORUnmarshaler) (bool, error) {
 
 // Delete removes the value at `k` from the hamt store.
 func (h *Map) Delete(k Keyer) error {
-	oldRoot, err := hamt.LoadNode(h.store.Context(), h.store, h.root)
+	root, err := hamt.LoadNode(h.store.Context(), h.store, h.root)
 	if err != nil {
 		return errors.Wrapf(err, "Map Delete failed to load node %v", h.root)
 	}
-	if err := oldRoot.Delete(h.store.Context(), k.Key()); err != nil {
+	if err = root.Delete(h.store.Context(), k.Key()); err != nil {
 		return errors.Wrapf(err, "Map Delete failed in node %v key %v", h.root, k.Key())
 	}
-	if err := oldRoot.Flush(h.store.Context()); err != nil {
+	if err = root.Flush(h.store.Context()); err != nil {
 		return errors.Wrapf(err, "Map Delete failed to flush node %v : %v", h.root, err)
 	}
 
-	// update the root
-	newRoot, err := h.store.Put(h.store.Context(), oldRoot)
+	return h.write(root)
+}
+
+// ForEach iterates all entries in the map, deserializing each value in turn into `out` and then
+// calling a function with the corresponding key.
+// If the output parameter is nil, deserialization is skipped.
+func (h *Map) ForEach(out vmr.CBORUnmarshaler, fn func(key string) error) error {
+	oldRoot, err := hamt.LoadNode(h.store.Context(), h.store, h.root)
 	if err != nil {
 		return errors.Wrapf(err, "Map Delete failed to persist changes to store %s", h.root)
 	}
-	h.root = newRoot
-	return nil
+	return oldRoot.ForEach(h.store.Context(), func(k string, val interface{}) error {
+		if out != nil {
+			// Why doesn't hamt.ForEach() just return the value as bytes?
+			err = out.UnmarshalCBOR(bytes.NewReader(val.(*cbg.Deferred).Raw))
+			if err != nil {
+				return err
+			}
+		}
+		return fn(k)
+	})
 }
 
-// ForEach applies fn to each key value in hamt.
-func (h *Map) ForEach(fn func(key string, v interface{}) error) error {
-	oldRoot, err := hamt.LoadNode(h.store.Context(), h.store, h.root)
+// Collects all the keys from the map into a slice of strings.
+func (h *Map) CollectKeys() (out []string, err error) {
+	err = h.ForEach(nil, func(key string) error {
+		out = append(out, key)
+		return nil
+	})
+	return
+}
+
+// Writes the root node to storage and sets the new root CID.
+func (h *Map) write(root *hamt.Node) error {
+	newCid, err := h.store.Put(h.store.Context(), root)
 	if err != nil {
 		return errors.Wrapf(err, "Map ForEach failed to load node %v", h.root)
 	}
-	if err := oldRoot.ForEach(h.store.Context(), fn); err != nil {
-		return errors.Wrapf(err, "Map ForEach failed to iterate node %v", h.root)
-	}
+	h.root = newCid
 	return nil
 }
 


### PR DESCRIPTION
Multisig and power actors correctly initialize empty maps at construction.