### PR TITLE
fix sector creation, drop winpost candidate req

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -344,10 +344,12 @@ func (a Actor) ProveCommitSector(rt Runtime, params *ProveCommitSectorParams) *a
 	// add sector to miner state
 	rt.State().Transaction(&st, func() interface{} {
 		newSectorInfo := &SectorOnChainInfo{
-			Info:              precommit.Info,
-			ActivationEpoch:   rt.CurrEpoch(),
-			DealWeight:        dealWeight,
-			PledgeRequirement: pledgeRequirement,
+			Info:                  precommit.Info,
+			ActivationEpoch:       rt.CurrEpoch(),
+			DealWeight:            dealWeight,
+			PledgeRequirement:     pledgeRequirement,
+			DeclaredFaultEpoch:    -1,
+			DeclaredFaultDuration: -1,
 		}
 
 		if err = st.PutSector(store, newSectorInfo); err != nil {
@@ -960,7 +962,7 @@ func (a Actor) verifyWindowedPost(rt Runtime, st *State, onChainInfo *abi.OnChai
 	store := adt.AsStore(rt)
 	sectorInfos, err := st.ComputeProvingSet(store)
 	if err != nil {
-		rt.Abortf(exitcode.ErrIllegalState, "Could not compute proving set.")
+		rt.Abortf(exitcode.ErrIllegalState, "Could not compute proving set: %s", err)
 	}
 
 	var addrBuf bytes.Buffer

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -30,7 +30,7 @@ const PoStLookback = abi.ChainEpoch(1) // PARAM_FINISH
 const ElectionLookback = PoStLookback // PARAM_FINISH
 
 // Number of sectors to be sampled as part of windowed PoSt
-const NumWindowedPoStSectors = 200 // PARAM_FINISH
+const NumWindowedPoStSectors = 1 // PARAM_FINISH
 
 // Delay between declaration of a temporary sector fault and effectiveness of reducing the active proving set for PoSts.
 const DeclaredFaultEffectiveDelay = abi.ChainEpoch(20) // PARAM_FINISH


### PR DESCRIPTION
These sector fields need to be initialized to -1 otherwise it fails when we try to enumerate the sector set for post.

I also lowered the number of sectors we need down to 1, so simplify implementation work. This is going to change anyways, so no big deal here.