### PR TITLE
Fix HAMT key encoding of unsigned integers

### DIFF
--- a/actors/builtin/market/market_actor.go
+++ b/actors/builtin/market/market_actor.go
@@ -169,10 +169,10 @@ func (a Actor) PublishStorageDeals(rt Runtime, params *PublishStorageDealsParams
 				rt.Abortf(exitcode.ErrIllegalState, "set deal: %v", err)
 			}
 
-			if err := dbp.Put(adt.AddrKey(deal.Proposal.Client), uint64(id)); err != nil {
+			if err = dbp.Put(deal.Proposal.Client, id); err != nil {
 				rt.Abortf(exitcode.ErrIllegalState, "set client deal id: %v", err)
 			}
-			if err := dbp.Put(adt.AddrKey(deal.Proposal.Provider), uint64(id)); err != nil {
+			if err = dbp.Put(deal.Proposal.Provider, id); err != nil {
 				rt.Abortf(exitcode.ErrIllegalState, "set provider deal id: %v", err)
 			}
 

--- a/actors/builtin/market/market_state.go
+++ b/actors/builtin/market/market_state.go
@@ -73,8 +73,8 @@ func (st *State) updatePendingDealStatesForParty(rt Runtime, addr addr.Address) 
 
 	dbp := AsSetMultimap(adt.AsStore(rt), st.DealIDsByParty)
 	var extractedDealIDs []abi.DealID
-	err := dbp.ForEach(adt.AddrKey(addr), func(id int64) error {
-		extractedDealIDs = append(extractedDealIDs, abi.DealID(id))
+	err := dbp.ForEach(addr, func(id abi.DealID) error {
+		extractedDealIDs = append(extractedDealIDs, id)
 		return nil
 	})
 	if err != nil {
@@ -184,7 +184,7 @@ func (st *State) deleteDeal(rt Runtime, dealID abi.DealID) {
 	st.Proposals = proposals.Root()
 
 	dbp := AsSetMultimap(adt.AsStore(rt), st.DealIDsByParty)
-	if err := dbp.Remove(adt.AddrKey(dealP.Client), uint64(dealID)); err != nil {
+	if err := dbp.Remove(dealP.Client, dealID); err != nil {
 		rt.Abortf(exitcode.ErrPlaceholder, "failed to delete deal from DealIDsByParty: %v", err)
 	}
 	st.DealIDsByParty = dbp.Root()


### PR DESCRIPTION
Added uint64 key encoder, and restructured to reduce the number of accidental conversions between int64 and uint64 possible. 

Before this change, the maps keyed by DealID and SectorNumber were both wrong, after #124.