### PR TITLE
Remove duplicate balance add in power actor state

### DIFF
--- a/actors/builtin/power/power_state.go
+++ b/actors/builtin/power/power_state.go
@@ -136,10 +136,11 @@ func (st *State) setMinerBalance(store adt.Store, miner addr.Address, amount abi
 func (st *State) addMinerBalance(store adt.Store, miner addr.Address, amount abi.TokenAmount) error {
 	Assert(amount.GreaterThanEqual(big.Zero()))
 	table := adt.AsBalanceTable(store, st.EscrowTable)
-	if table.Add(miner, amount) == nil {
+	err := table.Add(miner, amount)
+	if err == nil {
 		st.EscrowTable = table.Root()
 	}
-	return table.Add(miner, amount)
+	return err
 }
 
 func (st *State) subtractMinerBalance(store adt.Store, miner addr.Address, amount abi.TokenAmount,

--- a/actors/builtin/power/power_state.go
+++ b/actors/builtin/power/power_state.go
@@ -136,11 +136,11 @@ func (st *State) setMinerBalance(store adt.Store, miner addr.Address, amount abi
 func (st *State) addMinerBalance(store adt.Store, miner addr.Address, amount abi.TokenAmount) error {
 	Assert(amount.GreaterThanEqual(big.Zero()))
 	table := adt.AsBalanceTable(store, st.EscrowTable)
-	err := table.Add(miner, amount)
-	if err == nil {
-		st.EscrowTable = table.Root()
+	if err := table.Add(miner, amount); err != nil {
+		return err
 	}
-	return err
+	st.EscrowTable = table.Root()
+	return nil
 }
 
 func (st *State) subtractMinerBalance(store adt.Store, miner addr.Address, amount abi.TokenAmount,


### PR DESCRIPTION
amount is being added twice, which does not affect anything regarding consensus because the root is only updated after the first, but there are unnecessary values written to store (and of course unnecessary logic). 

With your implementation the call the second time is written to the underlying data storage, meaning you have a data leak of sorts having to store this updated state which may never be used.