### PR TITLE
Remove PoStDetectedFaultMiners from power actor state

### DIFF
--- a/actors/builtin/power/cbor_gen.go
+++ b/actors/builtin/power/cbor_gen.go
@@ -19,7 +19,7 @@ func (t *State) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{137}); err != nil {
+	if _, err := w.Write([]byte{136}); err != nil {
 		return err
 	}
 
@@ -66,12 +66,6 @@ func (t *State) MarshalCBOR(w io.Writer) error {
 		}
 	}
 
-	// t.PoStDetectedFaultMiners (cid.Cid) (struct)
-
-	if err := cbg.WriteCid(w, t.PoStDetectedFaultMiners); err != nil {
-		return xerrors.Errorf("failed to write cid field t.PoStDetectedFaultMiners: %w", err)
-	}
-
 	// t.Claims (cid.Cid) (struct)
 
 	if err := cbg.WriteCid(w, t.Claims); err != nil {
@@ -102,7 +96,7 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 9 {
+	if extra != 8 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -194,18 +188,6 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 		}
 
 		t.LastEpochTick = abi.ChainEpoch(extraI)
-	}
-	// t.PoStDetectedFaultMiners (cid.Cid) (struct)
-
-	{
-
-		c, err := cbg.ReadCid(br)
-		if err != nil {
-			return xerrors.Errorf("failed to read cid field t.PoStDetectedFaultMiners: %w", err)
-		}
-
-		t.PoStDetectedFaultMiners = c
-
 	}
 	// t.Claims (cid.Cid) (struct)
 

--- a/actors/builtin/power/power_actor.go
+++ b/actors/builtin/power/power_actor.go
@@ -445,37 +445,15 @@ func (a Actor) processDeferredCronEvents(rt Runtime) error {
 
 func (a Actor) deleteMinerActor(rt Runtime, miner addr.Address) error {
 	var st State
-	var txErr error
-	rt.State().Transaction(&st, func() interface{} {
-		var err error
-
-		err = st.deleteClaim(adt.AsStore(rt), miner)
-		if err != nil {
-			txErr = errors.Wrapf(err, "failed to delete %v from claimed power table", miner)
-			return big.Zero()
+	err := rt.State().Transaction(&st, func() interface{} {
+		if err := st.deleteClaim(adt.AsStore(rt), miner); err != nil {
+			return errors.Wrapf(err, "failed to delete %v from claimed power table", miner)
 		}
 
 		st.MinerCount -= 1
-		hasFault, err := st.hasDetectedFault(adt.AsStore(rt), miner)
-		if err != nil {
-			txErr = err
-			return big.Zero()
-		}
-		if hasFault {
-			if err := st.deleteDetectedFault(adt.AsStore(rt), miner); err != nil {
-				txErr = err
-				return big.Zero()
-			}
-		}
-
 		return nil
-	})
-
-	if txErr != nil {
-		return txErr
-	}
-
-	return nil
+	}).(error)
+	return err
 }
 
 func powersForWeights(weights []SectorStorageWeightDesc) (abi.StoragePower, abi.StoragePower) {
@@ -498,11 +476,4 @@ func abortIfError(rt Runtime, err error, msg string, args ...interface{}) {
 		fmtmst := fmt.Sprintf(msg, args...)
 		rt.Abortf(code, "%s: %v", fmtmst, err)
 	}
-}
-
-func bigProduct(p big.Int, rest ...big.Int) big.Int {
-	for _, r := range rest {
-		p = big.Mul(p, r)
-	}
-	return p
 }

--- a/actors/builtin/power/power_state.go
+++ b/actors/builtin/power/power_state.go
@@ -7,7 +7,6 @@ import (
 	addr "github.com/filecoin-project/go-address"
 	cid "github.com/ipfs/go-cid"
 	errors "github.com/pkg/errors"
-	xerrors "golang.org/x/xerrors"
 
 	abi "github.com/filecoin-project/specs-actors/actors/abi"
 	big "github.com/filecoin-project/specs-actors/actors/abi/big"
@@ -26,9 +25,6 @@ type State struct {
 
 	// Last chain epoch OnEpochTickEnd was called on
 	LastEpochTick abi.ChainEpoch
-
-	// Miners having failed to prove storage.
-	PoStDetectedFaultMiners cid.Cid // Set, HAMT[addr.Address]struct{}
 
 	// Claimed power for each miner.
 	Claims cid.Cid // Map, HAMT[address]Claim
@@ -58,7 +54,6 @@ func ConstructState(emptyMapCid cid.Cid) *State {
 		TotalQualityAdjPower:     abi.NewStoragePower(0),
 		TotalPledgeCollateral:    abi.NewTokenAmount(0),
 		CronEventQueue:           emptyMapCid,
-		PoStDetectedFaultMiners:  emptyMapCid,
 		Claims:                   emptyMapCid,
 		NumMinersMeetingMinPower: 0,
 	}
@@ -75,11 +70,7 @@ func (st *State) minerNominalPowerMeetsConsensusMinimum(s adt.Store, miner addr.
 		return false, errors.Errorf("no claim for actor %v", miner)
 	}
 
-	// nominal power will be in quality adjusted power
-	minerNominalPower, err := st.computeNominalPower(s, miner, claim.QualityAdjPower)
-	if err != nil {
-		return false, err
-	}
+	minerNominalPower := claim.QualityAdjPower
 
 	// if miner is larger than min power requirement, we're set
 	if minerNominalPower.GreaterThanEqual(ConsensusMinerMinPower) {
@@ -104,15 +95,8 @@ func (st *State) minerNominalPowerMeetsConsensusMinimum(s adt.Store, miner addr.
 
 	var minerSizes []abi.StoragePower
 	var claimed Claim
-	if err := m.ForEach(&claimed, func(k string) error {
-		maddr, err := addr.NewFromBytes([]byte(k))
-		if err != nil {
-			return err
-		}
-		nominalPower, err := st.computeNominalPower(s, maddr, claimed.QualityAdjPower)
-		if err != nil {
-			return err
-		}
+	if err = m.ForEach(&claimed, func(k string) error {
+		nominalPower := claimed.QualityAdjPower
 		minerSizes = append(minerSizes, nominalPower)
 		return nil
 	}); err != nil {
@@ -134,44 +118,31 @@ func (st *State) AddToClaim(s adt.Store, miner addr.Address, power abi.StoragePo
 		return errors.Errorf("no claim for actor %v", miner)
 	}
 
-	oldNominalPower, err := st.computeNominalPower(s, miner, claim.QualityAdjPower)
-	if err != nil {
-		return err
-	}
+	oldNominalPower := claim.QualityAdjPower
 
 	// update power
 	claim.RawBytePower = big.Add(claim.RawBytePower, power)
 	claim.QualityAdjPower = big.Add(claim.QualityAdjPower, qapower)
 
-	newNominalPower, err := st.computeNominalPower(s, miner, claim.QualityAdjPower)
-	if err != nil {
-		return err
-	}
+	newNominalPower := claim.QualityAdjPower
 
 	prevBelow := oldNominalPower.LessThan(ConsensusMinerMinPower)
 	stillBelow := newNominalPower.LessThan(ConsensusMinerMinPower)
 
-	faulty, err := st.hasDetectedFault(s, miner)
-	if err != nil {
-		return xerrors.Errorf("Failed to check if miner was faulty: %w", err)
-	}
-
-	if !faulty {
-		if prevBelow && !stillBelow {
-			// just passed min miner size
-			st.NumMinersMeetingMinPower++
-			st.TotalQualityAdjPower = big.Add(st.TotalQualityAdjPower, newNominalPower)
-			st.TotalRawBytePower = big.Add(st.TotalRawBytePower, claim.RawBytePower)
-		} else if !prevBelow && stillBelow {
-			// just went below min miner size
-			st.NumMinersMeetingMinPower--
-			st.TotalQualityAdjPower = big.Sub(st.TotalQualityAdjPower, oldNominalPower)
-			st.TotalRawBytePower = big.Sub(st.TotalRawBytePower, claim.RawBytePower)
-		} else if !prevBelow && !stillBelow {
-			// Was above the threshold, still above
-			st.TotalQualityAdjPower = big.Add(st.TotalQualityAdjPower, qapower)
-			st.TotalRawBytePower = big.Add(st.TotalRawBytePower, power)
-		}
+	if prevBelow && !stillBelow {
+		// just passed min miner size
+		st.NumMinersMeetingMinPower++
+		st.TotalQualityAdjPower = big.Add(st.TotalQualityAdjPower, newNominalPower)
+		st.TotalRawBytePower = big.Add(st.TotalRawBytePower, claim.RawBytePower)
+	} else if !prevBelow && stillBelow {
+		// just went below min miner size
+		st.NumMinersMeetingMinPower--
+		st.TotalQualityAdjPower = big.Sub(st.TotalQualityAdjPower, oldNominalPower)
+		st.TotalRawBytePower = big.Sub(st.TotalRawBytePower, claim.RawBytePower)
+	} else if !prevBelow && !stillBelow {
+		// Was above the threshold, still above
+		st.TotalQualityAdjPower = big.Add(st.TotalQualityAdjPower, qapower)
+		st.TotalRawBytePower = big.Add(st.TotalRawBytePower, power)
 	}
 
 	AssertMsg(claim.RawBytePower.GreaterThanEqual(big.Zero()), "negative claimed raw byte power: %v", claim.RawBytePower)
@@ -183,111 +154,6 @@ func (st *State) AddToClaim(s adt.Store, miner addr.Address, power abi.StoragePo
 func (st *State) addPledgeTotal(amount abi.TokenAmount) {
 	st.TotalPledgeCollateral = big.Add(st.TotalPledgeCollateral, amount)
 	Assert(st.TotalPledgeCollateral.GreaterThanEqual(big.Zero()))
-}
-
-func (st *State) computeNominalPower(s adt.Store, minerAddr addr.Address, claimedPower abi.StoragePower) (abi.StoragePower, error) {
-	// Compute nominal power: i.e., the power we infer the miner to have (based on the network's
-	// PoSt queries), which may not be the same as the claimed power.
-	// Currently, the nominal power may differ from claimed power because of
-	// detected faults.
-	nominalPower := claimedPower
-	if found, err := st.hasDetectedFault(s, minerAddr); err != nil {
-		return abi.NewStoragePower(0), err
-	} else if found {
-		nominalPower = big.Zero()
-	}
-	// no need to account for declared faults, since they
-	// are already accounted for in "claimed" power
-	// Likewise miners will never be undercollateralized so no
-	// check needed here
-
-	return nominalPower, nil
-}
-
-func (st *State) hasDetectedFault(s adt.Store, a addr.Address) (bool, error) {
-	faultyMiners, err := adt.AsSet(s, st.PoStDetectedFaultMiners)
-	if err != nil {
-		return false, err
-	}
-
-	found, err := faultyMiners.Has(AddrKey(a))
-	if err != nil {
-		return false, errors.Wrapf(err, "failed to get detected faults for address %v from set %s", a, st.PoStDetectedFaultMiners)
-	}
-	return found, nil
-}
-
-func (st *State) putDetectedFault(s adt.Store, a addr.Address) error {
-
-	// prior to making change verify whether we've lose a miner > min size
-	claim, ok, err := st.getClaim(s, a)
-	if err != nil {
-		return err
-	}
-	if !ok {
-		return errors.Errorf("no claim for actor %v", a)
-	}
-	// could be made more efficient by just taking claimed power given
-	// how computeNominal currently works, but that could change.
-	nominalPower, err := st.computeNominalPower(s, a, claim.QualityAdjPower)
-	if err != nil {
-		return err
-	}
-	if nominalPower.GreaterThanEqual(ConsensusMinerMinPower) {
-		// just lost a miner > min size
-		st.NumMinersMeetingMinPower--
-	}
-
-	faultyMiners, err := adt.AsSet(s, st.PoStDetectedFaultMiners)
-	if err != nil {
-		return err
-	}
-
-	if err := faultyMiners.Put(AddrKey(a)); err != nil {
-		return errors.Wrapf(err, "failed to put detected fault for miner %s in set %s", a, st.PoStDetectedFaultMiners)
-	}
-	st.PoStDetectedFaultMiners, err = faultyMiners.Root()
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (st *State) deleteDetectedFault(s adt.Store, a addr.Address) error {
-	faultyMiners, err := adt.AsSet(s, st.PoStDetectedFaultMiners)
-	if err != nil {
-		return err
-	}
-
-	if err := faultyMiners.Delete(AddrKey(a)); err != nil {
-		return errors.Wrapf(err, "failed to delete storage power at address %s from set %s", a, st.PoStDetectedFaultMiners)
-	}
-
-	st.PoStDetectedFaultMiners, err = faultyMiners.Root()
-	if err != nil {
-		return err
-	}
-
-	claim, ok, err := st.getClaim(s, a)
-	if err != nil {
-		return err
-	}
-	if !ok {
-		return errors.Errorf("no claim for actor %v", a)
-	}
-	nominalPower, err := st.computeNominalPower(s, a, claim.QualityAdjPower)
-	if err != nil {
-		return err
-	}
-	if nominalPower.GreaterThanEqual(ConsensusMinerMinPower) {
-		// just regained a miner > min size
-		st.NumMinersMeetingMinPower++
-		st.TotalRawBytePower = big.Add(st.TotalRawBytePower, claim.RawBytePower)
-		st.TotalQualityAdjPower = big.Add(st.TotalQualityAdjPower, claim.QualityAdjPower)
-	}
-
-	return nil
 }
 
 func (st *State) appendCronEvent(store adt.Store, epoch abi.ChainEpoch, event *CronEvent) error {
@@ -370,7 +236,7 @@ func (st *State) setClaim(s adt.Store, a addr.Address, claim *Claim) error {
 		return err
 	}
 
-	if err := hm.Put(AddrKey(a), claim); err != nil {
+	if err = hm.Put(AddrKey(a), claim); err != nil {
 		return errors.Wrapf(err, "failed to put claim with address %s power %v in store %s", a, claim, st.Claims)
 	}
 
@@ -387,7 +253,7 @@ func (st *State) deleteClaim(s adt.Store, a addr.Address) error {
 		return err
 	}
 
-	if err := hm.Delete(AddrKey(a)); err != nil {
+	if err = hm.Delete(AddrKey(a)); err != nil {
 		return errors.Wrapf(err, "failed to delete claim at address %s from store %s", a, st.Claims)
 	}
 	st.Claims, err = hm.Root()

--- a/actors/builtin/power/power_test.go
+++ b/actors/builtin/power/power_test.go
@@ -72,7 +72,6 @@ func TestConstruction(t *testing.T) {
 		assert.True(t, found)
 		assert.Equal(t, power.Claim{big.Zero(), big.Zero()}, actualClaim) // miner has not proven anything
 
-		verifyEmptyMap(t, rt, st.PoStDetectedFaultMiners)
 		verifyEmptyMap(t, rt, st.CronEventQueue)
 	})
 
@@ -167,7 +166,6 @@ func (h *spActorHarness) constructAndVerify(rt *mock.Runtime) {
 	assert.Equal(h.t, int64(0), st.NumMinersMeetingMinPower)
 
 	verifyEmptyMap(h.t, rt, st.Claims)
-	verifyEmptyMap(h.t, rt, st.PoStDetectedFaultMiners)
 	verifyEmptyMap(h.t, rt, st.CronEventQueue)
 }
 


### PR DESCRIPTION
Detection of missed PoSts is now done in the miner actor, and is per-partition rather than miner wide. 

This could have been removed with #286.