### PR TITLE
add challenge count to PoStVerifyInfo + change CommR to SealedCID

### DIFF
--- a/actors/abi/sector.go
+++ b/actors/abi/sector.go
@@ -87,11 +87,13 @@ type SealProof struct { //<curve, system> {
 type ChallengeTicketsCommitment []byte
 type PoStRandomness Randomness
 type PartialTicket []byte // 32 bytes
+type ChallengeCount uint64
 
 // TODO Porcu: refactor these types to get rid of the squishy optional fields.
 type PoStVerifyInfo struct {
+	ChallengeCount  ChallengeCount
 	Randomness      PoStRandomness
-	CommR           cid.Cid
+	SealedCID       cid.Cid
 	Candidates      []PoStCandidate // From OnChain*PoStVerifyInfo
 	Proof           []byte
 	EligibleSectors []SectorInfo

--- a/actors/builtin/paych/cbor_gen.go
+++ b/actors/builtin/paych/cbor_gen.go
@@ -207,15 +207,9 @@ func (t *LaneState) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.ID (int64) (int64)
-	if t.ID >= 0 {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.ID))); err != nil {
-			return err
-		}
-	} else {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.ID)-1)); err != nil {
-			return err
-		}
+	// t.ID (uint64) (uint64)
+	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.ID))); err != nil {
+		return err
 	}
 
 	// t.Redeemed (big.Int) (struct)
@@ -223,15 +217,9 @@ func (t *LaneState) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.Nonce (int64) (int64)
-	if t.Nonce >= 0 {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.Nonce))); err != nil {
-			return err
-		}
-	} else {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.Nonce)-1)); err != nil {
-			return err
-		}
+	// t.Nonce (uint64) (uint64)
+	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.Nonce))); err != nil {
+		return err
 	}
 	return nil
 }
@@ -251,31 +239,16 @@ func (t *LaneState) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
-	// t.ID (int64) (int64)
-	{
-		maj, extra, err := cbg.CborReadHeader(br)
-		var extraI int64
-		if err != nil {
-			return err
-		}
-		switch maj {
-		case cbg.MajUnsignedInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 positive overflow")
-			}
-		case cbg.MajNegativeInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 negative oveflow")
-			}
-			extraI = -1 - extraI
-		default:
-			return fmt.Errorf("wrong type for int64 field: %d", maj)
-		}
+	// t.ID (uint64) (uint64)
 
-		t.ID = int64(extraI)
+	maj, extra, err = cbg.CborReadHeader(br)
+	if err != nil {
+		return err
 	}
+	if maj != cbg.MajUnsignedInt {
+		return fmt.Errorf("wrong type for uint64 field")
+	}
+	t.ID = uint64(extra)
 	// t.Redeemed (big.Int) (struct)
 
 	{
@@ -285,31 +258,16 @@ func (t *LaneState) UnmarshalCBOR(r io.Reader) error {
 		}
 
 	}
-	// t.Nonce (int64) (int64)
-	{
-		maj, extra, err := cbg.CborReadHeader(br)
-		var extraI int64
-		if err != nil {
-			return err
-		}
-		switch maj {
-		case cbg.MajUnsignedInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 positive overflow")
-			}
-		case cbg.MajNegativeInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 negative oveflow")
-			}
-			extraI = -1 - extraI
-		default:
-			return fmt.Errorf("wrong type for int64 field: %d", maj)
-		}
+	// t.Nonce (uint64) (uint64)
 
-		t.Nonce = int64(extraI)
+	maj, extra, err = cbg.CborReadHeader(br)
+	if err != nil {
+		return err
 	}
+	if maj != cbg.MajUnsignedInt {
+		return fmt.Errorf("wrong type for uint64 field")
+	}
+	t.Nonce = uint64(extra)
 	return nil
 }
 
@@ -322,26 +280,14 @@ func (t *Merge) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.Lane (int64) (int64)
-	if t.Lane >= 0 {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.Lane))); err != nil {
-			return err
-		}
-	} else {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.Lane)-1)); err != nil {
-			return err
-		}
+	// t.Lane (uint64) (uint64)
+	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.Lane))); err != nil {
+		return err
 	}
 
-	// t.Nonce (int64) (int64)
-	if t.Nonce >= 0 {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.Nonce))); err != nil {
-			return err
-		}
-	} else {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.Nonce)-1)); err != nil {
-			return err
-		}
+	// t.Nonce (uint64) (uint64)
+	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.Nonce))); err != nil {
+		return err
 	}
 	return nil
 }
@@ -361,56 +307,26 @@ func (t *Merge) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
-	// t.Lane (int64) (int64)
-	{
-		maj, extra, err := cbg.CborReadHeader(br)
-		var extraI int64
-		if err != nil {
-			return err
-		}
-		switch maj {
-		case cbg.MajUnsignedInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 positive overflow")
-			}
-		case cbg.MajNegativeInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 negative oveflow")
-			}
-			extraI = -1 - extraI
-		default:
-			return fmt.Errorf("wrong type for int64 field: %d", maj)
-		}
+	// t.Lane (uint64) (uint64)
 
-		t.Lane = int64(extraI)
+	maj, extra, err = cbg.CborReadHeader(br)
+	if err != nil {
+		return err
 	}
-	// t.Nonce (int64) (int64)
-	{
-		maj, extra, err := cbg.CborReadHeader(br)
-		var extraI int64
-		if err != nil {
-			return err
-		}
-		switch maj {
-		case cbg.MajUnsignedInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 positive overflow")
-			}
-		case cbg.MajNegativeInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 negative oveflow")
-			}
-			extraI = -1 - extraI
-		default:
-			return fmt.Errorf("wrong type for int64 field: %d", maj)
-		}
+	if maj != cbg.MajUnsignedInt {
+		return fmt.Errorf("wrong type for uint64 field")
+	}
+	t.Lane = uint64(extra)
+	// t.Nonce (uint64) (uint64)
 
-		t.Nonce = int64(extraI)
+	maj, extra, err = cbg.CborReadHeader(br)
+	if err != nil {
+		return err
 	}
+	if maj != cbg.MajUnsignedInt {
+		return fmt.Errorf("wrong type for uint64 field")
+	}
+	t.Nonce = uint64(extra)
 	return nil
 }
 
@@ -609,26 +525,14 @@ func (t *SignedVoucher) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.Lane (int64) (int64)
-	if t.Lane >= 0 {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.Lane))); err != nil {
-			return err
-		}
-	} else {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.Lane)-1)); err != nil {
-			return err
-		}
+	// t.Lane (uint64) (uint64)
+	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.Lane))); err != nil {
+		return err
 	}
 
-	// t.Nonce (int64) (int64)
-	if t.Nonce >= 0 {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.Nonce))); err != nil {
-			return err
-		}
-	} else {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.Nonce)-1)); err != nil {
-			return err
-		}
+	// t.Nonce (uint64) (uint64)
+	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.Nonce))); err != nil {
+		return err
 	}
 
 	// t.Amount (big.Int) (struct)
@@ -746,56 +650,26 @@ func (t *SignedVoucher) UnmarshalCBOR(r io.Reader) error {
 		}
 
 	}
-	// t.Lane (int64) (int64)
-	{
-		maj, extra, err := cbg.CborReadHeader(br)
-		var extraI int64
-		if err != nil {
-			return err
-		}
-		switch maj {
-		case cbg.MajUnsignedInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 positive overflow")
-			}
-		case cbg.MajNegativeInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 negative oveflow")
-			}
-			extraI = -1 - extraI
-		default:
-			return fmt.Errorf("wrong type for int64 field: %d", maj)
-		}
+	// t.Lane (uint64) (uint64)
 
-		t.Lane = int64(extraI)
+	maj, extra, err = cbg.CborReadHeader(br)
+	if err != nil {
+		return err
 	}
-	// t.Nonce (int64) (int64)
-	{
-		maj, extra, err := cbg.CborReadHeader(br)
-		var extraI int64
-		if err != nil {
-			return err
-		}
-		switch maj {
-		case cbg.MajUnsignedInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 positive overflow")
-			}
-		case cbg.MajNegativeInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 negative oveflow")
-			}
-			extraI = -1 - extraI
-		default:
-			return fmt.Errorf("wrong type for int64 field: %d", maj)
-		}
+	if maj != cbg.MajUnsignedInt {
+		return fmt.Errorf("wrong type for uint64 field")
+	}
+	t.Lane = uint64(extra)
+	// t.Nonce (uint64) (uint64)
 
-		t.Nonce = int64(extraI)
+	maj, extra, err = cbg.CborReadHeader(br)
+	if err != nil {
+		return err
 	}
+	if maj != cbg.MajUnsignedInt {
+		return fmt.Errorf("wrong type for uint64 field")
+	}
+	t.Nonce = uint64(extra)
 	// t.Amount (big.Int) (struct)
 
 	{

--- a/actors/builtin/paych/paych_actor.go
+++ b/actors/builtin/paych/paych_actor.go
@@ -102,9 +102,9 @@ type SignedVoucher struct {
 	// (optional) Extra can be specified by `From` to add a verification method to the voucher
 	Extra *ModVerifyParams
 	// Specifies which lane the Voucher merges into (will be created if does not exist)
-	Lane int64
+	Lane uint64
 	// Nonce is set by `From` to prevent redemption of stale vouchers on a lane
-	Nonce int64
+	Nonce uint64
 	// Amount voucher can be redeemed for
 	Amount big.Int
 	// (optional) MinSettleHeight can extend channel MinSettleHeight if needed
@@ -324,11 +324,11 @@ func (t *SignedVoucher) SigningBytes() ([]byte, error) {
 }
 
 // Returns the insertion index for a lane ID, with the matching lane state if found, or nil.
-func findLane(lanes []*LaneState, ID int64) (int, *LaneState) {
+func findLane(lanes []*LaneState, ID uint64) (int, *LaneState) {
 	insertionIdx := sort.Search(len(lanes), func(i int) bool {
 		return lanes[i].ID >= ID
 	})
-	if insertionIdx == len(lanes) || lanes[insertionIdx].ID != int64(insertionIdx) {
+	if insertionIdx == len(lanes) || lanes[insertionIdx].ID != uint64(insertionIdx) {
 		// Not found
 		return insertionIdx, nil
 	}

--- a/actors/builtin/paych/paych_state.go
+++ b/actors/builtin/paych/paych_state.go
@@ -31,15 +31,15 @@ type State struct {
 // The Lane state tracks the latest (highest) voucher nonce used to merge the lane
 // as well as the amount it has already redeemed.
 type LaneState struct {
-	ID       int64 // Unique to this channel
+	ID       uint64 // Unique to this channel
 	Redeemed big.Int
-	Nonce    int64
+	Nonce    uint64
 }
 
 // Specifies which `Lane`s to be merged with what `Nonce` on channelUpdate
 type Merge struct {
-	Lane  int64
-	Nonce int64
+	Lane  uint64
+	Nonce uint64
 }
 
 func ConstructState(from addr.Address, to addr.Address) *State {

--- a/actors/builtin/paych/paych_test.go
+++ b/actors/builtin/paych/paych_test.go
@@ -111,8 +111,8 @@ func TestPaymentChannelActor_UpdateChannelState(t *testing.T) {
 		rt := builder.Build(t)
 		actor.constructAndVerify(rt, payerAddr, newPaychAddr)
 		amt := big.NewInt(10)
-		lane := int64(999)
-		nonce := int64(1)
+		lane := uint64(999)
+		nonce := uint64(1)
 		sig := &crypto.Signature{
 			Type: crypto.SigTypeBLS,
 			Data: []byte("doesn't matter"),
@@ -144,8 +144,8 @@ func TestPaymentChannelActor_UpdateChannelState(t *testing.T) {
 		actor.constructAndVerify(rt, payerAddr, newPaychAddr)
 		tl := abi.ChainEpoch(10)
 		amt := big.NewInt(9)
-		lane := int64(8)
-		nonce := int64(7)
+		lane := uint64(8)
+		nonce := uint64(7)
 		sig := &crypto.Signature{
 			Type: crypto.SigTypeBLS,
 			Data: []byte("doesn't matter"),


### PR DESCRIPTION
## Why does this PR exist?

### Naming and types

The protocol uses the term `SealedCID` (of type `cid.Cid`) instead of `CommR`.

### Verifying PoSts

The `VerifyPoSt` method (1) on the `Syscalls` interface in specs-actors is of the following type:

```
VerifyPoSt(sectorSize abi.SectorSize, vi abi.PoStVerifyInfo) bool
```

The `PoStVerifyInfo` type is defined like so:

```
type PoStVerifyInfo struct {
	Randomness      PoStRandomness
	CommR           cid.Cid
	Candidates      []PoStCandidate      // From OnChain*PoStVerifyInfo
	Proofs          []PoStProof          // From OnChain*PoStVerifyInfo
	EligibleSectors map[SectorID]cid.Cid // TODO: HAMT?
}
```

The underlying (Rust) `verify_post` operation (2) needs a challenge count.

1: https://github.com/filecoin-project/specs-actors/blob/master/actors/runtime/runtime.go#L115
2: https://github.com/filecoin-project/rust-filecoin-proofs-api/blob/782128d27b4625aecdc071de1bceb119ec2ed07b/src/post.rs#L60