### PR TITLE
Test multisig actor removal

### DIFF
--- a/actors/builtin/multisig/multisig_test.go
+++ b/actors/builtin/multisig/multisig_test.go
@@ -558,20 +558,20 @@ func TestCancel(t *testing.T) {
 		rt.Verify()
 
 		// anne fails to cancel a transaction - she is not a signer
-		rt.SetCaller(anne, builtin.AccountActorCodeID)
-		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
-		rt.ExpectAbort(exitcode.ErrForbidden, func() {
-			actor.cancel(rt, txnID)
-		})
-		rt.Verify()
+		//for some reason I cannot ExpectAbort again
+		//rt.SetCaller(anne, builtin.AccountActorCodeID)
+		//rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
+		//rt.ExpectAbort(exitcode.ErrForbidden, func() {
+		//	actor.cancel(rt, txnID)
+		//})
+		//rt.Verify()
 
 		// bob either fails to cancel a transaction - he is not a proposer
 		rt.SetCaller(bob, builtin.AccountActorCodeID)
 		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
-		// for some reason I cannot ExpectAbort again
-		//rt.ExpectAbort(exitcode.ErrForbidden, func() {
-		//	actor.cancel(rt, txnID)
-		//})
+		rt.ExpectAbort(exitcode.ErrForbidden, func() {
+			actor.cancel(rt, txnID)
+		})
 		rt.Verify()
 
 		// Transaction should remain after invalid cancel

--- a/actors/builtin/multisig/multisig_test.go
+++ b/actors/builtin/multisig/multisig_test.go
@@ -723,6 +723,19 @@ func TestRemoveSigner(t *testing.T) {
 			expectApprovals: int64(2),
 			code:            exitcode.ErrNotFound,
 		},
+		{
+			desc: "problem: now bob is proposal creator and can cancel tx",
+
+			initialSigners:   []addr.Address{anne, bob, chuck},
+			initialApprovals: int64(1),
+
+			removeSigner: anne,
+			decrease:     false,
+
+			expectSigners:   []addr.Address{bob, chuck},
+			expectApprovals: int64(1),
+			code:            exitcode.Ok,
+		},
 	}
 
 	builder := mock.NewBuilder(context.Background(), multisigWalletAdd).WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID)


### PR DESCRIPTION
Undefined behavior after tx creator removal - now the 2-nd signer is tx creator.

The order described [here](
https://github.com/filecoin-project/specs-actors/blob/master/actors/builtin/multisig/multisig_actor.go#L31) is violated. 