### PR TITLE
Safely return from updatePendingDealState if deal.StartEpoch hasn't begun

### DIFF
--- a/actors/builtin/market/market_state.go
+++ b/actors/builtin/market/market_state.go
@@ -111,7 +111,9 @@ func (st *State) updatePendingDealState(rt Runtime, dealID abi.DealID, epoch abi
 		return
 	}
 
-	Assert(deal.StartEpoch <= epoch)
+	if deal.StartEpoch > epoch {
+		return
+	}
 
 	dealEnd := deal.EndEpoch
 	if everSlashed {


### PR DESCRIPTION
Looking at the entries to this function, I don't think there's any reason why we should *fail* if it's called before a deal proposal has started, I think we can just return without doing anything.

I might be missing something, though.

This fixes https://github.com/filecoin-project/lotus/issues/1455