### PR TITLE
replace ComputeWindowedPoStChallengeCount method with constant

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -930,11 +930,6 @@ func (a Actor) verifyWindowedPost(rt Runtime, st *State, onChainInfo *abi.OnChai
 		rt.Abortf(exitcode.ErrIllegalState, "Could not compute proving set.")
 	}
 
-	challengeCount, err := st.ComputeWindowedPoStChallengeCount(store)
-	if err != nil {
-		rt.Abortf(exitcode.ErrIllegalState, "Could not compute challenge count.")
-	}
-
 	var addrBuf bytes.Buffer
 	err = rt.Message().Receiver().MarshalCBOR(&addrBuf)
 	AssertNoError(err)
@@ -947,7 +942,7 @@ func (a Actor) verifyWindowedPost(rt Runtime, st *State, onChainInfo *abi.OnChai
 		Proofs:          onChainInfo.Proofs,
 		Randomness:      abi.PoStRandomness(postRandomness),
 		EligibleSectors: sectorInfos,
-		ChallengeCount:  challengeCount,
+		ChallengeCount:  WindowedPoStChallengeCount,
 	}
 
 	// Verify the PoSt Proof

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -242,20 +242,6 @@ func (st *State) ComputeProvingSet(store adt.Store) ([]abi.SectorInfo, error) {
 	return sectorInfos, nil
 }
 
-func (st *State) ComputeWindowedPoStChallengeCount(store adt.Store) (uint64, error) {
-	// TODO: This is too slow. Subtract fault count from sector count when these
-	// are maintained consistently.
-	provingSet, err := st.ComputeProvingSet(store)
-	if err != nil {
-		return 0, errors.Wrapf(err, "failed to compute proving set: %v", err)
-	}
-
-	num := uint64(len(provingSet)) * WindowedPoStSampleRateNumer
-	den := uint64(WindowedPoStSampleRateDenom)
-
-	return num/den + 1, nil
-}
-
 func (mps *PoStState) IsPoStOk() bool {
 	return !mps.HasFailedPost()
 }

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -53,9 +53,5 @@ const MaxFaultsCount = 32 << 20
 // ProvingPeriod defines the frequency of PoSt challenges that a miner will have to respond to
 const ProvingPeriod = 300
 
-// WindowedPoStSampleRateNumer defines the numerator of the windowed PoSt sample rate, used to compute challenge count for PoSt generation
-// and verification.
-const WindowedPoStSampleRateNumer = 1
-
-// WindowedPoStSampleRateNumer defines the denominator of the windowed PoSt sample rate.
-const WindowedPoStSampleRateDenom = 25
+// WindowedPoStChallengeCount defines the number of windowed PoSt challenges
+const WindowedPoStChallengeCount = 2000


### PR DESCRIPTION
For more context, see [this thread](https://filecoinproject.slack.com/archives/CHMNDCK9P/p1582755841096200?thread_ts=1582735826.080900&cid=CHMNDCK9P).

## Why does this PR exist?

Windowed PoSt challenge count is not a function of miner size, rather a network constant.

## What's in this PR?

This PR replaces the windowed PoSt challenge count-computing method with a constant.