### PR TITLE
Use an empty value for params instead of nil on send

### DIFF
--- a/actors/builtin/paych/paych_actor.go
+++ b/actors/builtin/paych/paych_actor.go
@@ -294,7 +294,7 @@ func (pca Actor) Collect(rt vmr.Runtime, _ *adt.EmptyValue) *adt.EmptyValue {
 	_, codeFrom := rt.Send(
 		st.From,
 		builtin.MethodSend,
-		nil,
+		&adt.EmptyValue{},
 		abi.NewTokenAmount(big.Sub(rt.CurrentBalance(), st.ToSend).Int64()),
 	)
 	builtin.RequireSuccess(rt, codeFrom, "Failed to send balance to `From`")
@@ -303,7 +303,7 @@ func (pca Actor) Collect(rt vmr.Runtime, _ *adt.EmptyValue) *adt.EmptyValue {
 	_, codeTo := rt.Send(
 		st.To,
 		builtin.MethodSend,
-		nil,
+		&adt.EmptyValue{},
 		abi.NewTokenAmount(st.ToSend.Int64()),
 	)
 	builtin.RequireSuccess(rt, codeTo, "Failed to send funds to `To`")

--- a/actors/builtin/paych/paych_test.go
+++ b/actors/builtin/paych/paych_test.go
@@ -609,8 +609,8 @@ func TestActor_Collect(t *testing.T) {
 
 		bal := rt.GetBalance()
 		sentToFrom := big.Sub(bal, st.ToSend)
-		rt.ExpectSend(st.From, builtin.MethodSend, nil, sentToFrom, nil, exitcode.Ok)
-		rt.ExpectSend(st.To, builtin.MethodSend, nil, st.ToSend, nil, exitcode.Ok)
+		rt.ExpectSend(st.From, builtin.MethodSend, &adt.EmptyValue{}, sentToFrom, nil, exitcode.Ok)
+		rt.ExpectSend(st.To, builtin.MethodSend, &adt.EmptyValue{}, st.ToSend, nil, exitcode.Ok)
 
 		// Collect.
 		rt.SetCaller(st.From, builtin.AccountActorCodeID)
@@ -651,8 +651,8 @@ func TestActor_Collect(t *testing.T) {
 			rt.SetEpoch(12)
 
 			sentToFrom := big.Sub(rt.GetBalance(), st.ToSend)
-			rt.ExpectSend(st.From, builtin.MethodSend, nil, sentToFrom, nil, tc.expSendFromCode)
-			rt.ExpectSend(st.To, builtin.MethodSend, nil, st.ToSend, nil, tc.expSendToCode)
+			rt.ExpectSend(st.From, builtin.MethodSend, &adt.EmptyValue{}, sentToFrom, nil, tc.expSendFromCode)
+			rt.ExpectSend(st.To, builtin.MethodSend, &adt.EmptyValue{}, st.ToSend, nil, tc.expSendToCode)
 
 			// Collect.
 			rt.SetCaller(st.From, builtin.AccountActorCodeID)

--- a/actors/builtin/shared.go
+++ b/actors/builtin/shared.go
@@ -7,6 +7,7 @@ import (
 	runtime "github.com/filecoin-project/specs-actors/actors/runtime"
 	exitcode "github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 	autil "github.com/filecoin-project/specs-actors/actors/util"
+	"github.com/filecoin-project/specs-actors/actors/util/adt"
 )
 
 ///// Code shared by multiple built-in actors. /////
@@ -19,7 +20,7 @@ func RequireSuccess(rt runtime.Runtime, e exitcode.ExitCode, msg string, args ..
 }
 
 func RequestMinerControlAddrs(rt runtime.Runtime, minerAddr addr.Address) (ownerAddr addr.Address, workerAddr addr.Address) {
-	ret, code := rt.Send(minerAddr, MethodsMiner.ControlAddresses, nil, abi.NewTokenAmount(0))
+	ret, code := rt.Send(minerAddr, MethodsMiner.ControlAddresses, &adt.EmptyValue{}, abi.NewTokenAmount(0))
 	RequireSuccess(rt, code, "failed fetching control addresses")
 	var addrs MinerAddrs
 	autil.AssertNoError(ret.Into(&addrs))

--- a/support/mock/mockrt.go
+++ b/support/mock/mockrt.go
@@ -183,6 +183,9 @@ func (rt *Runtime) Send(toAddr addr.Address, methodNum abi.MethodNum, params run
 	if len(rt.expectSends) == 0 {
 		rt.t.Fatalf("unexpected expectedMessage to: %v method: %v, value: %v, params: %v", toAddr, methodNum, value, params)
 	}
+	if params == nil {
+		rt.t.Fatalf("nil params to send")
+	}
 	expectedMsg := rt.expectSends[0]
 
 	if !expectedMsg.Equal(toAddr, methodNum, params, value) {


### PR DESCRIPTION
This nil param on send requires non-ideal go-filecoin runtime workaround.  I think we want to enforce that all send calls use an adt empty val param when there are no params to send.