### PR TITLE
Fix BalanceTable AddCreate typo

### DIFF
--- a/actors/util/adt/adt_test.go
+++ b/actors/util/adt/adt_test.go
@@ -1,14 +1,12 @@
 package adt_test
 
 import (
-	"context"
-	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/specs-actors/actors/abi"
-	adt "github.com/filecoin-project/specs-actors/actors/util/adt"
-	"github.com/filecoin-project/specs-actors/support/mock"
-	tutil "github.com/filecoin-project/specs-actors/support/testing"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/filecoin-project/specs-actors/actors/util/adt"
+	tutil "github.com/filecoin-project/specs-actors/support/testing"
 )
 
 func TestAddrKey(t *testing.T) {
@@ -22,35 +20,5 @@ func TestAddrKey(t *testing.T) {
 		assert.Equal(t, "\x00\x66", adt.AddrKey(id_address_2).Key())
 		assert.Equal(t, "\x02\x58\xbe\x4f\xd7\x75\xa0\xc8\xcd\x9a\xed\x86\x4e\x73\xab\xb1\x86\x46\x5f\xef\xe1", adt.AddrKey(actor_address_1).Key())
 		assert.Equal(t, "\x02\xaa\xd0\xb2\x98\xa9\xde\xab\xbb\xb6\u007f\x80\x5f\x66\xaa\x68\x8c\xdd\x89\xad\xf5", adt.AddrKey(actor_address_2).Key())
-	})
-}
-
-func TestBalanceTable(t *testing.T) {
-	t.Run("AddCreate adds or creates", func(t *testing.T) {
-		addr := tutil.NewIDAddr(t, 100)
-		rt := mock.NewBuilder(context.Background(), address.Undef).Build(t)
-		store := adt.AsStore(rt)
-		emptyMap, err := adt.MakeEmptyMap(store)
-		assert.NoError(t, err)
-
-		bt := adt.AsBalanceTable(store, emptyMap.Root())
-
-		has, err := bt.Has(addr)
-		assert.NoError(t, err)
-		assert.False(t, has)
-
-		err = bt.AddCreate(addr, abi.NewTokenAmount(10))
-		assert.NoError(t, err)
-
-		amount, err := bt.Get(addr)
-		assert.NoError(t, err)
-		assert.Equal(t, abi.NewTokenAmount(10), amount)
-
-		err = bt.AddCreate(addr, abi.NewTokenAmount(20))
-		assert.NoError(t, err)
-
-		amount, err = bt.Get(addr)
-		assert.NoError(t, err)
-		assert.Equal(t, abi.NewTokenAmount(30), amount)
 	})
 }

--- a/actors/util/adt/adt_test.go
+++ b/actors/util/adt/adt_test.go
@@ -1,7 +1,11 @@
 package adt_test
 
 import (
+	"context"
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/specs-actors/actors/abi"
 	adt "github.com/filecoin-project/specs-actors/actors/util/adt"
+	"github.com/filecoin-project/specs-actors/support/mock"
 	tutil "github.com/filecoin-project/specs-actors/support/testing"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -18,5 +22,35 @@ func TestAddrKey(t *testing.T) {
 		assert.Equal(t, "\x00\x66", adt.AddrKey(id_address_2).Key())
 		assert.Equal(t, "\x02\x58\xbe\x4f\xd7\x75\xa0\xc8\xcd\x9a\xed\x86\x4e\x73\xab\xb1\x86\x46\x5f\xef\xe1", adt.AddrKey(actor_address_1).Key())
 		assert.Equal(t, "\x02\xaa\xd0\xb2\x98\xa9\xde\xab\xbb\xb6\u007f\x80\x5f\x66\xaa\x68\x8c\xdd\x89\xad\xf5", adt.AddrKey(actor_address_2).Key())
+	})
+}
+
+func TestBalanceTable(t *testing.T) {
+	t.Run("AddCreate adds or creates", func(t *testing.T) {
+		addr := tutil.NewIDAddr(t, 100)
+		rt := mock.NewBuilder(context.Background(), address.Undef).Build(t)
+		store := adt.AsStore(rt)
+		emptyMap, err := adt.MakeEmptyMap(store)
+		assert.NoError(t, err)
+
+		bt := adt.AsBalanceTable(store, emptyMap.Root())
+
+		has, err := bt.Has(addr)
+		assert.NoError(t, err)
+		assert.False(t, has)
+
+		err = bt.AddCreate(addr, abi.NewTokenAmount(10))
+		assert.NoError(t, err)
+
+		amount, err := bt.Get(addr)
+		assert.NoError(t, err)
+		assert.Equal(t, abi.NewTokenAmount(10), amount)
+
+		err = bt.AddCreate(addr, abi.NewTokenAmount(20))
+		assert.NoError(t, err)
+
+		amount, err = bt.Get(addr)
+		assert.NoError(t, err)
+		assert.Equal(t, abi.NewTokenAmount(30), amount)
 	})
 }

--- a/actors/util/adt/balancetable.go
+++ b/actors/util/adt/balancetable.go
@@ -64,7 +64,7 @@ func (t *BalanceTable) Add(key addr.Address, value abi.TokenAmount) error {
 // Adds an amount to a balance. Create entry if not exists
 func (t *BalanceTable) AddCreate(key addr.Address, value abi.TokenAmount) error {
 	var prev abi.TokenAmount
-	found, err := (*Map)(t).Get(AddrKey(key), &value)
+	found, err := (*Map)(t).Get(AddrKey(key), &prev)
 	if err != nil {
 		return err
 	}

--- a/actors/util/adt/balancetable_test.go
+++ b/actors/util/adt/balancetable_test.go
@@ -1,0 +1,44 @@
+package adt_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/specs-actors/actors/util/adt"
+	"github.com/filecoin-project/specs-actors/support/mock"
+	tutil "github.com/filecoin-project/specs-actors/support/testing"
+)
+
+func TestBalanceTable(t *testing.T) {
+	t.Run("AddCreate adds or creates", func(t *testing.T) {
+		addr := tutil.NewIDAddr(t, 100)
+		rt := mock.NewBuilder(context.Background(), address.Undef).Build(t)
+		store := adt.AsStore(rt)
+		emptyMap, err := adt.MakeEmptyMap(store)
+		assert.NoError(t, err)
+
+		bt := adt.AsBalanceTable(store, emptyMap.Root())
+
+		has, err := bt.Has(addr)
+		assert.NoError(t, err)
+		assert.False(t, has)
+
+		err = bt.AddCreate(addr, abi.NewTokenAmount(10))
+		assert.NoError(t, err)
+
+		amount, err := bt.Get(addr)
+		assert.NoError(t, err)
+		assert.Equal(t, abi.NewTokenAmount(10), amount)
+
+		err = bt.AddCreate(addr, abi.NewTokenAmount(20))
+		assert.NoError(t, err)
+
+		amount, err = bt.Get(addr)
+		assert.NoError(t, err)
+		assert.Equal(t, abi.NewTokenAmount(30), amount)
+	})
+}


### PR DESCRIPTION
## Problem
`BalanceTable.AddCreate()` was loading the table value into the incorrect value.

## Solution
Write value into the correct place.