### PR TITLE
Fix consensus fault reporting method params and syscall

### DIFF
--- a/actors/builtin/power/policy.go
+++ b/actors/builtin/power/policy.go
@@ -1,9 +1,12 @@
 package power
 
 import (
+	"fmt"
+
 	abi "github.com/filecoin-project/specs-actors/actors/abi"
 	big "github.com/filecoin-project/specs-actors/actors/abi/big"
 	reward "github.com/filecoin-project/specs-actors/actors/builtin/reward"
+	vmr "github.com/filecoin-project/specs-actors/actors/runtime"
 )
 
 // The time a miner has to respond to a surprise PoSt challenge.
@@ -40,17 +43,17 @@ func pledgePenaltyForWindowedPoStFailure(pledge abi.TokenAmount, failures int64)
 }
 
 // Penalty to pledge collateral for a consensus fault.
-func pledgePenaltyForConsensusFault(pledge abi.TokenAmount, faultType ConsensusFaultType) abi.TokenAmount {
+func pledgePenaltyForConsensusFault(pledge abi.TokenAmount, faultType vmr.ConsensusFaultType) abi.TokenAmount {
 	// PARAM_FINISH: always penalise the entire pledge.
 	switch faultType {
-	case ConsensusFaultDoubleForkMining:
+	case vmr.ConsensusFaultDoubleForkMining:
 		return pledge
-	case ConsensusFaultParentGrinding:
+	case vmr.ConsensusFaultParentGrinding:
 		return pledge
-	case ConsensusFaultTimeOffsetMining:
+	case vmr.ConsensusFaultTimeOffsetMining:
 		return pledge
 	default:
-		panic("Unsupported case for pledge collateral consensus fault slashing")
+		panic(fmt.Sprintf("unknown fault type %d", faultType))
 	}
 }
 

--- a/support/mock/mock_syscaller.go
+++ b/support/mock/mock_syscaller.go
@@ -49,9 +49,9 @@ func (s *syscaller) VerifyPoSt(vi abi.PoStVerifyInfo) error {
 	return nil
 }
 
-func (s *syscaller) VerifyConsensusFault(h1, h2 []byte) error {
+func (s *syscaller) VerifyConsensusFault(h1, h2, extra []byte) (*runtime.ConsensusFault, error) {
 	s.PanicOnUnsetFunc("ConsensusFaultVerifier")
-	return nil
+	return nil, nil
 }
 
 func (s *syscaller) PanicOnUnsetFunc(unsetFuncName string) {


### PR DESCRIPTION
Add third parameter to consensus fault reporting for the parent grinding witness.
Remove parameters that are derived from the block headers, return them from the syscall instead.