### PR TITLE
Required caller validation in control address get

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -100,6 +100,7 @@ type GetControlAddressesReturn struct {
 }
 
 func (a Actor) ControlAddresses(rt Runtime, _ *adt.EmptyValue) *GetControlAddressesReturn {
+	rt.ValidateImmediateCallerAcceptAny()
 	var st State
 	rt.State().Readonly(&st)
 	return &GetControlAddressesReturn{


### PR DESCRIPTION
Spec requires noop caller validation by runtime this adds it to control address get.