### PR TITLE
Update amount vested utility function

### DIFF
--- a/actors/builtin/reward/reward_state.go
+++ b/actors/builtin/reward/reward_state.go
@@ -115,7 +115,8 @@ func (r *Reward) AmountVested(currEpoch abi.ChainEpoch) abi.TokenAmount {
 			return r.Value
 		}
 
-		// totalReward * elapsedEpoch / vestDuration
+		// (totalReward * elapsedEpoch) / vestDuration
+		// Division must be done last to avoid precision loss with integer values
 		return big.Div(big.Mul(r.Value, big.NewInt(int64(elapsed))), big.NewInt(int64(vestDuration)))
 	default:
 		return abi.NewTokenAmount(0)

--- a/actors/builtin/reward/reward_state.go
+++ b/actors/builtin/reward/reward_state.go
@@ -1,6 +1,8 @@
 package reward
 
 import (
+	"fmt"
+
 	addr "github.com/filecoin-project/go-address"
 	cid "github.com/ipfs/go-cid"
 	errors "github.com/pkg/errors"
@@ -103,20 +105,23 @@ func (st *State) withdrawReward(store adt.Store, owner addr.Address, currEpoch a
 	return withdrawableSum, nil
 }
 
+// AmountVested returns the `TokenAmount` value of funds vested in the reward at an epoch
 func (r *Reward) AmountVested(currEpoch abi.ChainEpoch) abi.TokenAmount {
-	elapsed := currEpoch - r.StartEpoch
 	switch r.VestingFunction {
 	case None:
 		return r.Value
 	case Linear:
-		vestDuration := big.Sub(big.NewInt(int64(r.EndEpoch)), big.NewInt(int64(r.StartEpoch)))
-		if big.NewInt(int64(elapsed)).GreaterThanEqual(vestDuration) {
+		elapsed := currEpoch - r.StartEpoch
+
+		vestDuration := r.EndEpoch - r.StartEpoch
+		if elapsed >= vestDuration {
 			return r.Value
 		}
 
 		// totalReward * elapsedEpoch / vestDuration
-		return big.Div(big.Mul(r.Value, big.NewInt(int64(elapsed))), vestDuration)
+		return big.Mul(r.Value, big.NewInt(int64(elapsed/vestDuration)))
 	default:
-		return abi.NewTokenAmount(0)
+		panic(fmt.Sprintf("invalid vesting function %v", r.VestingFunction))
+
 	}
 }

--- a/actors/builtin/reward/reward_state.go
+++ b/actors/builtin/reward/reward_state.go
@@ -1,8 +1,6 @@
 package reward
 
 import (
-	"fmt"
-
 	addr "github.com/filecoin-project/go-address"
 	cid "github.com/ipfs/go-cid"
 	errors "github.com/pkg/errors"
@@ -118,8 +116,8 @@ func (r *Reward) AmountVested(currEpoch abi.ChainEpoch) abi.TokenAmount {
 		}
 
 		// totalReward * elapsedEpoch / vestDuration
-		return big.Mul(r.Value, big.NewInt(int64(elapsed/vestDuration)))
+		return big.Div(big.Mul(r.Value, big.NewInt(int64(elapsed))), big.NewInt(int64(vestDuration)))
 	default:
-		panic(fmt.Sprintf("invalid vesting function %v", r.VestingFunction))
+		return abi.NewTokenAmount(0)
 	}
 }

--- a/actors/builtin/reward/reward_state.go
+++ b/actors/builtin/reward/reward_state.go
@@ -112,7 +112,6 @@ func (r *Reward) AmountVested(currEpoch abi.ChainEpoch) abi.TokenAmount {
 		return r.Value
 	case Linear:
 		elapsed := currEpoch - r.StartEpoch
-
 		vestDuration := r.EndEpoch - r.StartEpoch
 		if elapsed >= vestDuration {
 			return r.Value
@@ -122,6 +121,5 @@ func (r *Reward) AmountVested(currEpoch abi.ChainEpoch) abi.TokenAmount {
 		return big.Mul(r.Value, big.NewInt(int64(elapsed/vestDuration)))
 	default:
 		panic(fmt.Sprintf("invalid vesting function %v", r.VestingFunction))
-
 	}
 }


### PR DESCRIPTION
- Removes unnecessary big.Int allocations
- Only initialize elapsed on linear vesting (not used for non-vesting)
- Panic on invalid vesting function instead of just returning 0
  - Obviously doesn't matter now because `None` vesting function is hard coded, but just want to make sure the call will not succeed in future if an invalid function

The heap allocations and verbose checks were hard to look at. Let me know what you would want the doc comment or panic message to say, or if you want this to behave differently than this