### PR TITLE
label TODOs

### DIFF
--- a/actors/abi/primitives.go
+++ b/actors/abi/primitives.go
@@ -35,9 +35,6 @@ type MethodNum int64
 // Method params are the CBOR-serialization of a heterogenous array of values.
 type MethodParams []byte
 
-// TODO: remove this alias after actor types are realized from .id files.
-type Bytes []byte
-
 // TokenAmount is an amount of Filecoin tokens. This type is used within
 // the VM in message execution, to account movement of tokens, payment
 // of VM gas, and more.

--- a/actors/abi/sector.go
+++ b/actors/abi/sector.go
@@ -20,14 +20,13 @@ type SectorNumber int64
 // }
 type SectorSize int64
 
-// TODO make sure this is globally unique
 type SectorID struct {
 	Miner  ActorID
 	Number SectorNumber
 }
 
 // The unit of sector weight (power-epochs)
-type SectorWeight int64 // TODO big
+type SectorWeight big.Int
 
 // The unit of storage power (measured in bytes)
 type StoragePower = big.Int
@@ -53,8 +52,8 @@ const (
 /// Sealing
 ///
 
-type SealRandomness Bytes
-type InteractiveSealRandomness Bytes
+type SealRandomness []byte
+type InteractiveSealRandomness []byte
 
 // SealVerifyInfo is the structure of all the information a verifier
 // needs to verify a Seal.
@@ -81,18 +80,18 @@ type OnChainSealVerifyInfo struct {
 }
 
 type SealProof struct { //<curve, system> {
-	ProofBytes Bytes
+	ProofBytes []byte
 }
 
 ///
 /// PoSting
 ///
 
-type ChallengeTicketsCommitment Bytes
-type PoStRandomness Bytes
+type ChallengeTicketsCommitment []byte
+type PoStRandomness []byte
 type PartialTicket []byte // 32 bytes
 
-// TODO: refactor these types to get rid of the squishy optional fields.
+// TODO Porcu: refactor these types to get rid of the squishy optional fields.
 type PoStVerifyInfo struct {
 	Randomness      PoStRandomness
 	CommR           SealedSectorCID
@@ -125,10 +124,10 @@ type PoStCandidate struct {
 }
 
 type PoStProof struct { //<curve, system> {
-	ProofBytes Bytes
+	ProofBytes []byte
 }
 
 type PrivatePoStCandidateProof struct {
 	RegisteredProof
-	Externalized Bytes
+	Externalized []byte
 }

--- a/actors/builtin/account/account_actor.go
+++ b/actors/builtin/account/account_actor.go
@@ -10,7 +10,7 @@ import (
 type AccountActor struct{}
 
 func (a *AccountActor) Constructor(rt vmr.Runtime) *adt.EmptyValue {
-	// TODO: set the pubkey address here from parameters
+	// TODO anorth/hs: set the pubkey address here from parameters
 	rt.ValidateImmediateCallerIs(builtin.SystemActorAddr)
 	return &adt.EmptyValue{}
 }

--- a/actors/builtin/cron/cron_actor.go
+++ b/actors/builtin/cron/cron_actor.go
@@ -1,6 +1,8 @@
 package cron
 
 import (
+	"io"
+
 	addr "github.com/filecoin-project/go-address"
 
 	abi "github.com/filecoin-project/specs-actors/actors/abi"
@@ -9,11 +11,11 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
 )
 
-type CronActorState struct{}
+type CronActorState struct {
+	Entries []CronTableEntry
+}
 
 type CronActor struct {
-	// TODO move Entries into the CronActorState struct
-	Entries []CronTableEntry
 }
 
 type CronTableEntry struct {
@@ -30,12 +32,22 @@ func (a *CronActor) Constructor(rt vmr.Runtime) *adt.EmptyValue {
 func (a *CronActor) EpochTick(rt vmr.Runtime) *adt.EmptyValue {
 	rt.ValidateImmediateCallerIs(builtin.SystemActorAddr)
 
-	// a.Entries is basically a static registry for now, loaded
+	var st CronActorState
+	rt.State().Readonly(&st)
+	// st.Entries is basically a static registry for now, loaded
 	// in the interpreter static registry.
-	for _, entry := range a.Entries {
+	for _, entry := range st.Entries {
 		_, _ = rt.Send(entry.ToAddr, entry.MethodNum, nil, abi.NewTokenAmount(0))
 		// Any error and return value are ignored.
 	}
 
 	return &adt.EmptyValue{}
+}
+
+func (st *CronActorState) MarshalCBOR(w io.Writer) error {
+	panic("replace with cbor-gen")
+}
+
+func (st *CronActorState) UnmarshalCBOR(r io.Reader) error {
+	panic("replace with cbor-gen")
 }

--- a/actors/builtin/init/init_actor.go
+++ b/actors/builtin/init/init_actor.go
@@ -15,7 +15,6 @@ import (
 )
 
 type Runtime = vmr.Runtime
-type Bytes = abi.Bytes
 
 var AssertMsg = autil.AssertMsg
 

--- a/actors/builtin/methods.go
+++ b/actors/builtin/methods.go
@@ -8,7 +8,7 @@ const (
 	MethodSend        = abi.MethodNum(0)
 	MethodConstructor = abi.MethodNum(1)
 
-	// TODO: remove this once canonical method numbers are finalized
+	// TODO fin: remove this once canonical method numbers are finalized
 	MethodPlaceholder = abi.MethodNum(1 << 30)
 )
 

--- a/actors/builtin/multisig/multisig_actor.go
+++ b/actors/builtin/multisig/multisig_actor.go
@@ -161,7 +161,7 @@ func (a *MultiSigActor) AddSigner(rt vmr.Runtime, params *AddSigner) *adt.EmptyV
 	var st MultiSigActorState
 	rt.State().Transaction(&st, func() interface{} {
 		if st.isSigner(params.Signer) {
-			rt.Abort(exitcode.ErrIllegalState, "party is already a signer")
+			rt.Abort(exitcode.ErrIllegalArgument, "party is already a signer")
 		}
 		st.Signers = append(st.Signers, params.Signer)
 		if params.Increase {
@@ -219,7 +219,7 @@ func (a *MultiSigActor) SwapSigner(rt vmr.Runtime, params *SwapSignerParams) *ad
 		}
 
 		if !st.isSigner(params.To) {
-			rt.Abort(exitcode.ErrIllegalState, "Party already present")
+			rt.Abort(exitcode.ErrIllegalArgument, "Party already present")
 		}
 
 		newSigners := make([]addr.Address, 0, len(st.Signers))

--- a/actors/builtin/multisig/multisig_test.go
+++ b/actors/builtin/multisig/multisig_test.go
@@ -226,7 +226,7 @@ func TestApprove(t *testing.T) {
 		// anne is going to approve it twice and fail, poor anne.
 		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
 		// TODO replace with correct exit code when multisig actor breaks the AbortStateMsg pattern.
-		rt.ExpectAbort(exitcode.ErrPlaceholder, func() {
+		rt.ExpectAbort(exitcode.ErrIllegalState, func() {
 			actor.approve(rt, txnID)
 		})
 		rt.Verify()
@@ -255,7 +255,7 @@ func TestApprove(t *testing.T) {
 		// bob is going to approve a transaction that doesn't exist.
 		rt.SetCaller(bob, builtin.AccountActorCodeID)
 		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
-		rt.ExpectAbort(exitcode.ErrIllegalState, func() {
+		rt.ExpectAbort(exitcode.ErrNotFound, func() {
 			actor.approve(rt, dneTxnID)
 		})
 		rt.Verify()
@@ -355,7 +355,7 @@ func TestCancel(t *testing.T) {
 		// bob (a signer) fails to cancel anne's transaction because bob didn't create it, nice try bob.
 		rt.SetCaller(bob, builtin.AccountActorCodeID)
 		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
-		rt.ExpectAbort(exitcode.ErrPlaceholder, func() {
+		rt.ExpectAbort(exitcode.ErrForbidden, func() {
 			actor.cancel(rt, txnID)
 		})
 		rt.Verify()
@@ -413,7 +413,7 @@ func TestCancel(t *testing.T) {
 
 		// anne fails to cancel a transaction that does not exists ID: 1 (dneTxnID)
 		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
-		rt.ExpectAbort(exitcode.ErrIllegalState, func() {
+		rt.ExpectAbort(exitcode.ErrNotFound, func() {
 			actor.cancel(rt, dneTxnID)
 		})
 		rt.Verify()

--- a/actors/builtin/reward/reward_actor.go
+++ b/actors/builtin/reward/reward_actor.go
@@ -62,7 +62,7 @@ type RewardActorState struct {
 func (st *RewardActorState) _withdrawReward(rt vmr.Runtime, ownerAddr addr.Address) abi.TokenAmount {
 	rewards, found := st.RewardMap[ownerAddr]
 	if !found {
-		rt.Abort(exitcode.ErrIllegalState, "ra._withdrawReward: ownerAddr not found in RewardMap.")
+		rt.Abort(exitcode.ErrNotFound, "ra._withdrawReward: ownerAddr not found in RewardMap.")
 	}
 
 	rewardToWithdrawTotal := abi.NewTokenAmount(0)

--- a/actors/builtin/storage_market/storage_market_actor.go
+++ b/actors/builtin/storage_market/storage_market_actor.go
@@ -338,31 +338,31 @@ func (a *StorageMarketActor) Constructor(rt Runtime) *adt.EmptyValue {
 
 func _rtAbortIfDealAlreadyProven(rt Runtime, deal OnChainDeal) {
 	if deal.SectorStartEpoch != epochUndefined {
-		rt.Abort(exitcode.ErrIllegalState, "Deal has already appeared in proven sector.")
+		rt.Abort(exitcode.ErrIllegalArgument, "Deal has already appeared in proven sector.")
 	}
 }
 
 func _rtAbortIfDealNotFromProvider(rt Runtime, dealP StorageDealProposal, minerAddr addr.Address) {
 	if dealP.Provider != minerAddr {
-		rt.Abort(exitcode.ErrIllegalState, "Deal has incorrect miner as its provider.")
+		rt.Abort(exitcode.ErrIllegalArgument, "Deal has incorrect miner as its provider.")
 	}
 }
 
 func _rtAbortIfDealStartElapsed(rt Runtime, dealP StorageDealProposal) {
 	if rt.CurrEpoch() > dealP.StartEpoch {
-		rt.Abort(exitcode.ErrIllegalState, "Deal start epoch has already elapsed.")
+		rt.Abort(exitcode.ErrIllegalArgument, "Deal start epoch has already elapsed.")
 	}
 }
 
 func _rtAbortIfDealEndElapsed(rt Runtime, dealP StorageDealProposal) {
 	if dealP.EndEpoch > rt.CurrEpoch() {
-		rt.Abort(exitcode.ErrIllegalState, "Deal end epoch has already elapsed.")
+		rt.Abort(exitcode.ErrIllegalArgument, "Deal end epoch has already elapsed.")
 	}
 }
 
 func _rtAbortIfDealExceedsSectorLifetime(rt Runtime, dealP StorageDealProposal, sectorExpiration abi.ChainEpoch) {
 	if dealP.EndEpoch > sectorExpiration {
-		rt.Abort(exitcode.ErrIllegalState, "Deal would outlive its containing sector.")
+		rt.Abort(exitcode.ErrIllegalArgument, "Deal would outlive its containing sector.")
 	}
 }
 

--- a/actors/builtin/storage_market/storage_market_actor_state.go
+++ b/actors/builtin/storage_market/storage_market_actor_state.go
@@ -335,7 +335,7 @@ func (st *StorageMarketActorState) _rtGetOnChainDealOrAbort(rt Runtime, dealID a
 	var found bool
 	deal, dealP, found = st._getOnChainDeal(dealID)
 	if !found {
-		rt.AbortStateMsg("dealID not found in Deals.")
+		rt.Abort(exitcode.ErrIllegalState, "dealID not found in Deals.")
 	}
 	return
 }

--- a/actors/builtin/storage_market/storage_market_actor_state.go
+++ b/actors/builtin/storage_market/storage_market_actor_state.go
@@ -335,7 +335,7 @@ func (st *StorageMarketActorState) _rtGetOnChainDealOrAbort(rt Runtime, dealID a
 	var found bool
 	deal, dealP, found = st._getOnChainDeal(dealID)
 	if !found {
-		rt.Abort(exitcode.ErrIllegalState, "dealID not found in Deals.")
+		rt.Abort(exitcode.ErrNotFound, "dealID not found in Deals.")
 	}
 	return
 }

--- a/actors/builtin/storage_miner/storage_miner_actor.go
+++ b/actors/builtin/storage_miner/storage_miner_actor.go
@@ -352,7 +352,7 @@ func (a *StorageMinerActor) ExtendSectorExpiration(rt Runtime, sectorNumber abi.
 
 		extensionLength = newExpiration - sectorInfo.Info.Expiration
 		if extensionLength < 0 {
-			rt.Abort(exitcode.ErrForbidden, "Cannot reduce sector expiration")
+			rt.Abort(exitcode.ErrIllegalArgument, "Cannot reduce sector expiration")
 		}
 
 		sectorInfo.Info.Expiration = newExpiration

--- a/actors/builtin/storage_miner/storage_miner_actor.go
+++ b/actors/builtin/storage_miner/storage_miner_actor.go
@@ -154,7 +154,7 @@ func (a *StorageMinerActor) SubmitSurprisePoStResponse(rt Runtime, onChainInfo a
 	rt.State().Transaction(&st, func() interface{} {
 		rt.ValidateImmediateCallerIs(st.Info.Worker)
 		if !st.PoStState.Is_Challenged() {
-			rt.AbortStateMsg("Not currently challenged")
+			rt.Abort(exitcode.ErrIllegalState, "Not currently challenged")
 		}
 		a.verifySurprisePost(rt, &st, &onChainInfo)
 
@@ -226,14 +226,14 @@ func (a *StorageMinerActor) PreCommitSector(rt Runtime, info SectorPreCommitInfo
 	rt.State().Readonly(&st)
 	rt.ValidateImmediateCallerIs(st.Info.Worker)
 	if _, found := st.Sectors[info.SectorNumber]; found {
-		rt.AbortStateMsg("Sector number already exists in table")
+		rt.Abort(exitcode.ErrIllegalArgument, "Sector number already exists in table")
 	}
 
 	cidx := rt.CurrIndices()
 	depositReq := cidx.StorageMining_PreCommitDeposit(st.Info.SectorSize, info.Expiration)
 	builtin.RT_ConfirmFundsReceiptOrAbort_RefundRemainder(rt, depositReq)
 
-	// TODO Check on valid SealEpoch
+	// TODO HS Check on valid SealEpoch
 
 	rt.State().Transaction(&st, func() interface{} {
 		st.PreCommittedSectors[info.SectorNumber] = SectorPreCommitOnChainInfo{
@@ -267,11 +267,11 @@ func (a *StorageMinerActor) ProveCommitSector(rt Runtime, info SectorProveCommit
 	}
 
 	if rt.CurrEpoch() > preCommitSector.PreCommitEpoch+indices.StorageMining_MaxProveCommitSectorEpoch() || rt.CurrEpoch() < preCommitSector.PreCommitEpoch+indices.StorageMining_MinProveCommitSectorEpoch() {
-		rt.AbortStateMsg("Invalid ProveCommitSector epoch")
+		rt.Abort(exitcode.ErrIllegalArgument, "Invalid ProveCommitSector epoch")
 	}
 
 	TODO()
-	// TODO: How are SealEpoch, InteractiveEpoch determined (and intended to be used)?
+	// TODO HS: How are SealEpoch, InteractiveEpoch determined (and intended to be used)?
 	// Presumably they cannot be derived from the SectorProveCommitInfo provided by an untrusted party.
 
 	a._rtVerifySealOrAbort(rt, &abi.OnChainSealVerifyInfo{
@@ -347,12 +347,12 @@ func (a *StorageMinerActor) ExtendSectorExpiration(rt Runtime, sectorNumber abi.
 
 		sectorInfo, found := st.Sectors[sectorNumber]
 		if !found {
-			rt.AbortStateMsg("Sector not found")
+			rt.Abort(exitcode.ErrNotFound, "Sector not found")
 		}
 
 		extensionLength = newExpiration - sectorInfo.Info.Expiration
 		if extensionLength < 0 {
-			rt.AbortStateMsg("Cannot reduce sector expiration")
+			rt.Abort(exitcode.ErrForbidden, "Cannot reduce sector expiration")
 		}
 
 		sectorInfo.Info.Expiration = newExpiration
@@ -748,13 +748,13 @@ func (a *StorageMinerActor) verifySurprisePost(rt Runtime, st *StorageMinerActor
 	challengeIndices := make(map[int64]bool)
 	for _, tix := range onChainInfo.Candidates {
 		if _, ok := challengeIndices[tix.ChallengeIndex]; ok {
-			rt.AbortStateMsg("Invalid Surprise PoSt. Duplicate ticket included.")
+			rt.Abort(exitcode.ErrIllegalArgument, "Invalid Surprise PoSt. Duplicate ticket included.")
 		}
 		challengeIndices[tix.ChallengeIndex] = true
 	}
 
 	TODO(challengedSectors)
-	// TODO: Determine what should be the acceptance criterion for sector numbers
+	// TODO HS: Determine what should be the acceptance criterion for sector numbers
 	// proven in SurprisePoSt proofs.
 	//
 	// Previous note:
@@ -781,7 +781,7 @@ func (a *StorageMinerActor) verifySurprisePost(rt Runtime, st *StorageMinerActor
 	isVerified := rt.Syscalls().VerifyPoSt(sectorSize, pvInfo)
 
 	if !isVerified {
-		rt.AbortStateMsg("Surprise PoSt failed to verify")
+		rt.Abort(exitcode.ErrIllegalArgument, "Surprise PoSt failed to verify")
 	}
 }
 
@@ -794,7 +794,7 @@ func (a *StorageMinerActor) _rtVerifySealOrAbort(rt Runtime, onChainInfo *abi.On
 	// if IsValidAtCommitEpoch(onChainInfo.RegisteredProof, rt.CurrEpoch()) // Ensure proof type is valid at current epoch.
 	// Check randomness.
 	if onChainInfo.SealEpoch < (rt.CurrEpoch() - indices.StorageMining_Finality() - indices.StorageMining_MaxSealTime32GiBWinStackedSDR()) {
-		rt.AbortStateMsg("Seal references ticket from invalid epoch")
+		rt.Abort(exitcode.ErrIllegalArgument, "Seal references ticket from invalid epoch")
 	}
 
 	var infos storage_market.GetPieceInfosForDealIDsReturn
@@ -820,12 +820,12 @@ func (a *StorageMinerActor) _rtVerifySealOrAbort(rt Runtime, onChainInfo *abi.On
 
 	unsealedCID, err := rt.Syscalls().ComputeUnsealedSectorCID(sectorSize, infos.Pieces)
 	if err != nil {
-		rt.AbortStateMsg("invalid sector piece infos")
+		rt.Abort(exitcode.ErrIllegalState, "invalid sector piece infos")
 	}
 
 	minerActorID, err := addr.IDFromAddress(rt.CurrReceiver())
 	if err != nil {
-		rt.AbortStateMsg("receiver must be ID address")
+		rt.Abort(exitcode.ErrIllegalState, "receiver must be ID address")
 	}
 
 	svInfoRandomness := rt.GetRandomness(onChainInfo.SealEpoch)
@@ -845,7 +845,7 @@ func (a *StorageMinerActor) _rtVerifySealOrAbort(rt Runtime, onChainInfo *abi.On
 	isVerified := rt.Syscalls().VerifySeal(sectorSize, svInfo)
 
 	if !isVerified {
-		rt.AbortStateMsg("Sector seal failed to verify")
+		rt.Abort(exitcode.ErrIllegalState, "Sector seal failed to verify")
 	}
 }
 
@@ -858,6 +858,7 @@ func getSectorNums(m map[abi.SectorNumber]SectorOnChainInfo) []abi.SectorNumber 
 }
 
 func _surprisePoStSampleChallengedSectors(sampleRandomness abi.Randomness, provingSet cid.Cid) []abi.SectorNumber {
+	// TODO: HS
 	TODO()
 	panic("")
 }

--- a/actors/builtin/storage_miner/storage_miner_actor_state.go
+++ b/actors/builtin/storage_miner/storage_miner_actor_state.go
@@ -17,7 +17,7 @@ import (
 type StorageMinerActorState struct {
 	PreCommittedSectors PreCommittedSectorsAMT // PreCommitted Sectors
 	Sectors             SectorsAMT             // Proven Sectors can be Active or in TemporaryFault
-	FaultSet            SectorNumberSetHAMT    // TODO bitfield of Sectors in TemporaryFault
+	FaultSet            SectorNumberSetHAMT    // TODO zx bitfield of Sectors in TemporaryFault
 	ProvingSet          cid.Cid                // cid of SectorsAMT - sectors in FaultSet
 
 	PoStState MinerPoStState
@@ -211,13 +211,13 @@ func MinerInfo_New(
 		PendingWorkerKey: WorkerKeyChange{},
 	}
 
-	TODO() // TODO: determine how to generate/validate VRF key and initialize other fields
+	TODO() // TODO anorth: determine how to generate/validate VRF key and initialize other fields
 
 	return *ret
 }
 
 func (st *StorageMinerActorState) VerifySurprisePoStMeetsTargetReq(candidate abi.PoStCandidate) bool {
-	// TODO: Determine what should be the acceptance criterion for sector numbers proven in SurprisePoSt proofs.
+	// TODO hs: Determine what should be the acceptance criterion for sector numbers proven in SurprisePoSt proofs.
 	TODO()
 	panic("")
 }

--- a/actors/builtin/storage_power/storage_power_actor_state.go
+++ b/actors/builtin/storage_power/storage_power_actor_state.go
@@ -48,14 +48,14 @@ func ConstructState(store adt.Store) (*StoragePowerActorState, error) {
 		return nil, err
 	}
 
-	return &StoragePowerActorState {
-		TotalNetworkPower: abi.NewStoragePower(0),
-		PowerTable: emptyMap.Root(),
-		EscrowTable: emptyMap.Root(),
-		CronEventQueue: make(CronEventQueue),
-		PoStDetectedFaultMiners: emptyMap.Root(),
-		ClaimedPower: emptyMap.Root(),
-		NominalPower: emptyMap.Root(),
+	return &StoragePowerActorState{
+		TotalNetworkPower:        abi.NewStoragePower(0),
+		PowerTable:               emptyMap.Root(),
+		EscrowTable:              emptyMap.Root(),
+		CronEventQueue:           make(CronEventQueue),
+		PoStDetectedFaultMiners:  emptyMap.Root(),
+		ClaimedPower:             emptyMap.Root(),
+		NominalPower:             emptyMap.Root(),
 		NumMinersMeetingMinPower: 0,
 	}, nil
 }
@@ -231,7 +231,7 @@ func (st *StoragePowerActorState) updatePowerEntriesFromClaimed(s adt.Store, min
 		power = big.Zero()
 	}
 
-	autil.TODO() // TODO: Decide effect of undercollateralization on (consensus) power.
+	autil.TODO() // TODO ZX: Decide effect of undercollateralization on (consensus) power.
 
 	return st.setPowerEntry(s, minerAddr, power)
 }

--- a/actors/crypto/randomness.go
+++ b/actors/crypto/randomness.go
@@ -39,7 +39,7 @@ func _deriveRandInternal(tag DomainSeparationTag, randSeed abi.RandomnessSeed, i
 	buffer := []byte{}
 	buffer = append(buffer, BigEndianBytesFromInt(int(tag))...)
 	buffer = append(buffer, BigEndianBytesFromInt(int(index))...)
-	buffer = append(buffer, abi.Bytes(randSeed)...)
+	buffer = append(buffer, randSeed...)
 	buffer = append(buffer, s...)
 	return abi.Randomness(SHA256(buffer))
 }
@@ -48,25 +48,25 @@ func RandomInt(randomness abi.Randomness, nonce int, limit int64) int {
 	nonceBytes := BigEndianBytesFromInt(nonce)
 	input := randomness
 	input = append(input, nonceBytes...)
-	ranHash := SHA256(abi.Bytes(input[:]))
+	ranHash := SHA256(input)
 	hashInt := IntFromBigEndianBytes(ranHash)
 	num := int(math.Mod(float64(hashInt), float64(limit)))
 	return num
 }
 
-func BigEndianBytesFromInt(x int) abi.Bytes {
+func BigEndianBytesFromInt(x int) []byte {
 	buf := bytes.NewBuffer(make([]byte, 0, 8))
 	err := binary.Write(buf, binary.BigEndian, x) // nolint: staticcheck
 	autil.AssertNoError(err)
 	return buf.Bytes()
 }
 
-func SHA256(abi.Bytes) abi.Bytes {
+func SHA256(data []byte) []byte {
 	autil.IMPL_FINISH()
 	return []byte{}
 }
 
-func IntFromBigEndianBytes(bytes []byte) int {
+func IntFromBigEndianBytes(data []byte) int {
 	autil.IMPL_FINISH()
 	return -1
 }

--- a/actors/runtime/exitcode/common.go
+++ b/actors/runtime/exitcode/common.go
@@ -12,7 +12,7 @@ const (
 	ErrForbidden
 	// Indicates a balance of funds is insufficient.
 	ErrInsufficientFunds
-	// Indicates an actors internal state is invalid.
+	// Indicates an actor's internal state is invalid.
 	ErrIllegalState
 	// An error code intended to be replaced by different code structure or a more descriptive error.
 	ErrPlaceholder = ExitCode(1000)

--- a/actors/runtime/indices/indices.go
+++ b/actors/runtime/indices/indices.go
@@ -67,7 +67,7 @@ type Indices interface {
 	GetCurrBlockRewardRewardForMiner(
 		minerStoragePower abi.StoragePower,
 		minerPledgeCollateral abi.TokenAmount,
-		// TODO extend or eliminate
+		// TODO ZX/JZ extend or eliminate
 	) abi.TokenAmount
 	StorageMining_PreCommitDeposit(
 		sectorSize abi.SectorSize,
@@ -206,7 +206,7 @@ func (inds *IndicesImpl) CurrEpochBlockReward() abi.TokenAmount {
 func (inds *IndicesImpl) GetCurrBlockRewardRewardForMiner(
 	minerStoragePower abi.StoragePower,
 	minerPledgeCollateral abi.TokenAmount,
-	// TODO extend or eliminate
+	// TODO ZX/JZ extend or eliminate
 ) abi.TokenAmount {
 	PARAM_FINISH()
 	panic("")
@@ -312,7 +312,6 @@ func StorageMining_DeclaredFaultEffectiveDelay() abi.ChainEpoch {
 // must appear between epochs
 //   (T + MIN_PROVE_COMMIT_SECTOR_EPOCH, T + MAX_PROVE_COMMIT_SECTOR_EPOCH)
 // inclusive.
-// TODO: placeholder epoch values -- will be set later
 func StorageMining_MinProveCommitSectorEpoch() abi.ChainEpoch {
 	PARAM_FINISH()
 	const MIN_PROVE_COMMIT_SECTOR_EPOCH = abi.ChainEpoch(5)
@@ -357,7 +356,8 @@ func StorageMining_SpcLookbackSeal() abi.ChainEpoch {
 
 func StorageMining_MaxSealTime32GiBWinStackedSDR() abi.ChainEpoch {
 	PARAM_FINISH()
-	MAX_SEAL_TIME_32GIB_WIN_STACKED_SDR := abi.ChainEpoch(1) // TODO: Change to a dictionary with RegisteredProofs as the key.
+
+	MAX_SEAL_TIME_32GIB_WIN_STACKED_SDR := abi.ChainEpoch(1) // TODO HS: Change to a dictionary with RegisteredProofs as the key.
 	return MAX_SEAL_TIME_32GIB_WIN_STACKED_SDR
 }
 

--- a/actors/runtime/runtime.go
+++ b/actors/runtime/runtime.go
@@ -68,10 +68,6 @@ type Runtime interface {
 	// passing to fmt.Errorf(msg, args...).
 	Abort(errExitCode exitcode.ExitCode, msg string, args ...interface{})
 
-	// Calls Abort with InconsistentState_User.
-	// TODO: replace all call sites with Abort(exitcode, msg, ...)
-	AbortStateMsg(msg string)
-
 	// Computes an address for a new actor. The returned address is intended to uniquely refer to
 	// the actor even in the event of a chain re-org (whereas an ID-address might refer to a
 	// different actor after messages are re-ordered).

--- a/actors/serde/serialization.go
+++ b/actors/serde/serialization.go
@@ -33,7 +33,7 @@ func MustSerializeParams(o ...interface{}) []byte {
 
 // Deserializes a structure or value from CBOR.
 func Deserialize(b []byte, out interface{}) error {
-	autil.TODO("CBOR-deserialization")
+	autil.TODO("CBOR-deserialization") //TODO: anorth
 	return nil
 }
 

--- a/actors/util/adt/store.go
+++ b/actors/util/adt/store.go
@@ -8,6 +8,7 @@ import (
 	hamt "github.com/ipfs/go-hamt-ipld"
 
 	vmr "github.com/filecoin-project/specs-actors/actors/runtime"
+	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 )
 
 // Store defines an interface required to back the ADTs in this package.
@@ -38,7 +39,7 @@ func (r rtStore) Context() context.Context {
 
 func (r rtStore) Get(ctx context.Context, c cid.Cid, out interface{}) error {
 	if !r.IpldGet(c, out.(vmr.CBORUnmarshaler)) {
-		r.AbortStateMsg("not found")
+		r.Abort(exitcode.ErrNotFound, "not found")
 	}
 	return nil
 }


### PR DESCRIPTION
**In this PR:**
- Handled a few rote TODOs, namely: 
  - `abortstatemsg` -> `abort`
  - `bytes` -> `[]byte`
  - stale TODOs
- labeled TODOs with likely DRIs

@zixuanzh see if you can knock any others out or pick other DRIs if you think there is better?

Thereafter good to merge.