### PR TITLE
Frrist/init actor basic unit test

### DIFF
--- a/actors/builtin/init/init_test.go
+++ b/actors/builtin/init/init_test.go
@@ -68,14 +68,21 @@ func TestExec(t *testing.T) {
 		rt.SetNewActorAddress(uniqueAddr)
 
 		// next id address
-		expectActor := tutil.NewIDAddr(t, 100)
-		rt.ExpectCreateActor(builtin.PaymentChannelActorCodeID, expectActor)
+		expectedIdAddr := tutil.NewIDAddr(t, 100)
+		rt.ExpectCreateActor(builtin.PaymentChannelActorCodeID, expectedIdAddr)
 
 		// expect anne creating a payment channel to trigger a send to the payment channels constructor
-		rt.ExpectSend(expectActor, builtin.MethodConstructor, fakeParams, balance, nil, exitcode.Ok)
+		rt.ExpectSend(expectedIdAddr, builtin.MethodConstructor, fakeParams, balance, nil, exitcode.Ok)
 		execRet := actor.execAndVerify(rt, builtin.PaymentChannelActorCodeID, fakeParams)
 		assert.Equal(t, uniqueAddr, execRet.RobustAddress)
-		assert.Equal(t, expectActor, execRet.IDAddress)
+		assert.Equal(t, expectedIdAddr, execRet.IDAddress)
+
+		var st _init.InitActorState
+		rt.GetState(&st)
+		actualIdAddr, err := st.ResolveAddress(rt.Store(), uniqueAddr)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedIdAddr, actualIdAddr)
+
 	})
 
 	t.Run("happy path exec create storage miner", func(t *testing.T) {
@@ -92,14 +99,27 @@ func TestExec(t *testing.T) {
 		rt.SetNewActorAddress(uniqueAddr)
 
 		// next id address
-		expectActor := tutil.NewIDAddr(t, 100)
-		rt.ExpectCreateActor(builtin.StorageMinerActorCodeID, expectActor)
+		expectedIdAddr := tutil.NewIDAddr(t, 100)
+		rt.ExpectCreateActor(builtin.StorageMinerActorCodeID, expectedIdAddr)
 
 		// expect storage power actor creating a storage miner actor to trigger a send to the storage miner actors constructor
-		rt.ExpectSend(expectActor, builtin.MethodConstructor, fakeParams, big.Zero(), nil, exitcode.Ok)
+		rt.ExpectSend(expectedIdAddr, builtin.MethodConstructor, fakeParams, big.Zero(), nil, exitcode.Ok)
 		execRet := actor.execAndVerify(rt, builtin.StorageMinerActorCodeID, fakeParams)
 		assert.Equal(t, uniqueAddr, execRet.RobustAddress)
-		assert.Equal(t, expectActor, execRet.IDAddress)
+		assert.Equal(t, expectedIdAddr, execRet.IDAddress)
+
+		var st _init.InitActorState
+		rt.GetState(&st)
+		actualIdAddr, err := st.ResolveAddress(rt.Store(), uniqueAddr)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedIdAddr, actualIdAddr)
+
+		// should return the same address if not able to resolve
+		expUnknowAddr := tutil.NewActorAddr(t, "flurbo")
+		actualUnknownAddr, err := st.ResolveAddress(rt.Store(), expUnknowAddr)
+		assert.NoError(t, err)
+		assert.Equal(t, expUnknowAddr, actualUnknownAddr)
+
 	})
 
 }

--- a/actors/builtin/init/init_test.go
+++ b/actors/builtin/init/init_test.go
@@ -39,7 +39,6 @@ func TestExec(t *testing.T) {
 		actor.constructAndVerify(rt)
 
 		rt.SetCaller(anne, builtin.AccountActorCodeID)
-		rt.SetActorCodeCID(anne, builtin.AccountActorCodeID)
 		rt.ExpectAbort(exitcode.ErrForbidden, func() {
 			actor.execAndVerify(rt, builtin.AccountActorCodeID, []byte{})
 		})
@@ -60,7 +59,6 @@ func TestExec(t *testing.T) {
 		rt.SetCaller(anne, builtin.AccountActorCodeID)
 		rt.SetBalance(balance)
 		rt.SetReceived(balance)
-		rt.SetActorCodeCID(anne, builtin.AccountActorCodeID)
 
 		// re-org-stable address of the payment channel actor
 		uniqueAddr := tutil.NewActorAddr(t, "paych")
@@ -91,7 +89,6 @@ func TestExec(t *testing.T) {
 
 		// only the storage power actor can create a miner
 		rt.SetCaller(builtin.StoragePowerActorAddr, builtin.StoragePowerActorCodeID)
-		rt.SetActorCodeCID(builtin.StoragePowerActorAddr, builtin.StoragePowerActorCodeID)
 
 		// re-org-stable address of the storage miner actor
 		uniqueAddr := tutil.NewActorAddr(t, "miner")

--- a/actors/builtin/init/init_test.go
+++ b/actors/builtin/init/init_test.go
@@ -101,7 +101,6 @@ func TestExec(t *testing.T) {
 		actualIdAddr2, err := st2.ResolveAddress(rt.Store(), uniqueAddr2)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedIdAddr2, actualIdAddr2)
-
 	})
 
 	t.Run("happy path exec create storage miner", func(t *testing.T) {
@@ -137,7 +136,6 @@ func TestExec(t *testing.T) {
 		actualUnknownAddr, err := st.ResolveAddress(rt.Store(), expUnknowAddr)
 		assert.NoError(t, err)
 		assert.Equal(t, expUnknowAddr, actualUnknownAddr)
-
 	})
 
 }

--- a/actors/builtin/init/init_test.go
+++ b/actors/builtin/init/init_test.go
@@ -40,7 +40,6 @@ func TestExec(t *testing.T) {
 
 		rt.SetCaller(anne, builtin.AccountActorCodeID)
 		rt.SetActorCodeCID(anne, builtin.AccountActorCodeID)
-		// TODO test case where `ok` == false, current impl panics
 		rt.ExpectAbort(exitcode.ErrForbidden, func() {
 			actor.execAndVerify(rt, builtin.AccountActorCodeID, []byte{})
 		})

--- a/actors/builtin/init/init_test.go
+++ b/actors/builtin/init/init_test.go
@@ -1,1 +1,134 @@
 package init_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ipfs/go-cid"
+	assert "github.com/stretchr/testify/assert"
+
+	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	builtin "github.com/filecoin-project/specs-actors/actors/builtin"
+	_init "github.com/filecoin-project/specs-actors/actors/builtin/init"
+	"github.com/filecoin-project/specs-actors/actors/runtime"
+	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	adt "github.com/filecoin-project/specs-actors/actors/util/adt"
+	mock "github.com/filecoin-project/specs-actors/support/mock"
+	tutil "github.com/filecoin-project/specs-actors/support/testing"
+)
+
+func TestConstructor(t *testing.T) {
+	actor := initHarness{_init.InitActor{}, t}
+
+	receiver := tutil.NewIDAddr(t, 1000)
+	builder := mock.NewBuilder(context.Background(), receiver).WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
+	rt := builder.Build(t)
+	actor.constructAndVerify(rt)
+}
+
+func TestExec(t *testing.T) {
+	actor := initHarness{_init.InitActor{}, t}
+
+	receiver := tutil.NewIDAddr(t, 1000)
+	anne := tutil.NewIDAddr(t, 1001)
+	builder := mock.NewBuilder(context.Background(), receiver).WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
+
+	t.Run("abort actors that cannot call exec", func(t *testing.T) {
+		rt := builder.Build(t)
+		actor.constructAndVerify(rt)
+
+		rt.SetCaller(anne, builtin.AccountActorCodeID)
+		rt.SetActorCodeCID(anne, builtin.AccountActorCodeID)
+		// TODO test case where `ok` == false, current impl panics
+		rt.ExpectAbort(exitcode.ErrForbidden, func() {
+			actor.execAndVerify(rt, builtin.AccountActorCodeID, []byte{})
+		})
+		rt.ExpectAbort(exitcode.ErrForbidden, func() {
+			actor.execAndVerify(rt, cid.Undef, []byte{})
+		})
+	})
+
+	var fakeParams = runtime.CBORBytes([]byte{'D', 'E', 'A', 'D', 'B', 'E', 'E', 'F'})
+	var balance = abi.NewTokenAmount(100)
+
+	t.Run("happy path exec create payment channel", func(t *testing.T) {
+		rt := builder.Build(t)
+
+		actor.constructAndVerify(rt)
+
+		// anne the account actor with 100 FIL in their balance is going to create a payment channel actor with 100 FIL.
+		rt.SetCaller(anne, builtin.AccountActorCodeID)
+		rt.SetBalance(balance)
+		rt.SetReceived(balance)
+		rt.SetActorCodeCID(anne, builtin.AccountActorCodeID)
+
+		// re-org-stable address of the payment channel actor
+		uniqueAddr := tutil.NewActorAddr(t, "paych")
+		rt.SetNewActorAddress(uniqueAddr)
+
+		// next id address
+		expectActor := tutil.NewIDAddr(t, 100)
+		rt.ExpectCreateActor(builtin.PaymentChannelActorCodeID, expectActor)
+
+		// expect anne creating a payment channel to trigger a send to the payment channels constructor
+		rt.ExpectSend(expectActor, builtin.MethodConstructor, fakeParams, balance, nil, exitcode.Ok)
+		execRet := actor.execAndVerify(rt, builtin.PaymentChannelActorCodeID, fakeParams)
+		assert.Equal(t, uniqueAddr, execRet.RobustAddress)
+		assert.Equal(t, expectActor, execRet.IDAddress)
+	})
+
+	t.Run("happy path exec create storage miner", func(t *testing.T) {
+		rt := builder.Build(t)
+
+		actor.constructAndVerify(rt)
+
+		// only the storage power actor can create a miner
+		rt.SetCaller(builtin.StoragePowerActorAddr, builtin.StoragePowerActorCodeID)
+		rt.SetActorCodeCID(builtin.StoragePowerActorAddr, builtin.StoragePowerActorCodeID)
+
+		// re-org-stable address of the storage miner actor
+		uniqueAddr := tutil.NewActorAddr(t, "miner")
+		rt.SetNewActorAddress(uniqueAddr)
+
+		// next id address
+		expectActor := tutil.NewIDAddr(t, 100)
+		rt.ExpectCreateActor(builtin.StorageMinerActorCodeID, expectActor)
+
+		// expect storage power actor creating a storage miner actor to trigger a send to the storage miner actors constructor
+		rt.ExpectSend(expectActor, builtin.MethodConstructor, fakeParams, big.Zero(), nil, exitcode.Ok)
+		execRet := actor.execAndVerify(rt, builtin.StorageMinerActorCodeID, fakeParams)
+		assert.Equal(t, uniqueAddr, execRet.RobustAddress)
+		assert.Equal(t, expectActor, execRet.IDAddress)
+	})
+
+}
+
+type initHarness struct {
+	_init.InitActor
+	t testing.TB
+}
+
+func (h *initHarness) constructAndVerify(rt *mock.Runtime) {
+	rt.ExpectValidateCallerAddr(builtin.SystemActorAddr)
+	ret := rt.Call(h.Constructor, &adt.EmptyValue{}).(*adt.EmptyValue)
+	assert.Equal(h.t, &adt.EmptyValue{}, ret)
+	rt.Verify()
+
+	var st _init.InitActorState
+	rt.GetState(&st)
+	emptyMap := adt.AsMap(rt.Store(), st.AddressMap)
+	assert.Equal(h.t, emptyMap.Root(), st.AddressMap)
+	assert.Equal(h.t, abi.ActorID(builtin.FirstNonSingletonActorId), st.NextID)
+	assert.Equal(h.t, "mock", st.NetworkName)
+}
+
+func (h *initHarness) execAndVerify(rt *mock.Runtime, codeID cid.Cid, constructorParams []byte) *_init.ExecReturn {
+	rt.ExpectValidateCallerAny()
+	ret := rt.Call(h.Exec, &_init.ExecParams{
+		CodeID:            codeID,
+		ConstructorParams: constructorParams,
+	}).(*_init.ExecReturn)
+	rt.Verify()
+	return ret
+}

--- a/actors/builtin/init/init_test.go
+++ b/actors/builtin/init/init_test.go
@@ -4,22 +4,22 @@ import (
 	"context"
 	"testing"
 
-	"github.com/ipfs/go-cid"
+	cid "github.com/ipfs/go-cid"
 	assert "github.com/stretchr/testify/assert"
 
-	"github.com/filecoin-project/specs-actors/actors/abi"
-	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	abi "github.com/filecoin-project/specs-actors/actors/abi"
+	big "github.com/filecoin-project/specs-actors/actors/abi/big"
 	builtin "github.com/filecoin-project/specs-actors/actors/builtin"
-	_init "github.com/filecoin-project/specs-actors/actors/builtin/init"
-	"github.com/filecoin-project/specs-actors/actors/runtime"
-	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	init_ "github.com/filecoin-project/specs-actors/actors/builtin/init"
+	runtime "github.com/filecoin-project/specs-actors/actors/runtime"
+	exitcode "github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 	adt "github.com/filecoin-project/specs-actors/actors/util/adt"
 	mock "github.com/filecoin-project/specs-actors/support/mock"
 	tutil "github.com/filecoin-project/specs-actors/support/testing"
 )
 
 func TestConstructor(t *testing.T) {
-	actor := initHarness{_init.InitActor{}, t}
+	actor := initHarness{init_.InitActor{}, t}
 
 	receiver := tutil.NewIDAddr(t, 1000)
 	builder := mock.NewBuilder(context.Background(), receiver).WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
@@ -28,7 +28,7 @@ func TestConstructor(t *testing.T) {
 }
 
 func TestExec(t *testing.T) {
-	actor := initHarness{_init.InitActor{}, t}
+	actor := initHarness{init_.InitActor{}, t}
 
 	receiver := tutil.NewIDAddr(t, 1000)
 	anne := tutil.NewIDAddr(t, 1001)
@@ -77,7 +77,7 @@ func TestExec(t *testing.T) {
 		assert.Equal(t, uniqueAddr, execRet.RobustAddress)
 		assert.Equal(t, expectedIdAddr, execRet.IDAddress)
 
-		var st _init.InitActorState
+		var st init_.InitActorState
 		rt.GetState(&st)
 		actualIdAddr, err := st.ResolveAddress(rt.Store(), uniqueAddr)
 		assert.NoError(t, err)
@@ -108,7 +108,7 @@ func TestExec(t *testing.T) {
 		assert.Equal(t, uniqueAddr, execRet.RobustAddress)
 		assert.Equal(t, expectedIdAddr, execRet.IDAddress)
 
-		var st _init.InitActorState
+		var st init_.InitActorState
 		rt.GetState(&st)
 		actualIdAddr, err := st.ResolveAddress(rt.Store(), uniqueAddr)
 		assert.NoError(t, err)
@@ -125,7 +125,7 @@ func TestExec(t *testing.T) {
 }
 
 type initHarness struct {
-	_init.InitActor
+	init_.InitActor
 	t testing.TB
 }
 
@@ -135,7 +135,7 @@ func (h *initHarness) constructAndVerify(rt *mock.Runtime) {
 	assert.Equal(h.t, &adt.EmptyValue{}, ret)
 	rt.Verify()
 
-	var st _init.InitActorState
+	var st init_.InitActorState
 	rt.GetState(&st)
 	emptyMap := adt.AsMap(rt.Store(), st.AddressMap)
 	assert.Equal(h.t, emptyMap.Root(), st.AddressMap)
@@ -143,12 +143,12 @@ func (h *initHarness) constructAndVerify(rt *mock.Runtime) {
 	assert.Equal(h.t, "mock", st.NetworkName)
 }
 
-func (h *initHarness) execAndVerify(rt *mock.Runtime, codeID cid.Cid, constructorParams []byte) *_init.ExecReturn {
+func (h *initHarness) execAndVerify(rt *mock.Runtime, codeID cid.Cid, constructorParams []byte) *init_.ExecReturn {
 	rt.ExpectValidateCallerAny()
-	ret := rt.Call(h.Exec, &_init.ExecParams{
+	ret := rt.Call(h.Exec, &init_.ExecParams{
 		CodeID:            codeID,
 		ConstructorParams: constructorParams,
-	}).(*_init.ExecReturn)
+	}).(*init_.ExecReturn)
 	rt.Verify()
 	return ret
 }

--- a/actors/builtin/init/init_test.go
+++ b/actors/builtin/init/init_test.go
@@ -56,7 +56,7 @@ func TestExec(t *testing.T) {
 
 		actor.constructAndVerify(rt)
 
-		// anne the account actor with 100 FIL in their balance is going to create a payment channel actor with 100 FIL.
+		// anne execs a payment channel actor with 100 FIL.
 		rt.SetCaller(anne, builtin.AccountActorCodeID)
 		rt.SetBalance(balance)
 		rt.SetReceived(balance)

--- a/support/mock/builder.go
+++ b/support/mock/builder.go
@@ -31,14 +31,16 @@ func NewBuilder(ctx context.Context, receiver addr.Address) *RuntimeBuilder {
 		balance:       abi.NewTokenAmount(0),
 		valueReceived: abi.NewTokenAmount(0),
 
+		actorCodeCIDs: make(map[addr.Address]cid.Cid),
+		newActorAddr:  addr.Undef,
+
 		t:                        nil, // Initialized at Build()
 		expectValidateCallerAny:  false,
 		expectValidateCallerAddr: nil,
 		expectValidateCallerType: nil,
+		expectCreateActor:        nil,
 
-		expectSends:   make([]*expectedMessage, 0),
-		actorCodeCIDs: make(map[addr.Address]cid.Cid),
-		newActorAddr:  addr.Undef,
+		expectSends: make([]*expectedMessage, 0),
 	}
 	return &RuntimeBuilder{m}
 }

--- a/support/mock/builder.go
+++ b/support/mock/builder.go
@@ -36,7 +36,9 @@ func NewBuilder(ctx context.Context, receiver addr.Address) *RuntimeBuilder {
 		expectValidateCallerAddr: nil,
 		expectValidateCallerType: nil,
 
-		expectSends: make([]*expectedMessage, 0),
+		expectSends:   make([]*expectedMessage, 0),
+		actorCodeCIDs: make(map[addr.Address]cid.Cid),
+		newActorAddr:  addr.Undef,
 	}
 	return &RuntimeBuilder{m}
 }

--- a/support/mock/mockrt.go
+++ b/support/mock/mockrt.go
@@ -49,10 +49,10 @@ type Runtime struct {
 	expectValidateCallerAddr []addr.Address
 	expectValidateCallerType []cid.Cid
 	expectSends              []*expectedMessage
-	expectCreateActor        *expectCreateActorPair
+	expectCreateActor        *expectCreateActor
 }
 
-type expectCreateActorPair struct {
+type expectCreateActor struct {
 	codeId  cid.Cid
 	address addr.Address
 }
@@ -255,8 +255,8 @@ func (rt *Runtime) CreateActor(codeId cid.Cid, address addr.Address) {
 		rt.t.Fatal("unexpected call to create actor")
 	}
 	if !rt.expectCreateActor.codeId.Equals(codeId) || rt.expectCreateActor.address != address {
-		rt.t.Errorf("unexpected actor being created, expected code: %v address: %v, actual code: %v address: %v",
-			rt.expectCreateActor.codeId.String(), rt.expectCreateActor.address.String(), codeId.String(), address.String())
+		rt.t.Errorf("unexpected actor being created, expected code: %s address: %s, actual code: %s address: %s",
+			rt.expectCreateActor.codeId, rt.expectCreateActor.address, codeId, address)
 	}
 	defer func() {
 		rt.expectCreateActor = nil
@@ -450,7 +450,7 @@ func (rt *Runtime) ExpectSend(toAddr addr.Address, methodNum abi.MethodNum, para
 }
 
 func (rt *Runtime) ExpectCreateActor(codeId cid.Cid, address addr.Address) {
-	rt.expectCreateActor = &expectCreateActorPair{
+	rt.expectCreateActor = &expectCreateActor{
 		codeId:  codeId,
 		address: address,
 	}

--- a/support/mock/mockrt.go
+++ b/support/mock/mockrt.go
@@ -403,6 +403,7 @@ func (m *expectedMessage) String() string {
 func (rt *Runtime) SetCaller(address addr.Address, actorType cid.Cid) {
 	rt.caller = address
 	rt.callerType = actorType
+	rt.actorCodeCIDs[address] = actorType
 }
 
 func (rt *Runtime) SetBalance(amt abi.TokenAmount) {
@@ -415,10 +416,6 @@ func (rt *Runtime) SetReceived(amt abi.TokenAmount) {
 
 func (rt *Runtime) SetEpoch(epoch abi.ChainEpoch) {
 	rt.epoch = epoch
-}
-
-func (rt *Runtime) SetActorCodeCID(actAddr addr.Address, codeCID cid.Cid) {
-	rt.actorCodeCIDs[actAddr] = codeCID
 }
 
 func (rt *Runtime) SetNewActorAddress(actAddr addr.Address) {

--- a/support/testing/address.go
+++ b/support/testing/address.go
@@ -44,3 +44,11 @@ func NewActorAddr(t *testing.T, data string) addr.Address {
 	}
 	return address
 }
+
+func NewActorAddr(t *testing.T, data string) addr.Address {
+	address, err := addr.NewActorAddress([]byte(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return address
+}

--- a/support/testing/address.go
+++ b/support/testing/address.go
@@ -44,11 +44,3 @@ func NewActorAddr(t *testing.T, data string) addr.Address {
 	}
 	return address
 }
-
-func NewActorAddr(t *testing.T, data string) addr.Address {
-	address, err := addr.NewActorAddress([]byte(data))
-	if err != nil {
-		t.Fatal(err)
-	}
-	return address
-}


### PR DESCRIPTION
### What
- add a testing util method for creating an actor address.
- implemented methods in mock runtime for mocking actor creation.
- add initial set of tests for the init actor:
  - Constructor
  - Actors that cannot exec the init actor should fail
  - Creating a payment channel via init actor
  - Creating a miner via init actor
  - Ensure all addresses can be resolved to an ID via ResolveAddress and address that cannot be resolved are returned.