### PR TITLE
Fix miner actor's check of BLS key associated with worker account.

### DIFF
--- a/actors/builtin/codes.go
+++ b/actors/builtin/codes.go
@@ -83,3 +83,14 @@ func ActorNameByCode(code cid.Cid) string {
 	}
 	return name
 }
+
+// Tests whether a code CID represents an actor that can be an external principal: i.e. an account or multisig.
+// We could do something more sophisticated here: https://github.com/filecoin-project/specs-actors/issues/178
+func IsPrincipal(code cid.Cid) bool {
+	for _, c := range CallerTypesSignable {
+		if c.Equals(code) {
+			return true
+		}
+	}
+	return false
+}

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -33,9 +33,7 @@ type MinerInfo struct {
 	Owner addr.Address // Must be an ID-address.
 
 	// Worker account for this miner.
-	// This will be the key that is used to sign blocks created by this miner, and
-	// sign messages sent on behalf of this miner to commit sectors, submit PoSts, and
-	// other day to day miner activities.
+	// The associated pubkey-type address is used to sign blocks and messages on behalf of this miner.
 	Worker addr.Address // Must be an ID-address.
 
 	PendingWorkerKey *WorkerKeyChange

--- a/actors/builtin/power/power_actor.go
+++ b/actors/builtin/power/power_actor.go
@@ -63,8 +63,8 @@ var _ abi.Invokee = Actor{}
 // Storage miner actor constructor params are defined here so the power actor can send them to the init actor
 // to instantiate miners.
 type MinerConstructorParams struct {
-	OwnerAddr  addr.Address
-	WorkerAddr addr.Address
+	OwnerAddr  addr.Address // Must be an ID-address.
+	WorkerAddr addr.Address // Must be an ID-address.
 	SectorSize abi.SectorSize
 	PeerId     peer.ID
 }
@@ -156,7 +156,7 @@ func (a Actor) WithdrawBalance(rt Runtime, params *WithdrawBalanceParams) *adt.E
 }
 
 type CreateMinerParams struct {
-	Worker     addr.Address
+	Worker     addr.Address // Must be an ID-address.
 	SectorSize abi.SectorSize
 	Peer       peer.ID
 }


### PR DESCRIPTION
Addresses written into state must be ID address in order to match caller validation. But the miner checks that the worker account has an associated BLS key that will later be able to sign blocks, as a fail-fast mechanism.

Closes #57 