### PR TITLE
Fix varint buffer lengths to avoid edge case panics

### DIFF
--- a/actors/util/adt/store.go
+++ b/actors/util/adt/store.go
@@ -72,7 +72,7 @@ func IntKey(k int64) intKey {
 }
 
 func (k intKey) Key() string {
-	buf := make([]byte, 8)
+	buf := make([]byte, 10)
 	n := binary.PutVarint(buf, k.int64)
 	return string(buf[:n])
 }
@@ -97,7 +97,7 @@ func UIntKey (k uint64) uintKey {
 }
 
 func (k uintKey) Key() string {
-	buf := make([]byte, 8)
+	buf := make([]byte, 10)
 	n := binary.PutUvarint(buf, k.uint64)
 	return string(buf[:n])
 }


### PR DESCRIPTION
I noticed you guys have an insufficiently long buffer for varints you are using for the hash keys. 

I don't know if this is intended but I did not want to assume a panic in this edge case without checking. I couldn't find any documentation referring to why this would be the case