### PR TITLE
add challenge count computing-method and plumb value to PoSt verification method

### DIFF
--- a/actors/abi/sector.go
+++ b/actors/abi/sector.go
@@ -169,6 +169,7 @@ type PoStVerifyInfo struct {
 	Proofs          []PoStProof
 	EligibleSectors []SectorInfo
 	Prover          ActorID // used to derive 32-byte prover ID
+	ChallengeCount  uint64
 }
 
 type SectorInfo struct {

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -909,7 +909,7 @@ func (a Actor) verifyWindowedPost(rt Runtime, st *State, onChainInfo *abi.OnChai
 		rt.Abortf(exitcode.ErrIllegalState, "Could not compute proving set.")
 	}
 
-	challengeCount, err := st.ComputePoStChallengeCount(store)
+	challengeCount, err := st.ComputeWindowedPoStChallengeCount(store)
 	if err != nil {
 		rt.Abortf(exitcode.ErrIllegalState, "Could not compute challenge count.")
 	}

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -909,6 +909,11 @@ func (a Actor) verifyWindowedPost(rt Runtime, st *State, onChainInfo *abi.OnChai
 		rt.Abortf(exitcode.ErrIllegalState, "Could not compute proving set.")
 	}
 
+	challengeCount, err := st.ComputePoStChallengeCount(store)
+	if err != nil {
+		rt.Abortf(exitcode.ErrIllegalState, "Could not compute challenge count.")
+	}
+
 	var addrBuf bytes.Buffer
 	err = rt.Message().Receiver().MarshalCBOR(&addrBuf)
 	AssertNoError(err)
@@ -921,6 +926,7 @@ func (a Actor) verifyWindowedPost(rt Runtime, st *State, onChainInfo *abi.OnChai
 		Proofs:          onChainInfo.Proofs,
 		Randomness:      abi.PoStRandomness(postRandomness),
 		EligibleSectors: sectorInfos,
+		ChallengeCount:  challengeCount,
 	}
 
 	// Verify the PoSt Proof

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -237,6 +237,8 @@ func (st *State) ComputeProvingSet(store adt.Store) ([]abi.SectorInfo, error) {
 }
 
 func (st *State) ComputeWindowedPoStChallengeCount(store adt.Store) (uint64, error) {
+	// TODO: This is too slow. Subtract fault count from sector count when these
+	// are maintained consistently.
 	provingSet, err := st.ComputeProvingSet(store)
 	if err != nil {
 		return 0, errors.Wrapf(err, "failed to compute proving set: %v", err)

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -236,13 +236,13 @@ func (st *State) ComputeProvingSet(store adt.Store) ([]abi.SectorInfo, error) {
 	return sectorInfos, nil
 }
 
-func (st *State) ComputePoStChallengeCount(store adt.Store) (uint64, error) {
+func (st *State) ComputeWindowedPoStChallengeCount(store adt.Store) (uint64, error) {
 	provingSet, err := st.ComputeProvingSet(store)
 	if err != nil {
 		return 0, errors.Wrapf(err, "failed to compute proving set: %v", err)
 	}
 
-	return uint64(len(provingSet)) * (PoStSampleRateNum / PoStSampleRateDenom), nil
+	return uint64(len(provingSet)) * (WindowedPoStSampleRateNum / WindowedPoStSampleRateDenom), nil
 }
 
 func (mps *PoStState) IsPoStOk() bool {

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -236,6 +236,15 @@ func (st *State) ComputeProvingSet(store adt.Store) ([]abi.SectorInfo, error) {
 	return sectorInfos, nil
 }
 
+func (st *State) ComputePoStChallengeCount(store adt.Store) (uint64, error) {
+	provingSet, err := st.ComputeProvingSet(store)
+	if err != nil {
+		return 0, errors.Wrapf(err, "failed to compute proving set: %v", err)
+	}
+
+	return uint64(len(provingSet)) * (PoStSampleRateNum / PoStSampleRateDenom), nil
+}
+
 func (mps *PoStState) IsPoStOk() bool {
 	return !mps.HasFailedPost()
 }

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -242,7 +242,7 @@ func (st *State) ComputeWindowedPoStChallengeCount(store adt.Store) (uint64, err
 		return 0, errors.Wrapf(err, "failed to compute proving set: %v", err)
 	}
 
-	return uint64(len(provingSet)) * (WindowedPoStSampleRateNum / WindowedPoStSampleRateDenom), nil
+	return (uint64(len(provingSet))*WindowedPoStSampleRateNum)/WindowedPoStSampleRateDenom + 1, nil
 }
 
 func (mps *PoStState) IsPoStOk() bool {

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -242,7 +242,10 @@ func (st *State) ComputeWindowedPoStChallengeCount(store adt.Store) (uint64, err
 		return 0, errors.Wrapf(err, "failed to compute proving set: %v", err)
 	}
 
-	return (uint64(len(provingSet))*WindowedPoStSampleRateNum)/WindowedPoStSampleRateDenom + 1, nil
+	num := uint64(len(provingSet)) * WindowedPoStSampleRateNumer
+	den := uint64(WindowedPoStSampleRateDenom)
+
+	return num/den + 1, nil
 }
 
 func (mps *PoStState) IsPoStOk() bool {

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -50,3 +50,10 @@ const MaxFaultsCount = 32 << 20
 
 // ProvingPeriod defines the frequency of PoSt challenges that a miner will have to respond to
 const ProvingPeriod = 300
+
+// PoStSampleRateNum defines the numerator of the PoStSampleRate, used to compute challenge count for PoSt generation
+// and verification.
+const PoStSampleRateNum = 1
+
+// PoStSampleRateNum defines the denominator of the PoStSampleRate.
+const PoStSampleRateDenom = 25

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -51,9 +51,9 @@ const MaxFaultsCount = 32 << 20
 // ProvingPeriod defines the frequency of PoSt challenges that a miner will have to respond to
 const ProvingPeriod = 300
 
-// PoStSampleRateNum defines the numerator of the PoStSampleRate, used to compute challenge count for PoSt generation
+// WindowedPoStSampleRateNum defines the numerator of the PoStSampleRate, used to compute challenge count for PoSt generation
 // and verification.
-const PoStSampleRateNum = 1
+const WindowedPoStSampleRateNum = 1
 
-// PoStSampleRateNum defines the denominator of the PoStSampleRate.
-const PoStSampleRateDenom = 25
+// WindowedPoStSampleRateNum defines the denominator of the PoStSampleRate.
+const WindowedPoStSampleRateDenom = 25

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -51,9 +51,9 @@ const MaxFaultsCount = 32 << 20
 // ProvingPeriod defines the frequency of PoSt challenges that a miner will have to respond to
 const ProvingPeriod = 300
 
-// WindowedPoStSampleRateNum defines the numerator of the PoStSampleRate, used to compute challenge count for PoSt generation
+// WindowedPoStSampleRateNumer defines the numerator of the windowed PoSt sample rate, used to compute challenge count for PoSt generation
 // and verification.
-const WindowedPoStSampleRateNum = 1
+const WindowedPoStSampleRateNumer = 1
 
-// WindowedPoStSampleRateNum defines the denominator of the PoStSampleRate.
+// WindowedPoStSampleRateNumer defines the denominator of the windowed PoSt sample rate.
 const WindowedPoStSampleRateDenom = 25


### PR DESCRIPTION
See [this thread](https://filecoinproject.slack.com/archives/CHMNDCK9P/p1582657646068400?thread_ts=1582648075.057600&cid=CHMNDCK9P) for more information.

## Why is this PR needed?

The libfilecoin `post_verify` function needs to know the prover's challenge count. Without that value, the verifier can't verify the provided proofs. 

## What's in this changeset?

This changeset adds a challenge count-computing method (which is a function of proving set) and plumbs its value to the `VerifyPoSt` method.

## What's not in this changeset?

This changeset does not add an operation which can be used to generate ePoSt challenge count.