### PR TITLE
Initialize Market State fields

### DIFF
--- a/actors/builtin/market/market_state.go
+++ b/actors/builtin/market/market_state.go
@@ -43,6 +43,11 @@ func ConstructState(store adt.Store) (*State, error) {
 		return nil, err
 	}
 
+	emptyMap, err := adt.MakeEmptyMap(store)
+	if err != nil {
+		return nil, err
+	}
+
 	emptyMSet, err := MakeEmptySetMultimap(store)
 	if err != nil {
 		return nil, err
@@ -50,8 +55,9 @@ func ConstructState(store adt.Store) (*State, error) {
 
 	return &State{
 		Proposals:      emptyArray.Root(),
-		EscrowTable:    emptyArray.Root(),
-		LockedTable:    emptyArray.Root(),
+		States:         emptyArray.Root(),
+		EscrowTable:    emptyMap.Root(),
+		LockedTable:    emptyMap.Root(),
 		NextID:         abi.DealID(0),
 		DealIDsByParty: emptyMSet.Root(),
 	}, nil

--- a/actors/builtin/market/market_state_test.go
+++ b/actors/builtin/market/market_state_test.go
@@ -14,17 +14,29 @@ import (
 )
 
 func TestConstruction(t *testing.T) {
-	rt := mock.NewBuilder(context.Background(), address.Undef).Build(t)
+	builder := mock.NewBuilder(context.Background(), address.Undef)
 
 	t.Run("initializes all fields", func(t *testing.T) {
-		state, err := market.ConstructState(adt.AsStore(rt))
+		rt := builder.Build(t)
+		store := adt.AsStore(rt)
 
+		emptyMap, err := adt.MakeEmptyMap(store)
 		assert.NoError(t, err)
-		assert.True(t, state.Proposals.Defined())
-		assert.True(t, state.States.Defined())
-		assert.True(t, state.EscrowTable.Defined())
-		assert.NotNil(t, state.LockedTable.Defined())
+
+		emptyArray, err := adt.MakeEmptyArray(store)
+		assert.NoError(t, err)
+
+		emptyMultiMap, err := market.MakeEmptySetMultimap(store)
+		assert.NoError(t, err)
+
+		state, err := market.ConstructState(store)
+		assert.NoError(t, err)
+
+		assert.Equal(t, emptyArray.Root(), state.Proposals)
+		assert.Equal(t, emptyArray.Root(), state.States)
+		assert.Equal(t, emptyMap.Root(), state.EscrowTable)
+		assert.Equal(t, emptyMap.Root(), state.LockedTable)
 		assert.Equal(t, abi.DealID(0), state.NextID)
-		assert.True(t, state.DealIDsByParty.Defined())
+		assert.Equal(t, emptyMultiMap.Root(), state.DealIDsByParty)
 	})
 }

--- a/actors/builtin/market/market_state_test.go
+++ b/actors/builtin/market/market_state_test.go
@@ -1,0 +1,30 @@
+package market_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/specs-actors/actors/builtin/market"
+	"github.com/filecoin-project/specs-actors/actors/util/adt"
+	"github.com/filecoin-project/specs-actors/support/mock"
+)
+
+func TestConstruction(t *testing.T) {
+	rt := mock.NewBuilder(context.Background(), address.Undef).Build(t)
+
+	t.Run("initializes all fields", func(t *testing.T) {
+		state, err := market.ConstructState(adt.AsStore(rt))
+
+		assert.NoError(t, err)
+		assert.True(t, state.Proposals.Defined())
+		assert.True(t, state.States.Defined())
+		assert.True(t, state.EscrowTable.Defined())
+		assert.NotNil(t, state.LockedTable.Defined())
+		assert.Equal(t, abi.DealID(0), state.NextID)
+		assert.True(t, state.DealIDsByParty.Defined())
+	})
+}


### PR DESCRIPTION
## Problem
`market.State` was initializing `EscrowTable`, `LockedTable` fields as arrays, even though they are indexed by `address.Address`.  Also, the `States` field was left uninitialized.

## Solution
Initialize EscrowTable, LockedTable as maps, States as array.