### PR TITLE
test: mockrt updates balance on sends

### DIFF
--- a/support/mock/mockrt.go
+++ b/support/mock/mockrt.go
@@ -217,7 +217,7 @@ func (rt *Runtime) Send(toAddr addr.Address, methodNum abi.MethodNum, params run
 	}
 
 	if value.GreaterThan(rt.balance) {
-		rt.Abort(exitcode.ErrInsufficientFunds, "cannot send value: %v exceeds balance: %v", value, rt.balance)
+		rt.Abort(exitcode.SysErrInsufficientFunds, "cannot send value: %v exceeds balance: %v", value, rt.balance)
 	}
 
 	// pop the expectedMessage from the queue and modify the mockrt balance to reflect the send.

--- a/support/mock/mockrt.go
+++ b/support/mock/mockrt.go
@@ -11,11 +11,12 @@ import (
 	cid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
 
-	"github.com/filecoin-project/specs-actors/actors/abi"
-	"github.com/filecoin-project/specs-actors/actors/runtime"
-	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
-	"github.com/filecoin-project/specs-actors/actors/runtime/indices"
-	"github.com/filecoin-project/specs-actors/actors/util/adt"
+	abi "github.com/filecoin-project/specs-actors/actors/abi"
+	big "github.com/filecoin-project/specs-actors/actors/abi/big"
+	runtime "github.com/filecoin-project/specs-actors/actors/runtime"
+	exitcode "github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	indices "github.com/filecoin-project/specs-actors/actors/runtime/indices"
+	adt "github.com/filecoin-project/specs-actors/actors/util/adt"
 )
 
 // A mock runtime for unit testing of actors in isolation.
@@ -215,9 +216,10 @@ func (rt *Runtime) Send(toAddr addr.Address, methodNum abi.MethodNum, params run
 	if expectedMsg.Equal(toAddr, methodNum, params, value) {
 		rt.t.Errorf("expectedMessage being sent does not match expectation. Message: to %v method: %v value: %v params: %v, Expected: %v", toAddr, methodNum, value, params, rt.expectSends[0].String())
 	}
-	// pop the expectedMessage from the queue
+	// pop the expectedMessage from the queue and modify the mockrt balance to reflect the send.
 	defer func() {
 		rt.expectSends = rt.expectSends[1:]
+		rt.balance = big.Sub(rt.balance, value)
 	}()
 	return expectedMsg.sendReturn, expectedMsg.exitCode
 }

--- a/support/mock/mockrt.go
+++ b/support/mock/mockrt.go
@@ -210,12 +210,16 @@ func (rt *Runtime) Send(toAddr addr.Address, methodNum abi.MethodNum, params run
 	if len(rt.expectSends) == 0 {
 		rt.t.Fatalf("unexpected expectedMessage to: %v method: %v, value: %v, params: %v", toAddr, methodNum, value, params)
 	}
-
 	expectedMsg := rt.expectSends[0]
 
 	if expectedMsg.Equal(toAddr, methodNum, params, value) {
 		rt.t.Errorf("expectedMessage being sent does not match expectation. Message: to %v method: %v value: %v params: %v, Expected: %v", toAddr, methodNum, value, params, rt.expectSends[0].String())
 	}
+
+	if value.GreaterThan(rt.balance) {
+		rt.Abort(exitcode.ErrInsufficientFunds, "cannot send value: %v exceeds balance: %v", value, rt.balance)
+	}
+
 	// pop the expectedMessage from the queue and modify the mockrt balance to reflect the send.
 	defer func() {
 		rt.expectSends = rt.expectSends[1:]


### PR DESCRIPTION
The mock runtime does not automatically track balance changes via message send. Currently this means test writers need to call `rt.SetBalance(/* expected balance after send */)` after a method performs a send operation to update actor balance. #90 has brought to our attention that this is not ergonomic for test writer. This PR updates the mock runtimes `Send()` operation to modify the `balance` value after a message is sent.
