### PR TITLE
Add address resolution call to runtime; resolve miner worker and power/market account-keeping addresses.

### DIFF
--- a/actors/builtin/account/account_actor.go
+++ b/actors/builtin/account/account_actor.go
@@ -43,6 +43,7 @@ func (a Actor) Constructor(rt vmr.Runtime, address *addr.Address) *adt.EmptyValu
 
 // Fetches the pubkey-type address from this actor.
 func (a Actor) PubkeyAddress(rt vmr.Runtime, _ *adt.EmptyValue) addr.Address {
+	rt.ValidateImmediateCallerAcceptAny()
 	var st State
 	rt.State().Readonly(&st)
 	return st.Address

--- a/actors/builtin/account/account_test.go
+++ b/actors/builtin/account/account_test.go
@@ -61,6 +61,7 @@ func TestAccountactor(t *testing.T) {
 				rt.GetState(&st)
 				assert.Equal(t, tc.addr, st.Address)
 
+				rt.ExpectValidateCallerAny()
 				pubkeyAddress := rt.Call(actor.PubkeyAddress, &adt.EmptyValue{}).(address.Address)
 				assert.Equal(t, tc.addr, pubkeyAddress)
 			} else {

--- a/actors/builtin/market/market_actor.go
+++ b/actors/builtin/market/market_actor.go
@@ -56,25 +56,24 @@ type WithdrawBalanceParams struct {
 // Attempt to withdraw the specified amount from the balance held in escrow.
 // If less than the specified amount is available, yields the entire available balance.
 func (a Actor) WithdrawBalance(rt Runtime, params *WithdrawBalanceParams) *adt.EmptyValue {
-	amountSlashedTotal := abi.NewTokenAmount(0)
-
 	if params.Amount.LessThan(big.Zero()) {
 		rt.Abortf(exitcode.ErrIllegalArgument, "negative amount %v", params.Amount)
 	}
 
-	recipientAddr := escrowAddress(rt, params.ProviderOrClientAddress)
+	nominal, recipient := escrowAddress(rt, params.ProviderOrClientAddress)
 
+	amountSlashedTotal := abi.NewTokenAmount(0)
 	var amountExtracted abi.TokenAmount
 	var st State
 	rt.State().Transaction(&st, func() interface{} {
 		// Before any operations that check the balance tables for funds, execute all deferred
 		// deal state updates.
-		amountSlashedTotal = big.Add(amountSlashedTotal, st.updatePendingDealStatesForParty(rt, params.ProviderOrClientAddress))
+		amountSlashedTotal = big.Add(amountSlashedTotal, st.updatePendingDealStatesForParty(rt, nominal))
 
-		minBalance := st.getLockedBalance(rt, params.ProviderOrClientAddress)
+		minBalance := st.getLockedBalance(rt, nominal)
 
 		et := adt.AsBalanceTable(adt.AsStore(rt), st.EscrowTable)
-		ex, err := et.SubtractWithMinimum(params.ProviderOrClientAddress, params.Amount, minBalance)
+		ex, err := et.SubtractWithMinimum(nominal, params.Amount, minBalance)
 		if err != nil {
 			rt.Abortf(exitcode.ErrIllegalState, "subtract form escrow table: %v", err)
 		}
@@ -86,14 +85,14 @@ func (a Actor) WithdrawBalance(rt Runtime, params *WithdrawBalanceParams) *adt.E
 
 	_, code := rt.Send(builtin.BurntFundsActorAddr, builtin.MethodSend, nil, amountSlashedTotal)
 	builtin.RequireSuccess(rt, code, "failed to burn slashed funds")
-	_, code = rt.Send(recipientAddr, builtin.MethodSend, nil, amountExtracted)
+	_, code = rt.Send(recipient, builtin.MethodSend, nil, amountExtracted)
 	builtin.RequireSuccess(rt, code, "failed to send funds")
 	return &adt.EmptyValue{}
 }
 
 // Deposits the received value into the balance held in escrow.
 func (a Actor) AddBalance(rt Runtime, providerOrClientAdrress *addr.Address) *adt.EmptyValue {
-	escrowAddress(rt, *providerOrClientAdrress)
+	nominal, _ := escrowAddress(rt, *providerOrClientAdrress)
 
 	var st State
 	rt.State().Transaction(&st, func() interface{} {
@@ -101,7 +100,7 @@ func (a Actor) AddBalance(rt Runtime, providerOrClientAdrress *addr.Address) *ad
 
 		{
 			et := adt.AsBalanceTable(adt.AsStore(rt), st.EscrowTable)
-			err := et.AddCreate(*providerOrClientAdrress, msgValue)
+			err := et.AddCreate(nominal, msgValue)
 			if err != nil {
 				rt.Abortf(exitcode.ErrIllegalState, "adding to escrow table: %v", err)
 			}
@@ -110,7 +109,7 @@ func (a Actor) AddBalance(rt Runtime, providerOrClientAdrress *addr.Address) *ad
 
 		{
 			lt := adt.AsBalanceTable(adt.AsStore(rt), st.LockedTable)
-			err := lt.AddCreate(*providerOrClientAdrress, big.NewInt(0))
+			err := lt.AddCreate(nominal, big.NewInt(0))
 			if err != nil {
 				rt.Abortf(exitcode.ErrIllegalArgument, "adding to locked table: %v", err)
 			}
@@ -390,20 +389,28 @@ func validateDeal(rt Runtime, deal ClientDealProposal) {
 	}
 }
 
-func escrowAddress(rt Runtime, addr addr.Address) addr.Address {
-	codeID, ok := rt.GetActorCodeCID(addr)
+// Resolves a provider or client address to the canonical form against which a balance should be held, and
+// the designated recipient address of withdrawals (which is the same, for simple account parties).
+func escrowAddress(rt Runtime, addr addr.Address) (nominal addr.Address, recipient addr.Address) {
+	// Resolve the provided address to the canonical form against which the balance is held.
+	nominal, ok := rt.ResolveAddress(addr)
 	if !ok {
-		rt.Abortf(exitcode.ErrIllegalArgument, "no code for address %v", addr)
+		rt.Abortf(exitcode.ErrIllegalArgument, "failed to resolve address %v", addr)
+	}
+
+	codeID, ok := rt.GetActorCodeCID(nominal)
+	if !ok {
+		rt.Abortf(exitcode.ErrIllegalArgument, "no code for address %v", nominal)
 	}
 
 	if codeID.Equals(builtin.StorageMinerActorCodeID) {
 		// Storage miner actor entry; implied funds recipient is the associated owner address.
-		ownerAddr, workerAddr := builtin.RequestMinerControlAddrs(rt, addr)
+		ownerAddr, workerAddr := builtin.RequestMinerControlAddrs(rt, nominal)
 		rt.ValidateImmediateCallerIs(ownerAddr, workerAddr)
-		return ownerAddr
+		return nominal, ownerAddr
 	}
 
 	// Ordinary account-style actor entry; funds recipient is just the entry address itself.
 	rt.ValidateImmediateCallerType(builtin.CallerTypesSignable...)
-	return addr
+	return nominal, nominal
 }

--- a/actors/builtin/miner/cbor_gen.go
+++ b/actors/builtin/miner/cbor_gen.go
@@ -1070,8 +1070,8 @@ func (t *ChangeWorkerAddressParams) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.NewKey (address.Address) (struct)
-	if err := t.NewKey.MarshalCBOR(w); err != nil {
+	// t.NewWorker (address.Address) (struct)
+	if err := t.NewWorker.MarshalCBOR(w); err != nil {
 		return err
 	}
 	return nil
@@ -1092,11 +1092,11 @@ func (t *ChangeWorkerAddressParams) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
-	// t.NewKey (address.Address) (struct)
+	// t.NewWorker (address.Address) (struct)
 
 	{
 
-		if err := t.NewKey.UnmarshalCBOR(br); err != nil {
+		if err := t.NewWorker.UnmarshalCBOR(br); err != nil {
 			return err
 		}
 

--- a/actors/builtin/reward/reward_actor.go
+++ b/actors/builtin/reward/reward_actor.go
@@ -64,6 +64,7 @@ type AwardBlockRewardParams struct {
 // - a penalty amount, provided as a parameter, which is burnt,
 func (a Actor) AwardBlockReward(rt vmr.Runtime, params *AwardBlockRewardParams) *adt.EmptyValue {
 	rt.ValidateImmediateCallerIs(builtin.SystemActorAddr)
+	AssertMsg(params.Miner.Protocol() == addr.ID, "miner address must be ID-address (%d), was %d", addr.ID, params.Miner.Protocol())
 	AssertMsg(params.GasReward.Equals(rt.Message().ValueReceived()),
 		"expected value received %v to match gas reward %v", rt.Message().ValueReceived(), params.GasReward)
 	priorBalance := rt.CurrentBalance()

--- a/actors/runtime/runtime.go
+++ b/actors/runtime/runtime.go
@@ -30,6 +30,11 @@ type Runtime interface {
 	// The balance of the receiver.
 	CurrentBalance() abi.TokenAmount
 
+	// Resolves an address of any protocol to an ID address (via the Init actor's table).
+	// This allows resolution of externally-provided SECP, BLS, or actor addresses to the canonical form.
+	// If the argument is an ID address it is returned directly.
+	ResolveAddress(address addr.Address) (ret addr.Address, ok bool)
+
 	// Look up the code ID at an actor address.
 	GetActorCodeCID(addr addr.Address) (ret cid.Cid, ok bool)
 
@@ -60,7 +65,7 @@ type Runtime interface {
 	// Always an ActorExec address.
 	NewActorAddress() addr.Address
 
-	// Creates an actor with code `codeID` and address `address`, with empty state. May only be called by InitActor.
+	// Creates an actor with code `codeID` and address `address`, with empty state. May only be called by Init actor.
 	CreateActor(codeId cid.Cid, address addr.Address)
 
 	// Deletes the executing actor from the state tree. May only be called by the actor itself.


### PR DESCRIPTION
This makes the miner worker address much more ergonomic to set, avoiding the need for either yanking the account's ID address out of the state, or waiting for finality for it to be safe to use.

The miner and power escrow keys were very easy to mis-use beforehand. This makes it clear that the address under which all balances are held is the canonical ID address of the miner or client.

An alternative to this approach would be to send a message to the Init actor. This seems like a reasonable facility to special-case, with less actual execution cost as well as less gas to be paid, since we can expect this table to be cached.

FYI @icorderi 