### PR TITLE
TODO fixes

### DIFF
--- a/actors/builtin/reward/reward_actor.go
+++ b/actors/builtin/reward/reward_actor.go
@@ -2,7 +2,6 @@ package reward
 
 import (
 	"io"
-	"math"
 	"sort"
 
 	addr "github.com/filecoin-project/go-address"
@@ -24,10 +23,6 @@ type VestingFunction int64
 const (
 	None VestingFunction = iota
 	Linear
-	// TODO zx: potential options
-	// PieceWise
-	// Quadratic
-	// Exponential
 )
 
 type Reward struct {
@@ -43,9 +38,9 @@ func (r *Reward) AmountVested(elapsedEpoch abi.ChainEpoch) abi.TokenAmount {
 	case None:
 		return r.Value
 	case Linear:
-		TODO() // zx BigInt
-		vestedProportion := math.Max(1.0, float64(elapsedEpoch)/float64(r.StartEpoch-r.EndEpoch))
-		return big.Mul(r.Value, big.NewInt(int64(vestedProportion)))
+		vestDuration := big.Sub(big.NewInt(int64(r.EndEpoch)), big.NewInt(int64(r.StartEpoch)))
+		unitVest := big.Div(r.Value, vestDuration)
+		return big.Mul(big.NewInt(int64(elapsedEpoch)), unitVest)
 	default:
 		return abi.NewTokenAmount(0)
 	}

--- a/actors/builtin/reward/reward_actor.go
+++ b/actors/builtin/reward/reward_actor.go
@@ -39,8 +39,12 @@ func (r *Reward) AmountVested(elapsedEpoch abi.ChainEpoch) abi.TokenAmount {
 		return r.Value
 	case Linear:
 		vestDuration := big.Sub(big.NewInt(int64(r.EndEpoch)), big.NewInt(int64(r.StartEpoch)))
-		unitVest := big.Div(r.Value, vestDuration)
-		return big.Mul(big.NewInt(int64(elapsedEpoch)), unitVest)
+		if big.NewInt(int64(elapsedEpoch)).GreaterThanEqual(vestDuration) {
+			return r.Value
+		}
+
+		// totalReward * elapsedEpoch / vestDuration
+		return big.Div(big.Mul(r.Value, big.NewInt(int64(elapsedEpoch))), vestDuration)
 	default:
 		return abi.NewTokenAmount(0)
 	}

--- a/actors/builtin/storage_market/storage_market_actor.go
+++ b/actors/builtin/storage_market/storage_market_actor.go
@@ -29,7 +29,6 @@ var IMPL_FINISH = autil.IMPL_FINISH
 // Attempt to withdraw the specified amount from the balance held in escrow.
 // If less than the specified amount is available, yields the entire available balance.
 func (a *StorageMarketActor) WithdrawBalance(rt Runtime, entryAddr addr.Address, amountRequested abi.TokenAmount) *adt.EmptyValue {
-	IMPL_FINISH() // BigInt arithmetic
 	amountSlashedTotal := abi.NewTokenAmount(0)
 
 	if amountRequested.LessThan(big.Zero()) {
@@ -90,7 +89,6 @@ func (a *StorageMarketActor) AddBalance(rt Runtime, entryAddr addr.Address) *adt
 
 // Publish a new set of storage deals (not yet included in a sector).
 func (a *StorageMarketActor) PublishStorageDeals(rt Runtime, newStorageDeals []StorageDeal) *adt.EmptyValue {
-	IMPL_FINISH() // BigInt arithmetic
 	amountSlashedTotal := abi.NewTokenAmount(0)
 
 	// Deal message must have a From field identical to the provider of all the deals.

--- a/actors/builtin/storage_market/storage_market_actor_state.go
+++ b/actors/builtin/storage_market/storage_market_actor_state.go
@@ -59,7 +59,6 @@ func (st *StorageMarketActorState) MarshalCBOR(w io.Writer) error {
 func (st *StorageMarketActorState) _updatePendingDealStates(dealIDs []abi.DealID, epoch abi.ChainEpoch) (
 	amountSlashedTotal abi.TokenAmount) {
 
-	IMPL_FINISH() // BigInt arithmetic
 	amountSlashedTotal = abi.NewTokenAmount(0)
 
 	for _, dealID := range dealIDs {
@@ -73,7 +72,6 @@ func (st *StorageMarketActorState) _updatePendingDealStates(dealIDs []abi.DealID
 func (st *StorageMarketActorState) _updatePendingDealState(dealID abi.DealID, epoch abi.ChainEpoch) (
 	amountSlashed abi.TokenAmount) {
 
-	IMPL_FINISH() // BigInt arithmetic
 	amountSlashed = abi.NewTokenAmount(0)
 
 	deal, dealP := st._getOnChainDealAssert(dealID)
@@ -144,7 +142,6 @@ func (st *StorageMarketActorState) _processDealPaymentEpochsElapsed(dealID abi.D
 	Assert(deal.SectorStartEpoch != epochUndefined)
 
 	// Process deal payment for the elapsed epochs.
-	IMPL_FINISH() // BigInt arithmetic
 	totalPayment := big.Mul(big.NewInt(int64(numEpochsElapsed)), dealP.StoragePricePerEpoch)
 	st._transferBalance(dealP.Client, dealP.Provider, abi.TokenAmount(totalPayment))
 }
@@ -386,7 +383,6 @@ func _dealGetPaymentRemaining(deal OnChainDeal, epoch abi.ChainEpoch) abi.TokenA
 	durationRemaining := dealP.EndEpoch - (epoch - 1)
 	Assert(durationRemaining > 0)
 
-	IMPL_FINISH() // BigInt arithmetic
 	return abi.TokenAmount(big.Mul(big.NewInt(int64(durationRemaining)), dealP.StoragePricePerEpoch))
 }
 

--- a/actors/builtin/storage_power/storage_power_actor_state.go
+++ b/actors/builtin/storage_power/storage_power_actor_state.go
@@ -211,7 +211,7 @@ func (st *StoragePowerActorState) updatePowerEntriesFromClaimed(s adt.Store, min
 	// Compute nominal power: i.e., the power we infer the miner to have (based on the network's
 	// PoSt queries), which may not be the same as the claimed power.
 	// Currently, the only reason for these to differ is if the miner is in DetectedFault state
-	// from a SurprisePoSt challenge.
+	// from a SurprisePoSt challenge. TODO: hs update this
 	nominalPower := claimedPower
 	if found, err := st.hasFault(s, minerAddr); err != nil {
 		return err
@@ -222,7 +222,7 @@ func (st *StoragePowerActorState) updatePowerEntriesFromClaimed(s adt.Store, min
 		return errors.Wrap(err, "failed to set nominal power while setting claimed power table entry")
 	}
 
-	// Compute actual (consensus) power, i.e., votes in leader election.
+	// Compute nominal power, storage power that meets consensus minimum
 	power := nominalPower
 	if found, err := st.minerNominalPowerMeetsConsensusMinimum(s, nominalPower); err != nil {
 		return errors.Wrap(err, "failed to check miners nominal power against consensus minimum")
@@ -230,8 +230,6 @@ func (st *StoragePowerActorState) updatePowerEntriesFromClaimed(s adt.Store, min
 	} else if !found {
 		power = big.Zero()
 	}
-
-	autil.TODO() // TODO ZX: Decide effect of undercollateralization on (consensus) power.
 
 	return st.setPowerEntry(s, minerAddr, power)
 }

--- a/actors/runtime/indices/indices.go
+++ b/actors/runtime/indices/indices.go
@@ -183,9 +183,9 @@ func (inds *IndicesImpl) StoragePower(
 		return minerNominalPower
 	}
 	
+	// minerNominalPower * minerPledgeCollateral / requiredPledge
 	// this is likely to change
-	unitPledgePower := big.Div(minerNominalPower, requiredPledge)
-	return big.Mul(unitPledgePower, minerPledgeCollateral)
+	return big.Div(big.Mul(minerNominalPower, minerPledgeCollateral), requiredPledge)
 }
 
 func (inds *IndicesImpl) StoragePowerProportion(

--- a/actors/runtime/indices/indices.go
+++ b/actors/runtime/indices/indices.go
@@ -56,19 +56,13 @@ type Indices interface {
 	SectorWeightProportion(minerActiveSectorWeight abi.SectorWeight) big.Int
 	PledgeCollateralProportion(minerPledgeCollateral abi.TokenAmount) big.Int
 	StoragePower(
-		minerActiveSectorWeight abi.SectorWeight,
-		minerInactiveSectorWeight abi.SectorWeight,
+		minerNominalPower abi.StoragePower,
 		minerPledgeCollateral abi.TokenAmount,
 	) abi.StoragePower
 	StoragePowerProportion(
 		minerStoragePower abi.StoragePower,
 	) big.Int
 	CurrEpochBlockReward() abi.TokenAmount
-	GetCurrBlockRewardRewardForMiner(
-		minerStoragePower abi.StoragePower,
-		minerPledgeCollateral abi.TokenAmount,
-		// TODO ZX/JZ extend or eliminate
-	) abi.TokenAmount
 	StorageMining_PreCommitDeposit(
 		sectorSize abi.SectorSize,
 		expirationEpoch abi.ChainEpoch,
@@ -178,14 +172,20 @@ func (inds *IndicesImpl) PledgeCollateralProportion(minerPledgeCollateral abi.To
 }
 
 func (inds *IndicesImpl) StoragePower(
-	minerActiveSectorWeight abi.SectorWeight,
-	minerInactiveSectorWeight abi.SectorWeight,
+	minerNominalPower abi.StoragePower,
 	minerPledgeCollateral abi.TokenAmount,
 ) abi.StoragePower {
 	// return StoragePower based on inputs
-	// StoragePower for miner = func(ActiveSectorWeight for miner, PledgeCollateral for miner, global indices)
-	PARAM_FINISH()
-	panic("")
+	// StoragePower for miner = func(NominalPower for miner, PledgeCollateral for miner, global indices)
+	// Tentatively, miners dont get ConsensusPower for the share of power that they dont have collateral for
+	requiredPledge := inds.PledgeCollateralReq(minerNominalPower)
+	if minerPledgeCollateral.GreaterThanEqual(requiredPledge){
+		return minerNominalPower
+	}
+	
+	// this is likely to change
+	unitPledgePower := big.Div(minerNominalPower, requiredPledge)
+	return big.Mul(unitPledgePower, minerPledgeCollateral)
 }
 
 func (inds *IndicesImpl) StoragePowerProportion(
@@ -198,16 +198,7 @@ func (inds *IndicesImpl) StoragePowerProportion(
 func (inds *IndicesImpl) CurrEpochBlockReward() abi.TokenAmount {
 	// total block reward allocated for CurrEpoch
 	// each expected winner get an equal share of this reward
-	// computed as a function of NetworkKPI, LastEpochReward, TotalUnmminedFIL, etc
-	PARAM_FINISH()
-	panic("")
-}
-
-func (inds *IndicesImpl) GetCurrBlockRewardRewardForMiner(
-	minerStoragePower abi.StoragePower,
-	minerPledgeCollateral abi.TokenAmount,
-	// TODO ZX/JZ extend or eliminate
-) abi.TokenAmount {
+	// computed as a function of NetworkKPI, NetworkTarget, LastEpochReward, TotalUnmminedFIL, etc
 	PARAM_FINISH()
 	panic("")
 }


### PR DESCRIPTION
per #60, in this PR,

- BigInt operations have been implemented in several places, removing IMPL_FINISH
- Implemented  BigInt in Reward vesting
- Reward vesting may still exist and linear should suffice unless research shows otherwise
- Tentatively, miners dont get consensus power for nominal power that they dont have pledge collateral for
