### PR TITLE
remove redundant caller asserion in miner actor

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -794,7 +794,6 @@ func (a Actor) terminateSectors(rt Runtime, sectorNos []abi.SectorNumber, termin
 }
 
 func (a Actor) checkPoStProvingPeriodExpiration(rt Runtime) {
-	rt.ValidateImmediateCallerIs(builtin.StoragePowerActorAddr)
 
 	var st State
 	expired := rt.State().Transaction(&st, func() interface{} {
@@ -1039,7 +1038,6 @@ func (a Actor) requestUnsealedSectorCID(rt Runtime, st abi.RegisteredProof, deal
 }
 
 func (a Actor) commitWorkerKeyChange(rt Runtime) *adt.EmptyValue {
-	rt.ValidateImmediateCallerIs(builtin.CronActorAddr)
 
 	var st State
 	rt.State().Transaction(&st, func() interface{} {


### PR DESCRIPTION
The methods modifies are only called from `OnDeferredCronEvent` which already validates the caller (note: calling ValidateCaller more than once for a single transactions causes the go-filecoin rt to panic). Furthermore `commitWorkerKeyChange` wrongly expected its caller to be the Cron actor, this check has been removed and is handed in `OnDeferredCronEvent`.