### PR TITLE
Remove direct call to blake2b from multisig actor by extracting transaction digest to pure function.

### DIFF
--- a/actors/builtin/multisig/multisig_actor.go
+++ b/actors/builtin/multisig/multisig_actor.go
@@ -3,9 +3,9 @@ package multisig
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 
 	addr "github.com/filecoin-project/go-address"
-	"github.com/minio/blake2b-simd"
 	cbg "github.com/whyrusleeping/cbor-gen"
 
 	abi "github.com/filecoin-project/specs-actors/actors/abi"
@@ -183,7 +183,10 @@ func (a Actor) Cancel(rt vmr.Runtime, params *TxnIDParams) *adt.EmptyValue {
 		}
 
 		// confirm the hashes match
-		calculatedHash := a.GetProposalHash(rt, txn)
+		calculatedHash, err := ComputeProposalHash(&txn, rt.Syscalls().HashBlake2b)
+		if err != nil {
+			rt.Abortf(exitcode.ErrIllegalState, "failed to compute proposal hash: %v", err)
+		}
 		if params.ProposalHash != nil && bytes.Compare(params.ProposalHash, calculatedHash[:]) != 0 {
 			rt.Abortf(exitcode.ErrIllegalState, "hash does not match proposal params")
 		}
@@ -307,33 +310,6 @@ func (a Actor) ChangeNumApprovalsThreshold(rt vmr.Runtime, params *ChangeNumAppr
 	return nil
 }
 
-func (ahd *ProposalHashData) Serialize() ([]byte, error) {
-	buf := new(bytes.Buffer)
-	if err := ahd.MarshalCBOR(buf); err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), nil
-}
-
-func (a Actor) GetProposalHash(rt vmr.Runtime, txn Transaction) []byte {
-	hashData := ProposalHashData{
-		Requester: txn.Approved[0],
-		To:        txn.To,
-		Value:     txn.Value,
-		Method:    txn.Method,
-		Params:    txn.Params,
-	}
-
-	data, err := hashData.Serialize()
-	if err != nil {
-		rt.Abortf(exitcode.ErrIllegalState, "failed to construct multisig approval hash: %v", err)
-	}
-
-	// TODO: Use syscalls for this (it currently breaks tests for some weird reason)
-	hashResult := blake2b.Sum256(data)
-	return hashResult[:]
-}
-
 func (a Actor) approveTransaction(rt vmr.Runtime, txnID TxnID, proposalHash []byte, checkHash bool) {
 	var st State
 	var txn Transaction
@@ -352,7 +328,10 @@ func (a Actor) approveTransaction(rt vmr.Runtime, txnID TxnID, proposalHash []by
 
 		// confirm the hashes match
 		if checkHash {
-			calculatedHash := a.GetProposalHash(rt, txn)
+			calculatedHash, err := ComputeProposalHash(&txn, rt.Syscalls().HashBlake2b)
+			if err != nil {
+				rt.Abortf(exitcode.ErrIllegalState, "failed to compute proposal hash: %v", err)
+			}
 			if proposalHash != nil && bytes.Compare(proposalHash, calculatedHash[:]) != 0 {
 				rt.Abortf(exitcode.ErrIllegalState, "hash does not match proposal params")
 			}
@@ -396,4 +375,32 @@ func (a Actor) validateSigner(rt vmr.Runtime, st *State, address addr.Address) {
 	if !st.isSigner(address) {
 		rt.Abortf(exitcode.ErrForbidden, "party not a signer")
 	}
+}
+
+// Computes a digest of a proposed transaction. This digest is used to confirm identity of the transaction
+// associated with an ID, which might change under chain re-orgs.
+func ComputeProposalHash(txn *Transaction, hash func([]byte) [32]byte) ([]byte, error) {
+	hashData := ProposalHashData{
+		Requester: txn.Approved[0],
+		To:        txn.To,
+		Value:     txn.Value,
+		Method:    txn.Method,
+		Params:    txn.Params,
+	}
+
+	data, err := hashData.Serialize()
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct multisig approval hash: %w", err)
+	}
+
+	hashResult := hash(data)
+	return hashResult[:], nil
+}
+
+func (phd *ProposalHashData) Serialize() ([]byte, error) {
+	buf := new(bytes.Buffer)
+	if err := phd.MarshalCBOR(buf); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }

--- a/actors/builtin/multisig/multisig_test.go
+++ b/actors/builtin/multisig/multisig_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	addr "github.com/filecoin-project/go-address"
+	"github.com/minio/blake2b-simd"
 	assert "github.com/stretchr/testify/assert"
 	require "github.com/stretchr/testify/require"
 
@@ -117,7 +118,8 @@ func TestVesting(t *testing.T) {
 		WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID).
 		WithEpoch(0).
 		// balance 0: current balance of the actor. receive: 100 the amount the multisig actor will be initalized with -- InitialBalance
-		WithBalance(multisigInitialBalance, multisigInitialBalance)
+		WithBalance(multisigInitialBalance, multisigInitialBalance).
+		WithHasher(blake2b.Sum256)
 
 	t.Run("happy path full vesting", func(t *testing.T) {
 		rt := builder.Build(t)
@@ -138,7 +140,7 @@ func TestVesting(t *testing.T) {
 		// expect darlene to receive the transaction proposed by anne.
 		rt.ExpectSend(darlene, builtin.MethodSend, fakeParams, multisigInitialBalance, nil, exitcode.Ok)
 		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
-		proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
+		proposalHashData := makeProposalHash(t, &multisig.Transaction{
 			To:       darlene,
 			Value:    multisigInitialBalance,
 			Method:   builtin.MethodSend,
@@ -167,7 +169,7 @@ func TestVesting(t *testing.T) {
 		rt.ExpectSend(darlene, builtin.MethodSend, fakeParams, big.Div(multisigInitialBalance, big.NewInt(2)), nil, exitcode.Ok)
 		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
 
-		proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
+		proposalHashData := makeProposalHash(t, &multisig.Transaction{
 			To:       darlene,
 			Value:    big.Div(multisigInitialBalance, big.NewInt(2)),
 			Method:   builtin.MethodSend,
@@ -220,7 +222,7 @@ func TestVesting(t *testing.T) {
 		rt.SetCaller(bob, builtin.AccountActorCodeID)
 		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
 		rt.ExpectAbort(exitcode.ErrInsufficientFunds, func() {
-			proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
+			proposalHashData := makeProposalHash(t, &multisig.Transaction{
 				To:       darlene,
 				Value:    big.Div(multisigInitialBalance, big.NewInt(2)),
 				Method:   builtin.MethodSend,
@@ -339,7 +341,9 @@ func TestApprove(t *testing.T) {
 	var fakeParams = runtime.CBORBytes([]byte{1, 2, 3, 4})
 	var signers = []addr.Address{anne, bob}
 
-	builder := mock.NewBuilder(context.Background(), receiver).WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID)
+	builder := mock.NewBuilder(context.Background(), receiver).
+		WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID).
+		WithHasher(blake2b.Sum256)
 
 	t.Run("simple propose and approval", func(t *testing.T) {
 		rt := builder.Build(t)
@@ -364,7 +368,7 @@ func TestApprove(t *testing.T) {
 		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
 		rt.ExpectSend(chuck, fakeMethod, fakeParams, sendValue, nil, 0)
 
-		proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
+		proposalHashData := makeProposalHash(t, &multisig.Transaction{
 			To:       chuck,
 			Value:    sendValue,
 			Method:   fakeMethod,
@@ -403,7 +407,7 @@ func TestApprove(t *testing.T) {
 		rt.ExpectSend(chuck, fakeMethod, fakeParams, sendValue, nil, 0)
 
 		rt.ExpectAbort(exitcode.ErrIllegalState, func() {
-			proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
+			proposalHashData := makeProposalHash(t, &multisig.Transaction{
 				To:       chuck,
 				Value:    sendValue,
 				Method:   fakeMethod,
@@ -429,7 +433,7 @@ func TestApprove(t *testing.T) {
 		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
 		// TODO replace with correct exit code when multisig actor breaks the AbortStateMsg pattern.
 		rt.ExpectAbort(exitcode.ErrIllegalState, func() {
-			proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
+			proposalHashData := makeProposalHash(t, &multisig.Transaction{
 				To:       chuck,
 				Value:    sendValue,
 				Method:   builtin.MethodSend,
@@ -465,7 +469,7 @@ func TestApprove(t *testing.T) {
 		rt.SetCaller(bob, builtin.AccountActorCodeID)
 		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
 		rt.ExpectAbort(exitcode.ErrNotFound, func() {
-			proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
+			proposalHashData := makeProposalHash(t, &multisig.Transaction{
 				To:       chuck,
 				Value:    sendValue,
 				Method:   builtin.MethodSend,
@@ -501,7 +505,7 @@ func TestApprove(t *testing.T) {
 		rt.SetCaller(richard, builtin.AccountActorCodeID)
 		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
 		rt.ExpectAbort(exitcode.ErrForbidden, func() {
-			proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
+			proposalHashData := makeProposalHash(t, &multisig.Transaction{
 				To:       chuck,
 				Value:    sendValue,
 				Method:   builtin.MethodSend,
@@ -540,7 +544,9 @@ func TestCancel(t *testing.T) {
 	var sendValue = abi.NewTokenAmount(10)
 	var signers = []addr.Address{anne, bob}
 
-	builder := mock.NewBuilder(context.Background(), receiver).WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID)
+	builder := mock.NewBuilder(context.Background(), receiver).
+		WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID).
+		WithHasher(blake2b.Sum256)
 
 	t.Run("simple propose and cancel", func(t *testing.T) {
 		rt := builder.Build(t)
@@ -557,7 +563,7 @@ func TestCancel(t *testing.T) {
 		rt.SetBalance(sendValue)
 		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
 
-		proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
+		proposalHashData := makeProposalHash(t, &multisig.Transaction{
 			To:       chuck,
 			Value:    sendValue,
 			Method:   fakeMethod,
@@ -587,7 +593,7 @@ func TestCancel(t *testing.T) {
 		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
 
 		rt.ExpectAbort(exitcode.ErrIllegalState, func() {
-			proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
+			proposalHashData := makeProposalHash(t, &multisig.Transaction{
 				To:       bob,
 				Value:    sendValue,
 				Method:   fakeMethod,
@@ -613,7 +619,7 @@ func TestCancel(t *testing.T) {
 		rt.SetCaller(bob, builtin.AccountActorCodeID)
 		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
 		rt.ExpectAbort(exitcode.ErrForbidden, func() {
-			proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
+			proposalHashData := makeProposalHash(t, &multisig.Transaction{
 				To:       chuck,
 				Value:    sendValue,
 				Method:   fakeMethod,
@@ -649,7 +655,7 @@ func TestCancel(t *testing.T) {
 		rt.SetCaller(richard, builtin.AccountActorCodeID)
 		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
 		rt.ExpectAbort(exitcode.ErrForbidden, func() {
-			proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
+			proposalHashData := makeProposalHash(t, &multisig.Transaction{
 				To:       chuck,
 				Value:    sendValue,
 				Method:   fakeMethod,
@@ -685,7 +691,7 @@ func TestCancel(t *testing.T) {
 		// anne fails to cancel a transaction that does not exists ID: 1 (dneTxnID)
 		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
 		rt.ExpectAbort(exitcode.ErrNotFound, func() {
-			proposalHashData := actor.a.GetProposalHash(rt, multisig.Transaction{
+			proposalHashData := makeProposalHash(t, &multisig.Transaction{
 				To:       chuck,
 				Value:    sendValue,
 				Method:   fakeMethod,
@@ -1151,6 +1157,12 @@ func (h *msActorHarness) assertTransactions(rt *mock.Runtime, expected ...multis
 		assert.True(h.t, found)
 		assert.Equal(h.t, expected[i], actual)
 	}
+}
+
+func makeProposalHash(t *testing.T, txn *multisig.Transaction) []byte {
+	proposalHashData, err := multisig.ComputeProposalHash(txn, blake2b.Sum256)
+	require.NoError(t, err)
+	return proposalHashData
 }
 
 type key string


### PR DESCRIPTION
#248 added GetProposalHash as an actor method (but didn't export it) and made a direct call to blake2b, instead of the syscall, as a workaround to make the GetProposalHash method callable as a function from tests.

This fixes it to make it actually a function (not a method). It should not have been a method unless the intent was to export it.

(An alternative workaround would have been to use `rt.Call(...)` in tests to init the mock runtime appropriately)

FYI @droark 