### PR TITLE
Implement a placeholder constant block reward function, removing dependence on pledge collateral.

### DIFF
--- a/actors/builtin/reward/cbor_gen.go
+++ b/actors/builtin/reward/cbor_gen.go
@@ -18,7 +18,7 @@ func (t *State) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{129}); err != nil {
+	if _, err := w.Write([]byte{130}); err != nil {
 		return err
 	}
 
@@ -28,6 +28,10 @@ func (t *State) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("failed to write cid field t.RewardMap: %w", err)
 	}
 
+	// t.RewardTotal (big.Int) (struct)
+	if err := t.RewardTotal.MarshalCBOR(w); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -42,7 +46,7 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 1 {
+	if extra != 2 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -58,6 +62,15 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 		t.RewardMap = c
 
 	}
+	// t.RewardTotal (big.Int) (struct)
+
+	{
+
+		if err := t.RewardTotal.UnmarshalCBOR(br); err != nil {
+			return err
+		}
+
+	}
 	return nil
 }
 
@@ -66,7 +79,7 @@ func (t *AwardBlockRewardParams) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{133}); err != nil {
+	if _, err := w.Write([]byte{132}); err != nil {
 		return err
 	}
 
@@ -89,11 +102,6 @@ func (t *AwardBlockRewardParams) MarshalCBOR(w io.Writer) error {
 	if err := t.NominalPower.MarshalCBOR(w); err != nil {
 		return err
 	}
-
-	// t.PledgeCollateral (big.Int) (struct)
-	if err := t.PledgeCollateral.MarshalCBOR(w); err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -108,7 +116,7 @@ func (t *AwardBlockRewardParams) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 5 {
+	if extra != 4 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -144,15 +152,6 @@ func (t *AwardBlockRewardParams) UnmarshalCBOR(r io.Reader) error {
 	{
 
 		if err := t.NominalPower.UnmarshalCBOR(br); err != nil {
-			return err
-		}
-
-	}
-	// t.PledgeCollateral (big.Int) (struct)
-
-	{
-
-		if err := t.PledgeCollateral.UnmarshalCBOR(br); err != nil {
 			return err
 		}
 

--- a/actors/runtime/indices/indices.go
+++ b/actors/runtime/indices/indices.go
@@ -21,15 +21,6 @@ type Indices interface {
 		minerNominalPower abi.StoragePower,
 		minerPledgeCollateral abi.TokenAmount,
 	) abi.StoragePower
-	CurrEpochBlockReward(
-		networkIndicator big.Int,
-		networkKPI big.Int,
-		networkTime big.Int,
-	) abi.TokenAmount
-	GetCurrBlockRewardForMiner(
-		minerStoragePower abi.StoragePower,
-		minerPledgeCollateral abi.TokenAmount,
-	) abi.TokenAmount
 }
 
 type IndicesImpl struct {
@@ -85,24 +76,4 @@ func (inds *IndicesImpl) StoragePower(
 	// this is likely to change
 	// PARAM_FINISH
 	return big.Div(big.Mul(minerNominalPower, minerPledgeCollateral), requiredPledge)
-}
-
-func (inds *IndicesImpl) CurrEpochBlockReward(
-	networkIndicator big.Int,
-	networkKPI big.Int,
-	networkTime big.Int,
-) abi.TokenAmount {
-	// total block reward allocated for CurrEpoch
-	// each expected winner get an equal share of this reward
-	// computed as a function of NetworkKPI, NetworkIndicator, LastEpochReward, TotalUnmminedFIL, etc
-	// PARAM_FINISH
-	return abi.NewTokenAmount(1)
-}
-
-func (inds *IndicesImpl) GetCurrBlockRewardForMiner(
-	minerStoragePower abi.StoragePower,
-	minerPledgeCollateral abi.TokenAmount,
-) abi.TokenAmount {
-	// PARAM_FINISH
-	return abi.NewTokenAmount(1)
 }


### PR DESCRIPTION
The reward actor now tracks the state of the available treasury balance, for sanity check and future use in epoch reward calculation.