### PR TITLE
fix(abi/big): match CBOR Marshalling to impls

### DIFF
--- a/actors/abi/big/int.go
+++ b/actors/abi/big/int.go
@@ -247,3 +247,7 @@ func (bi *Int) UnmarshalCBOR(br io.Reader) error {
 func (bi *Int) IsZero() bool {
 	return bi.Int.Sign() == 0
 }
+
+func (bi *Int) Nil() bool {
+	return bi.Int == nil
+}

--- a/actors/abi/big/int.go
+++ b/actors/abi/big/int.go
@@ -127,6 +127,10 @@ func (bi Int) Equals(o Int) bool {
 }
 
 func (bi *Int) MarshalJSON() ([]byte, error) {
+	if bi.Int == nil {
+		zero := NewInt(0)
+		return json.Marshal(zero)
+	}
 	return json.Marshal(bi.String())
 }
 
@@ -185,7 +189,8 @@ func FromCborBytes(buf []byte) (Int, error) {
 
 func (bi *Int) MarshalCBOR(w io.Writer) error {
 	if bi.Int == nil {
-		return fmt.Errorf("failed to Marshal to CBOR, big is nil")
+		zero := NewInt(0)
+		return zero.MarshalCBOR(w)
 	}
 
 	enc, err := bi.CborBytes()

--- a/actors/abi/big/int_test.go
+++ b/actors/abi/big/int_test.go
@@ -2,7 +2,12 @@ package big
 
 import (
 	"bytes"
+	"fmt"
+	"math/big"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBigIntSerializationRoundTrip(t *testing.T) {
@@ -31,4 +36,110 @@ func TestBigIntSerializationRoundTrip(t *testing.T) {
 		}
 
 	}
+
+	// nil check
+	bi := Int{}
+	var buf bytes.Buffer
+	err := bi.MarshalCBOR(&buf)
+	require.NoError(t, err)
+
+	assert.Equal(t, "@", buf.String())
+
+}
+
+func TestNewInt(t *testing.T) {
+	a := int64(999)
+	ta := NewInt(a)
+	b := big.NewInt(999)
+	tb := Int{Int: b}
+	assert.True(t, ta.Equals(tb))
+	assert.Equal(t, "999", ta.String())
+}
+
+func TestInt_MarshalUnmarshalJSON(t *testing.T) {
+	ta := NewInt(54321)
+	tb := NewInt(0)
+
+	res, err := ta.MarshalJSON()
+	require.NoError(t, err)
+	assert.Equal(t, "\"54321\"", string(res[:]))
+
+	require.NoError(t, tb.UnmarshalJSON(res))
+	assert.Equal(t, ta, tb)
+
+	assert.EqualError(t, tb.UnmarshalJSON([]byte("123garbage"[:])), "invalid character 'g' after top-level value")
+
+	tnil := Int{}
+	s, err := tnil.MarshalJSON()
+	require.NoError(t, err)
+	assert.Equal(t, "\"0\"", string(s))
+}
+
+func TestOperations(t *testing.T) {
+	testCases := []struct {
+		name     string
+		f        func(Int, Int) Int
+		expected Int
+	}{
+		{name: "Sum", f: Add, expected: NewInt(7000)},
+		{name: "Sub", f: Sub, expected: NewInt(3000)},
+		{name: "Mul", f: Mul, expected: NewInt(10000000)},
+		{name: "Div", f: Div, expected: NewInt(2)},
+		{name: "Mod", f: Mod, expected: NewInt(1000)},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ta := Int{Int: big.NewInt(5000)}
+			tb := Int{Int: big.NewInt(2000)}
+			assert.Equal(t, testCase.expected, testCase.f(ta, tb))
+		})
+	}
+
+	ta := NewInt(5000)
+	tb := NewInt(2000)
+	tc := NewInt(2000)
+	assert.Equal(t, Cmp(ta, tb), 1)
+	assert.Equal(t, Cmp(tb, ta), -1)
+	assert.Equal(t, Cmp(tb, tc), 0)
+	assert.True(t, ta.GreaterThan(tb))
+	assert.False(t, ta.LessThan(tb))
+	assert.True(t, tb.Equals(tc))
+
+	ta = Int{}
+	assert.True(t, ta.Nil())
+}
+
+func TestInt_Format(t *testing.T) {
+	ta := NewInt(33333000000)
+
+	s := fmt.Sprintf("%s", ta) // nolint: gosimple
+	assert.Equal(t, "33333000000", s)
+
+	s1 := fmt.Sprintf("%v", ta) // nolint: gosimple
+	assert.Equal(t, "33333000000", s1)
+
+	s2 := fmt.Sprintf("%-15d", ta) // nolint: gosimple
+	assert.Equal(t, "33333000000    ", s2)
+}
+
+func TestFromBytes(t *testing.T) {
+	res := FromBytes([]byte("garbage"[:]))
+	// garbage in, garbage out
+	expected := Int{Int: big.NewInt(29099066505914213)}
+	assert.Equal(t, expected, res)
+
+	expected2 := Int{Int: big.NewInt(12345)}
+	expectedRes := expected2.Bytes()
+	res = FromBytes(expectedRes)
+	assert.Equal(t, expected2, res)
+}
+
+func TestFromString(t *testing.T) {
+	_, err := FromString("garbage")
+	assert.EqualError(t, err, "failed to parse string as a big int")
+
+	res, err := FromString("12345")
+	require.NoError(t, err)
+	expected := Int{Int: big.NewInt(12345)}
+	assert.Equal(t, expected, res)
 }


### PR DESCRIPTION
# Goals

Many data structs in Lotus/go-fil-markets have big int values that are treated as essentially optional -- they can be set or not. However, currently, the zero value for big.Int (i.e. nothing set, internal Int data member == nil) throws an error when marshalled to CBOR. This will cause several errors in existing lotus & go-fil-markets code that don't show until run (or tested). It also might require extensive code changes.

# Implementation

This PR changes the MarshalJSON & MarshalCBOR methods of big.Int to match big.Int from Lotus & tokenamount.Tokenamount from go-fil-markets, which both do not error when marshalling CBOR for an empty big.Int.

# For DIscussion

I am not sure this is the right solution -- rather it's a strawman to start a converation. Because the difference blocks, or at least makes difficult, moving much of the spec actor types into go-fil-markets.

I believe the implementations are treating big.Int{} as essentially an optional type -- i.e. value undefined or value empty. I realize the cbor encode/decode is not 1-to-1 I think, and maybe that is worth looking at. Or maybe defining an explicit big.OptionalInt? It's possible the lotus folks have already come up with a solution and are trying something different for their code.

cc: @magik6k @whyrusleeping @anorth