### PR TITLE
Define two exclusive failed send codes

### DIFF
--- a/support/mock/mockrt.go
+++ b/support/mock/mockrt.go
@@ -190,7 +190,7 @@ func (rt *Runtime) Send(toAddr addr.Address, methodNum abi.MethodNum, params run
 	}
 
 	if value.GreaterThan(rt.balance) {
-		rt.Abortf(exitcode.SysErrInsufficientFunds, "cannot send value: %v exceeds balance: %v", value, rt.balance)
+		rt.Abortf(exitcode.SysErrSenderStateInvalid, "cannot send value: %v exceeds balance: %v", value, rt.balance)
 	}
 
 	// pop the expectedMessage from the queue and modify the mockrt balance to reflect the send.


### PR DESCRIPTION
Identify two exit codes which indicate message send failure, meaning that the sender's callseqnum is not incremented. The VM needs to handle such messages, and produce a receipt, lest we require full tipset re-evaluation for clients to be able to identify which receipt is for which message in a tipset.

The new `SysErrSenderInvalid` and `SysErrSenderStateInvalid` together capture all message send failures, and should be used *only* to indicate that.

I'm open to suggestions of better terminology than "send failure" to describe these cases. I chose it over "application failure" because it's all about where the message come from, rather than what it applies to.

Closes #251