### PR TITLE
Detach helper functions from miner actor that don't need to be methods

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -100,7 +100,7 @@ func (a Actor) Constructor(rt Runtime, params *ConstructorParams) *adt.EmptyValu
 	// Register cron callback for epoch before the next proving period starts.
 	deadline, _ := state.DeadlineInfo(rt.CurrEpoch())
 	periodEnd := deadline.PeriodStart + WPoStProvingPeriod - 1
-	a.enrollCronEvent(rt, periodEnd, &CronEventPayload{
+	enrollCronEvent(rt, periodEnd, &CronEventPayload{
 		EventType: CronEventProvingPeriod,
 	})
 
@@ -151,7 +151,7 @@ func (a Actor) ChangeWorkerAddress(rt Runtime, params *ChangeWorkerAddressParams
 	cronPayload := CronEventPayload{
 		EventType: CronEventWorkerKeyChange,
 	}
-	a.enrollCronEvent(rt, effectiveEpoch, &cronPayload)
+	enrollCronEvent(rt, effectiveEpoch, &cronPayload)
 	return nil
 }
 
@@ -225,13 +225,13 @@ func (a Actor) SubmitWindowedPoSt(rt Runtime, params *SubmitWindowedPoStParams) 
 		// Vesting will be at most one proving period old if computed in the cron callback.
 		verifyPledgeMeetsInitialRequirements(rt, &st)
 
-		deadlines, err := LoadDeadlines(adt.AsStore(rt), &st)
+		deadlines, err := st.LoadDeadlines(adt.AsStore(rt))
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deadlines")
 
 		// Traverse earlier submissions and enact detected faults.
 		// This isn't strictly necessary, but keeps the power table up to date eagerly and can force payment
 		// of penalties if locked pledge drops too low.
-		detectedFaultSectors, penalty = checkMissingPoStFaults(rt, st, store, deadlines, deadline.PeriodStart, deadline.Index, currEpoch)
+		detectedFaultSectors, penalty = checkMissingPoStFaults(rt, &st, store, deadlines, deadline.PeriodStart, deadline.Index, currEpoch)
 
 		// Work out which sectors are due in the declared partitions at this deadline.
 		partitionsSectors, err := ComputePartitionsSectors(deadlines, deadline.Index, params.Partitions)
@@ -272,7 +272,7 @@ func (a Actor) SubmitWindowedPoSt(rt Runtime, params *SubmitWindowedPoStParams) 
 
 		// Verify the proof.
 		// A failed verification doesn't immediately cause a penalty; the miner can try again.
-		a.verifyWindowedPost(rt, deadline.Challenge, sectorInfos, params.Proofs)
+		verifyWindowedPost(rt, deadline.Challenge, sectorInfos, params.Proofs)
 
 		// Record the successful submission
 		postedPartitions := bitfield.NewFromSet(params.Partitions)
@@ -310,12 +310,12 @@ func (a Actor) SubmitWindowedPoSt(rt Runtime, params *SubmitWindowedPoStParams) 
 	})
 
 	// Remove power for new faults, and burn penalties.
-	a.requestBeginFaults(rt, st.Info.SectorSize, detectedFaultSectors)
+	requestBeginFaults(rt, st.Info.SectorSize, detectedFaultSectors)
 	burnFundsAndNotifyPledgeChange(rt, penalty)
 
 	// Restore power for recovered sectors.
 	if len(recoveredSectors) > 0 {
-		a.requestEndFaults(rt, st.Info.SectorSize, recoveredSectors)
+		requestEndFaults(rt, st.Info.SectorSize, recoveredSectors)
 	}
 	return nil
 }
@@ -393,7 +393,7 @@ func (a Actor) PreCommitSector(rt Runtime, params *SectorPreCommitInfo) *adt.Emp
 	}
 
 	expiryBound := rt.CurrEpoch() + msd + 1
-	a.enrollCronEvent(rt, expiryBound, &cronPayload)
+	enrollCronEvent(rt, expiryBound, &cronPayload)
 
 	return nil
 }
@@ -427,7 +427,7 @@ func (a Actor) ProveCommitSector(rt Runtime, params *ProveCommitSectorParams) *a
 	}
 
 	// will abort if seal invalid
-	a.verifySeal(rt, &abi.OnChainSealVerifyInfo{
+	verifySeal(rt, &abi.OnChainSealVerifyInfo{
 		SealedCID:        precommit.Info.SealedCID,
 		InteractiveEpoch: precommit.PreCommitEpoch + PreCommitChallengeDelay,
 		SealRandEpoch:    precommit.Info.SealRandEpoch,
@@ -613,7 +613,7 @@ func (a Actor) TerminateSectors(rt Runtime, params *TerminateSectorsParams) *adt
 
 	// Note: this cannot terminate pre-committed but un-proven sectors.
 	// They must be allowed to expire (and deposit burnt).
-	a.terminateSectors(rt, params.Sectors, power.SectorTerminationManual)
+	terminateSectors(rt, params.Sectors, power.SectorTerminationManual)
 	return nil
 }
 
@@ -648,16 +648,16 @@ func (a Actor) DeclareFaults(rt Runtime, params *DeclareFaultsParams) *adt.Empty
 		// The proving period start may be negative for low epochs, but all the arithmetic should work out
 		// correctly in order to declare faults for an upcoming deadline or the next period.
 		deadline, _ := st.DeadlineInfo(currEpoch)
-		deadlines, err := LoadDeadlines(adt.AsStore(rt), &st)
+		deadlines, err := st.LoadDeadlines(adt.AsStore(rt))
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deadlines")
 
 		// Traverse earlier submissions and enact detected faults.
 		// This is necessary to prevent the miner "declaring" a fault for a PoSt already missed.
-		detectedFaultSectors, penalty = checkMissingPoStFaults(rt, st, store, deadlines, deadline.PeriodStart, deadline.Index, currEpoch)
+		detectedFaultSectors, penalty = checkMissingPoStFaults(rt, &st, store, deadlines, deadline.PeriodStart, deadline.Index, currEpoch)
 
 		var decaredSectors []*abi.BitField
 		for _, decl := range params.Faults {
-			err = validateFRDeclaration(deadline, deadlines, decl.Deadline, decl.Sectors)
+			err = validateFRDeclaration(deadlines, deadline, decl.Deadline, decl.Sectors)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalArgument, "invalid fault declaration")
 			decaredSectors = append(decaredSectors, decl.Sectors)
 		}
@@ -697,7 +697,7 @@ func (a Actor) DeclareFaults(rt Runtime, params *DeclareFaultsParams) *adt.Empty
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load fault sectors")
 
 			// Unlock penalty for declared faults.
-			declaredPenalty, err := unlockPenalty(store, &st, currEpoch, declaredFaultSectors, pledgePenaltyForSectorDeclaredFault)
+			declaredPenalty, err := unlockPenalty(&st, store, currEpoch, declaredFaultSectors, pledgePenaltyForSectorDeclaredFault)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to charge fault fee")
 			penalty = big.Add(penalty, declaredPenalty)
 		}
@@ -714,7 +714,7 @@ func (a Actor) DeclareFaults(rt Runtime, params *DeclareFaultsParams) *adt.Empty
 	})
 
 	// Remove power for new faulty sectors.
-	a.requestBeginFaults(rt, st.Info.SectorSize, append(detectedFaultSectors, declaredFaultSectors...))
+	requestBeginFaults(rt, st.Info.SectorSize, append(detectedFaultSectors, declaredFaultSectors...))
 	burnFundsAndNotifyPledgeChange(rt, penalty)
 
 	return nil
@@ -740,12 +740,12 @@ func (a Actor) DeclareFaultsRecovered(rt Runtime, params *DeclareFaultsRecovered
 		rt.ValidateImmediateCallerIs(st.Info.Worker)
 
 		deadline, _ := st.DeadlineInfo(currEpoch)
-		deadlines, err := LoadDeadlines(adt.AsStore(rt), &st)
+		deadlines, err := st.LoadDeadlines(adt.AsStore(rt))
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deadlines")
 
 		var declaredSectors []*abi.BitField
 		for _, decl := range params.Recoveries {
-			err = validateFRDeclaration(deadline, deadlines, decl.Deadline, decl.Sectors)
+			err = validateFRDeclaration(deadlines, deadline, decl.Deadline, decl.Sectors)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalArgument, "invalid recovery declaration")
 			declaredSectors = append(declaredSectors, decl.Sectors)
 		}
@@ -881,18 +881,22 @@ func (a Actor) OnDeferredCronEvent(rt Runtime, payload *CronEventPayload) *adt.E
 	rt.ValidateImmediateCallerIs(builtin.StoragePowerActorAddr)
 
 	switch payload.EventType {
-	case CronEventWorkerKeyChange:
-		a.commitWorkerKeyChange(rt)
-	case CronEventPreCommitExpiry:
-		a.checkPrecommitExpiry(rt, payload.Sectors, payload.RegisteredProof)
 	case CronEventProvingPeriod:
-		a.handleProvingPeriod(rt)
+		handleProvingPeriod(rt)
+	case CronEventPreCommitExpiry:
+		checkPrecommitExpiry(rt, payload.Sectors, payload.RegisteredProof)
+	case CronEventWorkerKeyChange:
+		commitWorkerKeyChange(rt)
 	}
 
 	return nil
 }
 
-func (a Actor) handleProvingPeriod(rt Runtime) {
+////////////////////////////////////////////////////////////////////////////////
+// Utility functions & helpers
+////////////////////////////////////////////////////////////////////////////////
+
+func handleProvingPeriod(rt Runtime) {
 	store := adt.AsStore(rt)
 	var st State
 	currEpoch := rt.CurrEpoch()
@@ -924,15 +928,15 @@ func (a Actor) handleProvingPeriod(rt Runtime) {
 			periodEnd = nextPeriodStart - 1
 			AssertMsg(currEpoch == periodEnd, "proving period cron at epoch %d, period ends at %d", currEpoch, periodEnd)
 
-			deadlines, err := LoadDeadlines(store, &st)
+			deadlines, err := st.LoadDeadlines(store)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deadlines")
 
-			detectedFaultSectors, penalty = checkMissingPoStFaults(rt, st, store, deadlines, deadline.PeriodStart, WPoStPeriodDeadlines, currEpoch)
+			detectedFaultSectors, penalty = checkMissingPoStFaults(rt, &st, store, deadlines, deadline.PeriodStart, WPoStPeriodDeadlines, currEpoch)
 			return nil
 		})
 
 		// Remove power for new faults, and burn penalties.
-		a.requestBeginFaults(rt, st.Info.SectorSize, detectedFaultSectors)
+		requestBeginFaults(rt, st.Info.SectorSize, detectedFaultSectors)
 		burnFundsAndNotifyPledgeChange(rt, penalty)
 	}
 
@@ -941,13 +945,13 @@ func (a Actor) handleProvingPeriod(rt Runtime) {
 		var expiredSectors *abi.BitField
 		var err error
 		rt.State().Transaction(&st, func() interface{} {
-			expiredSectors, err = popSectorExpirations(st, store, currEpoch)
+			expiredSectors, err = popSectorExpirations(&st, store, currEpoch)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load expired sectors")
 			return nil
 		})
 
 		// Terminate expired sectors (sends messages to power and market actors).
-		a.terminateSectors(rt, expiredSectors, power.SectorTerminationExpired)
+		terminateSectors(rt, expiredSectors, power.SectorTerminationExpired)
 	}
 
 	{
@@ -956,7 +960,7 @@ func (a Actor) handleProvingPeriod(rt Runtime) {
 		var ongoingFaultPenalty abi.TokenAmount
 		var err error
 		rt.State().Transaction(&st, func() interface{} {
-			expiredFaults, ongoingFaults, err = popExpiredFaults(st, store, currEpoch-FaultMaxAge)
+			expiredFaults, ongoingFaults, err = popExpiredFaults(&st, store, currEpoch-FaultMaxAge)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load fault epochs")
 
 			// Load info for ongoing faults.
@@ -965,19 +969,19 @@ func (a Actor) handleProvingPeriod(rt Runtime) {
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load fault sectors")
 
 			// Unlock penalty for ongoing faults.
-			ongoingFaultPenalty, err = unlockPenalty(store, &st, currEpoch, ongoingFaultInfos, pledgePenaltyForSectorDeclaredFault)
+			ongoingFaultPenalty, err = unlockPenalty(&st, store, currEpoch, ongoingFaultInfos, pledgePenaltyForSectorDeclaredFault)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to charge fault fee")
 			return nil
 		})
 
-		a.terminateSectors(rt, expiredFaults, power.SectorTerminationFaulty)
+		terminateSectors(rt, expiredFaults, power.SectorTerminationFaulty)
 		burnFundsAndNotifyPledgeChange(rt, ongoingFaultPenalty)
 	}
 
 	{
 		// Establish new proving sets and clear proofs.
 		rt.State().Transaction(&st, func() interface{} {
-			deadlines, err := LoadDeadlines(store, &st)
+			deadlines, err := st.LoadDeadlines(store,)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deadlines")
 
 			// Assign new sectors to deadlines.
@@ -989,7 +993,7 @@ func (a Actor) handleProvingPeriod(rt Runtime) {
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to assign new sectors to deadlines")
 
 			// Store updated deadline state.
-			st.Deadlines, err = store.Put(store.Context(), &deadlines)
+			err = st.SaveDeadlines(store, deadlines)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to store new deadlines")
 
 			// Reset PoSt submissions for next period.
@@ -1001,13 +1005,13 @@ func (a Actor) handleProvingPeriod(rt Runtime) {
 
 	// Schedule cron callback for next period
 	nextPeriodEnd := nextPeriodStart + WPoStProvingPeriod - 1
-	a.enrollCronEvent(rt, nextPeriodEnd, &CronEventPayload{
+	enrollCronEvent(rt, nextPeriodEnd, &CronEventPayload{
 		EventType: CronEventProvingPeriod,
 	})
 }
 
 // Detects faults from missing PoSt submissions that did not arrive.
-func checkMissingPoStFaults(rt Runtime, st State, store adt.Store, deadlines *Deadlines, periodStart abi.ChainEpoch, beforeDeadline uint64, currEpoch abi.ChainEpoch) ([]*SectorOnChainInfo, abi.TokenAmount) {
+func checkMissingPoStFaults(rt Runtime, st *State, store adt.Store, deadlines *Deadlines, periodStart abi.ChainEpoch, beforeDeadline uint64, currEpoch abi.ChainEpoch) ([]*SectorOnChainInfo, abi.TokenAmount) {
 	detectedFaults, failedRecoveries, err := computeFaultsFromMissingPoSts(st, deadlines, beforeDeadline)
 	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to compute detected faults")
 
@@ -1025,14 +1029,13 @@ func checkMissingPoStFaults(rt Runtime, st State, store adt.Store, deadlines *De
 	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load failed recovery sectors")
 
 	// Unlock sector penalty for all undeclared faults.
-	penalty, err := unlockPenalty(store, &st, currEpoch, append(detectedFaultSectors, failedRecoverySectors...),
-		pledgePenaltyForSectorUndeclaredFault)
+	penalty, err := unlockPenalty(st, store, currEpoch, append(detectedFaultSectors, failedRecoverySectors...), pledgePenaltyForSectorUndeclaredFault)
 	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to charge sector penalty")
 	return detectedFaultSectors, penalty
 }
 
 // Computes the sectors that were expected to be present in partitions of a PoSt submission but were not.
-func computeFaultsFromMissingPoSts(st State, deadlines *Deadlines, beforeDeadline uint64) (detectedFaults, failedRecoveries *abi.BitField, err error) {
+func computeFaultsFromMissingPoSts(st *State, deadlines *Deadlines, beforeDeadline uint64) (detectedFaults, failedRecoveries *abi.BitField, err error) {
 	// TODO: Iterating this bitfield and keeping track of what partitions we're expecting could remove the
 	// need to expand this into a potentially-giant map. But it's tricksy.
 	submissions, err := st.PostSubmissions.AllMap(PartitionsMax)
@@ -1089,7 +1092,7 @@ func computeFaultsFromMissingPoSts(st State, deadlines *Deadlines, beforeDeadlin
 }
 
 // Removes and returns sector numbers that expire at or before an epoch.
-func popSectorExpirations(st State, store adt.Store, epoch abi.ChainEpoch) (*abi.BitField, error) {
+func popSectorExpirations(st *State, store adt.Store, epoch abi.ChainEpoch) (*abi.BitField, error) {
 	var expiredEpochs []abi.ChainEpoch
 	var expiredSectors []*abi.BitField
 	errDone := fmt.Errorf("done")
@@ -1118,7 +1121,7 @@ func popSectorExpirations(st State, store adt.Store, epoch abi.ChainEpoch) (*abi
 
 // Removes and returns sector numbers that were faulty at or before an epoch, and returns the sector
 // numbers for other ongoing faults.
-func popExpiredFaults(st State, store adt.Store, latestTermination abi.ChainEpoch) (*abi.BitField, *abi.BitField, error) {
+func popExpiredFaults(st *State, store adt.Store, latestTermination abi.ChainEpoch) (*abi.BitField, *abi.BitField, error) {
 	var expiredEpochs []abi.ChainEpoch
 	var expiredFaults []*abi.BitField
 	var ongoingFaults []*abi.BitField
@@ -1152,11 +1155,7 @@ func popExpiredFaults(st State, store adt.Store, latestTermination abi.ChainEpoc
 	return allExpiries, allOngoing, err
 }
 
-////////////////////////////////////////////////////////////////////////////////
-// Method utility functions
-////////////////////////////////////////////////////////////////////////////////
-
-func (a Actor) checkPrecommitExpiry(rt Runtime, sectors *abi.BitField, regProof abi.RegisteredProof) {
+func checkPrecommitExpiry(rt Runtime, sectors *abi.BitField, regProof abi.RegisteredProof) {
 	store := adt.AsStore(rt)
 	var st State
 
@@ -1195,7 +1194,7 @@ func (a Actor) checkPrecommitExpiry(rt Runtime, sectors *abi.BitField, regProof 
 }
 
 // TODO: red flag that this method is potentially super expensive
-func (a Actor) terminateSectors(rt Runtime, sectorNos *abi.BitField, terminationType power.SectorTermination) {
+func terminateSectors(rt Runtime, sectorNos *abi.BitField, terminationType power.SectorTermination) {
 	empty, err := sectorNos.IsEmpty()
 	if err != nil {
 		rt.Abortf(exitcode.ErrIllegalState, "failed to count sectors")
@@ -1245,34 +1244,34 @@ func (a Actor) terminateSectors(rt Runtime, sectorNos *abi.BitField, termination
 		})
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load sector metadata")
 
-		deadlines, err := LoadDeadlines(store, &st)
+		deadlines, err := st.LoadDeadlines(store)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deadlines")
 
-		err = removeTerminatedSectors(st, store, deadlines, sectorNos)
+		err = removeTerminatedSectors(&st, store, deadlines, sectorNos)
 		if err != nil {
 			rt.Abortf(exitcode.ErrIllegalState, "failed to delete sectors: %v", err)
 		}
 
-		st.Deadlines, err = store.Put(store.Context(), &deadlines)
+		err = st.SaveDeadlines(store, deadlines)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to store new deadlines")
 
 		if terminationType != power.SectorTerminationExpired {
-			penalty, err = unlockPenalty(store, &st, rt.CurrEpoch(), allSectors, pledgePenaltyForSectorTermination)
+			penalty, err = unlockPenalty(&st, store, rt.CurrEpoch(), allSectors, pledgePenaltyForSectorTermination)
 		}
 		return nil
 	})
 
 	// End any fault state before terminating sector power.
 	// TODO: could we compress the three calls to power actor into one sector termination call?
-	a.requestEndFaults(rt, st.Info.SectorSize, faultySectors)
-	a.requestTerminateDeals(rt, dealIDs)
-	a.requestTerminatePower(rt, terminationType, st.Info.SectorSize, allSectors)
+	requestEndFaults(rt, st.Info.SectorSize, faultySectors)
+	requestTerminateDeals(rt, dealIDs)
+	requestTerminatePower(rt, terminationType, st.Info.SectorSize, allSectors)
 
 	burnFundsAndNotifyPledgeChange(rt, penalty)
 }
 
 // Removes a group sectors from the sector set and its number from all sector collections in state.
-func removeTerminatedSectors(st State, store adt.Store, deadlines *Deadlines, sectors *abi.BitField) error {
+func removeTerminatedSectors(st *State, store adt.Store, deadlines *Deadlines, sectors *abi.BitField) error {
 	err := st.DeleteSectors(store, sectors)
 	if err != nil {
 		return err
@@ -1293,7 +1292,7 @@ func removeTerminatedSectors(st State, store adt.Store, deadlines *Deadlines, se
 	return err
 }
 
-func (a Actor) enrollCronEvent(rt Runtime, eventEpoch abi.ChainEpoch, callbackPayload *CronEventPayload) {
+func enrollCronEvent(rt Runtime, eventEpoch abi.ChainEpoch, callbackPayload *CronEventPayload) {
 	payload := new(bytes.Buffer)
 	err := callbackPayload.MarshalCBOR(payload)
 	if err != nil {
@@ -1311,7 +1310,7 @@ func (a Actor) enrollCronEvent(rt Runtime, eventEpoch abi.ChainEpoch, callbackPa
 	builtin.RequireSuccess(rt, code, "failed to enroll cron event")
 }
 
-func (a Actor) requestBeginFaults(rt Runtime, sectorSize abi.SectorSize, sectors []*SectorOnChainInfo) {
+func requestBeginFaults(rt Runtime, sectorSize abi.SectorSize, sectors []*SectorOnChainInfo) {
 	if len(sectors) == 0 {
 		return
 	}
@@ -1331,7 +1330,7 @@ func (a Actor) requestBeginFaults(rt Runtime, sectorSize abi.SectorSize, sectors
 	builtin.RequireSuccess(rt, code, "failed to request faults %v", sectors)
 }
 
-func (a Actor) requestEndFaults(rt Runtime, sectorSize abi.SectorSize, sectors []*SectorOnChainInfo) {
+func requestEndFaults(rt Runtime, sectorSize abi.SectorSize, sectors []*SectorOnChainInfo) {
 	if len(sectors) == 0 {
 		return
 	}
@@ -1351,7 +1350,7 @@ func (a Actor) requestEndFaults(rt Runtime, sectorSize abi.SectorSize, sectors [
 	builtin.RequireSuccess(rt, code, "failed to request end faults %v", sectors)
 }
 
-func (a Actor) requestTerminateDeals(rt Runtime, dealIDs []abi.DealID) {
+func requestTerminateDeals(rt Runtime, dealIDs []abi.DealID) {
 	if len(dealIDs) == 0 {
 		return
 	}
@@ -1366,7 +1365,7 @@ func (a Actor) requestTerminateDeals(rt Runtime, dealIDs []abi.DealID) {
 	builtin.RequireSuccess(rt, code, "failed to terminate deals %v, exit code %v", dealIDs, code)
 }
 
-func (a Actor) requestTerminateAllDeals(rt Runtime, st *State) {
+func requestTerminateAllDeals(rt Runtime, st *State) {
 	// TODO: red flag this is an ~unbounded computation.
 	// Transform into an idempotent partial computation that can be progressed on each invocation.
 	dealIds := []abi.DealID{}
@@ -1376,10 +1375,10 @@ func (a Actor) requestTerminateAllDeals(rt Runtime, st *State) {
 		rt.Abortf(exitcode.ErrIllegalState, "failed to traverse sectors for termination: %v", err)
 	}
 
-	a.requestTerminateDeals(rt, dealIds)
+	requestTerminateDeals(rt, dealIds)
 }
 
-func (a Actor) requestTerminatePower(rt Runtime, terminationType power.SectorTermination, sectorSize abi.SectorSize, sectors []*SectorOnChainInfo) {
+func requestTerminatePower(rt Runtime, terminationType power.SectorTermination, sectorSize abi.SectorSize, sectors []*SectorOnChainInfo) {
 	if len(sectors) == 0 {
 		return
 	}
@@ -1400,7 +1399,7 @@ func (a Actor) requestTerminatePower(rt Runtime, terminationType power.SectorTer
 	builtin.RequireSuccess(rt, code, "failed to terminate sector power type %v, sectors %v", terminationType, sectors)
 }
 
-func (a Actor) verifyWindowedPost(rt Runtime, challengeEpoch abi.ChainEpoch, sectors []*SectorOnChainInfo, proofs []abi.PoStProof) {
+func verifyWindowedPost(rt Runtime, challengeEpoch abi.ChainEpoch, sectors []*SectorOnChainInfo, proofs []abi.PoStProof) {
 	minerActorID, err := addr.IDFromAddress(rt.Message().Receiver())
 	AssertNoError(err) // Runtime always provides ID-addresses
 
@@ -1429,8 +1428,7 @@ func (a Actor) verifyWindowedPost(rt Runtime, challengeEpoch abi.ChainEpoch, sec
 	}
 }
 
-func (a Actor) verifySeal(rt Runtime, onChainInfo *abi.OnChainSealVerifyInfo) {
-
+func verifySeal(rt Runtime, onChainInfo *abi.OnChainSealVerifyInfo) {
 	if rt.CurrEpoch() <= onChainInfo.InteractiveEpoch {
 		rt.Abortf(exitcode.ErrForbidden, "too early to prove sector")
 	}
@@ -1441,7 +1439,7 @@ func (a Actor) verifySeal(rt Runtime, onChainInfo *abi.OnChainSealVerifyInfo) {
 		rt.Abortf(exitcode.ErrIllegalArgument, "seal epoch %v too old, expected >= %v", onChainInfo.SealRandEpoch, sealRandEarliest)
 	}
 
-	commD := a.requestUnsealedSectorCID(rt, onChainInfo.RegisteredProof, onChainInfo.DealIDs)
+	commD := requestUnsealedSectorCID(rt, onChainInfo.RegisteredProof, onChainInfo.DealIDs)
 
 	minerActorID, err := addr.IDFromAddress(rt.Message().Receiver())
 	AssertNoError(err) // Runtime always provides ID-addresses
@@ -1465,13 +1463,13 @@ func (a Actor) verifySeal(rt Runtime, onChainInfo *abi.OnChainSealVerifyInfo) {
 }
 
 // Requests the storage market actor compute the unsealed sector CID from a sector's deals.
-func (a Actor) requestUnsealedSectorCID(rt Runtime, st abi.RegisteredProof, dealIDs []abi.DealID) cid.Cid {
+func requestUnsealedSectorCID(rt Runtime, proofType abi.RegisteredProof, dealIDs []abi.DealID) cid.Cid {
 	var unsealedCID cbg.CborCid
 	ret, code := rt.Send(
 		builtin.StorageMarketActorAddr,
 		builtin.MethodsMarket.ComputeDataCommitment,
 		&market.ComputeDataCommitmentParams{
-			SectorType: st,
+			SectorType: proofType,
 			DealIDs:    dealIDs,
 		},
 		abi.NewTokenAmount(0),
@@ -1481,7 +1479,7 @@ func (a Actor) requestUnsealedSectorCID(rt Runtime, st abi.RegisteredProof, deal
 	return cid.Cid(unsealedCID)
 }
 
-func (a Actor) commitWorkerKeyChange(rt Runtime) *adt.EmptyValue {
+func commitWorkerKeyChange(rt Runtime) *adt.EmptyValue {
 	var st State
 	rt.State().Transaction(&st, func() interface{} {
 		if st.Info.PendingWorkerKey == nil {
@@ -1499,10 +1497,6 @@ func (a Actor) commitWorkerKeyChange(rt Runtime) *adt.EmptyValue {
 	})
 	return nil
 }
-
-//
-// Helpers
-//
 
 // Verifies that the total locked balance exceeds the sum of sector initial pledges.
 func verifyPledgeMeetsInitialRequirements(rt Runtime, st *State) {
@@ -1606,7 +1600,7 @@ func assignProvingPeriodBoundary(myAddr addr.Address, currEpoch abi.ChainEpoch, 
 
 // Checks that a fault or recovery declaration of sectors at a specific deadline is valid and not within
 // the exclusion window for the deadline.
-func validateFRDeclaration(deadline *DeadlineInfo, deadlines *Deadlines, declaredDeadline uint64, declaredSectors *abi.BitField) error {
+func validateFRDeclaration(deadlines *Deadlines, deadline *DeadlineInfo, declaredDeadline uint64, declaredSectors *abi.BitField) error {
 	if declaredDeadline >= WPoStPeriodDeadlines {
 		return fmt.Errorf("invalid deadline %d, must be < %d", declaredDeadline, WPoStPeriodDeadlines)
 	}
@@ -1632,22 +1626,13 @@ func validateFRDeclaration(deadline *DeadlineInfo, deadlines *Deadlines, declare
 
 // Computes a fee for a collection of sectors and unlocks it from unvested funds (for burning).
 // The fee computation is a parameter.
-func unlockPenalty(store adt.Store, st *State, currEpoch abi.ChainEpoch, sectors []*SectorOnChainInfo,
+func unlockPenalty(st *State, store adt.Store, currEpoch abi.ChainEpoch, sectors []*SectorOnChainInfo,
 	feeCalc func(info *SectorOnChainInfo) abi.TokenAmount) (abi.TokenAmount, error) {
 	fee := big.Zero()
 	for _, s := range sectors {
 		fee = big.Add(fee, feeCalc(s))
 	}
 	return st.UnlockUnvestedFunds(store, currEpoch, fee)
-}
-
-func LoadDeadlines(store adt.Store, st *State) (*Deadlines, error) {
-	var deadlines Deadlines
-	if err := store.Get(store.Context(), st.Deadlines, &deadlines); err != nil {
-		return nil, fmt.Errorf("failed to load deadlines (%s): %w", st.Deadlines, err)
-	}
-
-	return &deadlines, nil
 }
 
 func min64(a, b uint64) uint64 {

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -686,6 +686,24 @@ func (st *State) ClearPoStSubmissions() error {
 	return nil
 }
 
+func (st *State) LoadDeadlines(store adt.Store) (*Deadlines, error) {
+	var deadlines Deadlines
+	if err := store.Get(store.Context(), st.Deadlines, &deadlines); err != nil {
+		return nil, fmt.Errorf("failed to load deadlines (%s): %w", st.Deadlines, err)
+	}
+
+	return &deadlines, nil
+}
+
+func (st *State) SaveDeadlines(store adt.Store, deadlines *Deadlines) error {
+	c, err := store.Put(store.Context(), deadlines)
+	if err != nil {
+		return err
+	}
+	st.Deadlines = c
+	return nil
+}
+
 //
 // PoSt Deadlines and partitions
 //


### PR DESCRIPTION
No semantic change intended here, just cleanup. But I fixed some errors where the state object, rather than a pointer to it, was passed to a function.