### PR TITLE
remove param finish

### DIFF
--- a/actors/abi/bitfield.go
+++ b/actors/abi/bitfield.go
@@ -182,7 +182,7 @@ func (bf BitField) AllMap(max uint64) (map[uint64]bool, error) {
 		return nil, errors.Wrap(err, "count error")
 	}
 	if c > max {
-		return nil, errors.Errorf("expected %d, got %d: %w", max, c, ErrBitFieldTooMany)
+		return nil, errors.Errorf("expected %d, got %d: %v", max, c, ErrBitFieldTooMany)
 	}
 
 	runs, err := bf.sum()

--- a/actors/builtin/storage_miner/policy.go
+++ b/actors/builtin/storage_miner/policy.go
@@ -3,10 +3,9 @@ package storage_miner
 import (
 	abi "github.com/filecoin-project/specs-actors/actors/abi"
 	storage_power "github.com/filecoin-project/specs-actors/actors/builtin/storage_power"
-	autil "github.com/filecoin-project/specs-actors/actors/util"
 )
 
 func temporaryFaultFee(weights []storage_power.SectorStorageWeightDesc, duration abi.ChainEpoch) abi.TokenAmount {
-	autil.PARAM_FINISH()
-	panic("")
+	// autil.PARAM_FINISH()
+	return abi.NewTokenAmount(0)
 }

--- a/actors/builtin/storage_miner/policy.go
+++ b/actors/builtin/storage_miner/policy.go
@@ -6,6 +6,6 @@ import (
 )
 
 func temporaryFaultFee(weights []storage_power.SectorStorageWeightDesc, duration abi.ChainEpoch) abi.TokenAmount {
-	// autil.PARAM_FINISH()
+	// PARAM_FINISH
 	return abi.NewTokenAmount(0)
 }

--- a/actors/builtin/storage_power/policy.go
+++ b/actors/builtin/storage_power/policy.go
@@ -1,26 +1,27 @@
 package storage_power
 
 import (
+	big "github.com/filecoin-project/specs-actors/actors/abi/big"
 	abi "github.com/filecoin-project/specs-actors/actors/abi"
 	builtin "github.com/filecoin-project/specs-actors/actors/builtin"
-	autil "github.com/filecoin-project/specs-actors/actors/util"
+	indices "github.com/filecoin-project/specs-actors/actors/runtime/indices"
 )
 
 // TerminationFault
 func pledgePenaltyForSectorTermination(weight SectorStorageWeightDesc, termType builtin.SectorTermination) abi.TokenAmount {
-	autil.PARAM_FINISH()
+	// autil.PARAM_FINISH()
 	return abi.NewTokenAmount(0)
 }
 
 // DetectedFault
 func pledgePenaltyForSurprisePoStFailure(claimedPower abi.StoragePower, failures int64) abi.TokenAmount {
-	autil.PARAM_FINISH()
+	// autil.PARAM_FINISH()
 	return abi.NewTokenAmount(0)
 }
 
 func pledgePenaltyForConsensusFault(currPledge abi.TokenAmount, faultType ConsensusFaultType) abi.TokenAmount {
 	// default is to slash all pledge collateral for all consensus fault
-	autil.TODO()
+	// autil.PARAM_FINISH()
 	switch faultType {
 	case DoubleForkMiningFault:
 		return currPledge
@@ -34,16 +35,18 @@ func pledgePenaltyForConsensusFault(currPledge abi.TokenAmount, faultType Consen
 }
 
 func rewardForConsensusSlashReport(elapsedEpoch abi.ChainEpoch, collateralToSlash abi.TokenAmount) abi.TokenAmount {
-	autil.TODO()
-	// BigInt Operation
-	// var growthRate = builtin.SLASHER_SHARE_GROWTH_RATE_NUM / builtin.SLASHER_SHARE_GROWTH_RATE_DENOM
-	// var multiplier = growthRate^elapsedEpoch
-	// var slasherProportion = min(INITIAL_SLASHER_SHARE * multiplier, 1.0)
-	// return collateralToSlash * slasherProportion
-	return abi.NewTokenAmount(0)
+	// autil.PARAM_FINISH()
+	growthRate := big.Div(indices.ConsensusFault_SlasherShareGrowthRateNum(), indices.ConsensusFault_SlasherShareGrowthRateDenom())
+	multiplier := big.NewInt(1)
+	for i := int64(0); i < int64(elapsedEpoch); i++ {
+		multiplier = big.Mul(multiplier, growthRate)
+	}
+	initial_slasher_share := big.Div(indices.ConsensusFault_SlasherInitialShareNum(), indices.ConsensusFault_SlasherInitialShareDenom())
+	slasher_proportion := big.Min(big.Mul(initial_slasher_share, multiplier), big.NewInt(1))
+	return big.Mul(collateralToSlash, slasher_proportion)
 }
 
 func consensusPowerForWeight(weight SectorStorageWeightDesc) abi.StoragePower {
-	autil.PARAM_FINISH()
-	panic("")
+	// autil.PARAM_FINISH()
+	return big.Mul(big.NewInt(int64(weight.SectorSize)), big.NewInt(int64(weight.Duration)))
 }

--- a/actors/runtime/indices/indices.go
+++ b/actors/runtime/indices/indices.go
@@ -59,7 +59,11 @@ type Indices interface {
 	StoragePowerProportion(
 		minerStoragePower abi.StoragePower,
 	) big.Int
-	CurrEpochBlockReward() abi.TokenAmount
+	CurrEpochBlockReward(
+		networkIndicator big.Int,
+		networkKPI big.Int,
+		networkTime big.Int,
+	) abi.TokenAmount
 	StorageMining_PreCommitDeposit(
 		sectorSize abi.SectorSize,
 		expirationEpoch abi.ChainEpoch,
@@ -79,6 +83,8 @@ type IndicesImpl struct {
 	// they are treated as globally available states
 	Epoch                      abi.ChainEpoch
 	NetworkKPI                 big.Int
+	NetworkIndicator           big.Int
+	NetworkTime                big.Int
 	TotalNetworkSectorWeight   abi.SectorWeight
 	TotalPledgeCollateral      abi.TokenAmount
 	TotalNetworkEffectivePower abi.StoragePower // power above minimum miner size
@@ -94,7 +100,7 @@ func (inds *IndicesImpl) StorageDeal_DurationBounds(
 	pieceSize abi.PieceSize,
 	startEpoch abi.ChainEpoch,
 ) (minDuration abi.ChainEpoch, maxDuration abi.ChainEpoch) {
-	// PARAM_FINISH()
+	// PARAM_FINISH
 	return abi.ChainEpoch(0), abi.ChainEpoch(1 << 20)
 }
 
@@ -103,7 +109,7 @@ func (inds *IndicesImpl) StorageDeal_StoragePricePerEpochBounds(
 	startEpoch abi.ChainEpoch,
 	endEpoch abi.ChainEpoch,
 ) (minPrice abi.TokenAmount, maxPrice abi.TokenAmount) {
-	// PARAM_FINISH()
+	// PARAM_FINISH
 	return abi.NewTokenAmount(0), abi.NewTokenAmount(1 << 20)
 }
 
@@ -112,7 +118,7 @@ func (inds *IndicesImpl) StorageDeal_ProviderCollateralBounds(
 	startEpoch abi.ChainEpoch,
 	endEpoch abi.ChainEpoch,
 ) (minProviderCollateral abi.TokenAmount, maxProviderCollateral abi.TokenAmount) {
-	// PARAM_FINISH()
+	// PARAM_FINISH
 	return abi.NewTokenAmount(0), abi.NewTokenAmount(1 << 20)
 }
 
@@ -121,7 +127,7 @@ func (inds *IndicesImpl) StorageDeal_ClientCollateralBounds(
 	startEpoch abi.ChainEpoch,
 	endEpoch abi.ChainEpoch,
 ) (minClientCollateral abi.TokenAmount, maxClientCollateral abi.TokenAmount) {
-	// PARAM_FINISH()
+	// PARAM_FINISH
 	return abi.NewTokenAmount(0), abi.NewTokenAmount(1 << 20)
 }
 
@@ -133,25 +139,24 @@ func (inds *IndicesImpl) SectorWeight(
 ) abi.SectorWeight {
 	// for every sector, given its size, start, end, and deals within the sector
 	// assign sector power for the duration of its lifetime
-	// PARAM_FINISH()
-	sectorDuration := endEpoch - startEpoch
-	return abi.SectorWeight(big.NewInt(int64(sectorDuration) * int64(sectorSize)))
+	// PARAM_FINISH
+	return abi.SectorWeight(big.NewInt(int64(sectorSize)))
 }
 
 func (inds *IndicesImpl) PledgeCollateralReq(minerNominalPower abi.StoragePower) abi.TokenAmount {
-	// PARAM_FINISH()
+	// PARAM_FINISH
 	return abi.NewTokenAmount(0)
 }
 
 func (inds *IndicesImpl) SectorWeightProportion(minerActiveSectorWeight abi.SectorWeight) big.Int {
 	// return proportion of SectorWeight for miner
-	// PARAM_FINISH()
+	// PARAM_FINISH
 	return big.NewInt(0)
 }
 
 func (inds *IndicesImpl) PledgeCollateralProportion(minerPledgeCollateral abi.TokenAmount) big.Int {
 	// return proportion of Pledge Collateral for miner
-	// PARAM_FINISH()
+	// PARAM_FINISH
 	return big.NewInt(0)
 }
 
@@ -169,23 +174,27 @@ func (inds *IndicesImpl) StoragePower(
 
 	// minerNominalPower * minerPledgeCollateral / requiredPledge
 	// this is likely to change
-	// PARAM_FINISH()
+	// PARAM_FINISH
 	return big.Div(big.Mul(minerNominalPower, minerPledgeCollateral), requiredPledge)
 }
 
 func (inds *IndicesImpl) StoragePowerProportion(
 	minerStoragePower abi.StoragePower,
 ) big.Int {
-	// PARAM_FINISH()
+	// PARAM_FINISH
 	return big.NewInt(0)
 }
 
-func (inds *IndicesImpl) CurrEpochBlockReward() abi.TokenAmount {
+func (inds *IndicesImpl) CurrEpochBlockReward(
+	networkIndicator big.Int,
+	networkKPI big.Int,
+	networkTime big.Int,
+) abi.TokenAmount {
 	// total block reward allocated for CurrEpoch
 	// each expected winner get an equal share of this reward
-	// computed as a function of NetworkKPI, NetworkTarget, LastEpochReward, TotalUnmminedFIL, etc
-	// PARAM_FINISH()
-	return abi.NewTokenAmount(0)
+	// computed as a function of NetworkKPI, NetworkIndicator, LastEpochReward, TotalUnmminedFIL, etc
+	// PARAM_FINISH
+	return abi.NewTokenAmount(1)
 }
 
 // FIL deposit per sector precommit in Interactive PoRep
@@ -194,8 +203,8 @@ func (inds *IndicesImpl) StorageMining_PreCommitDeposit(
 	sectorSize abi.SectorSize,
 	expirationEpoch abi.ChainEpoch,
 ) abi.TokenAmount {
-	// PARAM_FINISH()
-	PRECOMMIT_DEPOSIT_PER_BYTE := abi.TokenAmount(big.NewInt(0)) // placeholder
+	// PARAM_FINISH
+	PRECOMMIT_DEPOSIT_PER_BYTE := abi.NewTokenAmount(0) // placeholder
 	return abi.TokenAmount(big.Mul(PRECOMMIT_DEPOSIT_PER_BYTE, big.NewInt(int64(sectorSize))))
 }
 
@@ -203,7 +212,7 @@ func (inds *IndicesImpl) NetworkTransactionFee(
 	toActorCodeID cid.Cid,
 	methodNum abi.MethodNum,
 ) abi.TokenAmount {
-	// PARAM_FINISH()
+	// PARAM_FINISH
 	return abi.NewTokenAmount(0)
 }
 
@@ -211,51 +220,51 @@ func (inds *IndicesImpl) GetCurrBlockRewardForMiner(
 	minerStoragePower abi.StoragePower,
 	minerPledgeCollateral abi.TokenAmount,
 ) abi.TokenAmount {
-	// PARAM_FINISH()
-	return abi.NewTokenAmount(0)
+	// PARAM_FINISH
+	return abi.NewTokenAmount(1)
 }
 
 func StorageDeal_ProviderInitTimedOutSlashAmount(providerCollateral abi.TokenAmount) abi.TokenAmount {
-	// PARAM_FINISH()
+	// PARAM_FINISH
 	return providerCollateral
 }
 
 func StoragePower_MinMinerSizeStor() abi.StoragePower {
-	// PARAM_FINISH()
+	// PARAM_FINISH
 	var MIN_MINER_SIZE_STOR = abi.NewStoragePower(100 * (1 << 40)) // placeholder, 100 TB
 	return MIN_MINER_SIZE_STOR
 }
 
 func StoragePower_MinMinerSizeTarg() int64 {
-	// PARAM_FINISH()
+	// PARAM_FINISH
 	const MIN_MINER_SIZE_TARG = 3 // placeholder
 	return MIN_MINER_SIZE_TARG
 }
 
 // how long miner has to respond to the challenge before it expires
 func StorageMining_SurprisePoStChallengeDuration() abi.ChainEpoch {
-	// PARAM_FINISH()
+	// PARAM_FINISH
 	const CHALLENGE_DURATION = abi.ChainEpoch(4) // placeholder, 2 hours
 	return CHALLENGE_DURATION
 }
 
 // sets the average frequency
 func StorageMining_SurprisePoStProvingPeriod() abi.ChainEpoch {
-	// PARAM_FINISH()
+	// PARAM_FINISH
 	const PROVING_PERIOD = abi.ChainEpoch(2) // placeholder, 2 days
 	return PROVING_PERIOD
 }
 
 // how long after a POST challenge before a miner can get challenged again
 func StorageMining_PoStNoChallengePeriod() abi.ChainEpoch {
-	// PARAM_FINISH()
+	// PARAM_FINISH
 	const SURPRISE_NO_CHALLENGE_PERIOD = abi.ChainEpoch(0) // placeholder, 2 hours
 	return SURPRISE_NO_CHALLENGE_PERIOD
 }
 
 // number of detected faults before a miner's sectors are all terminated
 func StoragePower_SurprisePoStMaxConsecutiveFailures() int64 {
-	// PARAM_FINISH()
+	// PARAM_FINISH
 	const MAX_CONSECUTIVE_FAULTS = 3 // placeholder
 	return MAX_CONSECUTIVE_FAULTS
 }
@@ -263,7 +272,7 @@ func StoragePower_SurprisePoStMaxConsecutiveFailures() int64 {
 // Time between when a temporary sector fault is declared, and when it becomes
 // effective for purposes of reducing the active proving set for PoSts.
 func StorageMining_DeclaredFaultEffectiveDelay() abi.ChainEpoch {
-	// PARAM_FINISH()
+	// PARAM_FINISH
 	const DECLARED_FAULT_EFFECTIVE_DELAY = abi.ChainEpoch(20) // placeholder
 	return DECLARED_FAULT_EFFECTIVE_DELAY
 }
@@ -273,73 +282,73 @@ func StorageMining_DeclaredFaultEffectiveDelay() abi.ChainEpoch {
 //   (T + MIN_PROVE_COMMIT_SECTOR_EPOCH, T + MAX_PROVE_COMMIT_SECTOR_EPOCH)
 // inclusive.
 func StorageMining_MinProveCommitSectorEpoch() abi.ChainEpoch {
-	// PARAM_FINISH()
+	// PARAM_FINISH
 	const MIN_PROVE_COMMIT_SECTOR_EPOCH = abi.ChainEpoch(5)
 	return MIN_PROVE_COMMIT_SECTOR_EPOCH
 }
 
 func StorageMining_MaxProveCommitSectorEpoch() abi.ChainEpoch {
-	// PARAM_FINISH()
+	// PARAM_FINISH
 	const MAX_PROVE_COMMIT_SECTOR_EPOCH = abi.ChainEpoch(10)
 	return MAX_PROVE_COMMIT_SECTOR_EPOCH
 }
 
 func StorageMining_SpcLookbackPoSt() abi.ChainEpoch {
-	// PARAM_FINISH()
+	// PARAM_FINISH
 	const SPC_LOOKBACK_POST = abi.ChainEpoch(1) // cheap to generate, should be set as close to current TS as possible
 	return SPC_LOOKBACK_POST
 }
 
 func StorageMining_Finality() abi.ChainEpoch {
-	// PARAM_FINISH()
+	// PARAM_FINISH
 	const FINALITY = 500
 	return FINALITY
 }
 
 func StorageMining_SpcLookbackElection() abi.ChainEpoch {
-	// PARAM_FINISH()
+	// PARAM_FINISH
 	// same as the post lookback given EPoSt
 	spcLookbackElection := StorageMining_SpcLookbackPoSt()
 	return spcLookbackElection
 }
 
 func StorageMining_WorkerKeyChangeFreeze() abi.ChainEpoch {
-	// PARAM_FINISH()
+	// PARAM_FINISH
 	workerKeyChangeFreeze := 2 * StorageMining_SpcLookbackElection()
 	return workerKeyChangeFreeze
 }
 
 func StorageMining_SpcLookbackSeal() abi.ChainEpoch {
-	// PARAM_FINISH()
+	// PARAM_FINISH
 	return StorageMining_Finality() // should be approximately the same as finality
 }
 
 func StorageMining_MaxSealTime32GiBWinStackedSDR() abi.ChainEpoch {
-	// PARAM_FINISH()
+	// PARAM_FINISH
 	MAX_SEAL_TIME_32GIB_WIN_STACKED_SDR := abi.ChainEpoch(1) // TODO HS: Change to a dictionary with RegisteredProofs as the key.
 	return MAX_SEAL_TIME_32GIB_WIN_STACKED_SDR
 }
 
 func ConsensusFault_SlasherInitialShareNum() big.Int {
-	// PARAM_FINISH()
+	// PARAM_FINISH
 	SLASHER_INITIAL_SHARE_NUM := big.NewInt(1) // placeholder
 	return SLASHER_INITIAL_SHARE_NUM
 }
 
 func ConsensusFault_SlasherInitialShareDenom() big.Int {
-	// PARAM_FINISH()
+	// PARAM_FINISH
 	SLASHER_INITIAL_SHARE_DENOM := big.NewInt(1000) // placeholder
 	return SLASHER_INITIAL_SHARE_DENOM
 }
 
 func ConsensusFault_SlasherShareGrowthRateNum() big.Int {
-	// PARAM_FINISH()
+	// PARAM_FINISH
 	SLASHER_SHARE_GROWTH_RATE_NUM := big.NewInt(102813) // placeholder
 	return SLASHER_SHARE_GROWTH_RATE_NUM
 }
 
 func ConsensusFault_SlasherShareGrowthRateDenom() big.Int {
-	// PARAM_FINISH()
+	// PARAM_FINISH
 	SLASHER_SHARE_GROWTH_RATE_DENOM := big.NewInt(100000) // placeholder
 	return SLASHER_SHARE_GROWTH_RATE_DENOM
 }

--- a/actors/runtime/indices/indices.go
+++ b/actors/runtime/indices/indices.go
@@ -5,10 +5,7 @@ import (
 
 	abi "github.com/filecoin-project/specs-actors/actors/abi"
 	big "github.com/filecoin-project/specs-actors/actors/abi/big"
-	actor_util "github.com/filecoin-project/specs-actors/actors/util"
 )
-
-var PARAM_FINISH = actor_util.PARAM_FINISH
 
 // Data in Indices are populated at instantiation with data from the state tree
 // Indices itself has no state tree or access to the runtime
@@ -97,12 +94,8 @@ func (inds *IndicesImpl) StorageDeal_DurationBounds(
 	pieceSize abi.PieceSize,
 	startEpoch abi.ChainEpoch,
 ) (minDuration abi.ChainEpoch, maxDuration abi.ChainEpoch) {
-
-	// placeholder
-	PARAM_FINISH()
-	minDuration = abi.ChainEpoch(0)
-	maxDuration = abi.ChainEpoch(1 << 20)
-	return
+	// PARAM_FINISH()
+	return abi.ChainEpoch(0), abi.ChainEpoch(1 << 20)
 }
 
 func (inds *IndicesImpl) StorageDeal_StoragePricePerEpochBounds(
@@ -110,10 +103,8 @@ func (inds *IndicesImpl) StorageDeal_StoragePricePerEpochBounds(
 	startEpoch abi.ChainEpoch,
 	endEpoch abi.ChainEpoch,
 ) (minPrice abi.TokenAmount, maxPrice abi.TokenAmount) {
-
-	// placeholder
-	PARAM_FINISH()
-	panic("")
+	// PARAM_FINISH()
+	return abi.NewTokenAmount(0), abi.NewTokenAmount(1 << 20)
 }
 
 func (inds *IndicesImpl) StorageDeal_ProviderCollateralBounds(
@@ -121,10 +112,8 @@ func (inds *IndicesImpl) StorageDeal_ProviderCollateralBounds(
 	startEpoch abi.ChainEpoch,
 	endEpoch abi.ChainEpoch,
 ) (minProviderCollateral abi.TokenAmount, maxProviderCollateral abi.TokenAmount) {
-
-	// placeholder
-	PARAM_FINISH()
-	panic("")
+	// PARAM_FINISH()
+	return abi.NewTokenAmount(0), abi.NewTokenAmount(1 << 20)
 }
 
 func (inds *IndicesImpl) StorageDeal_ClientCollateralBounds(
@@ -132,10 +121,8 @@ func (inds *IndicesImpl) StorageDeal_ClientCollateralBounds(
 	startEpoch abi.ChainEpoch,
 	endEpoch abi.ChainEpoch,
 ) (minClientCollateral abi.TokenAmount, maxClientCollateral abi.TokenAmount) {
-
-	// placeholder
-	PARAM_FINISH()
-	panic("")
+	// PARAM_FINISH()
+	return abi.NewTokenAmount(0), abi.NewTokenAmount(1 << 20)
 }
 
 func (inds *IndicesImpl) SectorWeight(
@@ -146,25 +133,26 @@ func (inds *IndicesImpl) SectorWeight(
 ) abi.SectorWeight {
 	// for every sector, given its size, start, end, and deals within the sector
 	// assign sector power for the duration of its lifetime
-	PARAM_FINISH()
-	panic("")
+	// PARAM_FINISH()
+	sectorDuration := endEpoch - startEpoch
+	return abi.SectorWeight(big.NewInt(int64(sectorDuration) * int64(sectorSize)))
 }
 
 func (inds *IndicesImpl) PledgeCollateralReq(minerNominalPower abi.StoragePower) abi.TokenAmount {
-	PARAM_FINISH()
-	panic("")
+	// PARAM_FINISH()
+	return abi.NewTokenAmount(0)
 }
 
 func (inds *IndicesImpl) SectorWeightProportion(minerActiveSectorWeight abi.SectorWeight) big.Int {
 	// return proportion of SectorWeight for miner
-	PARAM_FINISH()
-	panic("")
+	// PARAM_FINISH()
+	return big.NewInt(0)
 }
 
 func (inds *IndicesImpl) PledgeCollateralProportion(minerPledgeCollateral abi.TokenAmount) big.Int {
 	// return proportion of Pledge Collateral for miner
-	PARAM_FINISH()
-	panic("")
+	// PARAM_FINISH()
+	return big.NewInt(0)
 }
 
 func (inds *IndicesImpl) StoragePower(
@@ -181,22 +169,23 @@ func (inds *IndicesImpl) StoragePower(
 
 	// minerNominalPower * minerPledgeCollateral / requiredPledge
 	// this is likely to change
+	// PARAM_FINISH()
 	return big.Div(big.Mul(minerNominalPower, minerPledgeCollateral), requiredPledge)
 }
 
 func (inds *IndicesImpl) StoragePowerProportion(
 	minerStoragePower abi.StoragePower,
 ) big.Int {
-	PARAM_FINISH()
-	panic("")
+	// PARAM_FINISH()
+	return big.NewInt(0)
 }
 
 func (inds *IndicesImpl) CurrEpochBlockReward() abi.TokenAmount {
 	// total block reward allocated for CurrEpoch
 	// each expected winner get an equal share of this reward
 	// computed as a function of NetworkKPI, NetworkTarget, LastEpochReward, TotalUnmminedFIL, etc
-	PARAM_FINISH()
-	panic("")
+	// PARAM_FINISH()
+	return abi.NewTokenAmount(0)
 }
 
 // FIL deposit per sector precommit in Interactive PoRep
@@ -205,7 +194,7 @@ func (inds *IndicesImpl) StorageMining_PreCommitDeposit(
 	sectorSize abi.SectorSize,
 	expirationEpoch abi.ChainEpoch,
 ) abi.TokenAmount {
-	PARAM_FINISH()
+	// PARAM_FINISH()
 	PRECOMMIT_DEPOSIT_PER_BYTE := abi.TokenAmount(big.NewInt(0)) // placeholder
 	return abi.TokenAmount(big.Mul(PRECOMMIT_DEPOSIT_PER_BYTE, big.NewInt(int64(sectorSize))))
 }
@@ -214,60 +203,59 @@ func (inds *IndicesImpl) NetworkTransactionFee(
 	toActorCodeID cid.Cid,
 	methodNum abi.MethodNum,
 ) abi.TokenAmount {
-	PARAM_FINISH()
-	panic("")
+	// PARAM_FINISH()
+	return abi.NewTokenAmount(0)
 }
 
 func (inds *IndicesImpl) GetCurrBlockRewardForMiner(
 	minerStoragePower abi.StoragePower,
 	minerPledgeCollateral abi.TokenAmount,
 ) abi.TokenAmount {
-	PARAM_FINISH()
-	panic("")
+	// PARAM_FINISH()
+	return abi.NewTokenAmount(0)
 }
 
 func StorageDeal_ProviderInitTimedOutSlashAmount(providerCollateral abi.TokenAmount) abi.TokenAmount {
-	// placeholder
-	PARAM_FINISH()
+	// PARAM_FINISH()
 	return providerCollateral
 }
 
 func StoragePower_MinMinerSizeStor() abi.StoragePower {
-	PARAM_FINISH()
+	// PARAM_FINISH()
 	var MIN_MINER_SIZE_STOR = abi.NewStoragePower(100 * (1 << 40)) // placeholder, 100 TB
 	return MIN_MINER_SIZE_STOR
 }
 
 func StoragePower_MinMinerSizeTarg() int64 {
-	PARAM_FINISH()
+	// PARAM_FINISH()
 	const MIN_MINER_SIZE_TARG = 3 // placeholder
 	return MIN_MINER_SIZE_TARG
 }
 
 // how long miner has to respond to the challenge before it expires
 func StorageMining_SurprisePoStChallengeDuration() abi.ChainEpoch {
-	PARAM_FINISH()
+	// PARAM_FINISH()
 	const CHALLENGE_DURATION = abi.ChainEpoch(4) // placeholder, 2 hours
 	return CHALLENGE_DURATION
 }
 
 // sets the average frequency
 func StorageMining_SurprisePoStProvingPeriod() abi.ChainEpoch {
-	PARAM_FINISH()
+	// PARAM_FINISH()
 	const PROVING_PERIOD = abi.ChainEpoch(2) // placeholder, 2 days
 	return PROVING_PERIOD
 }
 
 // how long after a POST challenge before a miner can get challenged again
 func StorageMining_PoStNoChallengePeriod() abi.ChainEpoch {
-	PARAM_FINISH()
+	// PARAM_FINISH()
 	const SURPRISE_NO_CHALLENGE_PERIOD = abi.ChainEpoch(0) // placeholder, 2 hours
 	return SURPRISE_NO_CHALLENGE_PERIOD
 }
 
 // number of detected faults before a miner's sectors are all terminated
 func StoragePower_SurprisePoStMaxConsecutiveFailures() int64 {
-	PARAM_FINISH()
+	// PARAM_FINISH()
 	const MAX_CONSECUTIVE_FAULTS = 3 // placeholder
 	return MAX_CONSECUTIVE_FAULTS
 }
@@ -275,7 +263,7 @@ func StoragePower_SurprisePoStMaxConsecutiveFailures() int64 {
 // Time between when a temporary sector fault is declared, and when it becomes
 // effective for purposes of reducing the active proving set for PoSts.
 func StorageMining_DeclaredFaultEffectiveDelay() abi.ChainEpoch {
-	PARAM_FINISH()
+	// PARAM_FINISH()
 	const DECLARED_FAULT_EFFECTIVE_DELAY = abi.ChainEpoch(20) // placeholder
 	return DECLARED_FAULT_EFFECTIVE_DELAY
 }
@@ -285,74 +273,73 @@ func StorageMining_DeclaredFaultEffectiveDelay() abi.ChainEpoch {
 //   (T + MIN_PROVE_COMMIT_SECTOR_EPOCH, T + MAX_PROVE_COMMIT_SECTOR_EPOCH)
 // inclusive.
 func StorageMining_MinProveCommitSectorEpoch() abi.ChainEpoch {
-	PARAM_FINISH()
+	// PARAM_FINISH()
 	const MIN_PROVE_COMMIT_SECTOR_EPOCH = abi.ChainEpoch(5)
 	return MIN_PROVE_COMMIT_SECTOR_EPOCH
 }
 
 func StorageMining_MaxProveCommitSectorEpoch() abi.ChainEpoch {
-	PARAM_FINISH()
+	// PARAM_FINISH()
 	const MAX_PROVE_COMMIT_SECTOR_EPOCH = abi.ChainEpoch(10)
 	return MAX_PROVE_COMMIT_SECTOR_EPOCH
 }
 
 func StorageMining_SpcLookbackPoSt() abi.ChainEpoch {
-	PARAM_FINISH()
+	// PARAM_FINISH()
 	const SPC_LOOKBACK_POST = abi.ChainEpoch(1) // cheap to generate, should be set as close to current TS as possible
 	return SPC_LOOKBACK_POST
 }
 
 func StorageMining_Finality() abi.ChainEpoch {
-	PARAM_FINISH()
+	// PARAM_FINISH()
 	const FINALITY = 500
 	return FINALITY
 }
 
 func StorageMining_SpcLookbackElection() abi.ChainEpoch {
-	PARAM_FINISH()
+	// PARAM_FINISH()
 	// same as the post lookback given EPoSt
 	spcLookbackElection := StorageMining_SpcLookbackPoSt()
 	return spcLookbackElection
 }
 
 func StorageMining_WorkerKeyChangeFreeze() abi.ChainEpoch {
-	PARAM_FINISH()
+	// PARAM_FINISH()
 	workerKeyChangeFreeze := 2 * StorageMining_SpcLookbackElection()
 	return workerKeyChangeFreeze
 }
 
 func StorageMining_SpcLookbackSeal() abi.ChainEpoch {
-	PARAM_FINISH()
+	// PARAM_FINISH()
 	return StorageMining_Finality() // should be approximately the same as finality
 }
 
 func StorageMining_MaxSealTime32GiBWinStackedSDR() abi.ChainEpoch {
-	PARAM_FINISH()
-
+	// PARAM_FINISH()
 	MAX_SEAL_TIME_32GIB_WIN_STACKED_SDR := abi.ChainEpoch(1) // TODO HS: Change to a dictionary with RegisteredProofs as the key.
 	return MAX_SEAL_TIME_32GIB_WIN_STACKED_SDR
 }
 
-func ConsensusFault_SlasherInitialShareNum() int {
-	PARAM_FINISH()
-	const SLASHER_INITIAL_SHARE_NUM = 1 // placeholder
+func ConsensusFault_SlasherInitialShareNum() big.Int {
+	// PARAM_FINISH()
+	SLASHER_INITIAL_SHARE_NUM := big.NewInt(1) // placeholder
 	return SLASHER_INITIAL_SHARE_NUM
 }
 
-func ConsensusFault_SlasherInitialShareDenom() int {
-	PARAM_FINISH()
-	const SLASHER_INITIAL_SHARE_DENOM = 1000 // placeholder
+func ConsensusFault_SlasherInitialShareDenom() big.Int {
+	// PARAM_FINISH()
+	SLASHER_INITIAL_SHARE_DENOM := big.NewInt(1000) // placeholder
 	return SLASHER_INITIAL_SHARE_DENOM
 }
 
-func ConsensusFault_SlasherShareGrowthRateNum() int {
-	PARAM_FINISH()
-	const SLASHER_SHARE_GROWTH_RATE_NUM = 102813 // placeholder
+func ConsensusFault_SlasherShareGrowthRateNum() big.Int {
+	// PARAM_FINISH()
+	SLASHER_SHARE_GROWTH_RATE_NUM := big.NewInt(102813) // placeholder
 	return SLASHER_SHARE_GROWTH_RATE_NUM
 }
 
-func ConsensusFault_SlasherShareGrowthRateDenom() int {
-	PARAM_FINISH()
-	const SLASHER_SHARE_GROWTH_RATE_DENOM = 100000 // placeholder
+func ConsensusFault_SlasherShareGrowthRateDenom() big.Int {
+	// PARAM_FINISH()
+	SLASHER_SHARE_GROWTH_RATE_DENOM := big.NewInt(100000) // placeholder
 	return SLASHER_SHARE_GROWTH_RATE_DENOM
 }

--- a/actors/util/assert.go
+++ b/actors/util/assert.go
@@ -31,10 +31,3 @@ func TODO(...interface{}) {
 func IMPL_FINISH(...interface{}) {
 	panic("Not yet implemented in the spec")
 }
-
-// Version of TODO() indicating that the operation is believed to be unambiguous,
-// but is not yet implemented as code in the spec repository.
-// Some parameters still need to be set for mainnet and implementations can slot in the parameters when decisions are finalized
-func PARAM_FINISH(...interface{}) {
-	panic("Not yet implemented in the spec")
-}


### PR DESCRIPTION
In this PR,

- Commented out PARAM_FINISH but did not remove to keep track of parameters and functions that need to be set so that it can be run
- Implemented big int operation for slashing reward
- Proportion related calculation, specifically related to power, is left as zero, they will be fixed in a separate PR when the power table is removed as discussed
