### PR TITLE
Batchify a bunch of per-sector operations to reduce messages and state transactions.

### DIFF
--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -151,7 +151,7 @@ func (st *State) getPrecommittedSector(store adt.Store, sectorNo abi.SectorNumbe
 	return &info, found, nil
 }
 
-func (st *State) deletePrecommitttedSector(store adt.Store, sectorNo abi.SectorNumber) error {
+func (st *State) deletePrecommittedSector(store adt.Store, sectorNo abi.SectorNumber) error {
 	precommitted := adt.AsMap(store, st.PreCommittedSectors)
 	err := precommitted.Delete(adt.IntKey(sectorNo))
 	if err != nil {
@@ -214,20 +214,6 @@ func (st *State) GetStorageWeightDescForSector(store adt.Store, sectorNo abi.Sec
 	}
 
 	return asStorageWeightDesc(st.Info.SectorSize, sectorInfo), nil
-}
-
-func (st *State) IsSectorInTemporaryFault(store adt.Store, sectorNo abi.SectorNumber) (bool, error) {
-	sectorInfo, found, err := st.getSector(store, sectorNo)
-	if err != nil {
-		return false, err
-	} else if !found {
-		return false, errors.Errorf("no such sector %v", sectorNo)
-	}
-	ret, err := st.FaultSet.Has(uint64(sectorNo))
-	AssertNoError(err)
-	Assert(sectorInfo.DeclaredFaultEpoch != epochUndefined)
-	Assert(sectorInfo.DeclaredFaultDuration != epochUndefined)
-	return ret, nil
 }
 
 func (st *State) ComputeProvingSet() cid.Cid {

--- a/actors/builtin/power/cbor_gen.go
+++ b/actors/builtin/power/cbor_gen.go
@@ -667,9 +667,18 @@ func (t *OnSectorTerminateParams) MarshalCBOR(w io.Writer) error {
 		}
 	}
 
-	// t.Weight (power.SectorStorageWeightDesc) (struct)
-	if err := t.Weight.MarshalCBOR(w); err != nil {
+	// t.Weights ([]power.SectorStorageWeightDesc) (slice)
+	if len(t.Weights) > cbg.MaxLength {
+		return xerrors.Errorf("Slice value in field t.Weights was too long")
+	}
+
+	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajArray, uint64(len(t.Weights)))); err != nil {
 		return err
+	}
+	for _, v := range t.Weights {
+		if err := v.MarshalCBOR(w); err != nil {
+			return err
+		}
 	}
 
 	// t.Pledge (big.Int) (struct)
@@ -719,15 +728,33 @@ func (t *OnSectorTerminateParams) UnmarshalCBOR(r io.Reader) error {
 
 		t.TerminationType = SectorTermination(extraI)
 	}
-	// t.Weight (power.SectorStorageWeightDesc) (struct)
+	// t.Weights ([]power.SectorStorageWeightDesc) (slice)
 
-	{
+	maj, extra, err = cbg.CborReadHeader(br)
+	if err != nil {
+		return err
+	}
 
-		if err := t.Weight.UnmarshalCBOR(br); err != nil {
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("t.Weights: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+	if extra > 0 {
+		t.Weights = make([]SectorStorageWeightDesc, extra)
+	}
+	for i := 0; i < int(extra); i++ {
+
+		var v SectorStorageWeightDesc
+		if err := v.UnmarshalCBOR(br); err != nil {
 			return err
 		}
 
+		t.Weights[i] = v
 	}
+
 	// t.Pledge (big.Int) (struct)
 
 	{
@@ -1101,9 +1128,18 @@ func (t *OnSectorTemporaryFaultEffectiveEndParams) MarshalCBOR(w io.Writer) erro
 		return err
 	}
 
-	// t.Weight (power.SectorStorageWeightDesc) (struct)
-	if err := t.Weight.MarshalCBOR(w); err != nil {
+	// t.Weights ([]power.SectorStorageWeightDesc) (slice)
+	if len(t.Weights) > cbg.MaxLength {
+		return xerrors.Errorf("Slice value in field t.Weights was too long")
+	}
+
+	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajArray, uint64(len(t.Weights)))); err != nil {
 		return err
+	}
+	for _, v := range t.Weights {
+		if err := v.MarshalCBOR(w); err != nil {
+			return err
+		}
 	}
 
 	// t.Pledge (big.Int) (struct)
@@ -1128,15 +1164,33 @@ func (t *OnSectorTemporaryFaultEffectiveEndParams) UnmarshalCBOR(r io.Reader) er
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
-	// t.Weight (power.SectorStorageWeightDesc) (struct)
+	// t.Weights ([]power.SectorStorageWeightDesc) (slice)
 
-	{
+	maj, extra, err = cbg.CborReadHeader(br)
+	if err != nil {
+		return err
+	}
 
-		if err := t.Weight.UnmarshalCBOR(br); err != nil {
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("t.Weights: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+	if extra > 0 {
+		t.Weights = make([]SectorStorageWeightDesc, extra)
+	}
+	for i := 0; i < int(extra); i++ {
+
+		var v SectorStorageWeightDesc
+		if err := v.UnmarshalCBOR(br); err != nil {
 			return err
 		}
 
+		t.Weights[i] = v
 	}
+
 	// t.Pledge (big.Int) (struct)
 
 	{
@@ -1158,9 +1212,18 @@ func (t *OnSectorTemporaryFaultEffectiveBeginParams) MarshalCBOR(w io.Writer) er
 		return err
 	}
 
-	// t.Weight (power.SectorStorageWeightDesc) (struct)
-	if err := t.Weight.MarshalCBOR(w); err != nil {
+	// t.Weights ([]power.SectorStorageWeightDesc) (slice)
+	if len(t.Weights) > cbg.MaxLength {
+		return xerrors.Errorf("Slice value in field t.Weights was too long")
+	}
+
+	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajArray, uint64(len(t.Weights)))); err != nil {
 		return err
+	}
+	for _, v := range t.Weights {
+		if err := v.MarshalCBOR(w); err != nil {
+			return err
+		}
 	}
 
 	// t.Pledge (big.Int) (struct)
@@ -1185,15 +1248,33 @@ func (t *OnSectorTemporaryFaultEffectiveBeginParams) UnmarshalCBOR(r io.Reader) 
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
-	// t.Weight (power.SectorStorageWeightDesc) (struct)
+	// t.Weights ([]power.SectorStorageWeightDesc) (slice)
 
-	{
+	maj, extra, err = cbg.CborReadHeader(br)
+	if err != nil {
+		return err
+	}
 
-		if err := t.Weight.UnmarshalCBOR(br); err != nil {
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("t.Weights: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+	if extra > 0 {
+		t.Weights = make([]SectorStorageWeightDesc, extra)
+	}
+	for i := 0; i < int(extra); i++ {
+
+		var v SectorStorageWeightDesc
+		if err := v.UnmarshalCBOR(br); err != nil {
 			return err
 		}
 
+		t.Weights[i] = v
 	}
+
 	// t.Pledge (big.Int) (struct)
 
 	{

--- a/actors/builtin/power/policy.go
+++ b/actors/builtin/power/policy.go
@@ -3,7 +3,7 @@ package power
 import (
 	abi "github.com/filecoin-project/specs-actors/actors/abi"
 	big "github.com/filecoin-project/specs-actors/actors/abi/big"
-	"github.com/filecoin-project/specs-actors/actors/builtin/reward"
+	reward "github.com/filecoin-project/specs-actors/actors/builtin/reward"
 )
 
 // The average period (i.e. 1/frequency) of surprise PoSt challenges to each miner.


### PR DESCRIPTION
This also paves the way for a fault representation that doesn't need to unset individual fault bits.

@Kubuxu tagging you for review as a good intro to the places the update the miner actor with a sequence of batch fault declarations.

cc @zixuanzh 