### PR TITLE
readdr miner owner param to createminer call

### DIFF
--- a/actors/builtin/cron/cbor_gen.go
+++ b/actors/builtin/cron/cbor_gen.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/filecoin-project/specs-actors/actors/abi"
+	abi "github.com/filecoin-project/specs-actors/actors/abi"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	xerrors "golang.org/x/xerrors"
 )

--- a/actors/builtin/market/cbor_gen.go
+++ b/actors/builtin/market/cbor_gen.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/filecoin-project/specs-actors/actors/abi"
+	abi "github.com/filecoin-project/specs-actors/actors/abi"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	xerrors "golang.org/x/xerrors"
 )

--- a/actors/builtin/power/cbor_gen.go
+++ b/actors/builtin/power/cbor_gen.go
@@ -378,7 +378,12 @@ func (t *CreateMinerParams) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{131}); err != nil {
+	if _, err := w.Write([]byte{132}); err != nil {
+		return err
+	}
+
+	// t.Owner (address.Address) (struct)
+	if err := t.Owner.MarshalCBOR(w); err != nil {
 		return err
 	}
 
@@ -417,10 +422,19 @@ func (t *CreateMinerParams) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 3 {
+	if extra != 4 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
+	// t.Owner (address.Address) (struct)
+
+	{
+
+		if err := t.Owner.UnmarshalCBOR(br); err != nil {
+			return err
+		}
+
+	}
 	// t.Worker (address.Address) (struct)
 
 	{

--- a/actors/builtin/power/power_actor.go
+++ b/actors/builtin/power/power_actor.go
@@ -168,6 +168,7 @@ func (a Actor) WithdrawBalance(rt Runtime, params *WithdrawBalanceParams) *adt.E
 }
 
 type CreateMinerParams struct {
+	Owner      addr.Address
 	Worker     addr.Address
 	SectorSize abi.SectorSize
 	Peer       peer.ID
@@ -180,10 +181,9 @@ type CreateMinerReturn struct {
 
 func (a Actor) CreateMiner(rt Runtime, params *CreateMinerParams) *CreateMinerReturn {
 	rt.ValidateImmediateCallerType(builtin.CallerTypesSignable...)
-	ownerAddr := rt.Message().Caller()
 
 	ctorParams := MinerConstructorParams{
-		OwnerAddr:  ownerAddr,
+		OwnerAddr:  params.Owner,
 		WorkerAddr: params.Worker,
 		SectorSize: params.SectorSize,
 		PeerId:     params.Peer,

--- a/actors/builtin/power/power_test.go
+++ b/actors/builtin/power/power_test.go
@@ -36,15 +36,16 @@ func TestConstruction(t *testing.T) {
 
 	t.Run("create miner", func(t *testing.T) {
 		createMinerParams := &power.CreateMinerParams{
+			Owner:      owner1,
 			Worker:     worker1,
 			SectorSize: abi.SectorSize(int64(32)),
 			Peer:       "miner1",
 		}
 		initCreateMinerParams := &power.MinerConstructorParams{
-			OwnerAddr:     owner1,
-			WorkerAddr:     worker1,
+			OwnerAddr:  owner1,
+			WorkerAddr: worker1,
 			SectorSize: abi.SectorSize(int64(32)),
-			PeerId:       "miner1",
+			PeerId:     "miner1",
 		}
 
 		rt := builder.Build(t)


### PR DESCRIPTION
Not sure why this got changed, but theres no reason not to allow someone to create a miner on someone elses behalf. We use this in the faucet to help people set up their miners.