### PR TITLE
Add beneficiary parameter to DeleteActor

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -201,10 +201,9 @@ func (a Actor) SubmitWindowedPoSt(rt Runtime, params *abi.OnChainPoStVerifyInfo)
 	return nil
 }
 
-// Called by Actor.
-func (a Actor) OnDeleteMiner(rt Runtime, _ *adt.EmptyValue) *adt.EmptyValue {
+func (a Actor) OnDeleteMiner(rt Runtime, beneficiary *addr.Address) *adt.EmptyValue {
 	rt.ValidateImmediateCallerIs(builtin.StoragePowerActorAddr)
-	rt.DeleteActor()
+	rt.DeleteActor(*beneficiary)
 	return nil
 }
 

--- a/actors/builtin/power/power_actor.go
+++ b/actors/builtin/power/power_actor.go
@@ -637,10 +637,11 @@ func (a Actor) deleteMinerActor(rt Runtime, miner addr.Address) error {
 		return txErr
 	}
 
+	// Delete the actor, burning any balance it has (sector pre-commit deposits).
 	_, code := rt.Send(
 		miner,
 		builtin.MethodsMiner.OnDeleteMiner,
-		nil,
+		&builtin.BurntFundsActorAddr,
 		abi.NewTokenAmount(0),
 	)
 	builtin.RequireSuccess(rt, code, "failed to delete miner actor")

--- a/actors/runtime/runtime.go
+++ b/actors/runtime/runtime.go
@@ -68,8 +68,10 @@ type Runtime interface {
 	// Creates an actor with code `codeID` and address `address`, with empty state. May only be called by Init actor.
 	CreateActor(codeId cid.Cid, address addr.Address)
 
-	// Deletes the executing actor from the state tree. May only be called by the actor itself.
-	DeleteActor()
+	// Deletes the executing actor from the state tree, transferring any balance to beneficiary.
+	// Aborts if the beneficiary does not exist.
+	// May only be called by the actor itself.
+	DeleteActor(beneficiary addr.Address)
 
 	// Provides the system call interface.
 	Syscalls() Syscalls

--- a/support/mock/mockrt.go
+++ b/support/mock/mockrt.go
@@ -161,7 +161,7 @@ func (rt *Runtime) GetActorCodeCID(addr addr.Address) (ret cid.Cid, ok bool) {
 	return
 }
 
-func (rt *Runtime) GetRandomness(personalization crypto.DomainSeparationTag, randEpoch abi.ChainEpoch, entropy []byte) abi.Randomness {
+func (rt *Runtime) GetRandomness(_ crypto.DomainSeparationTag, _ abi.ChainEpoch, _ []byte) abi.Randomness {
 	rt.requireInCall()
 	panic("implement me")
 }
@@ -228,7 +228,7 @@ func (rt *Runtime) CreateActor(codeId cid.Cid, address addr.Address) {
 	}()
 }
 
-func (rt *Runtime) DeleteActor() {
+func (rt *Runtime) DeleteActor(_ addr.Address) {
 	rt.requireInCall()
 	if rt.inTransaction {
 		rt.Abortf(exitcode.SysErrorIllegalActor, "side-effect within transaction")
@@ -257,7 +257,7 @@ func (rt *Runtime) Context() context.Context {
 	return rt.ctx
 }
 
-func (rt *Runtime) StartSpan(name string) runtime.TraceSpan {
+func (rt *Runtime) StartSpan(_ string) runtime.TraceSpan {
 	rt.requireInCall()
 	return &TraceSpan{}
 }


### PR DESCRIPTION
When an actor is deleted we need to do something with its funds to preserve the money supply invariant. One option is to refuse to delete the actor (i.e. abort), but since our one use case for this comes from cron and slashing, we really need it to succeed.

Better is to designate where the funds should go. Ethereum's `selfdestruct` opcode does the same thing.