### PR TITLE
Reward state should allow withdrawableSum to equal RewardTotal

### DIFF
--- a/actors/builtin/reward/reward_state.go
+++ b/actors/builtin/reward/reward_state.go
@@ -86,7 +86,7 @@ func (st *State) withdrawReward(store adt.Store, owner addr.Address, currEpoch a
 		return big.Zero(), err
 	}
 
-	AssertMsg(withdrawableSum.LessThan(st.RewardTotal), "withdrawable %v exceeds recorded prior total %v",
+	AssertMsg(withdrawableSum.LessThanEqual(st.RewardTotal), "withdrawable %v exceeds recorded prior total %v",
 		withdrawableSum, st.RewardTotal)
 
 	// Replace old reward list for this key with the updated list.

--- a/actors/builtin/reward/reward_test.go
+++ b/actors/builtin/reward/reward_test.go
@@ -2,6 +2,7 @@ package reward_test
 
 import (
 	"context"
+	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -46,6 +47,40 @@ func TestAwardBlockReward(t *testing.T) {
 				GasReward: gasreward,
 			})
 		})
+		rt.Verify()
+	})
+}
+
+func TestWithdrawReward(t *testing.T) {
+	actor := rewardHarness{reward.Actor{}, t}
+	owner := tutil.NewIDAddr(t, 101)
+	m := tutil.NewIDAddr(t, 1000)
+	builder := mock.NewBuilder(context.Background(), builtin.RewardActorAddr).
+		WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID).
+		WithActorType(m, builtin.StorageMinerActorCodeID).
+		WithActorType(owner, builtin.AccountActorCodeID)
+
+	t.Run("successfully withdraw reward total", func(t *testing.T) {
+		rt := builder.Build(t)
+		actor.constructAndVerify(rt)
+
+		gasreward := abi.NewTokenAmount(10)
+		rt.SetBalance(abi.NewTokenAmount(100000000))
+
+		rt.ExpectValidateCallerAddr(builtin.SystemActorAddr)
+		rt.ExpectSend(builtin.BurntFundsActorAddr, builtin.MethodSend, nil, big.Zero(), nil, 0)
+		rt.Call(actor.AwardBlockReward, &reward.AwardBlockRewardParams{
+			Miner:       m,
+			Penalty:     big.Zero(),
+			GasReward:   gasreward,
+			TicketCount: 50,
+		})
+		rt.SetCaller(owner, builtin.AccountActorCodeID)
+		rt.ExpectValidateCallerAddr(owner, owner)
+		rt.ExpectSend(m, builtin.MethodsMiner.ControlAddresses, nil, big.Zero(), &mock.ReturnWrapper{V: &miner.GetControlAddressesReturn{owner, owner}}, 0)
+		rt.ExpectSend(owner, builtin.MethodSend, nil, big.NewInt(100000000), nil, 0)
+		rt.Call(actor.WithdrawReward, &m)
+
 		rt.Verify()
 	})
 }


### PR DESCRIPTION
There's no conceptual reason to want withdrawableSum to be strictly less.