### PR TITLE
add test for address key encoding

### DIFF
--- a/actors/util/adt/adt_test.go
+++ b/actors/util/adt/adt_test.go
@@ -1,1 +1,22 @@
 package adt_test
+
+import (
+	adt "github.com/filecoin-project/specs-actors/actors/util/adt"
+	tutil "github.com/filecoin-project/specs-actors/support/testing"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestAddrKey(t *testing.T) {
+	id_address_1 := tutil.NewIDAddr(t, 101)
+	id_address_2 := tutil.NewIDAddr(t, 102)
+	actor_address_1 := tutil.NewActorAddr(t, "actor1")
+	actor_address_2 := tutil.NewActorAddr(t, "222")
+
+	t.Run("address to key string conversion", func(t *testing.T) {
+		assert.Equal(t, "\x00e", adt.AddrKey(id_address_1).Key())
+		assert.Equal(t, "\x00f", adt.AddrKey(id_address_2).Key())
+		assert.Equal(t, "\x02X\xbeO\xd7u\xa0\xc8͚\xed\x86Ns\xab\xb1\x86F_\xef\xe1", adt.AddrKey(actor_address_1).Key())
+		assert.Equal(t, "\x02\xaaв\x98\xa9ޫ\xbb\xb6\u007f\x80_f\xaah\x8c݉\xad\xf5", adt.AddrKey(actor_address_2).Key())
+	})
+}

--- a/actors/util/adt/adt_test.go
+++ b/actors/util/adt/adt_test.go
@@ -14,9 +14,9 @@ func TestAddrKey(t *testing.T) {
 	actor_address_2 := tutil.NewActorAddr(t, "222")
 
 	t.Run("address to key string conversion", func(t *testing.T) {
-		assert.Equal(t, "\x00e", adt.AddrKey(id_address_1).Key())
-		assert.Equal(t, "\x00f", adt.AddrKey(id_address_2).Key())
-		assert.Equal(t, "\x02X\xbeO\xd7u\xa0\xc8͚\xed\x86Ns\xab\xb1\x86F_\xef\xe1", adt.AddrKey(actor_address_1).Key())
-		assert.Equal(t, "\x02\xaaв\x98\xa9ޫ\xbb\xb6\u007f\x80_f\xaah\x8c݉\xad\xf5", adt.AddrKey(actor_address_2).Key())
+		assert.Equal(t, "t0101", adt.AddrKey(id_address_1).Key())
+		assert.Equal(t, "t0102", adt.AddrKey(id_address_2).Key())
+		assert.Equal(t, "t2lc7e7v3vudem3gxnqzhhhk5rqzdf737bv3bjjoq", adt.AddrKey(actor_address_1).Key())
+		assert.Equal(t, "t2vlilfgfj32v3xnt7qbpwnktirtoytlpv3u7jiuy", adt.AddrKey(actor_address_2).Key())
 	})
 }

--- a/actors/util/adt/adt_test.go
+++ b/actors/util/adt/adt_test.go
@@ -14,9 +14,9 @@ func TestAddrKey(t *testing.T) {
 	actor_address_2 := tutil.NewActorAddr(t, "222")
 
 	t.Run("address to key string conversion", func(t *testing.T) {
-		assert.Equal(t, "t0101", adt.AddrKey(id_address_1).Key())
-		assert.Equal(t, "t0102", adt.AddrKey(id_address_2).Key())
-		assert.Equal(t, "t2lc7e7v3vudem3gxnqzhhhk5rqzdf737bv3bjjoq", adt.AddrKey(actor_address_1).Key())
-		assert.Equal(t, "t2vlilfgfj32v3xnt7qbpwnktirtoytlpv3u7jiuy", adt.AddrKey(actor_address_2).Key())
+		assert.Equal(t, "\x00\x65", adt.AddrKey(id_address_1).Key())
+		assert.Equal(t, "\x00\x66", adt.AddrKey(id_address_2).Key())
+		assert.Equal(t, "\x02\x58\xbe\x4f\xd7\x75\xa0\xc8\xcd\x9a\xed\x86\x4e\x73\xab\xb1\x86\x46\x5f\xef\xe1", adt.AddrKey(actor_address_1).Key())
+		assert.Equal(t, "\x02\xaa\xd0\xb2\x98\xa9\xde\xab\xbb\xb6\u007f\x80\x5f\x66\xaa\x68\x8c\xdd\x89\xad\xf5", adt.AddrKey(actor_address_2).Key())
 	})
 }

--- a/actors/util/adt/store.go
+++ b/actors/util/adt/store.go
@@ -54,7 +54,7 @@ func (r rtStore) Put(ctx context.Context, v interface{}) (cid.Cid, error) {
 type AddrKey addr.Address
 
 func (k AddrKey) Key() string {
-	return addr.Address(k).String()
+	return string(addr.Address(k).Bytes())
 }
 
 // Adapts an int64 as a mapping key.

--- a/actors/util/adt/store.go
+++ b/actors/util/adt/store.go
@@ -54,7 +54,7 @@ func (r rtStore) Put(ctx context.Context, v interface{}) (cid.Cid, error) {
 type AddrKey addr.Address
 
 func (k AddrKey) Key() string {
-	return string(addr.Address(k).Bytes())
+	return addr.Address(k).String()
 }
 
 // Adapts an int64 as a mapping key.


### PR DESCRIPTION
There is a lack of encoding in the specification. Please, consider adding tests for actor state serialisation.

Please, see https://github.com/filecoin-project/specs-actors/pull/150 as corresponding improvement.