### PR TITLE
handle errors in AwardBlockReward

### DIFF
--- a/actors/builtin/reward/reward_actor.go
+++ b/actors/builtin/reward/reward_actor.go
@@ -101,7 +101,9 @@ func (a Actor) AwardBlockReward(rt vmr.Runtime, params *AwardBlockRewardParams) 
 				AmountWithdrawn: abi.NewTokenAmount(0),
 				VestingFunction: rewardVestingFunction,
 			}
-			return st.addReward(adt.AsStore(rt), miner, &newReward)
+			if err := st.addReward(adt.AsStore(rt), miner, &newReward); err != nil {
+				rt.Abortf(exitcode.ErrIllegalState, "failed to add reward to rewards map: %w", err)
+			}
 		}
 		return nil
 	})


### PR DESCRIPTION
We're seeing an issue where we don't get rewards mapped for every block, trying to debug it I found this. I havent confirmed this was the issue though.