### PR TITLE
Tests and fixes for miner actor pre-commits and cron

### DIFF
--- a/actors/builtin/miner/cbor_gen.go
+++ b/actors/builtin/miner/cbor_gen.go
@@ -1914,7 +1914,7 @@ func (t *CronEventPayload) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{131}); err != nil {
+	if _, err := w.Write([]byte{130}); err != nil {
 		return err
 	}
 
@@ -1933,17 +1933,6 @@ func (t *CronEventPayload) MarshalCBOR(w io.Writer) error {
 	if err := t.Sectors.MarshalCBOR(w); err != nil {
 		return err
 	}
-
-	// t.RegisteredProof (abi.RegisteredProof) (int64)
-	if t.RegisteredProof >= 0 {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.RegisteredProof))); err != nil {
-			return err
-		}
-	} else {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.RegisteredProof)-1)); err != nil {
-			return err
-		}
-	}
 	return nil
 }
 
@@ -1958,7 +1947,7 @@ func (t *CronEventPayload) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 3 {
+	if extra != 2 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -2007,31 +1996,6 @@ func (t *CronEventPayload) UnmarshalCBOR(r io.Reader) error {
 			}
 		}
 
-	}
-	// t.RegisteredProof (abi.RegisteredProof) (int64)
-	{
-		maj, extra, err := cbg.CborReadHeader(br)
-		var extraI int64
-		if err != nil {
-			return err
-		}
-		switch maj {
-		case cbg.MajUnsignedInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 positive overflow")
-			}
-		case cbg.MajNegativeInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 negative oveflow")
-			}
-			extraI = -1 - extraI
-		default:
-			return fmt.Errorf("wrong type for int64 field: %d", maj)
-		}
-
-		t.RegisteredProof = abi.RegisteredProof(extraI)
 	}
 	return nil
 }

--- a/actors/builtin/miner/deadlines.go
+++ b/actors/builtin/miner/deadlines.go
@@ -112,7 +112,8 @@ func ComputePartitionsSectors(d *Deadlines, deadlineIndex uint64, partitions []u
 	if err != nil {
 		return nil, fmt.Errorf("failed to count partitions for deadline %d: %w", deadlineIndex, err)
 	}
-	deadlinePartitionCount := deadlineSectorCount / WPoStPartitionSectors
+	// ceil(deadlineSectorCount / WPoStPartitionSectors)
+	deadlinePartitionCount := (deadlineSectorCount + WPoStPartitionSectors - 1) / WPoStPartitionSectors
 
 	// Work out which sector numbers the partitions correspond to.
 	deadlineSectors := d.Due[deadlineIndex]

--- a/actors/builtin/miner/deadlines.go
+++ b/actors/builtin/miner/deadlines.go
@@ -33,6 +33,14 @@ func (d *DeadlineInfo) FaultCutoffPassed() bool {
 	return d.CurrentEpoch >= d.FaultCutoff
 }
 
+func (d *DeadlineInfo) PeriodEnd() abi.ChainEpoch {
+	return d.PeriodStart + WPoStProvingPeriod - 1
+}
+
+func (d *DeadlineInfo) NextPeriodStart() abi.ChainEpoch {
+	return d.PeriodStart + WPoStProvingPeriod
+}
+
 // Returns the epoch that starts the current proving period, the current deadline index,
 // and whether the proving period starts on or after epoch 0 (i.e. is a whole period).
 // The proving period start is the largest number <= the current epoch that has remainder mod WPoStProvingPeriod

--- a/actors/builtin/miner/deadlines_test.go
+++ b/actors/builtin/miner/deadlines_test.go
@@ -3,12 +3,15 @@ package miner_test
 import (
 	"testing"
 
+	"github.com/filecoin-project/go-bitfield"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
 )
+
+const partSize = miner.WPoStPartitionSectors
 
 func TestProvingPeriodDeadlines(t *testing.T) {
 	PP := miner.WPoStProvingPeriod
@@ -264,11 +267,130 @@ func TestPartitionsForDeadline(t *testing.T) {
 	})
 }
 
+func TestComputePartitionsSectors(t *testing.T) {
+	t.Run("no partitions due at empty deadline", func(t *testing.T) {
+		dls := miner.ConstructDeadlines()
+		dls.Due[1] = bf(0, 1)
+
+		// No partitions at deadline 0
+		_, err := miner.ComputePartitionsSectors(dls, 0, []uint64{0})
+		require.Error(t, err)
+
+		// No partitions at deadline 2
+		_, err = miner.ComputePartitionsSectors(dls, 2, []uint64{0})
+		require.Error(t, err)
+		_, err = miner.ComputePartitionsSectors(dls, 2, []uint64{1})
+		require.Error(t, err)
+		_, err = miner.ComputePartitionsSectors(dls, 2, []uint64{2})
+		require.Error(t, err)
+	})
+	t.Run("single sector", func(t *testing.T) {
+		dls := miner.ConstructDeadlines()
+		dls.Due[1] = bf(0, 1)
+		partitions, err := miner.ComputePartitionsSectors(dls, 1, []uint64{0})
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(partitions))
+		assertBfEqual(t, bf(0, 1), partitions[0])
+	})
+	t.Run("full partition", func(t *testing.T) {
+		dls := miner.ConstructDeadlines()
+		dls.Due[10] = bf(1234, partSize)
+		partitions, err := miner.ComputePartitionsSectors(dls, 10, []uint64{0})
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(partitions))
+		assertBfEqual(t, bf(1234, partSize), partitions[0])
+	})
+	t.Run("full plus partial partition", func(t *testing.T) {
+		dls := miner.ConstructDeadlines()
+		dls.Due[10] = bf(5555, partSize+1)
+		partitions, err := miner.ComputePartitionsSectors(dls, 10, []uint64{0}) // First partition
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(partitions))
+		assertBfEqual(t, bf(5555, partSize), partitions[0])
+
+		partitions, err = miner.ComputePartitionsSectors(dls, 10, []uint64{1}) // Second partition
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(partitions))
+		assertBfEqual(t, bf(5555+partSize, 1), partitions[0])
+
+		partitions, err = miner.ComputePartitionsSectors(dls, 10, []uint64{0, 1}) // Both partitions
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(partitions))
+		assertBfEqual(t, bf(5555, partSize), partitions[0])
+		assertBfEqual(t, bf(5555+partSize, 1), partitions[1])
+	})
+	t.Run("multiple partitions", func(t *testing.T) {
+		dls := miner.ConstructDeadlines()
+		dls.Due[1] = bf(0, 3*partSize+1)
+		partitions, err := miner.ComputePartitionsSectors(dls, 1, []uint64{0, 1, 2, 3})
+		require.NoError(t, err)
+		assert.Equal(t, 4, len(partitions))
+		assertBfEqual(t, bf(0, partSize), partitions[0])
+		assertBfEqual(t, bf(1*partSize, partSize), partitions[1])
+		assertBfEqual(t, bf(2*partSize, partSize), partitions[2])
+		assertBfEqual(t, bf(3*partSize, 1), partitions[3])
+	})
+	t.Run("partitions numbered across deadlines", func(t *testing.T) {
+		dls := miner.ConstructDeadlines()
+		dls.Due[1] = bf(0, 3*partSize+1)
+		dls.Due[3] = bf(3*partSize+1, 1)
+		dls.Due[5] = bf(3*partSize+1+1, 2*partSize)
+
+		partitions, err := miner.ComputePartitionsSectors(dls, 1, []uint64{0, 1, 2, 3})
+		require.NoError(t, err)
+		assert.Equal(t, 4, len(partitions))
+
+		partitions, err = miner.ComputePartitionsSectors(dls, 3, []uint64{4})
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(partitions))
+		assertBfEqual(t, bf(3*partSize+1, 1), partitions[0])
+
+		partitions, err = miner.ComputePartitionsSectors(dls, 5, []uint64{5, 6})
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(partitions))
+		assertBfEqual(t, bf(3*partSize+1+1, partSize), partitions[0])
+		assertBfEqual(t, bf(3*partSize+1+1+partSize, partSize), partitions[1])
+
+		// Mismatched deadline/partition pairs
+		_, err = miner.ComputePartitionsSectors(dls, 1, []uint64{4})
+		require.Error(t, err)
+		_, err = miner.ComputePartitionsSectors(dls, 2, []uint64{4})
+		require.Error(t, err)
+		_, err = miner.ComputePartitionsSectors(dls, 3, []uint64{0})
+		require.Error(t, err)
+		_, err = miner.ComputePartitionsSectors(dls, 3, []uint64{3})
+		require.Error(t, err)
+		_, err = miner.ComputePartitionsSectors(dls, 3, []uint64{5})
+		require.Error(t, err)
+		_, err = miner.ComputePartitionsSectors(dls, 4, []uint64{5})
+		require.Error(t, err)
+		_, err = miner.ComputePartitionsSectors(dls, 5, []uint64{0})
+		require.Error(t, err)
+		_, err = miner.ComputePartitionsSectors(dls, 5, []uint64{7})
+		require.Error(t, err)
+	})
+}
+
 //
 // Deadlines Utils
 //
 
-const partSize = miner.WPoStPartitionSectors
+func assertBfEqual(t *testing.T, expected, actual *bitfield.BitField) {
+	ex, err := expected.All(1 << 20)
+	require.NoError(t, err)
+	ac, err := actual.All(1 << 20)
+	require.NoError(t, err)
+	assert.Equal(t, ex, ac)
+}
+
+// Creates a bitfield with a contiguous run of `count` values from `first.
+func bf(first uint64, count uint64) *abi.BitField {
+	values := make([]uint64, count)
+	for i := range values {
+		values[i] = first + uint64(i)
+	}
+	return bitfield.NewFromSet(values)
+}
 
 func deadlinesWithFullPartitions(t *testing.T, n uint64) *miner.Deadlines {
 	gen := [miner.WPoStPeriodDeadlines]uint64{}

--- a/actors/builtin/miner/deadlines_test.go
+++ b/actors/builtin/miner/deadlines_test.go
@@ -93,7 +93,7 @@ func TestProvingPeriodDeadlines(t *testing.T) {
 }
 
 func assertDeadlineInfo(t *testing.T, boundary, current, periodStart abi.ChainEpoch, index uint64, deadlineOpen abi.ChainEpoch) *miner.DeadlineInfo {
-	expected := deadline(current, periodStart, index, deadlineOpen)
+	expected := makeDeadline(current, periodStart, index, deadlineOpen)
 	actual, started := miner.ComputeProvingPeriodDeadline(boundary, current)
 	assert.Equal(t, actual.PeriodStart >= 0, started)
 	assert.True(t, actual.IsOpen())
@@ -102,7 +102,7 @@ func assertDeadlineInfo(t *testing.T, boundary, current, periodStart abi.ChainEp
 	return actual
 }
 
-func deadline(currEpoch, periodStart abi.ChainEpoch, deadline uint64, deadlineOpen abi.ChainEpoch) *miner.DeadlineInfo {
+func makeDeadline(currEpoch, periodStart abi.ChainEpoch, deadline uint64, deadlineOpen abi.ChainEpoch) *miner.DeadlineInfo {
 	return &miner.DeadlineInfo{
 		CurrentEpoch: currEpoch,
 		PeriodStart:  periodStart,

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -420,8 +420,9 @@ func (a Actor) ProveCommitSector(rt Runtime, params *ProveCommitSectorParams) *a
 	if !ok {
 		rt.Abortf(exitcode.ErrIllegalState, "no max seal duration for proof type: %d", precommit.Info.RegisteredProof)
 	}
-	if rt.CurrEpoch() > precommit.PreCommitEpoch+msd {
-		rt.Abortf(exitcode.ErrIllegalArgument, "commitment proof for %d too late at %d, due %d)", sectorNo, rt.CurrEpoch(), precommit.PreCommitEpoch+msd)
+	proveCommitDue := precommit.PreCommitEpoch + msd
+	if rt.CurrEpoch() > proveCommitDue {
+		rt.Abortf(exitcode.ErrIllegalArgument, "commitment proof for %d too late at %d, due %d", sectorNo, rt.CurrEpoch(), proveCommitDue)
 	}
 
 	// will abort if seal invalid

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -36,7 +36,6 @@ const (
 type CronEventPayload struct {
 	EventType       CronEventType
 	Sectors         *abi.BitField
-	RegisteredProof abi.RegisteredProof // Used for PreCommitExpiry verification}
 }
 
 type Actor struct{}
@@ -99,8 +98,7 @@ func (a Actor) Constructor(rt Runtime, params *ConstructorParams) *adt.EmptyValu
 
 	// Register cron callback for epoch before the next proving period starts.
 	deadline, _ := state.DeadlineInfo(rt.CurrEpoch())
-	periodEnd := deadline.PeriodStart + WPoStProvingPeriod - 1
-	enrollCronEvent(rt, periodEnd, &CronEventPayload{
+	enrollCronEvent(rt, deadline.PeriodEnd(), &CronEventPayload{
 		EventType: CronEventProvingPeriod,
 	})
 
@@ -324,10 +322,6 @@ func (a Actor) SubmitWindowedPoSt(rt Runtime, params *SubmitWindowedPoStParams) 
 // Sector Commitment //
 ///////////////////////
 
-type PreCommitSectorParams struct {
-	Info SectorPreCommitInfo
-}
-
 // Proposals must be posted on chain via sma.PublishStorageDeals before PreCommitSector.
 // Optimization: PreCommitSector could contain a list of deals that are not published yet.
 func (a Actor) PreCommitSector(rt Runtime, params *SectorPreCommitInfo) *adt.EmptyValue {
@@ -339,6 +333,12 @@ func (a Actor) PreCommitSector(rt Runtime, params *SectorPreCommitInfo) *adt.Emp
 	var st State
 	newlyVestedAmount := rt.State().Transaction(&st, func() interface{} {
 		rt.ValidateImmediateCallerIs(st.Info.Worker)
+		if _, found, err := st.GetPrecommittedSector(store, params.SectorNumber); err != nil {
+			rt.Abortf(exitcode.ErrIllegalState, "failed to check precommit %v: %v", params.SectorNumber, err)
+		} else if found {
+			rt.Abortf(exitcode.ErrIllegalArgument, "sector %v already precommitted", params.SectorNumber)
+		}
+
 		if found, err := st.HasSectorNo(store, params.SectorNumber); err != nil {
 			rt.Abortf(exitcode.ErrIllegalState, "failed to check sector %v: %v", params.SectorNumber, err)
 		} else if found {
@@ -383,7 +383,6 @@ func (a Actor) PreCommitSector(rt Runtime, params *SectorPreCommitInfo) *adt.Emp
 	cronPayload := CronEventPayload{
 		EventType:       CronEventPreCommitExpiry,
 		Sectors:         bf,
-		RegisteredProof: params.RegisteredProof,
 	}
 
 	msd, ok := MaxSealDuration[params.RegisteredProof]
@@ -419,10 +418,10 @@ func (a Actor) ProveCommitSector(rt Runtime, params *ProveCommitSectorParams) *a
 
 	msd, ok := MaxSealDuration[precommit.Info.RegisteredProof]
 	if !ok {
-		rt.Abortf(exitcode.ErrIllegalState, "No max seal duration for proof type: %d", precommit.Info.RegisteredProof)
+		rt.Abortf(exitcode.ErrIllegalState, "no max seal duration for proof type: %d", precommit.Info.RegisteredProof)
 	}
 	if rt.CurrEpoch() > precommit.PreCommitEpoch+msd {
-		rt.Abortf(exitcode.ErrIllegalArgument, "Invalid ProveCommitSector epoch (cur=%d, pcepoch=%d)", rt.CurrEpoch(), precommit.PreCommitEpoch)
+		rt.Abortf(exitcode.ErrIllegalArgument, "commitment proof for %d too late at %d, due %d)", sectorNo, rt.CurrEpoch(), precommit.PreCommitEpoch+msd)
 	}
 
 	// will abort if seal invalid
@@ -893,7 +892,7 @@ func (a Actor) OnDeferredCronEvent(rt Runtime, payload *CronEventPayload) *adt.E
 	case CronEventProvingPeriod:
 		handleProvingPeriod(rt)
 	case CronEventPreCommitExpiry:
-		checkPrecommitExpiry(rt, payload.Sectors, payload.RegisteredProof)
+		checkPrecommitExpiry(rt, payload.Sectors)
 	case CronEventWorkerKeyChange:
 		commitWorkerKeyChange(rt)
 	}
@@ -910,7 +909,6 @@ func handleProvingPeriod(rt Runtime) {
 	var st State
 	currEpoch := rt.CurrEpoch()
 	var deadline *DeadlineInfo
-	var periodEnd, nextPeriodStart abi.ChainEpoch
 	var fullPeriod bool
 	{
 		// Vest locked funds.
@@ -924,23 +922,17 @@ func handleProvingPeriod(rt Runtime) {
 	}
 
 	{
-		// Detect and penalize missing faults.
+		// Detect and penalize missing proofs.
 		var detectedFaultSectors []*SectorOnChainInfo
-		var penalty abi.TokenAmount
+		penalty := big.Zero()
 		rt.State().Transaction(&st, func() interface{} {
 			deadline, fullPeriod = st.DeadlineInfo(currEpoch)
-			if !fullPeriod {
-				penalty = big.Zero()
-				return nil // Skip checking faults on the first, incomplete period.
+			AssertMsg(currEpoch == deadline.PeriodEnd(), "proving period cron at epoch %d, period ends at %d", currEpoch, deadline.PeriodEnd())
+			if fullPeriod { // Skip checking faults on the first, incomplete period.
+				deadlines, err := st.LoadDeadlines(store)
+				builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deadlines")
+				detectedFaultSectors, penalty = checkMissingPoStFaults(rt, &st, store, deadlines, deadline.PeriodStart, WPoStPeriodDeadlines, currEpoch)
 			}
-			nextPeriodStart = deadline.PeriodStart + WPoStProvingPeriod
-			periodEnd = nextPeriodStart - 1
-			AssertMsg(currEpoch == periodEnd, "proving period cron at epoch %d, period ends at %d", currEpoch, periodEnd)
-
-			deadlines, err := st.LoadDeadlines(store)
-			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deadlines")
-
-			detectedFaultSectors, penalty = checkMissingPoStFaults(rt, &st, store, deadlines, deadline.PeriodStart, WPoStPeriodDeadlines, currEpoch)
 			return nil
 		})
 
@@ -997,13 +989,15 @@ func handleProvingPeriod(rt Runtime) {
 			newSectors, err := st.NewSectors.All(NewSectorsPerPeriodMax)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to expand new sectors")
 
-			assignmentSeed := rt.GetRandomness(crypto.DomainSeparationTag_WindowedPoStDeadlineAssignment, currEpoch-1, nil)
-			err = AssignNewSectors(deadlines, newSectors, assignmentSeed)
-			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to assign new sectors to deadlines")
+			if len(newSectors) > 0 {
+				assignmentSeed := rt.GetRandomness(crypto.DomainSeparationTag_WindowedPoStDeadlineAssignment, currEpoch-1, nil)
+				err = AssignNewSectors(deadlines, newSectors, assignmentSeed)
+				builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to assign new sectors to deadlines")
 
-			// Store updated deadline state.
-			err = st.SaveDeadlines(store, deadlines)
-			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to store new deadlines")
+				// Store updated deadline state.
+				err = st.SaveDeadlines(store, deadlines)
+				builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to store new deadlines")
+			}
 
 			// Reset PoSt submissions for next period.
 			err = st.ClearPoStSubmissions()
@@ -1013,7 +1007,7 @@ func handleProvingPeriod(rt Runtime) {
 	}
 
 	// Schedule cron callback for next period
-	nextPeriodEnd := nextPeriodStart + WPoStProvingPeriod - 1
+	nextPeriodEnd := deadline.PeriodEnd() + WPoStProvingPeriod
 	enrollCronEvent(rt, nextPeriodEnd, &CronEventPayload{
 		EventType: CronEventProvingPeriod,
 	})
@@ -1164,7 +1158,7 @@ func popExpiredFaults(st *State, store adt.Store, latestTermination abi.ChainEpo
 	return allExpiries, allOngoing, err
 }
 
-func checkPrecommitExpiry(rt Runtime, sectors *abi.BitField, regProof abi.RegisteredProof) {
+func checkPrecommitExpiry(rt Runtime, sectors *abi.BitField) {
 	store := adt.AsStore(rt)
 	var st State
 
@@ -1177,8 +1171,8 @@ func checkPrecommitExpiry(rt Runtime, sectors *abi.BitField, regProof abi.Regist
 			if err != nil {
 				return err
 			}
-			if !found || rt.CurrEpoch()-sector.PreCommitEpoch <= MaxSealDuration[regProof] {
-				// already deleted or not yet expired
+			if !found {
+				// already committed/deleted
 				return nil
 			}
 

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -138,7 +138,7 @@ func TestCommitments(t *testing.T) {
 		st := getState(rt)
 		deadline, _ := st.DeadlineInfo(precommitEpoch)
 
-		challengeEpoch := precommitEpoch - 20
+		challengeEpoch := precommitEpoch - miner.PreCommitChallengeDelay
 
 		// Good commitment.
 		actor.preCommitSector(rt, makePreCommit(100, challengeEpoch, deadline.PeriodEnd()), big.Zero())
@@ -153,16 +153,15 @@ func TestCommitments(t *testing.T) {
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			actor.preCommitSector(rt, makePreCommit(111, challengeEpoch, deadline.PeriodEnd()), big.Zero())
 		})
-		rt.SetEpoch(precommitEpoch)
 
 		// Expires before current epoch
 		rt.SetEpoch(deadline.PeriodEnd() + 1)
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			actor.preCommitSector(rt, makePreCommit(112, challengeEpoch, deadline.PeriodEnd()), big.Zero())
 		})
-		rt.SetEpoch(precommitEpoch)
 
 		// Expires not on period end
+		rt.SetEpoch(precommitEpoch)
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			actor.preCommitSector(rt, makePreCommit(113, challengeEpoch, deadline.PeriodEnd()-1), big.Zero())
 		})

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -3,18 +3,23 @@ package miner_test
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"testing"
 
 	addr "github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-bitfield"
 	"github.com/minio/blake2b-simd"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	cbg "github.com/whyrusleeping/cbor-gen"
 
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
+	"github.com/filecoin-project/specs-actors/actors/builtin/market"
 	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
 	"github.com/filecoin-project/specs-actors/actors/builtin/power"
+	"github.com/filecoin-project/specs-actors/actors/crypto"
 	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 	"github.com/filecoin-project/specs-actors/support/mock"
 	tutil "github.com/filecoin-project/specs-actors/support/testing"
@@ -53,7 +58,7 @@ func TestConstruction(t *testing.T) {
 		rt.ExpectSend(worker, builtin.MethodsAccount.PubkeyAddress, nil, big.Zero(), &workerKey, exitcode.Ok)
 		// Register proving period cron.
 		rt.ExpectSend(builtin.StoragePowerActorAddr, builtin.MethodsPower.EnrollCronEvent,
-			provingPeriodCronPayload(t, provingPeriodBoundary-1), big.Zero(), nil, exitcode.Ok)
+			makeProvingPeriodCronEventParams(t, provingPeriodBoundary-1), big.Zero(), nil, exitcode.Ok)
 		ret := rt.Call(actor.Constructor, &params)
 		assert.Nil(t, ret)
 		rt.Verify()
@@ -86,49 +91,144 @@ func TestConstruction(t *testing.T) {
 	})
 }
 
+// Tests for fetching and manipulating miner addresses.
 func TestControlAddresses(t *testing.T) {
-	actor := actorHarness{miner.Actor{}, t}
 	owner := tutil.NewIDAddr(t, 100)
 	worker := tutil.NewIDAddr(t, 101)
 	workerKey := tutil.NewBLSAddr(t, 0)
 	receiver := tutil.NewIDAddr(t, 1000)
+	actor := newHarness(t, owner, worker, workerKey)
 	builder := mock.NewBuilder(context.Background(), receiver).
 		WithActorType(owner, builtin.AccountActorCodeID).
 		WithActorType(worker, builtin.AccountActorCodeID).
-		WithHasher(blake2b.Sum256).
+		WithHasher(fixedHasher(0)).
 		WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID)
 
 	t.Run("get addresses", func(t *testing.T) {
 		rt := builder.Build(t)
-
-		actor.constructAndVerify(rt, owner, worker, workerKey)
+		actor.constructAndVerify(rt, miner.WPoStProvingPeriod)
 
 		o, w := actor.controlAddresses(rt)
 		assert.Equal(t, owner, o)
 		assert.Equal(t, worker, w)
+	})
+
+	// TODO: test changing worker (with delay), changing peer id
+}
+
+// Test for sector precommitment and proving.
+func TestCommitments(t *testing.T) {
+	owner := tutil.NewIDAddr(t, 100)
+	worker := tutil.NewIDAddr(t, 101)
+	workerKey := tutil.NewBLSAddr(t, 0)
+	receiver := tutil.NewIDAddr(t, 1000)
+	actor := newHarness(t, owner, worker, workerKey)
+	periodBoundary := abi.ChainEpoch(100)
+	builder := mock.NewBuilder(context.Background(), receiver).
+		WithActorType(owner, builtin.AccountActorCodeID).
+		WithActorType(worker, builtin.AccountActorCodeID).
+		WithHasher(fixedHasher(uint64(periodBoundary))).
+		WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID)
+
+	t.Run("invalid pre-commit rejected", func(t *testing.T) {
+		rt := builder.Build(t)
+		precommitEpoch := periodBoundary + 1
+		rt.SetEpoch(precommitEpoch)
+		actor.constructAndVerify(rt, periodBoundary+miner.WPoStProvingPeriod)
+		st := getState(rt)
+		deadline, _ := st.DeadlineInfo(precommitEpoch)
+
+		challengeEpoch := precommitEpoch - 20
+
+		// Good commitment.
+		actor.preCommitSector(rt, makePreCommit(100, challengeEpoch, deadline.PeriodEnd()), big.Zero())
+
+		// Duplicate sector ID
+		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
+			actor.preCommitSector(rt, makePreCommit(100, challengeEpoch, deadline.PeriodEnd()), big.Zero())
+		})
+
+		// Expires at current epoch
+		rt.SetEpoch(deadline.PeriodEnd())
+		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
+			actor.preCommitSector(rt, makePreCommit(111, challengeEpoch, deadline.PeriodEnd()), big.Zero())
+		})
+		rt.SetEpoch(precommitEpoch)
+
+		// Expires before current epoch
+		rt.SetEpoch(deadline.PeriodEnd() + 1)
+		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
+			actor.preCommitSector(rt, makePreCommit(112, challengeEpoch, deadline.PeriodEnd()), big.Zero())
+		})
+		rt.SetEpoch(precommitEpoch)
+
+		// Expires not on period end
+		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
+			actor.preCommitSector(rt, makePreCommit(113, challengeEpoch, deadline.PeriodEnd()-1), big.Zero())
+		})
+
+		// TODO: test insufficient funds when the precommit deposit is set above zero
+	})
+
+
+	// TODO
+	// already proven
+	// commitment expires before proof
+	// commitment proven ok
+}
+
+func TestProvingPeriodCron(t *testing.T) {
+	owner := tutil.NewIDAddr(t, 100)
+	worker := tutil.NewIDAddr(t, 101)
+	workerKey := tutil.NewBLSAddr(t, 0)
+	receiver := tutil.NewIDAddr(t, 1000)
+	actor := newHarness(t, owner, worker, workerKey)
+	periodBoundary := abi.ChainEpoch(100)
+	builder := mock.NewBuilder(context.Background(), receiver).
+		WithActorType(owner, builtin.AccountActorCodeID).
+		WithActorType(worker, builtin.AccountActorCodeID).
+		WithHasher(fixedHasher(uint64(periodBoundary))).
+		WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID)
+
+	t.Run("empty period", func(t *testing.T) {
+		rt := builder.Build(t)
+		actor.constructAndVerify(rt, periodBoundary)
+
+		rt.SetEpoch(periodBoundary - 1)
+		actor.onProvingPeriodCron(rt) // Checks that the expected re-enrollment is made for next period.
+
+		rt.SetEpoch(periodBoundary + miner.WPoStProvingPeriod - 1)
+		actor.onProvingPeriodCron(rt)
 	})
 }
 
 type actorHarness struct {
 	a miner.Actor
 	t testing.TB
+
+	owner  addr.Address
+	worker addr.Address
+	key    addr.Address
 }
 
-func (h *actorHarness) constructAndVerify(rt *mock.Runtime, owner, worker, key addr.Address) {
+func newHarness(t testing.TB, owner, worker, key addr.Address) *actorHarness {
+	return &actorHarness{miner.Actor{}, t, owner, worker, key}
+}
+
+func (h *actorHarness) constructAndVerify(rt *mock.Runtime, nextPPStart abi.ChainEpoch) {
 	params := miner.ConstructorParams{
-		OwnerAddr:  owner,
-		WorkerAddr: worker,
+		OwnerAddr:  h.owner,
+		WorkerAddr: h.worker,
 		SectorSize: SectorSize,
 		PeerId:     "peer",
 	}
 
-	provingPeriodBoundary := abi.ChainEpoch(2386) // This is just set from running the code.
 	rt.ExpectValidateCallerAddr(builtin.InitActorAddr)
 	// Fetch worker pubkey.
-	rt.ExpectSend(worker, builtin.MethodsAccount.PubkeyAddress, nil, big.Zero(), &key, exitcode.Ok)
+	rt.ExpectSend(h.worker, builtin.MethodsAccount.PubkeyAddress, nil, big.Zero(), &h.key, exitcode.Ok)
 	// Register proving period cron.
 	rt.ExpectSend(builtin.StoragePowerActorAddr, builtin.MethodsPower.EnrollCronEvent,
-		provingPeriodCronPayload(h.t, provingPeriodBoundary-1), big.Zero(), nil, exitcode.Ok)
+		makeProvingPeriodCronEventParams(h.t, nextPPStart-1), big.Zero(), nil, exitcode.Ok)
 	ret := rt.Call(h.a.Constructor, &params)
 	assert.Nil(h.t, ret)
 	rt.Verify()
@@ -138,10 +238,75 @@ func (h *actorHarness) controlAddresses(rt *mock.Runtime) (owner, worker addr.Ad
 	rt.ExpectValidateCallerAny()
 	ret := rt.Call(h.a.ControlAddresses, nil).(*miner.GetControlAddressesReturn)
 	require.NotNil(h.t, ret)
+	rt.Verify()
 	return ret.Owner, ret.Worker
 }
 
-func provingPeriodCronPayload(t testing.TB, epoch abi.ChainEpoch) *power.EnrollCronEventParams {
+func (h *actorHarness) preCommitSector(rt *mock.Runtime, params *miner.SectorPreCommitInfo, pledgeDelta abi.TokenAmount) {
+	rt.SetCaller(h.worker, builtin.AccountActorCodeID)
+	rt.ExpectValidateCallerAddr(h.worker)
+	if !pledgeDelta.IsZero() {
+		rt.ExpectSend(builtin.StoragePowerActorAddr, builtin.MethodsPower.UpdatePledgeTotal, &pledgeDelta, big.Zero(), nil, exitcode.Ok)
+	}
+
+	{
+		eventPayload := miner.CronEventPayload{
+			EventType: miner.CronEventPreCommitExpiry,
+			Sectors:   bitfield.NewFromSet([]uint64{uint64(params.SectorNumber)}),
+		}
+		buf := bytes.Buffer{}
+		err := eventPayload.MarshalCBOR(&buf)
+		require.NoError(h.t, err)
+		cronParams := power.EnrollCronEventParams{
+			EventEpoch: rt.GetEpoch() + miner.MaxSealDuration[params.RegisteredProof] + 1,
+			Payload:    buf.Bytes(),
+		}
+		rt.ExpectSend(builtin.StoragePowerActorAddr, builtin.MethodsPower.EnrollCronEvent, &cronParams, big.Zero(), nil, exitcode.Ok)
+	}
+
+	rt.Call(h.a.PreCommitSector, params)
+	rt.Verify()
+}
+
+func (h *actorHarness) proveCommitSector(rt *mock.Runtime, precommit *miner.SectorPreCommitInfo, params *miner.ProveCommitSectorParams) {
+	rt.ExpectValidateCallerAny()
+	commd := cbg.CborCid(tutil.MakeCID("commd"))
+	{
+		cdcParams := market.ComputeDataCommitmentParams{
+			DealIDs:    precommit.DealIDs,
+			SectorType: precommit.RegisteredProof,
+		}
+		rt.ExpectSend(builtin.StorageMarketActorAddr, builtin.MethodsMarket.ComputeDataCommitment, &cdcParams, big.Zero(), &commd, exitcode.Ok)
+	}
+	{
+		var buf bytes.Buffer
+		err := rt.GetReceiver().MarshalCBOR(&buf)
+		require.NoError(h.t, err)
+		rt.ExpectGetRandomness(crypto.DomainSeparationTag_SealRandomness, precommit.SealRandEpoch, buf.Bytes(), abi.Randomness("sealrand"))
+	}
+	rt.Call(h.a.ProveCommitSector, params)
+	rt.Verify()
+}
+
+func (h *actorHarness) onProvingPeriodCron(rt *mock.Runtime) {
+	rt.ExpectValidateCallerAddr(builtin.StoragePowerActorAddr)
+	// Re-enrollment for next period.
+	rt.ExpectSend(builtin.StoragePowerActorAddr, builtin.MethodsPower.EnrollCronEvent,
+		makeProvingPeriodCronEventParams(h.t, rt.GetEpoch()+miner.WPoStProvingPeriod), big.Zero(), nil, exitcode.Ok)
+	rt.SetCaller(builtin.StoragePowerActorAddr, builtin.StoragePowerActorCodeID)
+	rt.Call(h.a.OnDeferredCronEvent, &miner.CronEventPayload{
+		EventType: miner.CronEventProvingPeriod,
+	})
+	rt.Verify()
+}
+
+func getState(rt *mock.Runtime) *miner.State {
+	var st miner.State
+	rt.GetState(&st)
+	return &st
+}
+
+func makeProvingPeriodCronEventParams(t testing.TB, epoch abi.ChainEpoch) *power.EnrollCronEventParams {
 	eventPayload := miner.CronEventPayload{EventType: miner.CronEventProvingPeriod}
 	buf := bytes.Buffer{}
 	err := eventPayload.MarshalCBOR(&buf)
@@ -152,9 +317,42 @@ func provingPeriodCronPayload(t testing.TB, epoch abi.ChainEpoch) *power.EnrollC
 	}
 }
 
+func makePreCommit(sectorNo abi.SectorNumber, challenge, expiration abi.ChainEpoch) *miner.SectorPreCommitInfo {
+	return &miner.SectorPreCommitInfo{
+		RegisteredProof: abi.RegisteredProof_StackedDRG2KiBSeal,
+		SectorNumber:    sectorNo,
+		SealedCID:       tutil.MakeCID("commr"),
+		SealRandEpoch:   challenge,
+		DealIDs:         nil,
+		Expiration:      expiration,
+	}
+}
+
+func makeProveCommit(sectorNo abi.SectorNumber) *miner.ProveCommitSectorParams {
+	return &miner.ProveCommitSectorParams{
+		SectorNumber: sectorNo,
+		Proof:        []byte("proof"),
+	}
+}
+
 func assertEmptyBitfield(t *testing.T, b *abi.BitField) {
 	empty, err := b.IsEmpty()
 	require.NoError(t, err)
 	assert.True(t, empty)
 
+}
+
+// Returns a fake hashing function that always arranges the first 8 bytes of the digest to be the binary
+// encoding of a target uint64.
+func fixedHasher(target uint64) func([]byte) [32]byte {
+	return func(_ []byte) [32]byte {
+		var buf bytes.Buffer
+		err := binary.Write(&buf, binary.BigEndian, target)
+		if err != nil {
+			panic(err)
+		}
+		var digest [32]byte
+		copy(digest[:], buf.Bytes())
+		return digest
+	}
 }


### PR DESCRIPTION
- Tests for sector pre-commitment and cron scheduling
- Fixes incorrect cron scheduling when the first proving period was partial
- Removed RegisteredProof from sector pre-commit cron payload (unnecessary) 
- Improvements to the mock runtime for this and future tests (incl stack traces on errors)
- Test helpers for future tests (partially written elsewhere)