### PR TITLE
Seal TODOs

### DIFF
--- a/actors/abi/cbor_gen.go
+++ b/actors/abi/cbor_gen.go
@@ -387,13 +387,13 @@ func (t *OnChainSealVerifyInfo) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.SealEpoch (abi.ChainEpoch) (int64)
-	if t.SealEpoch >= 0 {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.SealEpoch))); err != nil {
+	// t.SealRandEpoch (abi.ChainEpoch) (int64)
+	if t.SealRandEpoch >= 0 {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.SealRandEpoch))); err != nil {
 			return err
 		}
 	} else {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.SealEpoch)-1)); err != nil {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.SealRandEpoch)-1)); err != nil {
 			return err
 		}
 	}
@@ -527,7 +527,7 @@ func (t *OnChainSealVerifyInfo) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("wrong type for uint64 field")
 	}
 	t.SectorNumber = SectorNumber(extra)
-	// t.SealEpoch (abi.ChainEpoch) (int64)
+	// t.SealRandEpoch (abi.ChainEpoch) (int64)
 	{
 		maj, extra, err := cbg.CborReadHeader(br)
 		var extraI int64
@@ -550,7 +550,7 @@ func (t *OnChainSealVerifyInfo) UnmarshalCBOR(r io.Reader) error {
 			return fmt.Errorf("wrong type for int64 field: %d", maj)
 		}
 
-		t.SealEpoch = ChainEpoch(extraI)
+		t.SealRandEpoch = ChainEpoch(extraI)
 	}
 	return nil
 }

--- a/actors/abi/sector.go
+++ b/actors/abi/sector.go
@@ -39,7 +39,6 @@ func NewStoragePower(n int64) StoragePower {
 type RegisteredProof int64
 
 const (
-	RegisteredProof_Undefined              = RegisteredProof(0)
 	RegisteredProof_WinStackedDRG32GiBSeal = RegisteredProof(1)
 	RegisteredProof_WinStackedDRG32GiBPoSt = RegisteredProof(2)
 	RegisteredProof_StackedDRG32GiBSeal    = RegisteredProof(3)

--- a/actors/abi/sector.go
+++ b/actors/abi/sector.go
@@ -39,6 +39,7 @@ func NewStoragePower(n int64) StoragePower {
 type RegisteredProof int64
 
 const (
+	RegisteredProof_Undefined              = RegisteredProof(0)
 	RegisteredProof_WinStackedDRG32GiBSeal = RegisteredProof(1)
 	RegisteredProof_WinStackedDRG32GiBPoSt = RegisteredProof(2)
 	RegisteredProof_StackedDRG32GiBSeal    = RegisteredProof(3)
@@ -81,7 +82,7 @@ type OnChainSealVerifyInfo struct {
 	Proof   SealProof
 	DealIDs []DealID
 	SectorNumber
-	SealEpoch ChainEpoch // Used to tie the seal to a chain.
+	SealRandEpoch ChainEpoch // Used to tie the seal to a chain.
 }
 
 type SealProof struct { //<curve, system> {

--- a/actors/builtin/miner/cbor_gen.go
+++ b/actors/builtin/miner/cbor_gen.go
@@ -473,13 +473,13 @@ func (t *SectorPreCommitInfo) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("failed to write cid field t.SealedCID: %w", err)
 	}
 
-	// t.SealEpoch (abi.ChainEpoch) (int64)
-	if t.SealEpoch >= 0 {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.SealEpoch))); err != nil {
+	// t.SealRandEpoch (abi.ChainEpoch) (int64)
+	if t.SealRandEpoch >= 0 {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.SealRandEpoch))); err != nil {
 			return err
 		}
 	} else {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.SealEpoch)-1)); err != nil {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.SealRandEpoch)-1)); err != nil {
 			return err
 		}
 	}
@@ -548,7 +548,7 @@ func (t *SectorPreCommitInfo) UnmarshalCBOR(r io.Reader) error {
 		t.SealedCID = c
 
 	}
-	// t.SealEpoch (abi.ChainEpoch) (int64)
+	// t.SealRandEpoch (abi.ChainEpoch) (int64)
 	{
 		maj, extra, err := cbg.CborReadHeader(br)
 		var extraI int64
@@ -571,7 +571,7 @@ func (t *SectorPreCommitInfo) UnmarshalCBOR(r io.Reader) error {
 			return fmt.Errorf("wrong type for int64 field: %d", maj)
 		}
 
-		t.SealEpoch = abi.ChainEpoch(extraI)
+		t.SealRandEpoch = abi.ChainEpoch(extraI)
 	}
 	// t.DealIDs ([]abi.DealID) (slice)
 

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -127,16 +127,11 @@ func (a Actor) ChangeWorkerAddress(rt Runtime, params *ChangeWorkerAddressParams
 			NewWorker:   worker,
 			EffectiveAt: effectiveEpoch,
 		}
-
-		cronPayload := CronEventPayload{
-			EventType: CronEventType_Miner_WorkerKeyChange,
-		}
 		return nil
 	})
 
 	cronPayload := CronEventPayload{
 		EventType: cronEventWorkerKeyChange,
-		Sectors:   nil,
 	}
 	a.enrollCronEvent(rt, effectiveEpoch, &cronPayload)
 	return &adt.EmptyValue{}
@@ -937,7 +932,7 @@ func (a Actor) verifySeal(rt Runtime, sectorSize abi.SectorSize, onChainInfo *ab
 	// Check randomness.
 	sealRandEarliest := rt.CurrEpoch() - ChainFinalityish - MaxSealDuration[onChainInfo.RegisteredProof]
 	if onChainInfo.SealRandEpoch < sealRandEarliest {
-		rt.Abort(exitcode.ErrIllegalArgument, "seal epoch %v too old, expected >= %v", onChainInfo.SealRandEpoch, sealRandEarliest)
+		rt.Abortf(exitcode.ErrIllegalArgument, "seal epoch %v too old, expected >= %v", onChainInfo.SealRandEpoch, sealRandEarliest)
 	}
 
 	commD := a.requestUnsealedSectorCID(rt, sectorSize, onChainInfo.DealIDs)

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -210,8 +210,7 @@ func (a Actor) OnDeleteMiner(rt Runtime, _ *adt.EmptyValue) *adt.EmptyValue {
 ///////////////////////
 
 type PreCommitSectorParams struct {
-	Info            SectorPreCommitInfo
-	RegisteredProof abi.RegisteredProof
+	Info SectorPreCommitInfo
 }
 
 // Proposals must be posted on chain via sma.PublishStorageDeals before PreCommitSector.
@@ -254,9 +253,9 @@ func (a Actor) PreCommitSector(rt Runtime, params *SectorPreCommitInfo) *adt.Emp
 	cronPayload := CronEventPayload{
 		EventType:       cronEventPreCommitExpiry,
 		Sectors:         &bf,
-		RegisteredProof: params.info.RegisteredProof,
+		RegisteredProof: params.Info.RegisteredProof,
 	}
-	expiryBound := rt.CurrEpoch() + MaxSealDuration[params.RegisteredProof] + 1
+	expiryBound := rt.CurrEpoch() + MaxSealDuration[params.Info.RegisteredProof] + 1
 	a.enrollCronEvent(rt, expiryBound, &cronPayload)
 
 	return &adt.EmptyValue{}

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -253,9 +253,9 @@ func (a Actor) PreCommitSector(rt Runtime, params *SectorPreCommitInfo) *adt.Emp
 	cronPayload := CronEventPayload{
 		EventType:       cronEventPreCommitExpiry,
 		Sectors:         &bf,
-		RegisteredProof: params.Info.RegisteredProof,
+		RegisteredProof: params.RegisteredProof,
 	}
-	expiryBound := rt.CurrEpoch() + MaxSealDuration[params.Info.RegisteredProof] + 1
+	expiryBound := rt.CurrEpoch() + MaxSealDuration[params.RegisteredProof] + 1
 	a.enrollCronEvent(rt, expiryBound, &cronPayload)
 
 	return &adt.EmptyValue{}
@@ -361,9 +361,8 @@ func (a Actor) ProveCommitSector(rt Runtime, params *ProveCommitSectorParams) *a
 
 	// Request deferred callback for sector expiry.
 	cronPayload := CronEventPayload{
-		EventType:       cronEventSectorExpiry,
-		Sectors:         &bf,
-		RegisteredProof: abi.RegisteredProof_Undefined,
+		EventType: cronEventSectorExpiry,
+		Sectors:   &bf,
 	}
 	a.enrollCronEvent(rt, precommit.Info.Expiration, &cronPayload)
 
@@ -643,7 +642,7 @@ func (a Actor) checkPrecommitExpiry(rt Runtime, sectors *abi.BitField, regProof 
 			}
 			if !found || rt.CurrEpoch()-sector.PreCommitEpoch <= MaxSealDuration[regProof] {
 				// already deleted or not yet expired
-				return
+				return nil
 			}
 
 			// delete sector

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -62,11 +62,12 @@ type WorkerKeyChange struct {
 }
 
 type SectorPreCommitInfo struct {
-	SectorNumber abi.SectorNumber
-	SealedCID    cid.Cid // CommR
-	SealEpoch    abi.ChainEpoch
-	DealIDs      []abi.DealID
-	Expiration   abi.ChainEpoch // Sector Expiration
+	RegisteredProof abi.RegisteredProof
+	SectorNumber    abi.SectorNumber
+	SealedCID       cid.Cid // CommR
+	SealRandEpoch   abi.ChainEpoch
+	DealIDs         []abi.DealID
+	Expiration      abi.ChainEpoch // Sector Expiration
 }
 
 type SectorPreCommitOnChainInfo struct {

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -10,10 +10,7 @@ import (
 
 	abi "github.com/filecoin-project/specs-actors/actors/abi"
 	power "github.com/filecoin-project/specs-actors/actors/builtin/power"
-<<<<<<< HEAD
 	exitcode "github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
-=======
->>>>>>> rebase and slight refactoring
 	adt "github.com/filecoin-project/specs-actors/actors/util/adt"
 )
 

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -65,11 +65,12 @@ type WorkerKeyChange struct {
 }
 
 type SectorPreCommitInfo struct {
-	SectorNumber  abi.SectorNumber
-	SealedCID     cid.Cid // CommR
-	SealRandEpoch abi.ChainEpoch
-	DealIDs       []abi.DealID
-	Expiration    abi.ChainEpoch // Sector Expiration
+	RegisteredProof abi.RegisteredProof
+	SectorNumber    abi.SectorNumber
+	SealedCID       cid.Cid // CommR
+	SealRandEpoch   abi.ChainEpoch
+	DealIDs         []abi.DealID
+	Expiration      abi.ChainEpoch // Sector Expiration
 }
 
 type SectorPreCommitOnChainInfo struct {

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -10,7 +10,10 @@ import (
 
 	abi "github.com/filecoin-project/specs-actors/actors/abi"
 	power "github.com/filecoin-project/specs-actors/actors/builtin/power"
+<<<<<<< HEAD
 	exitcode "github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+=======
+>>>>>>> rebase and slight refactoring
 	adt "github.com/filecoin-project/specs-actors/actors/util/adt"
 )
 

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -62,12 +62,11 @@ type WorkerKeyChange struct {
 }
 
 type SectorPreCommitInfo struct {
-	RegisteredProof abi.RegisteredProof
-	SectorNumber    abi.SectorNumber
-	SealedCID       cid.Cid // CommR
-	SealRandEpoch   abi.ChainEpoch
-	DealIDs         []abi.DealID
-	Expiration      abi.ChainEpoch // Sector Expiration
+	SectorNumber  abi.SectorNumber
+	SealedCID     cid.Cid // CommR
+	SealRandEpoch abi.ChainEpoch
+	DealIDs       []abi.DealID
+	Expiration    abi.ChainEpoch // Sector Expiration
 }
 
 type SectorPreCommitOnChainInfo struct {

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -6,22 +6,18 @@ import (
 	power "github.com/filecoin-project/specs-actors/actors/builtin/power"
 )
 
-// An approximation to chain state finality.
+// An approximation to chain state finality (should include message propagation time as well).
 const ChainFinalityish = abi.ChainEpoch(500) // PARAM_FINISH
-
-// Lookback from current epoch from which to obtain a PoRep challenge.
-// TODO: HS why is this value unused?
-const PoRepLookback = ChainFinalityish // Should be approximately chain ~finality. PARAM_FINISH
-
-// Minimum and maximum delay (inclusive) between a sector pre-commitment and corresponding proof of commitment.
-const PoRepMinDelay = abi.ChainEpoch(5)  // PARAM_FINISH
-const PoRepMaxDelay = abi.ChainEpoch(10) // PARAM_FINISH
 
 // Maximum duration to allow for the sealing process for seal algorithms.
 var MaxSealDuration = map[abi.RegisteredProof]abi.ChainEpoch{
 	abi.RegisteredProof_StackedDRG32GiBSeal:    abi.ChainEpoch(1), // PARAM_FINISH
 	abi.RegisteredProof_WinStackedDRG32GiBSeal: abi.ChainEpoch(1), // PARAM_FINISH
 }
+
+// Number of epochs between publishing the precommit and when the challenge for interactive PoRep is drawn
+// used to ensure it is not predictable by miner.
+const PreCommitChallengeDelay = abi.ChainEpoch(10)
 
 // Lookback from the current epoch from which to obtain a PoSt challenge.
 const PoStLookback = abi.ChainEpoch(1) // PARAM_FINISH

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -10,6 +10,7 @@ import (
 const ChainFinalityish = abi.ChainEpoch(500) // PARAM_FINISH
 
 // Maximum duration to allow for the sealing process for seal algorithms.
+// Dependent on algorithm and sector size
 var MaxSealDuration = map[abi.RegisteredProof]abi.ChainEpoch{
 	abi.RegisteredProof_StackedDRG32GiBSeal:    abi.ChainEpoch(1), // PARAM_FINISH
 	abi.RegisteredProof_WinStackedDRG32GiBSeal: abi.ChainEpoch(1), // PARAM_FINISH


### PR DESCRIPTION
from https://github.com/filecoin-project/specs/issues/867

In this PR:
- Made `MaxSealTime` a variable dependent on proof type everywhere (including cron callbacks for precommitExpiry)
- Added `PreCommitChallengeDelay` as Lotus uses to determine time between `PreCommit` appears on chain and challenge is drawn for interactive PoRep.
- Collapsing of redundant parameters `MaxSealTime` and `PoRepMaxDelay`. (@jzimmerman to verify no missing of purpose)