### PR TITLE
update RegisteredProof values to conform v23 supported sector sizes

### DIFF
--- a/actors/abi/sector.go
+++ b/actors/abi/sector.go
@@ -44,14 +44,12 @@ const (
 	RegisteredProof_WinStackedDRG32GiBPoSt = RegisteredProof(2)
 	RegisteredProof_StackedDRG32GiBSeal    = RegisteredProof(3)
 	RegisteredProof_StackedDRG32GiBPoSt    = RegisteredProof(4)
-	RegisteredProof_StackedDRG1KiBSeal     = RegisteredProof(5)
-	RegisteredProof_StackedDRG1KiBPoSt     = RegisteredProof(6)
-	RegisteredProof_StackedDRG16MiBSeal    = RegisteredProof(7)
-	RegisteredProof_StackedDRG16MiBPoSt    = RegisteredProof(8)
-	RegisteredProof_StackedDRG256MiBSeal   = RegisteredProof(9)
-	RegisteredProof_StackedDRG256MiBPoSt   = RegisteredProof(10)
-	RegisteredProof_StackedDRG1GiBSeal     = RegisteredProof(11)
-	RegisteredProof_StackedDRG1GiBPoSt     = RegisteredProof(12)
+	RegisteredProof_StackedDRG2KiBSeal     = RegisteredProof(5)
+	RegisteredProof_StackedDRG2KiBPoSt     = RegisteredProof(6)
+	RegisteredProof_StackedDRG8MiBSeal     = RegisteredProof(7)
+	RegisteredProof_StackedDRG8MiBPoSt     = RegisteredProof(8)
+	RegisteredProof_StackedDRG512MiBSeal   = RegisteredProof(9)
+	RegisteredProof_StackedDRG512MiBPoSt   = RegisteredProof(10)
 )
 
 // RegisteredPoStProof produces the PoSt-specific RegisteredProof corresponding
@@ -66,22 +64,18 @@ func (p RegisteredProof) RegisteredPoStProof() (RegisteredProof, error) {
 		return RegisteredProof_StackedDRG32GiBPoSt, nil
 	case RegisteredProof_StackedDRG32GiBPoSt:
 		return RegisteredProof_StackedDRG32GiBPoSt, nil
-	case RegisteredProof_StackedDRG1KiBSeal:
-		return RegisteredProof_StackedDRG1KiBPoSt, nil
-	case RegisteredProof_StackedDRG1KiBPoSt:
-		return RegisteredProof_StackedDRG1KiBPoSt, nil
-	case RegisteredProof_StackedDRG16MiBSeal:
-		return RegisteredProof_StackedDRG16MiBPoSt, nil
-	case RegisteredProof_StackedDRG16MiBPoSt:
-		return RegisteredProof_StackedDRG16MiBPoSt, nil
-	case RegisteredProof_StackedDRG256MiBSeal:
-		return RegisteredProof_StackedDRG256MiBPoSt, nil
-	case RegisteredProof_StackedDRG256MiBPoSt:
-		return RegisteredProof_StackedDRG256MiBPoSt, nil
-	case RegisteredProof_StackedDRG1GiBSeal:
-		return RegisteredProof_StackedDRG1GiBPoSt, nil
-	case RegisteredProof_StackedDRG1GiBPoSt:
-		return RegisteredProof_StackedDRG1GiBPoSt, nil
+	case RegisteredProof_StackedDRG2KiBSeal:
+		return RegisteredProof_StackedDRG2KiBPoSt, nil
+	case RegisteredProof_StackedDRG2KiBPoSt:
+		return RegisteredProof_StackedDRG2KiBPoSt, nil
+	case RegisteredProof_StackedDRG8MiBSeal:
+		return RegisteredProof_StackedDRG8MiBPoSt, nil
+	case RegisteredProof_StackedDRG8MiBPoSt:
+		return RegisteredProof_StackedDRG8MiBPoSt, nil
+	case RegisteredProof_StackedDRG512MiBSeal:
+		return RegisteredProof_StackedDRG512MiBPoSt, nil
+	case RegisteredProof_StackedDRG512MiBPoSt:
+		return RegisteredProof_StackedDRG512MiBPoSt, nil
 	default:
 		return 0, errors.Errorf("unsupported mapping from %+v to PoSt-specific RegisteredProof", p)
 	}
@@ -99,22 +93,18 @@ func (p RegisteredProof) RegisteredSealProof() (RegisteredProof, error) {
 		return RegisteredProof_StackedDRG32GiBSeal, nil
 	case RegisteredProof_StackedDRG32GiBPoSt:
 		return RegisteredProof_StackedDRG32GiBSeal, nil
-	case RegisteredProof_StackedDRG1KiBSeal:
-		return RegisteredProof_StackedDRG1KiBSeal, nil
-	case RegisteredProof_StackedDRG1KiBPoSt:
-		return RegisteredProof_StackedDRG1KiBSeal, nil
-	case RegisteredProof_StackedDRG16MiBSeal:
-		return RegisteredProof_StackedDRG16MiBSeal, nil
-	case RegisteredProof_StackedDRG16MiBPoSt:
-		return RegisteredProof_StackedDRG16MiBSeal, nil
-	case RegisteredProof_StackedDRG256MiBSeal:
-		return RegisteredProof_StackedDRG256MiBSeal, nil
-	case RegisteredProof_StackedDRG256MiBPoSt:
-		return RegisteredProof_StackedDRG256MiBSeal, nil
-	case RegisteredProof_StackedDRG1GiBSeal:
-		return RegisteredProof_StackedDRG1GiBSeal, nil
-	case RegisteredProof_StackedDRG1GiBPoSt:
-		return RegisteredProof_StackedDRG1GiBSeal, nil
+	case RegisteredProof_StackedDRG2KiBSeal:
+		return RegisteredProof_StackedDRG2KiBSeal, nil
+	case RegisteredProof_StackedDRG2KiBPoSt:
+		return RegisteredProof_StackedDRG2KiBSeal, nil
+	case RegisteredProof_StackedDRG8MiBSeal:
+		return RegisteredProof_StackedDRG8MiBSeal, nil
+	case RegisteredProof_StackedDRG8MiBPoSt:
+		return RegisteredProof_StackedDRG8MiBSeal, nil
+	case RegisteredProof_StackedDRG512MiBSeal:
+		return RegisteredProof_StackedDRG512MiBSeal, nil
+	case RegisteredProof_StackedDRG512MiBPoSt:
+		return RegisteredProof_StackedDRG512MiBSeal, nil
 	default:
 		return 0, errors.Errorf("unsupported mapping from %+v to seal-specific RegisteredProof", p)
 	}

--- a/actors/abi/sector.go
+++ b/actors/abi/sector.go
@@ -40,26 +40,20 @@ func NewStoragePower(n int64) StoragePower {
 type RegisteredProof int64
 
 const (
-	RegisteredProof_WinStackedDRG32GiBSeal = RegisteredProof(1)
-	RegisteredProof_WinStackedDRG32GiBPoSt = RegisteredProof(2)
-	RegisteredProof_StackedDRG32GiBSeal    = RegisteredProof(3)
-	RegisteredProof_StackedDRG32GiBPoSt    = RegisteredProof(4)
-	RegisteredProof_StackedDRG2KiBSeal     = RegisteredProof(5)
-	RegisteredProof_StackedDRG2KiBPoSt     = RegisteredProof(6)
-	RegisteredProof_StackedDRG8MiBSeal     = RegisteredProof(7)
-	RegisteredProof_StackedDRG8MiBPoSt     = RegisteredProof(8)
-	RegisteredProof_StackedDRG512MiBSeal   = RegisteredProof(9)
-	RegisteredProof_StackedDRG512MiBPoSt   = RegisteredProof(10)
+	RegisteredProof_StackedDRG32GiBSeal  = RegisteredProof(1)
+	RegisteredProof_StackedDRG32GiBPoSt  = RegisteredProof(2)
+	RegisteredProof_StackedDRG2KiBSeal   = RegisteredProof(3)
+	RegisteredProof_StackedDRG2KiBPoSt   = RegisteredProof(4)
+	RegisteredProof_StackedDRG8MiBSeal   = RegisteredProof(5)
+	RegisteredProof_StackedDRG8MiBPoSt   = RegisteredProof(6)
+	RegisteredProof_StackedDRG512MiBSeal = RegisteredProof(7)
+	RegisteredProof_StackedDRG512MiBPoSt = RegisteredProof(8)
 )
 
 // RegisteredPoStProof produces the PoSt-specific RegisteredProof corresponding
 // to the receiving RegisteredProof.
 func (p RegisteredProof) RegisteredPoStProof() (RegisteredProof, error) {
 	switch p {
-	case RegisteredProof_WinStackedDRG32GiBSeal:
-		return RegisteredProof_WinStackedDRG32GiBPoSt, nil
-	case RegisteredProof_WinStackedDRG32GiBPoSt:
-		return RegisteredProof_WinStackedDRG32GiBPoSt, nil
 	case RegisteredProof_StackedDRG32GiBSeal:
 		return RegisteredProof_StackedDRG32GiBPoSt, nil
 	case RegisteredProof_StackedDRG32GiBPoSt:
@@ -85,10 +79,6 @@ func (p RegisteredProof) RegisteredPoStProof() (RegisteredProof, error) {
 // to the receiving RegisteredProof.
 func (p RegisteredProof) RegisteredSealProof() (RegisteredProof, error) {
 	switch p {
-	case RegisteredProof_WinStackedDRG32GiBSeal:
-		return RegisteredProof_WinStackedDRG32GiBSeal, nil
-	case RegisteredProof_WinStackedDRG32GiBPoSt:
-		return RegisteredProof_WinStackedDRG32GiBSeal, nil
 	case RegisteredProof_StackedDRG32GiBSeal:
 		return RegisteredProof_StackedDRG32GiBSeal, nil
 	case RegisteredProof_StackedDRG32GiBPoSt:

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -12,8 +12,7 @@ const ChainFinalityish = abi.ChainEpoch(500) // PARAM_FINISH
 // Maximum duration to allow for the sealing process for seal algorithms.
 // Dependent on algorithm and sector size
 var MaxSealDuration = map[abi.RegisteredProof]abi.ChainEpoch{
-	abi.RegisteredProof_StackedDRG32GiBSeal:    abi.ChainEpoch(1), // PARAM_FINISH
-	abi.RegisteredProof_WinStackedDRG32GiBSeal: abi.ChainEpoch(1), // PARAM_FINISH
+	abi.RegisteredProof_StackedDRG32GiBSeal: abi.ChainEpoch(1), // PARAM_FINISH
 }
 
 // Number of epochs between publishing the precommit and when the challenge for interactive PoRep is drawn


### PR DESCRIPTION
## Why does this PR exist?

The [v23](https://github.com/filecoin-project/rust-fil-proofs/blob/master/filecoin-proofs/src/constants.rs#L11) version of libfilecoin moves to a new set of supported sector sizes. For more information about this change, read [this thread](https://filecoinproject.slack.com/archives/CEGB67XJ8/p1581971606377800?thread_ts=1581971606.377800).

## What's in this PR?

This PR updates the `RegisteredProof` enum to use the latest and greatest sector sizes.

## Note

Note that I've repurposed some of the old `RegisteredProof` values.