### PR TITLE
extend RegisteredProof to include other, currently-in-use proofs

### DIFF
--- a/actors/abi/sector.go
+++ b/actors/abi/sector.go
@@ -43,6 +43,14 @@ const (
 	RegisteredProof_WinStackedDRG32GiBPoSt = RegisteredProof(2)
 	RegisteredProof_StackedDRG32GiBSeal    = RegisteredProof(3)
 	RegisteredProof_StackedDRG32GiBPoSt    = RegisteredProof(4)
+	RegisteredProof_StackedDRG1KiBSeal     = RegisteredProof(5)
+	RegisteredProof_StackedDRG1KiBPoSt     = RegisteredProof(6)
+	RegisteredProof_StackedDRG16MiBSeal    = RegisteredProof(7)
+	RegisteredProof_StackedDRG16MiBPoSt    = RegisteredProof(8)
+	RegisteredProof_StackedDRG256MiBSeal   = RegisteredProof(9)
+	RegisteredProof_StackedDRG256MiBPoSt   = RegisteredProof(10)
+	RegisteredProof_StackedDRG1GiBSeal     = RegisteredProof(11)
+	RegisteredProof_StackedDRG1GiBPoSt     = RegisteredProof(12)
 )
 
 ///


### PR DESCRIPTION
## Why does this PR exist?

The specs-actors `RegisteredProof` type, in its current form, [is missing some of the proofs](https://github.com/filecoin-project/rust-filecoin-proofs-api/blob/master/src/registry.rs#L9) supported by the current proofs library (and which are used by lotus and go-filecoin).