### PR TITLE
Add a proposal hash to multisig "Approve" message params

### DIFF
--- a/actors/builtin/multisig/cbor_gen.go
+++ b/actors/builtin/multisig/cbor_gen.go
@@ -403,6 +403,121 @@ func (t *Transaction) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
+func (t *ProposalHashData) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+        if _, err := w.Write([]byte{133}); err != nil {
+		return err
+	}
+
+	// t.Requester (address.Address) (struct)
+	if err := t.Requester.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.To (address.Address) (struct)
+	if err := t.To.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.Value (big.Int) (struct)
+	if err := t.Value.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.Method (abi.MethodNum) (uint64)
+	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.Method))); err != nil {
+		return err
+	}
+
+	// t.Params ([]uint8) (slice)
+	if len(t.Params) > cbg.ByteArrayMaxLen {
+		return xerrors.Errorf("Byte array in field t.Params was too long")
+	}
+
+	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajByteString, uint64(len(t.Params)))); err != nil {
+		return err
+	}
+	if _, err := w.Write(t.Params); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *ProposalHashData) UnmarshalCBOR(r io.Reader) error {
+	br := cbg.GetPeeker(r)
+
+	maj, extra, err := cbg.CborReadHeader(br)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+        if extra != 5 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.Requester (address.Address) (struct)
+
+	{
+
+		if err := t.Requester.UnmarshalCBOR(br); err != nil {
+			return err
+		}
+
+	}
+	// t.To (address.Address) (struct)
+
+	{
+
+		if err := t.To.UnmarshalCBOR(br); err != nil {
+			return err
+		}
+
+	}
+	// t.Value (big.Int) (struct)
+
+	{
+
+		if err := t.Value.UnmarshalCBOR(br); err != nil {
+			return err
+		}
+
+	}
+	// t.Method (abi.MethodNum) (uint64)
+
+	maj, extra, err = cbg.CborReadHeader(br)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajUnsignedInt {
+		return fmt.Errorf("wrong type for uint64 field")
+	}
+	t.Method = abi.MethodNum(extra)
+	// t.Params ([]uint8) (slice)
+
+	maj, extra, err = cbg.CborReadHeader(br)
+	if err != nil {
+		return err
+	}
+
+	if extra > cbg.ByteArrayMaxLen {
+		return fmt.Errorf("t.Params: byte array too large (%d)", extra)
+	}
+	if maj != cbg.MajByteString {
+		return fmt.Errorf("expected byte array")
+	}
+	t.Params = make([]byte, extra)
+	if _, err := io.ReadFull(br, t.Params); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (t *ConstructorParams) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)

--- a/actors/builtin/multisig/multisig_actor.go
+++ b/actors/builtin/multisig/multisig_actor.go
@@ -161,6 +161,12 @@ func (a Actor) Cancel(rt vmr.Runtime, params *TxnIDParams) *adt.EmptyValue {
 			rt.Abortf(exitcode.ErrForbidden, "Cannot cancel another signers transaction")
 		}
 
+                // confirm the hashes match
+                calculatedHash := a.getApprovalHash(rt, txn)
+                if params.ProposalHash != nil && bytes.Compare(params.ProposalHash, calculatedHash[:]) != 0 {
+                        rt.Abortf(exitcode.ErrIllegalState, "hash does not match proposal params")
+                }
+
 		if err = st.deletePendingTransaction(adt.AsStore(rt), params.ID); err != nil {
 			rt.Abortf(exitcode.ErrIllegalState, "failed to delete transaction for cancel: %v", err)
 		}

--- a/actors/builtin/multisig/multisig_actor.go
+++ b/actors/builtin/multisig/multisig_actor.go
@@ -179,7 +179,7 @@ func (a Actor) Cancel(rt vmr.Runtime, params *TxnIDParams) *adt.EmptyValue {
 		}
 
 		// confirm the hashes match
-		calculatedHash := a.getProposalHash(rt, txn)
+                calculatedHash := a.GetProposalHash(rt, txn)
 		if params.ProposalHash != nil && bytes.Compare(params.ProposalHash, calculatedHash[:]) != 0 {
 			rt.Abortf(exitcode.ErrIllegalState, "hash does not match proposal params")
 		}
@@ -308,10 +308,10 @@ func (ahd *ProposalHashData) Serialize() ([]byte, error) {
 	if err := ahd.MarshalCBOR(buf); err != nil {
 		return nil, err
 	}
-	return buf.Bytes(), nil
+        return buf.Bytes(), nil
 }
 
-func (a Actor) getProposalHash(rt vmr.Runtime, txn Transaction) [32]byte {
+func (a Actor) GetProposalHash(rt vmr.Runtime, txn Transaction) [32]byte {
         hashData := ProposalHashData{
                 Requester: txn.Approved[0],
                 To:        txn.To,
@@ -391,13 +391,13 @@ func (a Actor) approveTransactionWithHash(rt vmr.Runtime, params *TxnIDParams) {
 			if previousApprover == rt.Message().Caller() {
 				rt.Abortf(exitcode.ErrIllegalState, "already approved this message")
 			}
-		}
+                }
 
-		// confirm the hashes match
-                calculatedHash := a.getProposalHash(rt, txn)
-		if params.ProposalHash != nil && bytes.Compare(params.ProposalHash, calculatedHash[:]) != 0 {
-			rt.Abortf(exitcode.ErrIllegalState, "hash does not match proposal params")
-		}
+                // confirm the hashes match
+                calculatedHash := a.GetProposalHash(rt, txn)
+                if params.ProposalHash != nil && bytes.Compare(params.ProposalHash, calculatedHash[:]) != 0 {
+                        rt.Abortf(exitcode.ErrIllegalState, "hash does not match proposal params")
+                }
 
 		// update approved on the transaction
 		txn.Approved = append(txn.Approved, rt.Message().Caller())

--- a/actors/builtin/multisig/multisig_actor.go
+++ b/actors/builtin/multisig/multisig_actor.go
@@ -1,6 +1,7 @@
 package multisig
 
 import (
+	"bytes"
 	"encoding/binary"
 
 	addr "github.com/filecoin-project/go-address"
@@ -288,13 +289,13 @@ func (ahd *ApprovalHashData) Serialize() ([]byte, error) {
 }
 
 func (a Actor) getApprovalHash(rt vmr.Runtime, txn Transaction) [32]byte {
-        hashData := ApprovalHashData {
+        hashData := ApprovalHashData{
                 MsigWallet: rt.Message().Receiver(),
-                Requester : txn.Approved[0],
-                To        : txn.To,
-                Value     : txn.Value,
-                Method    : txn.Method,
-                Params    : txn.Params,
+                Requester:  txn.Approved[0],
+                To:         txn.To,
+                Value:      txn.Value,
+                Method:     txn.Method,
+                Params:     txn.Params,
         }
 
         data, err := hashData.Serialize()

--- a/actors/builtin/multisig/multisig_test.go
+++ b/actors/builtin/multisig/multisig_test.go
@@ -322,11 +322,11 @@ func TestApprove(t *testing.T) {
 		rt.Verify()
 
 		actor.assertTransactions(rt, multisig.Transaction{
-			To:       chuck,
-			Value:    sendValue,
-			Method:   fakeMethod,
-			Params:   fakeParams,
-			Approved: []addr.Address{anne},
+                        To:       chuck,
+                        Value:    sendValue,
+                        Method:   fakeMethod,
+                        Params:   fakeParams,
+                        Approved: []addr.Address{anne},
 		})
 
 		rt.SetBalance(sendValue)
@@ -390,11 +390,11 @@ func TestApprove(t *testing.T) {
 
 		// Transaction was not removed from store.
 		actor.assertTransactions(rt, multisig.Transaction{
-                        To:         chuck,
-                        Value:      sendValue,
-                        Method:     builtin.MethodSend,
-                        Params:     fakeParams,
-                        Approved:   []addr.Address{anne},
+                        To:       chuck,
+                        Value:    sendValue,
+                        Method:   builtin.MethodSend,
+                        Params:   fakeParams,
+                        Approved: []addr.Address{anne},
 		})
 	})
 

--- a/actors/builtin/multisig/multisig_test.go
+++ b/actors/builtin/multisig/multisig_test.go
@@ -390,11 +390,11 @@ func TestApprove(t *testing.T) {
 
 		// Transaction was not removed from store.
 		actor.assertTransactions(rt, multisig.Transaction{
-			To:       chuck,
-			Value:    sendValue,
-			Method:   builtin.MethodSend,
-			Params:   fakeParams,
-			Approved: []addr.Address{anne},
+                        To:         chuck,
+                        Value:      sendValue,
+                        Method:     builtin.MethodSend,
+                        Params:     fakeParams,
+                        Approved:   []addr.Address{anne},
 		})
 	})
 

--- a/actors/builtin/multisig/multisig_test.go
+++ b/actors/builtin/multisig/multisig_test.go
@@ -131,14 +131,14 @@ func TestVesting(t *testing.T) {
 		// expect darlene to receive the transaction proposed by anne.
 		rt.ExpectSend(darlene, builtin.MethodSend, fakeParams, multisigInitialBalance, nil, exitcode.Ok)
 		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
-                proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
-                        To:       darlene,
-                        Value:    multisigInitialBalance,
-                        Method:   builtin.MethodSend,
-                        Params:   fakeParams,
-                        Approved: []addr.Address{anne},
-                })
-                actor.approve(rt, 0, proposalHashData)
+		proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
+			To:       darlene,
+			Value:    multisigInitialBalance,
+			Method:   builtin.MethodSend,
+			Params:   fakeParams,
+			Approved: []addr.Address{anne},
+		})
+		actor.approve(rt, 0, proposalHashData)
 		rt.Verify()
 
 	})
@@ -160,15 +160,15 @@ func TestVesting(t *testing.T) {
 		rt.ExpectSend(darlene, builtin.MethodSend, fakeParams, big.Div(multisigInitialBalance, big.NewInt(2)), nil, exitcode.Ok)
 		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
 
-                proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
-                        To:       darlene,
-                        Value:    big.Div(multisigInitialBalance, big.NewInt(2)),
-                        Method:   builtin.MethodSend,
-                        Params:   fakeParams,
-                        Approved: []addr.Address{anne},
-                })
+		proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
+			To:       darlene,
+			Value:    big.Div(multisigInitialBalance, big.NewInt(2)),
+			Method:   builtin.MethodSend,
+			Params:   fakeParams,
+			Approved: []addr.Address{anne},
+		})
 
-                actor.approve(rt, 0, proposalHashData)
+		actor.approve(rt, 0, proposalHashData)
 		rt.Verify()
 
 	})
@@ -213,14 +213,14 @@ func TestVesting(t *testing.T) {
 		rt.SetCaller(bob, builtin.AccountActorCodeID)
 		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
 		rt.ExpectAbort(exitcode.ErrInsufficientFunds, func() {
-                        proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
-                                To:       darlene,
-                                Value:    big.Div(multisigInitialBalance, big.NewInt(2)),
-                                Method:   builtin.MethodSend,
-                                Params:   fakeParams,
-                                Approved: []addr.Address{anne},
-                        })
-                        actor.approve(rt, 0, proposalHashData)
+			proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
+				To:       darlene,
+				Value:    big.Div(multisigInitialBalance, big.NewInt(2)),
+				Method:   builtin.MethodSend,
+				Params:   fakeParams,
+				Approved: []addr.Address{anne},
+			})
+			actor.approve(rt, 0, proposalHashData)
 		})
 		rt.Verify()
 	})
@@ -345,11 +345,11 @@ func TestApprove(t *testing.T) {
 		rt.Verify()
 
 		actor.assertTransactions(rt, multisig.Transaction{
-                        To:       chuck,
-                        Value:    sendValue,
-                        Method:   fakeMethod,
-                        Params:   fakeParams,
-                        Approved: []addr.Address{anne},
+			To:       chuck,
+			Value:    sendValue,
+			Method:   fakeMethod,
+			Params:   fakeParams,
+			Approved: []addr.Address{anne},
 		})
 
 		rt.SetBalance(sendValue)
@@ -357,55 +357,55 @@ func TestApprove(t *testing.T) {
 		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
 		rt.ExpectSend(chuck, fakeMethod, fakeParams, sendValue, nil, 0)
 
-                proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
-                        To:       chuck,
-                        Value:    sendValue,
-                        Method:   fakeMethod,
-                        Params:   fakeParams,
-                        Approved: []addr.Address{anne},
-                })
+		proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
+			To:       chuck,
+			Value:    sendValue,
+			Method:   fakeMethod,
+			Params:   fakeParams,
+			Approved: []addr.Address{anne},
+		})
 
-                actor.approve(rt, txnID, proposalHashData)
+		actor.approve(rt, txnID, proposalHashData)
 		rt.Verify()
 
 		// Transaction should be removed from actor state after send
 		actor.assertTransactions(rt)
 	})
 
-        t.Run("fail approval with bad proposal hash", func(t *testing.T) {
-                rt := builder.Build(t)
+	t.Run("fail approval with bad proposal hash", func(t *testing.T) {
+		rt := builder.Build(t)
 
-                actor.constructAndVerify(rt, numApprovals, noUnlockDuration, signers...)
+		actor.constructAndVerify(rt, numApprovals, noUnlockDuration, signers...)
 
-                rt.SetCaller(anne, builtin.AccountActorCodeID)
-                rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
-                actor.propose(rt, chuck, sendValue, fakeMethod, fakeParams)
-                rt.Verify()
+		rt.SetCaller(anne, builtin.AccountActorCodeID)
+		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
+		actor.propose(rt, chuck, sendValue, fakeMethod, fakeParams)
+		rt.Verify()
 
-                actor.assertTransactions(rt, multisig.Transaction{
-                        To:       chuck,
-                        Value:    sendValue,
-                        Method:   fakeMethod,
-                        Params:   fakeParams,
-                        Approved: []addr.Address{anne},
-                })
+		actor.assertTransactions(rt, multisig.Transaction{
+			To:       chuck,
+			Value:    sendValue,
+			Method:   fakeMethod,
+			Params:   fakeParams,
+			Approved: []addr.Address{anne},
+		})
 
-                rt.SetBalance(sendValue)
-                rt.SetCaller(bob, builtin.AccountActorCodeID)
-                rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
-                rt.ExpectSend(chuck, fakeMethod, fakeParams, sendValue, nil, 0)
+		rt.SetBalance(sendValue)
+		rt.SetCaller(bob, builtin.AccountActorCodeID)
+		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
+		rt.ExpectSend(chuck, fakeMethod, fakeParams, sendValue, nil, 0)
 
-                rt.ExpectAbort(exitcode.ErrIllegalState, func() {
-                        proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
-                                To:       chuck,
-                                Value:    sendValue,
-                                Method:   fakeMethod,
-                                Params:   fakeParams,
-                                Approved: []addr.Address{bob},
-                        })
-                        actor.approve(rt, txnID, proposalHashData)
-                })
-        })
+		rt.ExpectAbort(exitcode.ErrIllegalState, func() {
+			proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
+				To:       chuck,
+				Value:    sendValue,
+				Method:   fakeMethod,
+				Params:   fakeParams,
+				Approved: []addr.Address{bob},
+			})
+			actor.approve(rt, txnID, proposalHashData)
+		})
+	})
 
 	t.Run("fail approve transaction more than once", func(t *testing.T) {
 		const numApprovals = int64(2)
@@ -422,14 +422,14 @@ func TestApprove(t *testing.T) {
 		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
 		// TODO replace with correct exit code when multisig actor breaks the AbortStateMsg pattern.
 		rt.ExpectAbort(exitcode.ErrIllegalState, func() {
-                        proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
-                                To:       chuck,
-                                Value:    sendValue,
-                                Method:   builtin.MethodSend,
-                                Params:   fakeParams,
-                                Approved: []addr.Address{anne},
-                        })
-                        actor.approve(rt, txnID, proposalHashData)
+			proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
+				To:       chuck,
+				Value:    sendValue,
+				Method:   builtin.MethodSend,
+				Params:   fakeParams,
+				Approved: []addr.Address{anne},
+			})
+			actor.approve(rt, txnID, proposalHashData)
 		})
 		rt.Verify()
 
@@ -458,24 +458,24 @@ func TestApprove(t *testing.T) {
 		rt.SetCaller(bob, builtin.AccountActorCodeID)
 		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
 		rt.ExpectAbort(exitcode.ErrNotFound, func() {
-                        proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
-                                To:       chuck,
-                                Value:    sendValue,
-                                Method:   builtin.MethodSend,
-                                Params:   fakeParams,
-                                Approved: []addr.Address{bob},
-                        })
-                        actor.approve(rt, dneTxnID, proposalHashData)
+			proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
+				To:       chuck,
+				Value:    sendValue,
+				Method:   builtin.MethodSend,
+				Params:   fakeParams,
+				Approved: []addr.Address{bob},
+			})
+			actor.approve(rt, dneTxnID, proposalHashData)
 		})
 		rt.Verify()
 
 		// Transaction was not removed from store.
 		actor.assertTransactions(rt, multisig.Transaction{
-                        To:       chuck,
-                        Value:    sendValue,
-                        Method:   builtin.MethodSend,
-                        Params:   fakeParams,
-                        Approved: []addr.Address{anne},
+			To:       chuck,
+			Value:    sendValue,
+			Method:   builtin.MethodSend,
+			Params:   fakeParams,
+			Approved: []addr.Address{anne},
 		})
 	})
 
@@ -494,14 +494,14 @@ func TestApprove(t *testing.T) {
 		rt.SetCaller(richard, builtin.AccountActorCodeID)
 		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
 		rt.ExpectAbort(exitcode.ErrForbidden, func() {
-                        proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
-                                To:       chuck,
-                                Value:    sendValue,
-                                Method:   builtin.MethodSend,
-                                Params:   fakeParams,
-                                Approved: []addr.Address{richard},
-                        })
-                        actor.approve(rt, txnID, proposalHashData)
+			proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
+				To:       chuck,
+				Value:    sendValue,
+				Method:   builtin.MethodSend,
+				Params:   fakeParams,
+				Approved: []addr.Address{richard},
+			})
+			actor.approve(rt, txnID, proposalHashData)
 		})
 		rt.Verify()
 
@@ -550,46 +550,46 @@ func TestCancel(t *testing.T) {
 		rt.SetBalance(sendValue)
 		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
 
-                proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
-                        To:       chuck,
-                        Value:    sendValue,
-                        Method:   fakeMethod,
-                        Params:   fakeParams,
-                        Approved: []addr.Address{anne},
-                })
-                actor.cancel(rt, txnID, proposalHashData)
+		proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
+			To:       chuck,
+			Value:    sendValue,
+			Method:   fakeMethod,
+			Params:   fakeParams,
+			Approved: []addr.Address{anne},
+		})
+		actor.cancel(rt, txnID, proposalHashData)
 		rt.Verify()
 
 		// Transaction should be removed from actor state after cancel
 		actor.assertTransactions(rt)
 	})
 
-        t.Run("fail cancel with bad proposal hash", func(t *testing.T) {
-                rt := builder.Build(t)
+	t.Run("fail cancel with bad proposal hash", func(t *testing.T) {
+		rt := builder.Build(t)
 
-                actor.constructAndVerify(rt, numApprovals, noUnlockDuration, signers...)
+		actor.constructAndVerify(rt, numApprovals, noUnlockDuration, signers...)
 
-                // anne proposes a transaction
-                rt.SetCaller(anne, builtin.AccountActorCodeID)
-                rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
-                actor.propose(rt, chuck, sendValue, fakeMethod, fakeParams)
-                rt.Verify()
+		// anne proposes a transaction
+		rt.SetCaller(anne, builtin.AccountActorCodeID)
+		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
+		actor.propose(rt, chuck, sendValue, fakeMethod, fakeParams)
+		rt.Verify()
 
-                // anne cancels their transaction
-                rt.SetBalance(sendValue)
-                rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
+		// anne cancels their transaction
+		rt.SetBalance(sendValue)
+		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
 
-                rt.ExpectAbort(exitcode.ErrIllegalState, func() {
-                        proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
-                                To:       bob,
-                                Value:    sendValue,
-                                Method:   fakeMethod,
-                                Params:   fakeParams,
-                                Approved: []addr.Address{chuck},
-                        })
-                        actor.cancel(rt, txnID, proposalHashData)
-                })
-        })
+		rt.ExpectAbort(exitcode.ErrIllegalState, func() {
+			proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
+				To:       bob,
+				Value:    sendValue,
+				Method:   fakeMethod,
+				Params:   fakeParams,
+				Approved: []addr.Address{chuck},
+			})
+			actor.cancel(rt, txnID, proposalHashData)
+		})
+	})
 
 	t.Run("signer fails to cancel transaction from another signer", func(t *testing.T) {
 		rt := builder.Build(t)
@@ -606,14 +606,14 @@ func TestCancel(t *testing.T) {
 		rt.SetCaller(bob, builtin.AccountActorCodeID)
 		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
 		rt.ExpectAbort(exitcode.ErrForbidden, func() {
-                        proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
-                                To:       chuck,
-                                Value:    sendValue,
-                                Method:   fakeMethod,
-                                Params:   fakeParams,
-                                Approved: []addr.Address{anne},
-                        })
-                        actor.cancel(rt, txnID, proposalHashData)
+			proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
+				To:       chuck,
+				Value:    sendValue,
+				Method:   fakeMethod,
+				Params:   fakeParams,
+				Approved: []addr.Address{anne},
+			})
+			actor.cancel(rt, txnID, proposalHashData)
 		})
 		rt.Verify()
 
@@ -642,14 +642,14 @@ func TestCancel(t *testing.T) {
 		rt.SetCaller(richard, builtin.AccountActorCodeID)
 		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
 		rt.ExpectAbort(exitcode.ErrForbidden, func() {
-                        proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
-                                To:       chuck,
-                                Value:    sendValue,
-                                Method:   fakeMethod,
-                                Params:   fakeParams,
-                                Approved: []addr.Address{anne},
-                        })
-                        actor.cancel(rt, txnID, proposalHashData)
+			proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
+				To:       chuck,
+				Value:    sendValue,
+				Method:   fakeMethod,
+				Params:   fakeParams,
+				Approved: []addr.Address{anne},
+			})
+			actor.cancel(rt, txnID, proposalHashData)
 		})
 		rt.Verify()
 
@@ -678,14 +678,14 @@ func TestCancel(t *testing.T) {
 		// anne fails to cancel a transaction that does not exists ID: 1 (dneTxnID)
 		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
 		rt.ExpectAbort(exitcode.ErrNotFound, func() {
-                        proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
-                                To:       chuck,
-                                Value:    sendValue,
-                                Method:   fakeMethod,
-                                Params:   fakeParams,
-                                Approved: []addr.Address{anne},
-                        })
-                        actor.cancel(rt, dneTxnID, proposalHashData)
+			proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
+				To:       chuck,
+				Value:    sendValue,
+				Method:   fakeMethod,
+				Params:   fakeParams,
+				Approved: []addr.Address{anne},
+			})
+			actor.cancel(rt, dneTxnID, proposalHashData)
 		})
 		rt.Verify()
 
@@ -1059,7 +1059,7 @@ func TestChangeThreshold(t *testing.T) {
 //
 
 type msActorHarness struct {
-        a multisig.Actor
+	a multisig.Actor
 	t testing.TB
 }
 
@@ -1071,7 +1071,7 @@ func (h *msActorHarness) constructAndVerify(rt *mock.Runtime, numApprovalsThresh
 	}
 
 	rt.ExpectValidateCallerAddr(builtin.InitActorAddr)
-        ret := rt.Call(h.a.Constructor, &constructParams)
+	ret := rt.Call(h.a.Constructor, &constructParams)
 	assert.Nil(h.t, ret)
 	rt.Verify()
 }
@@ -1083,19 +1083,19 @@ func (h *msActorHarness) propose(rt *mock.Runtime, to addr.Address, value abi.To
 		Method: method,
 		Params: params,
 	}
-        rt.Call(h.a.Propose, proposeParams)
+	rt.Call(h.a.Propose, proposeParams)
 }
 
 // TODO In a follow-up, this method should also verify the return value from Approve contains the exit code prescribed in ExpectSend.
 // exercise both un/successful sends.
-func (h *msActorHarness) approve(rt *mock.Runtime, txnID int64, proposalParams [32]byte) {
-        approveParams := &multisig.TxnIDParams{ID: multisig.TxnID(txnID), ProposalHash: proposalParams[:]}
-        rt.Call(h.a.Approve, approveParams)
+func (h *msActorHarness) approve(rt *mock.Runtime, txnID int64, proposalParams []byte) {
+	approveParams := &multisig.TxnIDParams{ID: multisig.TxnID(txnID), ProposalHash: proposalParams}
+	rt.Call(h.a.Approve, approveParams)
 }
 
-func (h *msActorHarness) cancel(rt *mock.Runtime, txnID int64, proposalParams [32]byte) {
-        cancelParams := &multisig.TxnIDParams{ID: multisig.TxnID(txnID), ProposalHash: proposalParams[:]}
-        rt.Call(h.a.Cancel, cancelParams)
+func (h *msActorHarness) cancel(rt *mock.Runtime, txnID int64, proposalParams []byte) {
+	cancelParams := &multisig.TxnIDParams{ID: multisig.TxnID(txnID), ProposalHash: proposalParams}
+	rt.Call(h.a.Cancel, cancelParams)
 }
 
 func (h *msActorHarness) addSigner(rt *mock.Runtime, signer addr.Address, increase bool) {
@@ -1103,7 +1103,7 @@ func (h *msActorHarness) addSigner(rt *mock.Runtime, signer addr.Address, increa
 		Signer:   signer,
 		Increase: increase,
 	}
-        rt.Call(h.a.AddSigner, addSignerParams)
+	rt.Call(h.a.AddSigner, addSignerParams)
 }
 
 func (h *msActorHarness) removeSigner(rt *mock.Runtime, signer addr.Address, decrease bool) {
@@ -1111,7 +1111,7 @@ func (h *msActorHarness) removeSigner(rt *mock.Runtime, signer addr.Address, dec
 		Signer:   signer,
 		Decrease: decrease,
 	}
-        rt.Call(h.a.RemoveSigner, rmSignerParams)
+	rt.Call(h.a.RemoveSigner, rmSignerParams)
 }
 
 func (h *msActorHarness) swapSigners(rt *mock.Runtime, oldSigner, newSigner addr.Address) {
@@ -1119,12 +1119,12 @@ func (h *msActorHarness) swapSigners(rt *mock.Runtime, oldSigner, newSigner addr
 		From: oldSigner,
 		To:   newSigner,
 	}
-        rt.Call(h.a.SwapSigner, swpParams)
+	rt.Call(h.a.SwapSigner, swpParams)
 }
 
 func (h *msActorHarness) changeNumApprovalsThreshold(rt *mock.Runtime, newThreshold int64) {
 	thrshParams := &multisig.ChangeNumApprovalsThresholdParams{NewThreshold: newThreshold}
-        rt.Call(h.a.ChangeNumApprovalsThreshold, thrshParams)
+	rt.Call(h.a.ChangeNumApprovalsThreshold, thrshParams)
 }
 
 func (h *msActorHarness) assertTransactions(rt *mock.Runtime, expected ...multisig.Transaction) {

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -90,6 +90,7 @@ func main() {
 		// actor state
 		multisig.State{},
 		multisig.Transaction{},
+		multisig.ProposalHashData{},
 		// method params
 		multisig.ConstructorParams{},
 		multisig.ProposeParams{},


### PR DESCRIPTION
As written, multisig has an issue. When approving a message, approvers have no cryptographic method for confirming that they are truly signing a message related to the original proposal. Add a proposal hash field to the "Approve" message params. The field contains a BLAKE2B-256 hash of the CBOR bytes of the multisig wallet address, the proposer's address, and the fields in the multisig "Propose" params. When an approval occurs, the actor code compares the hash it receives with the data from the original transaction it received. If there's a match, the approval proceeds. If not, the code errors out.