### PR TITLE
Remove duplicate pledge update in spa state

### DIFF
--- a/actors/builtin/power/power_state.go
+++ b/actors/builtin/power/power_state.go
@@ -201,8 +201,6 @@ func (st *State) AddToClaim(s adt.Store, miner addr.Address, power abi.StoragePo
 		}
 	}
 
-	claim.Pledge = big.Add(claim.Pledge, pledge)
-
 	AssertMsg(claim.Power.GreaterThanEqual(big.Zero()), "negative claimed power: %v", claim.Power)
 	AssertMsg(claim.Pledge.GreaterThanEqual(big.Zero()), "negative claimed pledge: %v", claim.Pledge)
 	AssertMsg(st.NumMinersMeetingMinPower >= 0, "negative number of miners larger than min: %v", st.NumMinersMeetingMinPower)


### PR DESCRIPTION
Maybe this should be an issue but I don't see any possible reason why the claim pledge would be updated twice in this function. I assume this is a bug from updates that were made?