### PR TITLE
avoid flushing merkle structures on every single operation

### DIFF
--- a/actors/builtin/init/init_actor.go
+++ b/actors/builtin/init/init_actor.go
@@ -31,11 +31,12 @@ type ConstructorParams struct {
 
 func (a Actor) Constructor(rt runtime.Runtime, params *ConstructorParams) *adt.EmptyValue {
 	rt.ValidateImmediateCallerIs(builtin.SystemActorAddr)
-	emptyMap, err := adt.MakeEmptyMap(adt.AsStore(rt))
+	emptyMap, err := adt.MakeEmptyMap(adt.AsStore(rt)).Root()
 	if err != nil {
 		rt.Abortf(exitcode.ErrIllegalState, "failed to construct state: %v", err)
 	}
-	st := ConstructState(emptyMap.Root(), params.NetworkName)
+
+	st := ConstructState(emptyMap, params.NetworkName)
 	rt.State().Create(st)
 	return nil
 }

--- a/actors/builtin/init/init_test.go
+++ b/actors/builtin/init/init_test.go
@@ -214,8 +214,9 @@ func (h *initHarness) constructAndVerify(rt *mock.Runtime) {
 
 	var st init_.State
 	rt.GetState(&st)
-	emptyMap := adt.AsMap(adt.AsStore(rt), st.AddressMap)
-	assert.Equal(h.t, emptyMap.Root(), st.AddressMap)
+	emptyMap, err := adt.AsMap(adt.AsStore(rt), st.AddressMap)
+	assert.NoError(h.t, err)
+	assert.Equal(h.t, tutil.MustRoot(h.t, emptyMap), st.AddressMap)
 	assert.Equal(h.t, abi.ActorID(builtin.FirstNonSingletonActorId), st.NextID)
 	assert.Equal(h.t, "mock", st.NetworkName)
 }

--- a/actors/builtin/market/market_test.go
+++ b/actors/builtin/market/market_test.go
@@ -62,24 +62,24 @@ func TestMarketActor(t *testing.T) {
 
 		store := adt.AsStore(rt)
 
-		emptyMap, err := adt.MakeEmptyMap(store)
+		emptyMap, err := adt.MakeEmptyMap(store).Root()
 		assert.NoError(t, err)
 
-		emptyArray, err := adt.MakeEmptyArray(store)
+		emptyArray, err := adt.MakeEmptyArray(store).Root()
 		assert.NoError(t, err)
 
-		emptyMultiMap, err := market.MakeEmptySetMultimap(store)
+		emptyMultiMap, err := market.MakeEmptySetMultimap(store).Root()
 		assert.NoError(t, err)
 
 		var state market.State
 		rt.GetState(&state)
 
-		assert.Equal(t, emptyArray.Root(), state.Proposals)
-		assert.Equal(t, emptyArray.Root(), state.States)
-		assert.Equal(t, emptyMap.Root(), state.EscrowTable)
-		assert.Equal(t, emptyMap.Root(), state.LockedTable)
+		assert.Equal(t, emptyArray, state.Proposals)
+		assert.Equal(t, emptyArray, state.States)
+		assert.Equal(t, emptyMap, state.EscrowTable)
+		assert.Equal(t, emptyMap, state.LockedTable)
 		assert.Equal(t, abi.DealID(0), state.NextID)
-		assert.Equal(t, emptyMultiMap.Root(), state.DealIDsByParty)
+		assert.Equal(t, emptyMultiMap, state.DealIDsByParty)
 	})
 
 	t.Run("AddBalance", func(t *testing.T) {

--- a/actors/builtin/market/types.go
+++ b/actors/builtin/market/types.go
@@ -15,12 +15,16 @@ type DealArray struct {
 }
 
 // Interprets a store as balance table with root `r`.
-func AsDealProposalArray(s Store, r cid.Cid) *DealArray {
-	return &DealArray{AsArray(s, r)}
+func AsDealProposalArray(s Store, r cid.Cid) (*DealArray, error) {
+	a, err := AsArray(s, r)
+	if err != nil {
+		return nil, err
+	}
+	return &DealArray{a}, nil
 }
 
 // Returns the root cid of underlying AMT.
-func (t *DealArray) Root() cid.Cid {
+func (t *DealArray) Root() (cid.Cid, error) {
 	return t.Array.Root()
 }
 
@@ -52,12 +56,17 @@ type DealMetaArray struct {
 }
 
 // Interprets a store as balance table with root `r`.
-func AsDealStateArray(s Store, r cid.Cid) *DealMetaArray {
-	return &DealMetaArray{AsArray(s, r)}
+func AsDealStateArray(s Store, r cid.Cid) (*DealMetaArray, error) {
+	dsa, err := AsArray(s, r)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DealMetaArray{dsa}, nil
 }
 
 // Returns the root cid of underlying AMT.
-func (t *DealMetaArray) Root() cid.Cid {
+func (t *DealMetaArray) Root() (cid.Cid, error) {
 	return t.Array.Root()
 }
 

--- a/actors/builtin/multisig/multisig_actor.go
+++ b/actors/builtin/multisig/multisig_actor.go
@@ -68,7 +68,7 @@ func (a Actor) Constructor(rt vmr.Runtime, params *ConstructorParams) *adt.Empty
 		signers = append(signers, sa)
 	}
 
-	pending, err := adt.MakeEmptyMap(adt.AsStore(rt))
+	pending, err := adt.MakeEmptyMap(adt.AsStore(rt)).Root()
 	if err != nil {
 		rt.Abortf(exitcode.ErrIllegalState, "failed to create empty map: %v", err)
 	}
@@ -76,7 +76,7 @@ func (a Actor) Constructor(rt vmr.Runtime, params *ConstructorParams) *adt.Empty
 	var st State
 	st.Signers = signers
 	st.NumApprovalsThreshold = params.NumApprovalsThreshold
-	st.PendingTxns = pending.Root()
+	st.PendingTxns = pending
 	st.InitialBalance = abi.NewTokenAmount(0)
 	if params.UnlockDuration != 0 {
 		st.InitialBalance = rt.Message().ValueReceived()

--- a/actors/builtin/multisig/multisig_test.go
+++ b/actors/builtin/multisig/multisig_test.go
@@ -55,7 +55,8 @@ func TestConstruction(t *testing.T) {
 		assert.Equal(t, abi.NewTokenAmount(0), st.InitialBalance)
 		assert.Equal(t, abi.ChainEpoch(0), st.UnlockDuration)
 		assert.Equal(t, abi.ChainEpoch(0), st.StartEpoch)
-		txns := adt.AsMap(adt.AsStore(rt), st.PendingTxns)
+		txns, err := adt.AsMap(adt.AsStore(rt), st.PendingTxns)
+		assert.NoError(t, err)
 		keys, err := txns.CollectKeys()
 		require.NoError(t, err)
 		assert.Empty(t, keys)
@@ -993,7 +994,8 @@ func (h *msActorHarness) assertTransactions(rt *mock.Runtime, expected ...multis
 	var st multisig.State
 	rt.GetState(&st)
 
-	txns := adt.AsMap(adt.AsStore(rt), st.PendingTxns)
+	txns, err := adt.AsMap(adt.AsStore(rt), st.PendingTxns)
+	assert.NoError(h.t, err)
 	keys, err := txns.CollectKeys()
 	assert.NoError(h.t, err)
 

--- a/actors/builtin/power/power_test.go
+++ b/actors/builtin/power/power_test.go
@@ -61,7 +61,8 @@ func TestConstruction(t *testing.T) {
 		assert.Equal(t, abi.NewStoragePower(0), st.TotalRawBytePower)
 		assert.Equal(t, int64(0), st.NumMinersMeetingMinPower)
 
-		claim := adt.AsMap(adt.AsStore(rt), st.Claims)
+		claim, err := adt.AsMap(adt.AsStore(rt), st.Claims)
+		assert.NoError(t, err)
 		keys, err := claim.CollectKeys()
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(keys))
@@ -136,7 +137,8 @@ func asKey(in string) adt.Keyer {
 }
 
 func verifyEmptyMap(t testing.TB, rt *mock.Runtime, cid cid.Cid) {
-	mapChecked := adt.AsMap(adt.AsStore(rt), cid)
+	mapChecked, err := adt.AsMap(adt.AsStore(rt), cid)
+	assert.NoError(t, err)
 	keys, err := mapChecked.CollectKeys()
 	require.NoError(t, err)
 	assert.Empty(t, keys)

--- a/actors/builtin/reward/reward_actor.go
+++ b/actors/builtin/reward/reward_actor.go
@@ -36,12 +36,12 @@ var _ abi.Invokee = Actor{}
 func (a Actor) Constructor(rt vmr.Runtime, _ *adt.EmptyValue) *adt.EmptyValue {
 	rt.ValidateImmediateCallerIs(builtin.SystemActorAddr)
 
-	rewards, err := adt.MakeEmptyMultimap(adt.AsStore(rt))
+	rewards, err := adt.MakeEmptyMultimap(adt.AsStore(rt)).Root()
 	if err != nil {
 		rt.Abortf(exitcode.ErrIllegalState, "failed to construct state: %v", err)
 	}
 
-	st := ConstructState(rewards.Root())
+	st := ConstructState(rewards)
 	rt.State().Create(st)
 	return nil
 }

--- a/actors/builtin/reward/reward_test.go
+++ b/actors/builtin/reward/reward_test.go
@@ -63,4 +63,5 @@ func (h *rewardHarness) constructAndVerify(rt *mock.Runtime) {
 	ret := rt.Call(h.Constructor, nil)
 	assert.Nil(h.t, ret)
 	rt.Verify()
+
 }

--- a/actors/util/adt/array.go
+++ b/actors/util/adt/array.go
@@ -14,79 +14,75 @@ import (
 
 // Array stores a sparse sequence of values in an AMT.
 type Array struct {
-	root  cid.Cid
+	root  *amt.Root
 	store Store
 }
 
 // AsArray interprets a store as an AMT-based array with root `r`.
-func AsArray(s Store, r cid.Cid) *Array {
+func AsArray(s Store, r cid.Cid) (*Array, error) {
+	root, err := amt.LoadAMT(s.Context(), s, r)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to root: %w", err)
+	}
+
 	return &Array{
-		root:  r,
+		root:  root,
+		store: s,
+	}, nil
+}
+
+// Creates a new map backed by an empty HAMT and flushes it to the store.
+func MakeEmptyArray(s Store) *Array {
+	root := amt.NewAMT(s)
+	return &Array{
+		root:  root,
 		store: s,
 	}
 }
 
-// Creates a new map backed by an empty HAMT and flushes it to the store.
-func MakeEmptyArray(s Store) (*Array, error) {
-	root := amt.NewAMT(s)
-	newArray := AsArray(s, cid.Undef)
-	err := newArray.write(root)
-	return newArray, err
-}
-
 // Returns the root CID of the underlying AMT.
-func (a *Array) Root() cid.Cid {
-	return a.root
+func (a *Array) Root() (cid.Cid, error) {
+	return a.root.Flush(a.store.Context())
 }
 
 // Appends a value to the end of the array. Assumes continuous array.
 // If the array isn't continuous use Set and a separate counter
 func (a *Array) AppendContinuous(value runtime.CBORMarshaler) error {
-	root, err := amt.LoadAMT(a.store.Context(), a.store, a.root)
-	if err != nil {
-		return errors.Wrapf(err, "array append failed to load root %v", a.root)
+	if err := a.root.Set(a.store.Context(), a.root.Count, value); err != nil {
+		return errors.Wrapf(err, "array append failed to set index %v value %v in root %v, ", a.root.Count, value, a.root)
 	}
-	if err := root.Set(a.store.Context(), root.Count, value); err != nil {
-		return errors.Wrapf(err, "array append failed to set index %v value %v in root %v, ", root.Count, value, a.root)
-	}
-	return a.write(root)
+	return nil
 }
 
 func (a *Array) Set(i uint64, value runtime.CBORMarshaler) error {
-	root, err := amt.LoadAMT(a.store.Context(), a.store, a.root)
-	if err != nil {
-		return errors.Wrapf(err, "array set failed to load root %v", a.root)
+	if err := a.root.Set(a.store.Context(), i, value); err != nil {
+		return xerrors.Errorf("array set failed to set index %v value %v in root %v: %w", i, value, a.root, err)
 	}
-	if err := root.Set(a.store.Context(), i, value); err != nil {
-		return errors.Wrapf(err, "array set failed to set index %v value %v in root %v, ", i, value, a.root)
-	}
-	return a.write(root)
+	return nil
 }
 
 func (a *Array) Delete(i uint64) error {
-	root, err := amt.LoadAMT(a.store.Context(), a.store, a.root)
-	if err != nil {
-		return errors.Wrapf(err, "array delete failed to load root %v", a.root)
+	if err := a.root.Delete(a.store.Context(), i); err != nil {
+		return xerrors.Errorf("array delete failed to delete index %v in root %v: %w", i, a.root, err)
 	}
-	if err := root.Delete(a.store.Context(), i); err != nil {
-		return errors.Wrapf(err, "array delete failed to delete index %v in root %v, ", i, a.root)
+	return nil
+}
+
+func (a *Array) BatchDelete(ix []uint64) error {
+	if err := a.root.BatchDelete(a.store.Context(), ix); err != nil {
+		return xerrors.Errorf("array delete failed to batchdelete: %w", err)
 	}
-	return a.write(root)
+	return nil
 }
 
 // Iterates all entries in the array, deserializing each value in turn into `out` and then calling a function.
 // Iteration halts if the function returns an error.
 // If the output parameter is nil, deserialization is skipped.
 func (a *Array) ForEach(out runtime.CBORUnmarshaler, fn func(i int64) error) error {
-	root, err := amt.LoadAMT(a.store.Context(), a.store, a.root)
-	if err != nil {
-		return errors.Wrapf(err, "array foreach failed to load root %v", a.root)
-	}
-	return root.ForEach(a.store.Context(), func(k uint64, val *cbg.Deferred) error {
+	return a.root.ForEach(a.store.Context(), func(k uint64, val *cbg.Deferred) error {
 		if out != nil {
 			// Why doesn't amt.ForEach() just return the value as bytes?
-			err = out.UnmarshalCBOR(bytes.NewReader(val.Raw))
-			if err != nil {
+			if err := out.UnmarshalCBOR(bytes.NewReader(val.Raw)); err != nil {
 				return err
 			}
 		}
@@ -94,39 +90,19 @@ func (a *Array) ForEach(out runtime.CBORUnmarshaler, fn func(i int64) error) err
 	})
 }
 
-func (a *Array) Length() (uint64, error) {
-	root, err := amt.LoadAMT(a.store.Context(), a.store, a.root)
-	if err != nil {
-		return 0, err
-	}
-	return root.Count, nil
-}
-
-// Writes the root node to storage and sets the new root CID.
-func (a *Array) write(root *amt.Root) error {
-	newCid, err := root.Flush(a.store.Context()) // this does the store.Put() too, differing from HAMT
-	if err != nil {
-		return errors.Wrapf(err, "failed to write AMT root %v", root)
-	}
-	a.root = newCid
-	return nil
+func (a *Array) Length() uint64 {
+	return a.root.Count
 }
 
 // Get retrieves array element into the 'out' unmarshaler, returning a boolean
 //  indicating whether the element was found in the array
 func (a *Array) Get(k uint64, out runtime.CBORUnmarshaler) (bool, error) {
-	root, err := amt.LoadAMT(a.store.Context(), a.store, a.root)
-	if err != nil {
-		return false, xerrors.Errorf("array get failed to load root %v: %w", a.root, err)
-	}
 
-	err = root.Get(a.store.Context(), k, out)
-	if err == nil {
+	if err := a.root.Get(a.store.Context(), k, out); err == nil {
 		return true, nil
-	}
-	if _, nf := err.(*amt.ErrNotFound); nf {
+	} else if _, nf := err.(*amt.ErrNotFound); nf {
 		return false, nil
+	} else {
+		return false, err
 	}
-
-	return false, err
 }

--- a/actors/util/adt/array_test.go
+++ b/actors/util/adt/array_test.go
@@ -14,8 +14,7 @@ import (
 func TestArrayNotFound(t *testing.T) {
 	rt := mock.NewBuilder(context.Background(), address.Undef).Build(t)
 	store := adt.AsStore(rt)
-	arr, err := adt.MakeEmptyArray(store)
-	require.NoError(t, err)
+	arr := adt.MakeEmptyArray(store)
 
 	found, err := arr.Get(7, nil)
 	require.NoError(t, err)

--- a/actors/util/adt/balancetable_test.go
+++ b/actors/util/adt/balancetable_test.go
@@ -19,10 +19,10 @@ func TestBalanceTable(t *testing.T) {
 		addr := tutil.NewIDAddr(t, 100)
 		rt := mock.NewBuilder(context.Background(), address.Undef).Build(t)
 		store := adt.AsStore(rt)
-		emptyMap, err := adt.MakeEmptyMap(store)
-		assert.NoError(t, err)
+		emptyMap := adt.MakeEmptyMap(store)
 
-		bt := adt.AsBalanceTable(store, emptyMap.Root())
+		bt, err := adt.AsBalanceTable(store, tutil.MustRoot(t, emptyMap))
+		assert.NoError(t, err)
 
 		has, err := bt.Has(addr)
 		assert.NoError(t, err)
@@ -49,10 +49,10 @@ func TestBalanceTable(t *testing.T) {
 
 		rt := mock.NewBuilder(context.Background(), address.Undef).Build(t)
 		store := adt.AsStore(rt)
-		emptyMap, err := adt.MakeEmptyMap(store)
-		assert.NoError(t, err)
+		emptyMap := adt.MakeEmptyMap(store)
 
-		bt := adt.AsBalanceTable(store, emptyMap.Root())
+		bt, err := adt.AsBalanceTable(store, tutil.MustRoot(t, emptyMap))
+		assert.NoError(t, err)
 		total, err := bt.Total()
 		assert.NoError(t, err)
 		assert.Equal(t, big.Zero(), total)

--- a/actors/util/adt/map.go
+++ b/actors/util/adt/map.go
@@ -7,6 +7,7 @@ import (
 	hamt "github.com/ipfs/go-hamt-ipld"
 	errors "github.com/pkg/errors"
 	cbg "github.com/whyrusleeping/cbor-gen"
+	"golang.org/x/xerrors"
 
 	runtime "github.com/filecoin-project/specs-actors/actors/runtime"
 )
@@ -18,76 +19,76 @@ const hamtBitwidth = 5
 
 // Map stores key-value pairs in a HAMT.
 type Map struct {
-	root  cid.Cid
-	store Store
+	lastCid cid.Cid
+	root    *hamt.Node
+	store   Store
 }
 
 // AsMap interprets a store as a HAMT-based map with root `r`.
-func AsMap(s Store, r cid.Cid) *Map {
-	return &Map{
-		root:  r,
-		store: s,
+func AsMap(s Store, r cid.Cid) (*Map, error) {
+	nd, err := hamt.LoadNode(s.Context(), s, r, hamt.UseTreeBitWidth(hamtBitwidth))
+	if err != nil {
+		return nil, xerrors.Errorf("failed to load hamt node: %w", err)
 	}
+
+	return &Map{
+		lastCid: r,
+		root:    nd,
+		store:   s,
+	}, nil
 }
 
 // Creates a new map backed by an empty HAMT and flushes it to the store.
-func MakeEmptyMap(s Store) (*Map, error) {
+func MakeEmptyMap(s Store) *Map {
 	nd := hamt.NewNode(s, hamt.UseTreeBitWidth(hamtBitwidth))
-	newMap := AsMap(s, cid.Undef)
-	err := newMap.write(nd)
-	return newMap, err
+	return &Map{
+		lastCid: cid.Undef,
+		root:    nd,
+		store:   s,
+	}
 }
 
 // Returns the root cid of underlying HAMT.
-func (m *Map) Root() cid.Cid {
-	return m.root
+func (m *Map) Root() (cid.Cid, error) {
+	if err := m.root.Flush(m.store.Context()); err != nil {
+		return cid.Undef, xerrors.Errorf("failed to flush map root: %w", err)
+	}
+
+	c, err := m.store.Put(m.store.Context(), m.root)
+	if err != nil {
+		return cid.Undef, xerrors.Errorf("writing map root object: %w", err)
+	}
+	m.lastCid = c
+
+	return c, nil
 }
 
 // Put adds value `v` with key `k` to the hamt store.
 func (m *Map) Put(k Keyer, v runtime.CBORMarshaler) error {
-	root, err := m.loadRoot()
-	if err != nil {
-		return errors.Wrapf(err, "map put failed to load node %v", m.root)
+	if err := m.root.Set(m.store.Context(), k.Key(), v); err != nil {
+		return errors.Wrapf(err, "map put failed set in node %v with key %v value %v", m.lastCid, k.Key(), v)
 	}
-	if err = root.Set(m.store.Context(), k.Key(), v); err != nil {
-		return errors.Wrapf(err, "map put failed set in node %v with key %v value %v", m.root, k.Key(), v)
-	}
-	if err = root.Flush(m.store.Context()); err != nil {
-		return errors.Wrapf(err, "map put failed to flush node %v : %v", m.root, err)
-	}
-
-	return m.write(root)
+	return nil
 }
 
 // Get puts the value at `k` into `out`.
 func (m *Map) Get(k Keyer, out runtime.CBORUnmarshaler) (bool, error) {
-	root, err := m.loadRoot()
-	if err != nil {
-		return false, errors.Wrapf(err, "map get failed to load node %v", m.root)
-	}
-	if err = root.Find(m.store.Context(), k.Key(), out); err != nil {
+	if err := m.root.Find(m.store.Context(), k.Key(), out); err != nil {
 		if err == hamt.ErrNotFound {
 			return false, nil
 		}
-		return false, errors.Wrapf(err, "map get failed find in node %v with key %v", m.root, k.Key())
+		return false, errors.Wrapf(err, "map get failed find in node %v with key %v", m.lastCid, k.Key())
 	}
 	return true, nil
 }
 
 // Delete removes the value at `k` from the hamt store.
 func (m *Map) Delete(k Keyer) error {
-	root, err := m.loadRoot()
-	if err != nil {
-		return errors.Wrapf(err, "map delete failed to load node %v", m.root)
-	}
-	if err = root.Delete(m.store.Context(), k.Key()); err != nil {
+	if err := m.root.Delete(m.store.Context(), k.Key()); err != nil {
 		return errors.Wrapf(err, "map delete failed in node %v key %v", m.root, k.Key())
 	}
-	if err = root.Flush(m.store.Context()); err != nil {
-		return errors.Wrapf(err, "map delete failed to flush node %v : %v", m.root, err)
-	}
 
-	return m.write(root)
+	return nil
 }
 
 // Iterates all entries in the map, deserializing each value in turn into `out` and then
@@ -95,14 +96,10 @@ func (m *Map) Delete(k Keyer) error {
 // Iteration halts if the function returns an error.
 // If the output parameter is nil, deserialization is skipped.
 func (m *Map) ForEach(out runtime.CBORUnmarshaler, fn func(key string) error) error {
-	root, err := m.loadRoot()
-	if err != nil {
-		return errors.Wrapf(err, "map foreach failed to load root %s", m.root)
-	}
-	return root.ForEach(m.store.Context(), func(k string, val interface{}) error {
+	return m.root.ForEach(m.store.Context(), func(k string, val interface{}) error {
 		if out != nil {
 			// Why doesn't hamt.ForEach() just return the value as bytes?
-			err = out.UnmarshalCBOR(bytes.NewReader(val.(*cbg.Deferred).Raw))
+			err := out.UnmarshalCBOR(bytes.NewReader(val.(*cbg.Deferred).Raw))
 			if err != nil {
 				return err
 			}
@@ -118,19 +115,4 @@ func (m *Map) CollectKeys() (out []string, err error) {
 		return nil
 	})
 	return
-}
-
-// Loads the root node.
-func (m *Map) loadRoot() (*hamt.Node, error) {
-	return hamt.LoadNode(m.store.Context(), m.store, m.root, hamt.UseTreeBitWidth(hamtBitwidth))
-}
-
-// Writes the root node to storage and sets the new root CID.
-func (m *Map) write(root *hamt.Node) error {
-	newCid, err := m.store.Put(m.store.Context(), root)
-	if err != nil {
-		return errors.Wrapf(err, "map failed to write node %v", root)
-	}
-	m.root = newCid
-	return nil
 }

--- a/actors/util/adt/set.go
+++ b/actors/util/adt/set.go
@@ -10,24 +10,26 @@ type Set struct {
 }
 
 // AsSet interprets a store as a HAMT-based set with root `r`.
-func AsSet(s Store, r cid.Cid) *Set {
-	return &Set{
-		m: AsMap(s, r),
-	}
-}
-
-// NewSet creates a new HAMT with root `r` and store `s`.
-func MakeEmptySet(s Store) (*Set, error) {
-	m, err := MakeEmptyMap(s)
+func AsSet(s Store, r cid.Cid) (*Set, error) {
+	m, err := AsMap(s, r)
 	if err != nil {
 		return nil, err
 	}
-	return &Set{m}, nil
+
+	return &Set{
+		m: m,
+	}, nil
+}
+
+// NewSet creates a new HAMT with root `r` and store `s`.
+func MakeEmptySet(s Store) *Set {
+	m := MakeEmptyMap(s)
+	return &Set{m}
 }
 
 // Root return the root cid of HAMT.
-func (h *Set) Root() cid.Cid {
-	return h.m.root
+func (h *Set) Root() (cid.Cid, error) {
+	return h.m.Root()
 }
 
 // Put adds `k` to the set.

--- a/support/testing/address.go
+++ b/support/testing/address.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	addr "github.com/filecoin-project/go-address"
+	"github.com/ipfs/go-cid"
 )
 
 func NewIDAddr(t *testing.T, id uint64) addr.Address {
@@ -43,4 +44,17 @@ func NewActorAddr(t *testing.T, data string) addr.Address {
 		t.Fatal(err)
 	}
 	return address
+}
+
+type rooter interface {
+	Root() (cid.Cid, error)
+}
+
+func MustRoot(t testing.TB, r rooter) cid.Cid {
+	t.Helper()
+	c, err := r.Root()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
 }

--- a/support/testing/address.go
+++ b/support/testing/address.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	addr "github.com/filecoin-project/go-address"
-	"github.com/ipfs/go-cid"
 )
 
 func NewIDAddr(t *testing.T, id uint64) addr.Address {
@@ -44,17 +43,4 @@ func NewActorAddr(t *testing.T, data string) addr.Address {
 		t.Fatal(err)
 	}
 	return address
-}
-
-type rooter interface {
-	Root() (cid.Cid, error)
-}
-
-func MustRoot(t testing.TB, r rooter) cid.Cid {
-	t.Helper()
-	c, err := r.Root()
-	if err != nil {
-		t.Fatal(err)
-	}
-	return c
 }

--- a/support/testing/adt.go
+++ b/support/testing/adt.go
@@ -1,0 +1,20 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/ipfs/go-cid"
+)
+
+type rooter interface {
+	Root() (cid.Cid, error)
+}
+
+func MustRoot(t testing.TB, r rooter) cid.Cid {
+	t.Helper()
+	c, err := r.Root()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}


### PR DESCRIPTION
This is the first phase, where we just change the apis a bit to only flush when root is called, and actually load the objects up front when we instantiate the structures.

I put in a few helpers in an attempt to write less code, but expect things to change more in the next step where I try to combine multiple operations on the same structure in the same transaction.