### PR TITLE
MarshalBinary handles zero val

### DIFF
--- a/actors/abi/big/int.go
+++ b/actors/abi/big/int.go
@@ -195,6 +195,10 @@ func FromBytes(buf []byte) (Int, error) {
 }
 
 func (bi *Int) MarshalBinary() ([]byte, error) {
+	if bi.Int == nil {
+		zero := Zero()
+		return zero.Bytes()
+	}	
 	return bi.Bytes()
 }
 


### PR DESCRIPTION
This allows MarshalBinary to be called on zero valued big.Ints without erroring in the same way MarshalCBOR can.

This might not be the most correct place to do this.  It might be better to do it directly on the Bytes method and remove the checks from MarshalBinary and MarhsalCBOR. This is the least invasive is it doesn't imply removing the error from the Bytes method avoiding the breaking change.