### PR TITLE
DO NOT MERGE - Incorrect test for vesting more funds than locked at the moment.

### DIFF
--- a/actors/builtin/multisig/multisig_test.go
+++ b/actors/builtin/multisig/multisig_test.go
@@ -141,6 +141,37 @@ func TestVesting(t *testing.T) {
 
 	})
 
+	t.Run("send 150% vesting after 50% of lock period in 3 txs", func(t *testing.T) {
+		rt := builder.Build(t)
+
+		actor.constructAndVerify(rt, 1, 10, []addr.Address{anne, bob, charlie}...)
+
+		rt.SetEpoch(0 + unlockDuration/2)
+		rt.SetCaller(anne, builtin.AccountActorCodeID)
+		rt.ExpectSend(darlene, builtin.MethodSend, nilParams, big.Div(multisigInitialBalance, big.NewInt(2)), nil, exitcode.Ok)
+		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
+		actor.propose(rt, darlene, big.Div(multisigInitialBalance, big.NewInt(2)), builtin.MethodSend, nilParams)
+		rt.Verify()
+
+		// Should be thrown funds locked
+		// set the current balance of the multisig actor to its InitialBalance amount
+		rt.SetEpoch(0 + unlockDuration/2)
+		rt.SetCaller(bob, builtin.AccountActorCodeID)
+		rt.ExpectSend(charlie, builtin.MethodSend, nilParams, big.Div(multisigInitialBalance, big.NewInt(2)), nil, exitcode.Ok)
+		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
+		actor.propose(rt, charlie, big.Div(multisigInitialBalance, big.NewInt(2)), builtin.MethodSend, nilParams)
+		rt.Verify()
+
+		// Should be thrown funds locked either
+		// set the current balance of the multisig actor to its InitialBalance amount
+		rt.SetEpoch(0 + unlockDuration/2)
+		rt.SetCaller(bob, builtin.AccountActorCodeID)
+		rt.ExpectSend(bob, builtin.MethodSend, nilParams, big.Div(multisigInitialBalance, big.NewInt(2)), nil, exitcode.Ok)
+		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
+		actor.propose(rt, bob, big.Div(multisigInitialBalance, big.NewInt(2)), builtin.MethodSend, nilParams)
+		rt.Verify()
+	})
+
 	t.Run("propose and autoapprove transaction above locked amount fails", func(t *testing.T) {
 		rt := builder.Build(t)
 


### PR DESCRIPTION
MultisigActorState doesn't save initial amount spent. Here is an example how to spend 150% of initial amount in 3 transactions after 50% of locked period has past.

IMO MultisigActor logic is overloaded with vesting logic, i'd split into MultisigActor and VestingActor if locked amount is needed, so MultisigActor could send msgs to VestingActor to unlock amount with multisig.