### PR TITLE
implement reward actor unit tests

### DIFF
--- a/actors/abi/big/int.go
+++ b/actors/abi/big/int.go
@@ -198,7 +198,7 @@ func (bi *Int) MarshalBinary() ([]byte, error) {
 	if bi.Int == nil {
 		zero := Zero()
 		return zero.Bytes()
-	}	
+	}
 	return bi.Bytes()
 }
 

--- a/actors/builtin/paych/paych_actor.go
+++ b/actors/builtin/paych/paych_actor.go
@@ -72,7 +72,7 @@ func (pca *Actor) resolveAccount(rt vmr.Runtime, raw addr.Address) (addr.Address
 
 	codeCID, ok := rt.GetActorCodeCID(resolved)
 	if !ok {
-		return addr.Undef,fmt.Errorf("no code for address %v", resolved)
+		return addr.Undef, fmt.Errorf("no code for address %v", resolved)
 	}
 	if codeCID != builtin.AccountActorCodeID {
 		return addr.Undef, fmt.Errorf("actor %v must be an account (%v), was %v", raw, builtin.AccountActorCodeID, codeCID)

--- a/actors/builtin/power/power_test.go
+++ b/actors/builtin/power/power_test.go
@@ -41,10 +41,10 @@ func TestConstruction(t *testing.T) {
 			Peer:       "miner1",
 		}
 		initCreateMinerParams := &power.MinerConstructorParams{
-			OwnerAddr:     owner1,
-			WorkerAddr:     worker1,
+			OwnerAddr:  owner1,
+			WorkerAddr: worker1,
 			SectorSize: abi.SectorSize(int64(32)),
-			PeerId:       "miner1",
+			PeerId:     "miner1",
 		}
 
 		rt := builder.Build(t)

--- a/actors/builtin/reward/reward_actor.go
+++ b/actors/builtin/reward/reward_actor.go
@@ -67,7 +67,10 @@ type AwardBlockRewardParams struct {
 // - a penalty amount, provided as a parameter, which is burnt,
 func (a Actor) AwardBlockReward(rt vmr.Runtime, params *AwardBlockRewardParams) *adt.EmptyValue {
 	rt.ValidateImmediateCallerIs(builtin.SystemActorAddr)
-	AssertMsg(params.Miner.Protocol() == addr.ID, "miner address must be ID-address (%d), was %d", addr.ID, params.Miner.Protocol())
+	AssertMsg(params.Miner.Protocol() == addr.ID,
+		"miner address must be ID-address protocol (%d), was protocol %d", addr.ID, params.Miner.Protocol())
+	AssertMsg(rt.CurrentBalance().GreaterThanEqual(params.GasReward),
+		"actor current balance %v insufficient to pay gas reward %v", rt.CurrentBalance(), params.GasReward)
 	priorBalance := rt.CurrentBalance()
 
 	var penalty abi.TokenAmount

--- a/actors/builtin/reward/reward_actor.go
+++ b/actors/builtin/reward/reward_actor.go
@@ -68,8 +68,6 @@ type AwardBlockRewardParams struct {
 func (a Actor) AwardBlockReward(rt vmr.Runtime, params *AwardBlockRewardParams) *adt.EmptyValue {
 	rt.ValidateImmediateCallerIs(builtin.SystemActorAddr)
 	AssertMsg(params.Miner.Protocol() == addr.ID, "miner address must be ID-address (%d), was %d", addr.ID, params.Miner.Protocol())
-	AssertMsg(params.GasReward.Equals(rt.Message().ValueReceived()),
-		"expected value received %v to match gas reward %v", rt.Message().ValueReceived(), params.GasReward)
 	priorBalance := rt.CurrentBalance()
 
 	var penalty abi.TokenAmount

--- a/actors/builtin/reward/reward_actor.go
+++ b/actors/builtin/reward/reward_actor.go
@@ -20,8 +20,8 @@ const TokenPrecision = int64(1_000_000_000_000_000_000)
 // Target reward released to each block winner.
 var BlockRewardTarget = big.Mul(big.NewInt(100), big.NewInt(TokenPrecision))
 
-const rewardVestingFunction = None            // PARAM_FINISH
-const rewardVestingPeriod = abi.ChainEpoch(0) // PARAM_FINISH
+const RewardVestingFunction = None            // PARAM_FINISH
+const RewardVestingPeriod = abi.ChainEpoch(0) // PARAM_FINISH
 
 type Actor struct{}
 
@@ -92,10 +92,10 @@ func (a Actor) AwardBlockReward(rt vmr.Runtime, params *AwardBlockRewardParams) 
 		if rewardPayable.GreaterThan(abi.NewTokenAmount(0)) {
 			newReward := Reward{
 				StartEpoch:      rt.CurrEpoch(),
-				EndEpoch:        rt.CurrEpoch() + rewardVestingPeriod,
+				EndEpoch:        rt.CurrEpoch() + RewardVestingPeriod,
 				Value:           rewardPayable,
 				AmountWithdrawn: abi.NewTokenAmount(0),
-				VestingFunction: rewardVestingFunction,
+				VestingFunction: RewardVestingFunction,
 			}
 			return st.addReward(adt.AsStore(rt), params.Miner, &newReward)
 		}

--- a/actors/builtin/reward/reward_test.go
+++ b/actors/builtin/reward/reward_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
@@ -32,7 +33,7 @@ func TestAwardBlockReward(t *testing.T) {
 	receiver := tutil.NewIDAddr(t, 1000)
 	builder := mock.NewBuilder(context.Background(), receiver).WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
 
-	t.Run("happy path block reward", func(t *testing.T) {
+	t.Run("block reward with no payable reward", func(t *testing.T) {
 		rt := builder.Build(t)
 		actor.constructAndVerify(rt)
 
@@ -42,7 +43,119 @@ func TestAwardBlockReward(t *testing.T) {
 		nominalpwr := abi.NewStoragePower(10)
 		rt.SetBalance(gasreward)
 		actor.blockRewardAndVerify(rt, miner, penalty, gasreward, nominalpwr)
+
+		var st reward.State
+		rt.GetState(&st)
+		rewardMap := adt.AsMultimap(adt.AsStore(rt), st.RewardMap)
+		assert.Equal(t, big.Zero(), st.RewardTotal)
+		var r []reward.Reward
+		var rwd reward.Reward
+		err := rewardMap.ForEach(reward.AddrKey(miner), &rwd, func(i int64) error {
+			r = append(r, rwd)
+			return nil
+		})
+		require.NoError(t, err)
+		// there are 0 rewards in the actors state
+		assert.Equal(t, 0, len(r))
 	})
+
+	t.Run("block reward with reward payable", func(t *testing.T) {
+		rt := builder.Build(t)
+		actor.constructAndVerify(rt)
+
+		miner := tutil.NewIDAddr(t, 1000)
+		penalty := abi.NewTokenAmount(10)
+		gasreward := abi.NewTokenAmount(10)
+		nominalpwr := abi.NewStoragePower(10)
+		rt.SetBalance(big.NewInt(20))
+		actor.blockRewardAndVerify(rt, miner, penalty, gasreward, nominalpwr)
+
+		var st reward.State
+		rt.GetState(&st)
+		rewardMap := adt.AsMultimap(adt.AsStore(rt), st.RewardMap)
+		assert.Equal(t, big.NewInt(10), st.RewardTotal)
+		var r []reward.Reward
+		var rwd reward.Reward
+		err := rewardMap.ForEach(reward.AddrKey(miner), &rwd, func(i int64) error {
+			r = append(r, rwd)
+			return nil
+		})
+		require.NoError(t, err)
+		// there is a single reward in the actor state.
+		require.Equal(t, 1, len(r))
+
+		assert.Equal(t, abi.ChainEpoch(0), r[0].StartEpoch)
+		assert.Equal(t, 0+reward.RewardVestingPeriod, r[0].EndEpoch)
+		assert.Equal(t, big.NewInt(10), r[0].Value)
+		assert.Equal(t, big.Zero(), r[0].AmountWithdrawn)
+		assert.Equal(t, reward.RewardVestingFunction, r[0].VestingFunction)
+
+	})
+
+	t.Run("block reward send failure", func(t *testing.T) {
+		rt := builder.Build(t)
+		actor.constructAndVerify(rt)
+
+		miner := tutil.NewIDAddr(t, 1000)
+		penalty := abi.NewTokenAmount(10)
+		gasreward := abi.NewTokenAmount(10)
+		nominalpwr := abi.NewStoragePower(10)
+		rt.SetBalance(gasreward)
+		rt.ExpectValidateCallerAddr(builtin.SystemActorAddr)
+		rt.ExpectSend(builtin.BurntFundsActorAddr, builtin.MethodSend, nil, penalty, nil, exitcode.ErrForbidden)
+		rt.ExpectAbort(exitcode.ErrForbidden, func() {
+			rt.Call(actor.AwardBlockReward, &reward.AwardBlockRewardParams{
+				Miner:        miner,
+				Penalty:      penalty,
+				GasReward:    gasreward,
+				NominalPower: nominalpwr,
+			})
+		})
+		rt.Verify()
+	})
+
+	t.Run("assertion failure when miner is not ID-address protocol", func(t *testing.T) {
+		rt := builder.Build(t)
+		actor.constructAndVerify(rt)
+
+		miner := tutil.NewSECP256K1Addr(t, "bleepbloob")
+		penalty := abi.NewTokenAmount(10)
+		gasreward := abi.NewTokenAmount(10)
+		nominalpwr := abi.NewStoragePower(10)
+		rt.SetBalance(gasreward)
+		rt.ExpectValidateCallerAddr(builtin.SystemActorAddr)
+		rt.ExpectAssertionFailure("miner address must be ID-address protocol (0), was protocol 1", func() {
+			rt.Call(actor.AwardBlockReward, &reward.AwardBlockRewardParams{
+				Miner:        miner,
+				Penalty:      penalty,
+				GasReward:    gasreward,
+				NominalPower: nominalpwr,
+			})
+		})
+		rt.Verify()
+	})
+
+	t.Run("assertion failure when current balance is less than gas reward", func(t *testing.T) {
+		rt := builder.Build(t)
+		actor.constructAndVerify(rt)
+
+		miner := tutil.NewIDAddr(t, 1000)
+		penalty := abi.NewTokenAmount(10)
+		gasreward := abi.NewTokenAmount(10)
+		nominalpwr := abi.NewStoragePower(10)
+		rt.SetBalance(abi.NewTokenAmount(0))
+		rt.ExpectValidateCallerAddr(builtin.SystemActorAddr)
+		rt.ExpectAssertionFailure("actor current balance 0 insufficient to pay gas reward 10", func() {
+			rt.Call(actor.AwardBlockReward, &reward.AwardBlockRewardParams{
+				Miner:        miner,
+				Penalty:      penalty,
+				GasReward:    gasreward,
+				NominalPower: nominalpwr,
+			})
+		})
+		rt.Verify()
+	})
+	// TODO test reward payable + penalty exceeds balance assertion failure when blockreward function is complete
 }
 
 type rewardHarness struct {

--- a/actors/builtin/reward/reward_test.go
+++ b/actors/builtin/reward/reward_test.go
@@ -1,1 +1,78 @@
 package reward_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/specs-actors/actors/builtin"
+	"github.com/filecoin-project/specs-actors/actors/builtin/reward"
+	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	"github.com/filecoin-project/specs-actors/actors/util/adt"
+	"github.com/filecoin-project/specs-actors/support/mock"
+	tutil "github.com/filecoin-project/specs-actors/support/testing"
+)
+
+func TestConstructor(t *testing.T) {
+	actor := rewardHarness{reward.Actor{}, t}
+
+	receiver := tutil.NewIDAddr(t, 1000)
+	builder := mock.NewBuilder(context.Background(), receiver).WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
+	rt := builder.Build(t)
+	actor.constructAndVerify(rt)
+}
+
+func TestAwardBlockReward(t *testing.T) {
+	actor := rewardHarness{reward.Actor{}, t}
+
+	receiver := tutil.NewIDAddr(t, 1000)
+	builder := mock.NewBuilder(context.Background(), receiver).WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
+
+	t.Run("happy path block reward", func(t *testing.T) {
+		rt := builder.Build(t)
+		actor.constructAndVerify(rt)
+
+		miner := tutil.NewIDAddr(t, 1000)
+		penalty := abi.NewTokenAmount(10)
+		gasreward := abi.NewTokenAmount(10)
+		nominalpwr := abi.NewStoragePower(10)
+		rt.SetBalance(gasreward)
+		actor.blockRewardAndVerify(rt, miner, penalty, gasreward, nominalpwr)
+	})
+}
+
+type rewardHarness struct {
+	reward.Actor
+	t testing.TB
+}
+
+func (h *rewardHarness) constructAndVerify(rt *mock.Runtime) {
+	rt.ExpectValidateCallerAddr(builtin.SystemActorAddr)
+	ret := rt.Call(h.Constructor, &adt.EmptyValue{})
+	assert.Equal(h.t, &adt.EmptyValue{}, ret)
+	rt.Verify()
+
+	var st reward.State
+	rt.GetState(&st)
+	emptyMap := adt.AsMultimap(adt.AsStore(rt), st.RewardMap)
+	assert.Equal(h.t, emptyMap.Root(), st.RewardMap)
+	assert.Equal(h.t, big.Zero(), st.RewardTotal)
+}
+
+func (h *rewardHarness) blockRewardAndVerify(rt *mock.Runtime, miner address.Address,
+	penalty, gasReward abi.TokenAmount, nominal abi.StoragePower) *adt.EmptyValue {
+	rt.ExpectValidateCallerAddr(builtin.SystemActorAddr)
+	rt.ExpectSend(builtin.BurntFundsActorAddr, builtin.MethodSend, nil, penalty, nil, exitcode.Ok)
+	ret := rt.Call(h.AwardBlockReward, &reward.AwardBlockRewardParams{
+		Miner:        miner,
+		Penalty:      penalty,
+		GasReward:    gasReward,
+		NominalPower: nominal,
+	}).(*adt.EmptyValue)
+	rt.Verify()
+	return ret
+}

--- a/actors/builtin/system/system_actor.go
+++ b/actors/builtin/system/system_actor.go
@@ -17,7 +17,6 @@ func (a Actor) Exports() []interface{} {
 
 var _ abi.Invokee = Actor{}
 
-
 func (a Actor) Constructor(rt runtime.Runtime, params *adt.EmptyValue) *adt.EmptyValue {
 	rt.ValidateImmediateCallerIs(builtin.SystemActorAddr)
 

--- a/actors/util/adt/store.go
+++ b/actors/util/adt/store.go
@@ -92,7 +92,7 @@ type uintKey struct {
 }
 
 //noinspection GoExportedFuncWithUnexportedType
-func UIntKey (k uint64) uintKey {
+func UIntKey(k uint64) uintKey {
 	return uintKey{k}
 }
 

--- a/support/mock/mockrt.go
+++ b/support/mock/mockrt.go
@@ -496,6 +496,33 @@ func (rt *Runtime) Reset() {
 	rt.expectCreateActor = nil
 }
 
+func (rt *Runtime) ExpectAssertionFailure(expected string, f func()) {
+	prevState := rt.state
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			rt.t.Errorf("expected panic with message %v but call succeeded", expected)
+			return
+		}
+		a, ok := r.(abort)
+		if ok {
+			rt.t.Errorf("expected panic with message %v but got abort %v", expected, a)
+			return
+		}
+		p, ok := r.(string)
+		if !ok {
+			panic(r)
+		}
+		if p != expected {
+			rt.t.Errorf("expected panic with message \"%v\" but got message \"%v\"", expected, p)
+		}
+		// Roll back state change.
+		rt.state = prevState
+	}()
+	f()
+}
+
 // Calls f() expecting it to invoke Runtime.Abortf() with a specified exit code.
 func (rt *Runtime) ExpectAbort(expected exitcode.ExitCode, f func()) {
 	prevState := rt.state


### PR DESCRIPTION
The [makeBlockRewardMessage](https://filecoin-project.github.io/specs/#vminterpreter-implementation) method defined in the spec indicates that messages being sent to the reward actor from the system actor for block reward should contain a value of zero. I believe this means the RewardActor should not assert the value received is equal to the gas reward since value received will always be zero.
```
// Builds a message for paying block reward to a miner's owner.
func _makeBlockRewardMessage(state st.StateTree, minerAddr addr.Address, penalty abi.TokenAmount, gasReward abi.TokenAmount) msg.UnsignedMessage {
	params := serde.MustSerializeParams(minerAddr, penalty)
	TODO() // serialize other inputs to BlockRewardMessage or get this from query in RewardActor

	sysActor, ok := state.GetActor(builtin.SystemActorAddr)
	Assert(ok)

	return &msg.UnsignedMessage_I{
		From_:       builtin.SystemActorAddr,
		To_:         builtin.RewardActorAddr,
		Method_:     builtin.Method_RewardActor_AwardBlockReward,
		Params_:     params,
		CallSeqNum_: sysActor.CallSeqNum(),
		Value_:      0,
		GasPrice_:   0,
		GasLimit_:   msg.GasAmount_SentinelUnlimited(),
	}
}

```
