### PR TITLE
add method to fetch available multisig balance

### DIFF
--- a/actors/builtin/multisig/multisig_actor.go
+++ b/actors/builtin/multisig/multisig_actor.go
@@ -7,6 +7,7 @@ import (
 	cbg "github.com/whyrusleeping/cbor-gen"
 
 	abi "github.com/filecoin-project/specs-actors/actors/abi"
+	big "github.com/filecoin-project/specs-actors/actors/abi/big"
 	builtin "github.com/filecoin-project/specs-actors/actors/builtin"
 	vmr "github.com/filecoin-project/specs-actors/actors/runtime"
 	exitcode "github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
@@ -309,4 +310,14 @@ func (a *MultiSigActor) validateSigner(rt vmr.Runtime, st *MultiSigActorState, a
 	if !st.isSigner(address) {
 		rt.Abort(exitcode.ErrForbidden, "party not a signer")
 	}
+}
+
+func (a *MultiSigActor) SpendableBalance(rt vmr.Runtime, _ *struct{}) *abi.TokenAmount {
+	var mst MultiSigActorState
+	rt.State().Readonly(&mst)
+
+	locked := mst.AmountLocked(rt.CurrEpoch())
+
+	spendable := big.Sub(rt.CurrentBalance(), locked)
+	return &spendable
 }


### PR DESCRIPTION
This is a quick PR to prompt the discussion:
This is a very useful piece of information that people will want to query often. It makes sense to me to include it as a method here. However, I also had a conversation with @anorth about similar things, where we said it also makes sense to make these be methods on the state object, and that queries could load actor state into that struct and call the methods on the state objects.

Happy with whatever outcome, let's use this PR as a discussion space to all come to agreement on the desired approach.