### PR TITLE
add mappings between seal and PoSt-specific RegisteredProof values

### DIFF
--- a/actors/abi/sector.go
+++ b/actors/abi/sector.go
@@ -2,6 +2,7 @@ package abi
 
 import (
 	cid "github.com/ipfs/go-cid"
+	"github.com/pkg/errors"
 
 	big "github.com/filecoin-project/specs-actors/actors/abi/big"
 )
@@ -52,6 +53,72 @@ const (
 	RegisteredProof_StackedDRG1GiBSeal     = RegisteredProof(11)
 	RegisteredProof_StackedDRG1GiBPoSt     = RegisteredProof(12)
 )
+
+// RegisteredPoStProof produces the PoSt-specific RegisteredProof corresponding
+// to the receiving RegisteredProof.
+func (p RegisteredProof) RegisteredPoStProof() (RegisteredProof, error) {
+	switch p {
+	case RegisteredProof_WinStackedDRG32GiBSeal:
+		return RegisteredProof_WinStackedDRG32GiBPoSt, nil
+	case RegisteredProof_WinStackedDRG32GiBPoSt:
+		return RegisteredProof_WinStackedDRG32GiBPoSt, nil
+	case RegisteredProof_StackedDRG32GiBSeal:
+		return RegisteredProof_StackedDRG32GiBPoSt, nil
+	case RegisteredProof_StackedDRG32GiBPoSt:
+		return RegisteredProof_StackedDRG32GiBPoSt, nil
+	case RegisteredProof_StackedDRG1KiBSeal:
+		return RegisteredProof_StackedDRG1KiBPoSt, nil
+	case RegisteredProof_StackedDRG1KiBPoSt:
+		return RegisteredProof_StackedDRG1KiBPoSt, nil
+	case RegisteredProof_StackedDRG16MiBSeal:
+		return RegisteredProof_StackedDRG16MiBPoSt, nil
+	case RegisteredProof_StackedDRG16MiBPoSt:
+		return RegisteredProof_StackedDRG16MiBPoSt, nil
+	case RegisteredProof_StackedDRG256MiBSeal:
+		return RegisteredProof_StackedDRG256MiBPoSt, nil
+	case RegisteredProof_StackedDRG256MiBPoSt:
+		return RegisteredProof_StackedDRG256MiBPoSt, nil
+	case RegisteredProof_StackedDRG1GiBSeal:
+		return RegisteredProof_StackedDRG1GiBPoSt, nil
+	case RegisteredProof_StackedDRG1GiBPoSt:
+		return RegisteredProof_StackedDRG1GiBPoSt, nil
+	default:
+		return 0, errors.Errorf("unsupported mapping from %+v to PoSt-specific RegisteredProof", p)
+	}
+}
+
+// RegisteredSealProof produces the seal-specific RegisteredProof corresponding
+// to the receiving RegisteredProof.
+func (p RegisteredProof) RegisteredSealProof() (RegisteredProof, error) {
+	switch p {
+	case RegisteredProof_WinStackedDRG32GiBSeal:
+		return RegisteredProof_WinStackedDRG32GiBSeal, nil
+	case RegisteredProof_WinStackedDRG32GiBPoSt:
+		return RegisteredProof_WinStackedDRG32GiBSeal, nil
+	case RegisteredProof_StackedDRG32GiBSeal:
+		return RegisteredProof_StackedDRG32GiBSeal, nil
+	case RegisteredProof_StackedDRG32GiBPoSt:
+		return RegisteredProof_StackedDRG32GiBSeal, nil
+	case RegisteredProof_StackedDRG1KiBSeal:
+		return RegisteredProof_StackedDRG1KiBSeal, nil
+	case RegisteredProof_StackedDRG1KiBPoSt:
+		return RegisteredProof_StackedDRG1KiBSeal, nil
+	case RegisteredProof_StackedDRG16MiBSeal:
+		return RegisteredProof_StackedDRG16MiBSeal, nil
+	case RegisteredProof_StackedDRG16MiBPoSt:
+		return RegisteredProof_StackedDRG16MiBSeal, nil
+	case RegisteredProof_StackedDRG256MiBSeal:
+		return RegisteredProof_StackedDRG256MiBSeal, nil
+	case RegisteredProof_StackedDRG256MiBPoSt:
+		return RegisteredProof_StackedDRG256MiBSeal, nil
+	case RegisteredProof_StackedDRG1GiBSeal:
+		return RegisteredProof_StackedDRG1GiBSeal, nil
+	case RegisteredProof_StackedDRG1GiBPoSt:
+		return RegisteredProof_StackedDRG1GiBSeal, nil
+	default:
+		return 0, errors.Errorf("unsupported mapping from %+v to seal-specific RegisteredProof", p)
+	}
+}
 
 ///
 /// Sealing


### PR DESCRIPTION
For more background, see [this thread](https://filecoinproject.slack.com/archives/CHMNDCK9P/p1582571498038300?thread_ts=1582571005.037100&cid=CHMNDCK9P).

## Why does this PR exist?

A PoSt verifier needs to know, for each replica in a prover's proving set, the appropriate PoSt-specific `RegisteredProof` value. This value encodes proof version (e.g. "v1") and also sector size (e.g. 32GiB).

## What's in this PR?

This changeset adds a deterministic mapping from PoSt to seal-specific `RegisteredProof` (and vice-versa). A PoSt verifier will acquire the seal-specific `RegisteredProof` value for each sector in the prover's sector set which they will map to PoSt-specific `RegisteredProof` for purpose of PoSt verification.