### PR TITLE
Patch/power update [WIP]

### DIFF
--- a/actors/builtin/methods.go
+++ b/actors/builtin/methods.go
@@ -110,7 +110,6 @@ const (
 	Method_StoragePowerActor_ReportConsensusFault
 
 	// Internal mechanism events
-	Method_StoragePowerActor_OnSectorProveCommit
 	Method_StoragePowerActor_OnSectorTemporaryFaultEffectiveBegin
 	Method_StoragePowerActor_OnSectorTemporaryFaultEffectiveEnd
 	Method_StoragePowerActor_OnSectorModifyWeightDesc

--- a/actors/builtin/storage_miner/cbor_gen.go
+++ b/actors/builtin/storage_miner/cbor_gen.go
@@ -29,12 +29,6 @@ func (t *StorageMinerActorState) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("failed to write cid field t.PreCommittedSectors: %w", err)
 	}
 
-	// t.Sectors (cid.Cid) (struct)
-
-	if err := cbg.WriteCid(w, t.Sectors); err != nil {
-		return xerrors.Errorf("failed to write cid field t.Sectors: %w", err)
-	}
-
 	// t.FaultSet (abi.BitField) (struct)
 	if err := t.FaultSet.MarshalCBOR(w); err != nil {
 		return err
@@ -83,18 +77,6 @@ func (t *StorageMinerActorState) UnmarshalCBOR(r io.Reader) error {
 		}
 
 		t.PreCommittedSectors = c
-
-	}
-	// t.Sectors (cid.Cid) (struct)
-
-	{
-
-		c, err := cbg.ReadCid(br)
-		if err != nil {
-			return xerrors.Errorf("failed to read cid field t.Sectors: %w", err)
-		}
-
-		t.Sectors = c
 
 	}
 	// t.FaultSet (abi.BitField) (struct)

--- a/actors/builtin/storage_miner/storage_miner_actor_state.go
+++ b/actors/builtin/storage_miner/storage_miner_actor_state.go
@@ -150,7 +150,7 @@ func (st *StorageMinerActorState) getPrecommittedSector(store adt.Store, sectorN
 	return &info, found, nil
 }
 
-func (st *StorageMinerActorState) deletePrecommitttedSector(store adt.Store, sectorNo abi.SectorNumber) error {
+func (st *StorageMinerActorState) deletePrecommittedSector(store adt.Store, sectorNo abi.SectorNumber) error {
 	precommitted := adt.AsMap(store, st.PreCommittedSectors)
 	err := precommitted.Delete(adt.IntKey(sectorNo))
 	if err != nil {

--- a/actors/builtin/storage_power/cbor_gen.go
+++ b/actors/builtin/storage_power/cbor_gen.go
@@ -747,49 +747,6 @@ func (t *OnSectorModifyWeightDescParams) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
-func (t *OnSectorProveCommitParams) MarshalCBOR(w io.Writer) error {
-	if t == nil {
-		_, err := w.Write(cbg.CborNull)
-		return err
-	}
-	if _, err := w.Write([]byte{129}); err != nil {
-		return err
-	}
-
-	// t.Weight (storage_power.SectorStorageWeightDesc) (struct)
-	if err := t.Weight.MarshalCBOR(w); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (t *OnSectorProveCommitParams) UnmarshalCBOR(r io.Reader) error {
-	br := cbg.GetPeeker(r)
-
-	maj, extra, err := cbg.CborReadHeader(br)
-	if err != nil {
-		return err
-	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
-	}
-
-	if extra != 1 {
-		return fmt.Errorf("cbor input had wrong number of fields")
-	}
-
-	// t.Weight (storage_power.SectorStorageWeightDesc) (struct)
-
-	{
-
-		if err := t.Weight.UnmarshalCBOR(br); err != nil {
-			return err
-		}
-
-	}
-	return nil
-}
-
 func (t *ReportConsensusFaultParams) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)


### PR DESCRIPTION
Still a long way to go but idea is this:
We have:
  - `preCommitSectors`: preCommitted
  -  `commitSet`: Committed, not SPoSted
  - `provingSet`: now SPoSted. Can be used for EPoSt
  - `PoStState.ChallengedSectors`: from `provingSet` + `commitSet` challenged as part of SPoSt.

States transition as follows:
- Seal: `preComm` -> `commitSet`
- SPoSt: `commitSet` -> `provingSet`
- EPoSt: `using only provingSet`
- Fault: `provingSet` -> `commitSet`

Thereafter, in this PR:
- Power only comes from provingSet