### PR TITLE
Changes to support a PoRep outsourcing market

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -274,7 +274,7 @@ func (a Actor) ProveCommitSector(rt Runtime, params *ProveCommitSectorParams) *a
 
 	var st State
 	rt.State().Readonly(&st)
-	rt.ValidateImmediateCallerIs(st.Info.Worker)
+	rt.ValidateImmediateCallerAcceptAny()
 
 	precommit, found, err := st.GetPrecommittedSector(store, sectorNo)
 	if err != nil {


### PR DESCRIPTION
As in #189, this PR has 3 commits, one for each of the following changes:

- Add a new method to the miner actor, `CheckSectorProven`, which succeeds if a given sector has been proven, fails otherwise
- Allow miner actor's `ProveCommitSector` to be called by anyone
- Add a `TimeLockMax` to vouchers in payment channels. Vouchers cannot be redeemed beyond the `TimeLockMax`.