### PR TITLE
plumb required values into PoSt verification-input

### DIFF
--- a/actors/abi/cbor_gen.go
+++ b/actors/abi/cbor_gen.go
@@ -718,8 +718,19 @@ func (t *PoStProof) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{129}); err != nil {
+	if _, err := w.Write([]byte{130}); err != nil {
 		return err
+	}
+
+	// t.RegisteredProof (abi.RegisteredProof) (int64)
+	if t.RegisteredProof >= 0 {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.RegisteredProof))); err != nil {
+			return err
+		}
+	} else {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.RegisteredProof)-1)); err != nil {
+			return err
+		}
 	}
 
 	// t.ProofBytes ([]uint8) (slice)
@@ -747,10 +758,35 @@ func (t *PoStProof) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 1 {
+	if extra != 2 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
+	// t.RegisteredProof (abi.RegisteredProof) (int64)
+	{
+		maj, extra, err := cbg.CborReadHeader(br)
+		var extraI int64
+		if err != nil {
+			return err
+		}
+		switch maj {
+		case cbg.MajUnsignedInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 positive overflow")
+			}
+		case cbg.MajNegativeInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 negative oveflow")
+			}
+			extraI = -1 - extraI
+		default:
+			return fmt.Errorf("wrong type for int64 field: %d", maj)
+		}
+
+		t.RegisteredProof = RegisteredProof(extraI)
+	}
 	// t.ProofBytes ([]uint8) (slice)
 
 	maj, extra, err = cbg.CborReadHeader(br)
@@ -870,19 +906,8 @@ func (t *OnChainPoStVerifyInfo) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{131}); err != nil {
+	if _, err := w.Write([]byte{130}); err != nil {
 		return err
-	}
-
-	// t.ProofType (abi.RegisteredProof) (int64)
-	if t.ProofType >= 0 {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.ProofType))); err != nil {
-			return err
-		}
-	} else {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.ProofType)-1)); err != nil {
-			return err
-		}
 	}
 
 	// t.Candidates ([]abi.PoStCandidate) (slice)
@@ -926,35 +951,10 @@ func (t *OnChainPoStVerifyInfo) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 3 {
+	if extra != 2 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
-	// t.ProofType (abi.RegisteredProof) (int64)
-	{
-		maj, extra, err := cbg.CborReadHeader(br)
-		var extraI int64
-		if err != nil {
-			return err
-		}
-		switch maj {
-		case cbg.MajUnsignedInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 positive overflow")
-			}
-		case cbg.MajNegativeInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 negative oveflow")
-			}
-			extraI = -1 - extraI
-		default:
-			return fmt.Errorf("wrong type for int64 field: %d", maj)
-		}
-
-		t.ProofType = RegisteredProof(extraI)
-	}
 	// t.Candidates ([]abi.PoStCandidate) (slice)
 
 	maj, extra, err = cbg.CborReadHeader(br)
@@ -1017,28 +1017,8 @@ func (t *OnChainElectionPoStVerifyInfo) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{132}); err != nil {
+	if _, err := w.Write([]byte{131}); err != nil {
 		return err
-	}
-
-	// t.RegisteredProofs ([]abi.RegisteredProof) (slice)
-	if len(t.RegisteredProofs) > cbg.MaxLength {
-		return xerrors.Errorf("Slice value in field t.RegisteredProofs was too long")
-	}
-
-	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajArray, uint64(len(t.RegisteredProofs)))); err != nil {
-		return err
-	}
-	for _, v := range t.RegisteredProofs {
-		if v >= 0 {
-			if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(v))); err != nil {
-				return err
-			}
-		} else {
-			if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-v)-1)); err != nil {
-				return err
-			}
-		}
 	}
 
 	// t.Candidates ([]abi.PoStCandidate) (slice)
@@ -1094,52 +1074,8 @@ func (t *OnChainElectionPoStVerifyInfo) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 4 {
+	if extra != 3 {
 		return fmt.Errorf("cbor input had wrong number of fields")
-	}
-
-	// t.RegisteredProofs ([]abi.RegisteredProof) (slice)
-
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
-	}
-
-	if extra > cbg.MaxLength {
-		return fmt.Errorf("t.RegisteredProofs: array too large (%d)", extra)
-	}
-
-	if maj != cbg.MajArray {
-		return fmt.Errorf("expected cbor array")
-	}
-	if extra > 0 {
-		t.RegisteredProofs = make([]RegisteredProof, extra)
-	}
-	for i := 0; i < int(extra); i++ {
-		{
-			maj, extra, err := cbg.CborReadHeader(br)
-			var extraI int64
-			if err != nil {
-				return err
-			}
-			switch maj {
-			case cbg.MajUnsignedInt:
-				extraI = int64(extra)
-				if extraI < 0 {
-					return fmt.Errorf("int64 positive overflow")
-				}
-			case cbg.MajNegativeInt:
-				extraI = int64(extra)
-				if extraI < 0 {
-					return fmt.Errorf("int64 negative oveflow")
-				}
-				extraI = -1 - extraI
-			default:
-				return fmt.Errorf("wrong type for int64 field: %d", maj)
-			}
-
-			t.RegisteredProofs[i] = RegisteredProof(extraI)
-		}
 	}
 
 	// t.Candidates ([]abi.PoStCandidate) (slice)

--- a/actors/abi/sector.go
+++ b/actors/abi/sector.go
@@ -178,17 +178,14 @@ type SectorInfo struct {
 }
 
 type OnChainElectionPoStVerifyInfo struct {
-	// There should be one RegisteredProof for each PoSt Candidate
-	RegisteredProofs []RegisteredProof
-	Candidates       []PoStCandidate
-	Proofs           []PoStProof
-	Randomness       PoStRandomness
+	Candidates []PoStCandidate // each PoStCandidate has its own RegisteredProof
+	Proofs     []PoStProof     // each PoStProof has its own RegisteredProof
+	Randomness PoStRandomness
 }
 
 type OnChainPoStVerifyInfo struct {
-	ProofType  RegisteredProof
-	Candidates []PoStCandidate
-	Proofs     []PoStProof
+	Candidates []PoStCandidate // each PoStCandidate has its own RegisteredProof
+	Proofs     []PoStProof     // each PoStProof has its own RegisteredProof
 }
 
 type PoStCandidate struct {
@@ -200,6 +197,7 @@ type PoStCandidate struct {
 }
 
 type PoStProof struct { //<curve, system> {
+	RegisteredProof
 	ProofBytes []byte
 }
 

--- a/actors/abi/sector.go
+++ b/actors/abi/sector.go
@@ -166,7 +166,6 @@ type PartialTicket []byte // 32 bytes
 // TODO Porcu: refactor these types to get rid of the squishy optional fields.
 type PoStVerifyInfo struct {
 	Randomness      PoStRandomness
-	SealedCID       cid.Cid         // CommR
 	Candidates      []PoStCandidate // From OnChain*PoStVerifyInfo
 	Proofs          []PoStProof
 	EligibleSectors []SectorInfo

--- a/actors/abi/sector.go
+++ b/actors/abi/sector.go
@@ -169,6 +169,7 @@ type PoStVerifyInfo struct {
 	Candidates      []PoStCandidate // From OnChain*PoStVerifyInfo
 	Proofs          []PoStProof
 	EligibleSectors []SectorInfo
+	Prover          ActorID // used to derive 32-byte prover ID
 }
 
 type SectorInfo struct {

--- a/actors/abi/sector.go
+++ b/actors/abi/sector.go
@@ -163,7 +163,6 @@ type ChallengeTicketsCommitment []byte
 type PoStRandomness Randomness
 type PartialTicket []byte // 32 bytes
 
-// TODO Porcu: refactor these types to get rid of the squishy optional fields.
 type PoStVerifyInfo struct {
 	Randomness      PoStRandomness
 	Candidates      []PoStCandidate // From OnChain*PoStVerifyInfo

--- a/actors/builtin/miner/cbor_gen.go
+++ b/actors/builtin/miner/cbor_gen.go
@@ -458,8 +458,19 @@ func (t *SectorPreCommitInfo) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{133}); err != nil {
+	if _, err := w.Write([]byte{134}); err != nil {
 		return err
+	}
+
+	// t.RegisteredProof (abi.RegisteredProof) (int64)
+	if t.RegisteredProof >= 0 {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.RegisteredProof))); err != nil {
+			return err
+		}
+	} else {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.RegisteredProof)-1)); err != nil {
+			return err
+		}
 	}
 
 	// t.SectorNumber (abi.SectorNumber) (uint64)
@@ -522,10 +533,35 @@ func (t *SectorPreCommitInfo) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 5 {
+	if extra != 6 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
+	// t.RegisteredProof (abi.RegisteredProof) (int64)
+	{
+		maj, extra, err := cbg.CborReadHeader(br)
+		var extraI int64
+		if err != nil {
+			return err
+		}
+		switch maj {
+		case cbg.MajUnsignedInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 positive overflow")
+			}
+		case cbg.MajNegativeInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 negative oveflow")
+			}
+			extraI = -1 - extraI
+		default:
+			return fmt.Errorf("wrong type for int64 field: %d", maj)
+		}
+
+		t.RegisteredProof = abi.RegisteredProof(extraI)
+	}
 	// t.SectorNumber (abi.SectorNumber) (uint64)
 
 	maj, extra, err = cbg.CborReadHeader(br)
@@ -1376,7 +1412,7 @@ func (t *CronEventPayload) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{130}); err != nil {
+	if _, err := w.Write([]byte{131}); err != nil {
 		return err
 	}
 
@@ -1395,6 +1431,17 @@ func (t *CronEventPayload) MarshalCBOR(w io.Writer) error {
 	if err := t.Sectors.MarshalCBOR(w); err != nil {
 		return err
 	}
+
+	// t.RegisteredProof (abi.RegisteredProof) (int64)
+	if t.RegisteredProof >= 0 {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.RegisteredProof))); err != nil {
+			return err
+		}
+	} else {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.RegisteredProof)-1)); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -1409,7 +1456,7 @@ func (t *CronEventPayload) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 2 {
+	if extra != 3 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -1458,6 +1505,31 @@ func (t *CronEventPayload) UnmarshalCBOR(r io.Reader) error {
 			}
 		}
 
+	}
+	// t.RegisteredProof (abi.RegisteredProof) (int64)
+	{
+		maj, extra, err := cbg.CborReadHeader(br)
+		var extraI int64
+		if err != nil {
+			return err
+		}
+		switch maj {
+		case cbg.MajUnsignedInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 positive overflow")
+			}
+		case cbg.MajNegativeInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 negative oveflow")
+			}
+			extraI = -1 - extraI
+		default:
+			return fmt.Errorf("wrong type for int64 field: %d", maj)
+		}
+
+		t.RegisteredProof = abi.RegisteredProof(extraI)
 	}
 	return nil
 }

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -923,7 +923,7 @@ func (a Actor) verifyWindowedPost(rt Runtime, st *State, onChainInfo *abi.OnChai
 	}
 
 	// Verify the PoSt Proof
-	if !rt.Syscalls().VerifyPoSt(sectorSize, pvInfo) {
+	if !rt.Syscalls().VerifyPoSt(pvInfo) {
 		rt.Abortf(exitcode.ErrIllegalArgument, "invalid PoSt %+v", pvInfo)
 	}
 }
@@ -953,7 +953,7 @@ func (a Actor) verifySeal(rt Runtime, sectorSize abi.SectorSize, onChainInfo *ab
 		InteractiveRandomness: abi.InteractiveSealRandomness(svInfoInteractiveRandomness),
 		UnsealedCID:           commD,
 	}
-	if !rt.Syscalls().VerifySeal(sectorSize, svInfo) {
+	if !rt.Syscalls().VerifySeal(svInfo) {
 		rt.Abortf(exitcode.ErrIllegalState, "invalid seal %+v", svInfo)
 	}
 }

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -879,10 +879,11 @@ func (a Actor) requestTerminatePower(rt Runtime, terminationType power.SectorTer
 }
 
 func (a Actor) verifyWindowedPost(rt Runtime, st *State, onChainInfo *abi.OnChainPoStVerifyInfo) {
-	sectorSize := st.Info.SectorSize
-
 	// TODO: verifying no duplicates here seems wrong, we should be verifying
 	// that exactly what we expect is passed in (this isnt election post)
+
+	minerActorID, err := addr.IDFromAddress(rt.Message().Receiver())
+	AssertNoError(err) // Runtime always provides ID-addresses
 
 	// verify no duplicate tickets
 	challengeIndices := make(map[int64]bool)
@@ -914,6 +915,7 @@ func (a Actor) verifyWindowedPost(rt Runtime, st *State, onChainInfo *abi.OnChai
 
 	// Get public inputs
 	pvInfo := abi.PoStVerifyInfo{
+		Prover:          abi.ActorID(minerActorID),
 		Candidates:      onChainInfo.Candidates,
 		Proofs:          onChainInfo.Proofs,
 		Randomness:      abi.PoStRandomness(postRandomness),

--- a/actors/runtime/runtime.go
+++ b/actors/runtime/runtime.go
@@ -112,9 +112,9 @@ type Syscalls interface {
 	// Computes an unsealed sector CID (CommD) from its constituent piece CIDs (CommPs) and sizes.
 	ComputeUnsealedSectorCID(sectorSize abi.SectorSize, pieces []abi.PieceInfo) (cid.Cid, error)
 	// Verifies a sector seal proof.
-	VerifySeal(sectorSize abi.SectorSize, vi abi.SealVerifyInfo) bool
+	VerifySeal(vi abi.SealVerifyInfo) bool
 	// Verifies a proof of spacetime.
-	VerifyPoSt(sectorSize abi.SectorSize, vi abi.PoStVerifyInfo) bool
+	VerifyPoSt(vi abi.PoStVerifyInfo) bool
 	// Verifies valid consensus fault committed with two block headers:
 	// - both headers mined by the same actor
 	// - headers are different

--- a/support/mock/mock_syscaller.go
+++ b/support/mock/mock_syscaller.go
@@ -39,12 +39,12 @@ func (s *syscaller) ComputeUnsealedSectorCID(sectorSize abi.SectorSize, pieces [
 	return cid.Undef, nil
 }
 
-func (s *syscaller) VerifySeal(sectorSize abi.SectorSize, vi abi.SealVerifyInfo) bool {
+func (s *syscaller) VerifySeal(vi abi.SealVerifyInfo) bool {
 	s.PanicOnUnsetFunc("SealVerifier")
 	return false
 }
 
-func (s *syscaller) VerifyPoSt(sectorSize abi.SectorSize, vi abi.PoStVerifyInfo) bool {
+func (s *syscaller) VerifyPoSt(vi abi.PoStVerifyInfo) bool {
 	s.PanicOnUnsetFunc("PoStVerifier")
 	return false
 }


### PR DESCRIPTION
## Why is this PR needed?

The existing PoSt verification types are lacking in a few ways:

1. The PoSt verifier needs some way to know the `RegisteredProof` that corresponds to a `PoStProof`
1. The PoSt verifier needs some value from which they can derive a 32-byte prover ID
1. Sector size is a function of `RegisteredProof`

## What's in this PR?

This changeset:

1. Enables a storage miner's proving set to contain sectors sealed and proven using more than one `RegisteredProof`; it adds `RegisteredProof` to the `PoStProof` struct.
1. Adds `Prover ActorID` to the `PoStVerifyInfo` struct so that verifiers can map to a 32-byte prover id (for libfilecoin's `verify_post` call).
1. Drops the `sectorSize SectorSize` parameter from `VerifySeal` and `VerifyPoSt` calls