### PR TITLE
implement computeProvingSet()

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -904,6 +904,9 @@ func (a Actor) verifyWindowedPost(rt Runtime, st *State, onChainInfo *abi.OnChai
 
 	store := adt.AsStore(rt)
 	provingSet, err := st.ComputeProvingSet(store)
+	if err != nil {
+		rt.Abortf(exitcode.ErrIllegalState, "Could not compute proving set.")
+	}
 
 	var sectorInfos []abi.SectorInfo
 	var ssinfo SectorOnChainInfo

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -905,24 +905,9 @@ func (a Actor) verifyWindowedPost(rt Runtime, st *State, onChainInfo *abi.OnChai
 	// the same was not used to generate the proof
 
 	store := adt.AsStore(rt)
-	provingSet, err := st.ComputeProvingSet(store)
+	sectorInfos, err := st.ComputeProvingSet(store)
 	if err != nil {
 		rt.Abortf(exitcode.ErrIllegalState, "Could not compute proving set.")
-	}
-
-	var sectorInfos []abi.SectorInfo
-	var ssinfo SectorOnChainInfo
-	err := provingSet.ForEach(&ssinfo, func(i int64) error {
-
-		// TODO: faults!!!!
-		sectorInfos = append(sectorInfos, abi.SectorInfo{
-			SealedCID:    ssinfo.Info.SealedCID,
-			SectorNumber: ssinfo.Info.SectorNumber,
-		})
-		return nil
-	})
-	if err != nil {
-		rt.Abortf(exitcode.ErrIllegalState, "failed to enumerate proving set: %v", err)
 	}
 
 	var addrBuf bytes.Buffer

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -285,6 +285,7 @@ func (a Actor) ProveCommitSector(rt Runtime, params *ProveCommitSectorParams) *a
 	// TODO HS: How are SealEpoch, InteractiveEpoch determined (and intended to be used)?
 	// Presumably they cannot be derived from the SectorProveCommitInfo provided by an untrusted party.
 
+	// will abort if seal invalid
 	a.verifySeal(rt, st.Info.SectorSize, &abi.OnChainSealVerifyInfo{
 		SealedCID:    precommit.Info.SealedCID,
 		SealEpoch:    precommit.Info.SealEpoch,
@@ -309,6 +310,7 @@ func (a Actor) ProveCommitSector(rt Runtime, params *ProveCommitSectorParams) *a
 	AssertNoError(ret.Into(&dealWeight))
 
 	// Request power for activated sector.
+	// Returns relevant pledge requirement.
 	var pledgeRequirement abi.TokenAmount
 	ret, code = rt.Send(
 		builtin.StoragePowerActorAddr,
@@ -325,6 +327,7 @@ func (a Actor) ProveCommitSector(rt Runtime, params *ProveCommitSectorParams) *a
 	builtin.RequireSuccess(rt, code, "failed to notify power actor")
 	AssertNoError(ret.Into(&pledgeRequirement))
 
+	// add sector to miner state
 	rt.State().Transaction(&st, func() interface{} {
 		newSectorInfo := &SectorOnChainInfo{
 			Info:              precommit.Info,

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -176,6 +176,8 @@ func (a Actor) SubmitWindowedPoSt(rt Runtime, params *abi.OnChainPoStVerifyInfo)
 		a.verifyWindowedPost(rt, &st, params)
 
 		// increment proving period start
+		// Note: this must happen after verifyWindowedPoSt, lest verification use the wrong randomness
+		// (drawn from ProvingPeriodStart)
 		st.PoStState = PoStState{
 			ProvingPeriodStart:     st.PoStState.ProvingPeriodStart + ProvingPeriod,
 			NumConsecutiveFailures: 0,


### PR DESCRIPTION
Updating PoSt to compute provingSet at appropriate time. 

The same `computeProvingSet` call should be used as part of computing electionPoSts, but without updating the `minerState.ProvingSet`after the call.