### PR TITLE
test: add cron actor unit tests

### DIFF
--- a/actors/builtin/cron/cron_test.go
+++ b/actors/builtin/cron/cron_test.go
@@ -1,1 +1,116 @@
 package cron_test
+
+import (
+	"context"
+	"testing"
+
+	addr "github.com/filecoin-project/go-address"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	builtin "github.com/filecoin-project/specs-actors/actors/builtin"
+	cron "github.com/filecoin-project/specs-actors/actors/builtin/cron"
+	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	"github.com/filecoin-project/specs-actors/actors/util/adt"
+	mock "github.com/filecoin-project/specs-actors/support/mock"
+)
+
+func TestConstructor(t *testing.T) {
+	actor := cronHarness{cron.CronActor{}, t}
+
+	receiver := newIDAddr(t, 100)
+	builder := mock.NewBuilder(context.Background(), receiver).WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
+
+	t.Run("construct with empty entries", func(t *testing.T) {
+		rt := builder.Build(t)
+
+		var nilCronEntries = []cron.CronTableEntry(nil)
+		actor.constructAndVerify(rt, nilCronEntries...)
+
+		var st cron.CronActorState
+		rt.GetState(&st)
+		assert.Equal(t, nilCronEntries, st.Entries)
+	})
+
+	t.Run("construct with non-empty entries", func(t *testing.T) {
+		rt := builder.Build(t)
+
+		var cronEntries = []cron.CronTableEntry{
+			{Receiver: newIDAddr(t, 1001), MethodNum: abi.MethodNum(1001)},
+			{Receiver: newIDAddr(t, 1002), MethodNum: abi.MethodNum(1002)},
+			{Receiver: newIDAddr(t, 1003), MethodNum: abi.MethodNum(1003)},
+			{Receiver: newIDAddr(t, 1004), MethodNum: abi.MethodNum(1004)},
+		}
+		actor.constructAndVerify(rt, cronEntries...)
+
+		var st cron.CronActorState
+		rt.GetState(&st)
+		assert.Equal(t, cronEntries, st.Entries)
+	})
+}
+
+func TestEpochTick(t *testing.T) {
+	actor := cronHarness{cron.CronActor{}, t}
+
+	receiver := newIDAddr(t, 100)
+	builder := mock.NewBuilder(context.Background(), receiver).WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
+
+	t.Run("epoch tick with empty entries", func(t *testing.T) {
+		rt := builder.Build(t)
+
+		var nilCronEntries = []cron.CronTableEntry(nil)
+		actor.constructAndVerify(rt, nilCronEntries...)
+		actor.epochTickAndVerify(rt)
+	})
+
+	t.Run("epoch tick with non-empty entries", func(t *testing.T) {
+		rt := builder.Build(t)
+
+		entry1 := cron.CronTableEntry{Receiver: newIDAddr(t, 1001), MethodNum: abi.MethodNum(1001)}
+		entry2 := cron.CronTableEntry{Receiver: newIDAddr(t, 1002), MethodNum: abi.MethodNum(1002)}
+		entry3 := cron.CronTableEntry{Receiver: newIDAddr(t, 1003), MethodNum: abi.MethodNum(1003)}
+		entry4 := cron.CronTableEntry{Receiver: newIDAddr(t, 1004), MethodNum: abi.MethodNum(1004)}
+
+		actor.constructAndVerify(rt, entry1, entry2, entry3, entry4)
+		// exit code should not matter
+		rt.ExpectSend(entry1.Receiver, entry1.MethodNum, adt.EmptyValue{}, big.Zero(), nil, exitcode.Ok)
+		rt.ExpectSend(entry2.Receiver, entry2.MethodNum, adt.EmptyValue{}, big.Zero(), nil, exitcode.ErrIllegalArgument)
+		rt.ExpectSend(entry3.Receiver, entry3.MethodNum, adt.EmptyValue{}, big.Zero(), nil, exitcode.ErrInsufficientFunds)
+		rt.ExpectSend(entry4.Receiver, entry4.MethodNum, adt.EmptyValue{}, big.Zero(), nil, exitcode.ErrForbidden)
+		actor.epochTickAndVerify(rt)
+	})
+
+}
+
+type cronHarness struct {
+	cron.CronActor
+	t testing.TB
+}
+
+func (h *cronHarness) constructAndVerify(rt *mock.Runtime, entries ...cron.CronTableEntry) {
+	params := cron.ConstructorParams{Entries: entries}
+	rt.ExpectValidateCallerAddr(builtin.SystemActorAddr)
+	ret := rt.Call(h.Constructor, &params).(*adt.EmptyValue)
+	assert.Equal(h.t, &adt.EmptyValue{}, ret)
+	rt.Verify()
+}
+
+func (h *cronHarness) epochTickAndVerify(rt *mock.Runtime) {
+	rt.ExpectValidateCallerAddr(builtin.SystemActorAddr)
+	ret := rt.Call(h.EpochTick, &adt.EmptyValue{}).(*adt.EmptyValue)
+	assert.Equal(h.t, &adt.EmptyValue{}, ret)
+	rt.Verify()
+}
+
+//
+// Misc. Utility Functions
+//
+
+func newIDAddr(t *testing.T, id uint64) addr.Address {
+	address, err := addr.NewIDAddress(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return address
+}

--- a/actors/builtin/cron/cron_test.go
+++ b/actors/builtin/cron/cron_test.go
@@ -4,22 +4,22 @@ import (
 	"context"
 	"testing"
 
-	addr "github.com/filecoin-project/go-address"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/filecoin-project/specs-actors/actors/abi"
-	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	abi "github.com/filecoin-project/specs-actors/actors/abi"
+	big "github.com/filecoin-project/specs-actors/actors/abi/big"
 	builtin "github.com/filecoin-project/specs-actors/actors/builtin"
 	cron "github.com/filecoin-project/specs-actors/actors/builtin/cron"
-	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
-	"github.com/filecoin-project/specs-actors/actors/util/adt"
+	exitcode "github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	adt "github.com/filecoin-project/specs-actors/actors/util/adt"
 	mock "github.com/filecoin-project/specs-actors/support/mock"
+	tutil "github.com/filecoin-project/specs-actors/support/testing"
 )
 
 func TestConstructor(t *testing.T) {
 	actor := cronHarness{cron.CronActor{}, t}
 
-	receiver := newIDAddr(t, 100)
+	receiver := tutil.NewIDAddr(t, 100)
 	builder := mock.NewBuilder(context.Background(), receiver).WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
 
 	t.Run("construct with empty entries", func(t *testing.T) {
@@ -37,10 +37,10 @@ func TestConstructor(t *testing.T) {
 		rt := builder.Build(t)
 
 		var cronEntries = []cron.CronTableEntry{
-			{Receiver: newIDAddr(t, 1001), MethodNum: abi.MethodNum(1001)},
-			{Receiver: newIDAddr(t, 1002), MethodNum: abi.MethodNum(1002)},
-			{Receiver: newIDAddr(t, 1003), MethodNum: abi.MethodNum(1003)},
-			{Receiver: newIDAddr(t, 1004), MethodNum: abi.MethodNum(1004)},
+			{Receiver: tutil.NewIDAddr(t, 1001), MethodNum: abi.MethodNum(1001)},
+			{Receiver: tutil.NewIDAddr(t, 1002), MethodNum: abi.MethodNum(1002)},
+			{Receiver: tutil.NewIDAddr(t, 1003), MethodNum: abi.MethodNum(1003)},
+			{Receiver: tutil.NewIDAddr(t, 1004), MethodNum: abi.MethodNum(1004)},
 		}
 		actor.constructAndVerify(rt, cronEntries...)
 
@@ -53,7 +53,7 @@ func TestConstructor(t *testing.T) {
 func TestEpochTick(t *testing.T) {
 	actor := cronHarness{cron.CronActor{}, t}
 
-	receiver := newIDAddr(t, 100)
+	receiver := tutil.NewIDAddr(t, 100)
 	builder := mock.NewBuilder(context.Background(), receiver).WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
 
 	t.Run("epoch tick with empty entries", func(t *testing.T) {
@@ -67,10 +67,10 @@ func TestEpochTick(t *testing.T) {
 	t.Run("epoch tick with non-empty entries", func(t *testing.T) {
 		rt := builder.Build(t)
 
-		entry1 := cron.CronTableEntry{Receiver: newIDAddr(t, 1001), MethodNum: abi.MethodNum(1001)}
-		entry2 := cron.CronTableEntry{Receiver: newIDAddr(t, 1002), MethodNum: abi.MethodNum(1002)}
-		entry3 := cron.CronTableEntry{Receiver: newIDAddr(t, 1003), MethodNum: abi.MethodNum(1003)}
-		entry4 := cron.CronTableEntry{Receiver: newIDAddr(t, 1004), MethodNum: abi.MethodNum(1004)}
+		entry1 := cron.CronTableEntry{Receiver: tutil.NewIDAddr(t, 1001), MethodNum: abi.MethodNum(1001)}
+		entry2 := cron.CronTableEntry{Receiver: tutil.NewIDAddr(t, 1002), MethodNum: abi.MethodNum(1002)}
+		entry3 := cron.CronTableEntry{Receiver: tutil.NewIDAddr(t, 1003), MethodNum: abi.MethodNum(1003)}
+		entry4 := cron.CronTableEntry{Receiver: tutil.NewIDAddr(t, 1004), MethodNum: abi.MethodNum(1004)}
 
 		actor.constructAndVerify(rt, entry1, entry2, entry3, entry4)
 		// exit code should not matter
@@ -101,16 +101,4 @@ func (h *cronHarness) epochTickAndVerify(rt *mock.Runtime) {
 	ret := rt.Call(h.EpochTick, &adt.EmptyValue{}).(*adt.EmptyValue)
 	assert.Equal(h.t, &adt.EmptyValue{}, ret)
 	rt.Verify()
-}
-
-//
-// Misc. Utility Functions
-//
-
-func newIDAddr(t *testing.T, id uint64) addr.Address {
-	address, err := addr.NewIDAddress(id)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return address
 }

--- a/actors/builtin/multisig/multisig_test.go
+++ b/actors/builtin/multisig/multisig_test.go
@@ -16,15 +16,16 @@ import (
 	exitcode "github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 	adt "github.com/filecoin-project/specs-actors/actors/util/adt"
 	mock "github.com/filecoin-project/specs-actors/support/mock"
+	tutil "github.com/filecoin-project/specs-actors/support/testing"
 )
 
 func TestConstruction(t *testing.T) {
 	actor := multisig.MultiSigActor{}
 
-	receiver := newIDAddr(t, 100)
-	anne := newIDAddr(t, 101)
-	bob := newIDAddr(t, 102)
-	charlie := newIDAddr(t, 103)
+	receiver := tutil.NewIDAddr(t, 100)
+	anne := tutil.NewIDAddr(t, 101)
+	bob := tutil.NewIDAddr(t, 102)
+	charlie := tutil.NewIDAddr(t, 103)
 
 	builder := mock.NewBuilder(context.Background(), receiver).WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID)
 
@@ -80,11 +81,11 @@ func TestConstruction(t *testing.T) {
 func TestVesting(t *testing.T) {
 	actor := msActorHarness{multisig.MultiSigActor{}, t}
 
-	receiver := newIDAddr(t, 100)
-	anne := newIDAddr(t, 101)
-	bob := newIDAddr(t, 102)
-	charlie := newIDAddr(t, 103)
-	darlene := newIDAddr(t, 103)
+	receiver := tutil.NewIDAddr(t, 100)
+	anne := tutil.NewIDAddr(t, 101)
+	bob := tutil.NewIDAddr(t, 102)
+	charlie := tutil.NewIDAddr(t, 103)
+	darlene := tutil.NewIDAddr(t, 103)
 
 	const unlockDuration = 10
 	var multisigInitialBalance = abi.NewTokenAmount(100)
@@ -191,10 +192,10 @@ func TestVesting(t *testing.T) {
 func TestPropose(t *testing.T) {
 	actor := msActorHarness{multisig.MultiSigActor{}, t}
 
-	receiver := newIDAddr(t, 100)
-	anne := newIDAddr(t, 101)
-	bob := newIDAddr(t, 102)
-	chuck := newIDAddr(t, 103)
+	receiver := tutil.NewIDAddr(t, 100)
+	anne := tutil.NewIDAddr(t, 101)
+	bob := tutil.NewIDAddr(t, 102)
+	chuck := tutil.NewIDAddr(t, 103)
 
 	const noUnlockDuration = int64(0)
 	var sendValue = abi.NewTokenAmount(10)
@@ -258,7 +259,7 @@ func TestPropose(t *testing.T) {
 
 	t.Run("fail propose from non-signer", func(t *testing.T) {
 		// non-signer address
-		richard := newIDAddr(t, 105)
+		richard := tutil.NewIDAddr(t, 105)
 		const numApprovals = int64(2)
 
 		rt := builder.Build(t)
@@ -280,10 +281,10 @@ func TestPropose(t *testing.T) {
 func TestApprove(t *testing.T) {
 	actor := msActorHarness{multisig.MultiSigActor{}, t}
 
-	receiver := newIDAddr(t, 100)
-	anne := newIDAddr(t, 101)
-	bob := newIDAddr(t, 102)
-	chuck := newIDAddr(t, 103)
+	receiver := tutil.NewIDAddr(t, 100)
+	anne := tutil.NewIDAddr(t, 101)
+	bob := tutil.NewIDAddr(t, 102)
+	chuck := tutil.NewIDAddr(t, 103)
 
 	const noUnlockDuration = int64(0)
 	const numApprovals = int64(2)
@@ -385,7 +386,7 @@ func TestApprove(t *testing.T) {
 
 	t.Run("fail to approve transaction by non-signer", func(t *testing.T) {
 		// non-signer address
-		richard := newIDAddr(t, 105)
+		richard := tutil.NewIDAddr(t, 105)
 		rt := builder.Build(t)
 
 		actor.constructAndVerify(rt, numApprovals, noUnlockDuration, signers...)
@@ -416,11 +417,11 @@ func TestApprove(t *testing.T) {
 func TestCancel(t *testing.T) {
 	actor := msActorHarness{multisig.MultiSigActor{}, t}
 
-	richard := newIDAddr(t, 104)
-	receiver := newIDAddr(t, 100)
-	anne := newIDAddr(t, 101)
-	bob := newIDAddr(t, 102)
-	chuck := newIDAddr(t, 103)
+	richard := tutil.NewIDAddr(t, 104)
+	receiver := tutil.NewIDAddr(t, 100)
+	anne := tutil.NewIDAddr(t, 101)
+	bob := tutil.NewIDAddr(t, 102)
+	chuck := tutil.NewIDAddr(t, 103)
 
 	const noUnlockDuration = int64(0)
 	const numApprovals = int64(2)
@@ -558,10 +559,10 @@ type addSignerTestCase struct {
 func TestAddSigner(t *testing.T) {
 	actor := msActorHarness{multisig.MultiSigActor{}, t}
 
-	multisigWalletAdd := newIDAddr(t, 100)
-	anne := newIDAddr(t, 101)
-	bob := newIDAddr(t, 102)
-	chuck := newIDAddr(t, 103)
+	multisigWalletAdd := tutil.NewIDAddr(t, 100)
+	anne := tutil.NewIDAddr(t, 101)
+	bob := tutil.NewIDAddr(t, 102)
+	chuck := tutil.NewIDAddr(t, 103)
 	const noUnlockDuration = int64(0)
 
 	testCases := []addSignerTestCase{
@@ -648,11 +649,11 @@ type removeSignerTestCase struct {
 func TestRemoveSigner(t *testing.T) {
 	actor := msActorHarness{multisig.MultiSigActor{}, t}
 
-	multisigWalletAdd := newIDAddr(t, 100)
-	anne := newIDAddr(t, 101)
-	bob := newIDAddr(t, 102)
-	chuck := newIDAddr(t, 103)
-	richard := newIDAddr(t, 104)
+	multisigWalletAdd := tutil.NewIDAddr(t, 100)
+	anne := tutil.NewIDAddr(t, 101)
+	bob := tutil.NewIDAddr(t, 102)
+	chuck := tutil.NewIDAddr(t, 103)
+	richard := tutil.NewIDAddr(t, 104)
 
 	const noUnlockDuration = int64(0)
 
@@ -761,11 +762,11 @@ type swapTestCase struct {
 func TestSwapSigners(t *testing.T) {
 	actor := msActorHarness{multisig.MultiSigActor{}, t}
 
-	multisigWalletAdd := newIDAddr(t, 100)
-	anne := newIDAddr(t, 101)
-	bob := newIDAddr(t, 102)
-	chuck := newIDAddr(t, 103)
-	darlene := newIDAddr(t, 104)
+	multisigWalletAdd := tutil.NewIDAddr(t, 100)
+	anne := tutil.NewIDAddr(t, 101)
+	bob := tutil.NewIDAddr(t, 102)
+	chuck := tutil.NewIDAddr(t, 103)
+	darlene := tutil.NewIDAddr(t, 104)
 
 	const noUnlockDuration = int64(0)
 	const numApprovals = int64(1)
@@ -829,10 +830,10 @@ type thresholdTestCase struct {
 func TestChangeThreshold(t *testing.T) {
 	actor := msActorHarness{multisig.MultiSigActor{}, t}
 
-	multisigWalletAdd := newIDAddr(t, 100)
-	anne := newIDAddr(t, 101)
-	bob := newIDAddr(t, 102)
-	chuck := newIDAddr(t, 103)
+	multisigWalletAdd := tutil.NewIDAddr(t, 100)
+	anne := tutil.NewIDAddr(t, 101)
+	bob := tutil.NewIDAddr(t, 102)
+	chuck := tutil.NewIDAddr(t, 103)
 
 	const noUnlockDuration = int64(0)
 	var initialSigner = []addr.Address{anne, bob, chuck}
@@ -995,16 +996,4 @@ func (s key) Key() string {
 
 func asKey(in string) adt.Keyer {
 	return key(in)
-}
-
-//
-// Misc. Utility Functions
-//
-
-func newIDAddr(t *testing.T, id uint64) addr.Address {
-	address, err := addr.NewIDAddress(id)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return address
 }

--- a/actors/builtin/storage_power/storage_power_test.go
+++ b/actors/builtin/storage_power/storage_power_test.go
@@ -2,26 +2,27 @@ package storage_power_test
 
 import (
 	"context"
-	"github.com/filecoin-project/specs-actors/actors/abi"
-	"github.com/ipfs/go-cid"
-	"github.com/stretchr/testify/require"
 	"testing"
 
-	addr "github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/specs-actors/actors/builtin"
-	"github.com/filecoin-project/specs-actors/actors/builtin/storage_power"
-	"github.com/filecoin-project/specs-actors/actors/util/adt"
-	"github.com/filecoin-project/specs-actors/support/mock"
-	"github.com/stretchr/testify/assert"
+	cid "github.com/ipfs/go-cid"
+	assert "github.com/stretchr/testify/assert"
+	require "github.com/stretchr/testify/require"
+
+	abi "github.com/filecoin-project/specs-actors/actors/abi"
+	builtin "github.com/filecoin-project/specs-actors/actors/builtin"
+	storage_power "github.com/filecoin-project/specs-actors/actors/builtin/storage_power"
+	adt "github.com/filecoin-project/specs-actors/actors/util/adt"
+	mock "github.com/filecoin-project/specs-actors/support/mock"
+	tutil "github.com/filecoin-project/specs-actors/support/testing"
 )
 
 func TestConstruction(t *testing.T) {
 	actor := spActorHarness{storage_power.StoragePowerActor{}, t}
-	powerActor := newIDAddr(t, 100)
-	owner1 := newIDAddr(t, 101)
-	worker1 := newIDAddr(t, 102)
-	miner1 := newIDAddr(t, 103)
-	unused := newIDAddr(t, 104)
+	powerActor := tutil.NewIDAddr(t, 100)
+	owner1 := tutil.NewIDAddr(t, 101)
+	worker1 := tutil.NewIDAddr(t, 102)
+	miner1 := tutil.NewIDAddr(t, 103)
+	unused := tutil.NewIDAddr(t, 104)
 
 	builder := mock.NewBuilder(context.Background(), powerActor).WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
 
@@ -46,7 +47,7 @@ func TestConstruction(t *testing.T) {
 		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
 
 		createMinerRet := &storage_power.CreateMinerReturn{
-			IDAddress:     miner1,     // miner actor id address
+			IDAddress:     miner1, // miner actor id address
 			RobustAddress: unused, // should be long miner actor address
 		}
 		rt.ExpectSend(owner1, builtin.MethodSend, createMinerParams, abi.NewTokenAmount(10), &mock.ReturnWrapper{createMinerRet}, 0)
@@ -92,14 +93,6 @@ type key string
 
 func asKey(in string) adt.Keyer {
 	return key(in)
-}
-
-func newIDAddr(t *testing.T, id uint64) addr.Address {
-	address, err := addr.NewIDAddress(id)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return address
 }
 
 func verifyEmptyMap(t testing.TB, rt *mock.Runtime, cid cid.Cid) {

--- a/support/testing/address.go
+++ b/support/testing/address.go
@@ -1,0 +1,15 @@
+package testing
+
+import (
+	"testing"
+
+	addr "github.com/filecoin-project/go-address"
+)
+
+func NewIDAddr(t *testing.T, id uint64) addr.Address {
+	address, err := addr.NewIDAddress(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return address
+}


### PR DESCRIPTION
### What
- Add unit tests for the cron actor: constructor and epoch tick.
- Extract newIDAddr to testing utils package and refactor all tests to use it.