### PR TITLE
update NumMinersMeetingMinPower

### DIFF
--- a/actors/builtin/power/power_actor.go
+++ b/actors/builtin/power/power_actor.go
@@ -46,6 +46,7 @@ func (a Actor) Exports() []interface{} {
 		13:                        a.EnrollCronEvent,
 		14:                        a.ReportConsensusFault,
 		15:                        a.OnEpochTickEnd,
+		16:                        a.MinerNominalPowerMeetsConsensusMinimum,
 	}
 }
 
@@ -528,6 +529,19 @@ func (a Actor) OnEpochTickEnd(rt Runtime, _ *adt.EmptyValue) *adt.EmptyValue {
 		rt.Abortf(exitcode.ErrIllegalState, "Failed to process deferred cron events: %v", err)
 	}
 	return nil
+}
+
+func (a Actor) MinerNominalPowerMeetsConsensusMinimum(rt Runtime, _ *adt.EmptyValue) bool {
+	var st State
+	rt.State().Readonly(&st)
+	store := adt.AsStore(rt)
+	minerAddr := rt.Message().Receiver()
+
+	gtMinSize, err := st.minerNominalPowerMeetsConsensusMinimum(store, minerAddr)
+	if err != nil {
+		rt.Abortf(exitcode.ErrIllegalState, "Failed to check miner %v meets min required size: %v", minerAddr, err)
+	}
+	return gtMinSize
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/actors/builtin/power/power_actor.go
+++ b/actors/builtin/power/power_actor.go
@@ -46,7 +46,6 @@ func (a Actor) Exports() []interface{} {
 		13:                        a.EnrollCronEvent,
 		14:                        a.ReportConsensusFault,
 		15:                        a.OnEpochTickEnd,
-		16:                        a.MinerNominalPowerMeetsConsensusMinimum,
 	}
 }
 
@@ -529,19 +528,6 @@ func (a Actor) OnEpochTickEnd(rt Runtime, _ *adt.EmptyValue) *adt.EmptyValue {
 		rt.Abortf(exitcode.ErrIllegalState, "Failed to process deferred cron events: %v", err)
 	}
 	return nil
-}
-
-func (a Actor) MinerNominalPowerMeetsConsensusMinimum(rt Runtime, _ *adt.EmptyValue) bool {
-	var st State
-	rt.State().Readonly(&st)
-	store := adt.AsStore(rt)
-	minerAddr := rt.Message().Receiver()
-
-	gtMinSize, err := st.minerNominalPowerMeetsConsensusMinimum(store, minerAddr)
-	if err != nil {
-		rt.Abortf(exitcode.ErrIllegalState, "Failed to check miner %v meets min required size: %v", minerAddr, err)
-	}
-	return gtMinSize
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/actors/builtin/power/power_state.go
+++ b/actors/builtin/power/power_state.go
@@ -165,6 +165,7 @@ func (st *State) AddToClaim(s adt.Store, miner addr.Address, power abi.StoragePo
 	}
 
 	// update pledge and power
+	// TODO: ZX, update to ensure that pledge is appropriate for given power update
 	claim.Power = big.Add(claim.Power, power)
 	claim.Pledge = big.Add(claim.Pledge, pledge)
 


### PR DESCRIPTION
Note that this explicitly bases all `minMinerSize` considerations on nominal power (cc @zixuanzh to confirm this is right -- seems right).

Also added actor endpoint for checking this (when validating ePost)