### PR TITLE
improve deal accounting performance

### DIFF
--- a/actors/builtin/cron/cron_state.go
+++ b/actors/builtin/cron/cron_state.go
@@ -22,8 +22,14 @@ func ConstructState(entries []Entry) *State {
 
 // The default entries to install in the cron actor's state at genesis.
 func BuiltInEntries() []Entry {
-	return []Entry{{
-		Receiver:  builtin.StoragePowerActorAddr,
-		MethodNum: builtin.MethodsPower.OnEpochTickEnd,
-	}}
+	return []Entry{
+		{
+			Receiver:  builtin.StoragePowerActorAddr,
+			MethodNum: builtin.MethodsPower.OnEpochTickEnd,
+		},
+		{
+			Receiver:  builtin.StorageMarketActorAddr,
+			MethodNum: builtin.MethodsMarket.CronTick,
+		},
+	}
 }

--- a/actors/builtin/market/cbor_gen.go
+++ b/actors/builtin/market/cbor_gen.go
@@ -54,7 +54,7 @@ func (t *State) MarshalCBOR(w io.Writer) error {
 
 	// t.DealIDsByParty (cid.Cid) (struct)
 
-	if err := cbg.WriteCid(w, t.DealIDsByParty); err != nil {
+	if err := cbg.WriteCid(w, t.DealOpsByEpoch); err != nil {
 		return xerrors.Errorf("failed to write cid field t.DealIDsByParty: %w", err)
 	}
 
@@ -147,7 +147,7 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 			return xerrors.Errorf("failed to read cid field t.DealIDsByParty: %w", err)
 		}
 
-		t.DealIDsByParty = c
+		t.DealOpsByEpoch = c
 
 	}
 	return nil
@@ -634,158 +634,6 @@ func (t *OnMinerSectorsTerminateParams) UnmarshalCBOR(r io.Reader) error {
 		}
 
 		t.DealIDs[i] = abi.DealID(val)
-	}
-
-	return nil
-}
-
-func (t *HandleExpiredDealsParams) MarshalCBOR(w io.Writer) error {
-	if t == nil {
-		_, err := w.Write(cbg.CborNull)
-		return err
-	}
-	if _, err := w.Write([]byte{129}); err != nil {
-		return err
-	}
-
-	// t.Deals ([]abi.DealID) (slice)
-	if len(t.Deals) > cbg.MaxLength {
-		return xerrors.Errorf("Slice value in field t.Deals was too long")
-	}
-
-	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajArray, uint64(len(t.Deals)))); err != nil {
-		return err
-	}
-	for _, v := range t.Deals {
-		if err := cbg.CborWriteHeader(w, cbg.MajUnsignedInt, uint64(v)); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (t *HandleExpiredDealsParams) UnmarshalCBOR(r io.Reader) error {
-	br := cbg.GetPeeker(r)
-
-	maj, extra, err := cbg.CborReadHeader(br)
-	if err != nil {
-		return err
-	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
-	}
-
-	if extra != 1 {
-		return fmt.Errorf("cbor input had wrong number of fields")
-	}
-
-	// t.Deals ([]abi.DealID) (slice)
-
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
-	}
-
-	if extra > cbg.MaxLength {
-		return fmt.Errorf("t.Deals: array too large (%d)", extra)
-	}
-
-	if maj != cbg.MajArray {
-		return fmt.Errorf("expected cbor array")
-	}
-
-	if extra > 0 {
-		t.Deals = make([]abi.DealID, extra)
-	}
-
-	for i := 0; i < int(extra); i++ {
-
-		maj, val, err := cbg.CborReadHeader(br)
-		if err != nil {
-			return xerrors.Errorf("failed to read uint64 for t.Deals slice: %w", err)
-		}
-
-		if maj != cbg.MajUnsignedInt {
-			return xerrors.Errorf("value read for array t.Deals was not a uint, instead got %d", maj)
-		}
-
-		t.Deals[i] = abi.DealID(val)
-	}
-
-	return nil
-}
-
-func (t *HandleInitTimeoutDealsParams) MarshalCBOR(w io.Writer) error {
-	if t == nil {
-		_, err := w.Write(cbg.CborNull)
-		return err
-	}
-	if _, err := w.Write([]byte{129}); err != nil {
-		return err
-	}
-
-	// t.Deals ([]abi.DealID) (slice)
-	if len(t.Deals) > cbg.MaxLength {
-		return xerrors.Errorf("Slice value in field t.Deals was too long")
-	}
-
-	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajArray, uint64(len(t.Deals)))); err != nil {
-		return err
-	}
-	for _, v := range t.Deals {
-		if err := cbg.CborWriteHeader(w, cbg.MajUnsignedInt, uint64(v)); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (t *HandleInitTimeoutDealsParams) UnmarshalCBOR(r io.Reader) error {
-	br := cbg.GetPeeker(r)
-
-	maj, extra, err := cbg.CborReadHeader(br)
-	if err != nil {
-		return err
-	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
-	}
-
-	if extra != 1 {
-		return fmt.Errorf("cbor input had wrong number of fields")
-	}
-
-	// t.Deals ([]abi.DealID) (slice)
-
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
-	}
-
-	if extra > cbg.MaxLength {
-		return fmt.Errorf("t.Deals: array too large (%d)", extra)
-	}
-
-	if maj != cbg.MajArray {
-		return fmt.Errorf("expected cbor array")
-	}
-
-	if extra > 0 {
-		t.Deals = make([]abi.DealID, extra)
-	}
-
-	for i := 0; i < int(extra); i++ {
-
-		maj, val, err := cbg.CborReadHeader(br)
-		if err != nil {
-			return xerrors.Errorf("failed to read uint64 for t.Deals slice: %w", err)
-		}
-
-		if maj != cbg.MajUnsignedInt {
-			return xerrors.Errorf("value read for array t.Deals was not a uint, instead got %d", maj)
-		}
-
-		t.Deals[i] = abi.DealID(val)
 	}
 
 	return nil

--- a/actors/builtin/market/market_actor.go
+++ b/actors/builtin/market/market_actor.go
@@ -284,7 +284,7 @@ func (a Actor) VerifyDealsOnSectorProveCommit(rt Runtime, params *VerifyDealsOnS
 		}
 
 		for _, dealID := range params.DealIDs {
-			deal, err := states.Get(dealID)
+			deal, _, err := states.Get(dealID)
 			if err != nil {
 				rt.Abortf(exitcode.ErrIllegalState, "get deal %v", err)
 			}
@@ -385,7 +385,7 @@ func (a Actor) OnMinerSectorsTerminate(rt Runtime, params *OnMinerSectorsTermina
 			}
 			Assert(deal.Provider == minerAddr)
 
-			state, err := states.Get(dealID)
+			state, _, err := states.Get(dealID)
 			if err != nil {
 				rt.Abortf(exitcode.ErrIllegalState, "get deal: %v", err)
 			}

--- a/actors/builtin/market/market_actor.go
+++ b/actors/builtin/market/market_actor.go
@@ -24,11 +24,11 @@ func (a Actor) Exports() []interface{} {
 		builtin.MethodConstructor: a.Constructor,
 		2:                         a.AddBalance,
 		3:                         a.WithdrawBalance,
-		5:                         a.PublishStorageDeals,
-		6:                         a.VerifyDealsOnSectorProveCommit,
-		7:                         a.OnMinerSectorsTerminate,
-		8:                         a.ComputeDataCommitment,
-		10:                        a.CronTick,
+		4:                         a.PublishStorageDeals,
+		5:                         a.VerifyDealsOnSectorProveCommit,
+		6:                         a.OnMinerSectorsTerminate,
+		7:                         a.ComputeDataCommitment,
+		8:                         a.CronTick,
 	}
 }
 

--- a/actors/builtin/market/market_actor.go
+++ b/actors/builtin/market/market_actor.go
@@ -24,12 +24,11 @@ func (a Actor) Exports() []interface{} {
 		builtin.MethodConstructor: a.Constructor,
 		2:                         a.AddBalance,
 		3:                         a.WithdrawBalance,
-		4:                         a.HandleExpiredDeals,
 		5:                         a.PublishStorageDeals,
 		6:                         a.VerifyDealsOnSectorProveCommit,
 		7:                         a.OnMinerSectorsTerminate,
 		8:                         a.ComputeDataCommitment,
-		9:                         a.HandleInitTimeoutDeals,
+		10:                        a.CronTick,
 	}
 }
 
@@ -82,7 +81,6 @@ func (a Actor) WithdrawBalance(rt Runtime, params *WithdrawBalanceParams) *adt.E
 	rt.State().Transaction(&st, func() interface{} {
 		// Before any operations that check the balance tables for funds, execute all deferred
 		// deal state updates.
-		amountSlashedTotal = big.Add(amountSlashedTotal, st.updatePendingDealStatesForParty(rt, nominal))
 
 		minBalance := st.GetLockedBalance(rt, nominal)
 
@@ -148,7 +146,6 @@ type PublishStorageDealsReturn struct {
 
 // Publish a new set of storage deals (not yet included in a sector).
 func (a Actor) PublishStorageDeals(rt Runtime, params *PublishStorageDealsParams) *PublishStorageDealsReturn {
-	amountSlashedTotal := abi.NewTokenAmount(0)
 
 	// Deal message must have a From field identical to the provider of all the deals.
 	// This allows us to retain and verify only the client's signature in each deal proposal itself.
@@ -195,7 +192,7 @@ func (a Actor) PublishStorageDeals(rt Runtime, params *PublishStorageDealsParams
 			rt.Abortf(exitcode.ErrIllegalState, "failed to load proposals array: %s", err)
 		}
 
-		dbp, err := AsSetMultimap(adt.AsStore(rt), st.DealIDsByParty)
+		dbp, err := AsSetMultimap(adt.AsStore(rt), st.DealOpsByEpoch)
 		if err != nil {
 			rt.Abortf(exitcode.ErrIllegalState, "failed to load deal ids set: %s", err)
 		}
@@ -216,29 +213,17 @@ func (a Actor) PublishStorageDeals(rt Runtime, params *PublishStorageDealsParams
 			deal.Proposal.Provider = provider
 			deal.Proposal.Client = client
 
-			// Before any operations that check the balance tables for funds, execute all deferred
-			// deal state updates.
-			//
-			// Note: as an optimization, implementations may cache efficient data structures indicating
-			// which of the following set of updates are redundant and can be skipped.
-			amountSlashedTotal = big.Add(amountSlashedTotal, st.updatePendingDealStatesForParty(rt, client))
-			amountSlashedTotal = big.Add(amountSlashedTotal, st.updatePendingDealStatesForParty(rt, provider))
-
 			st.lockBalanceOrAbort(rt, client, deal.Proposal.ClientBalanceRequirement())
 			st.lockBalanceOrAbort(rt, provider, deal.Proposal.ProviderBalanceRequirement())
 
 			id := st.generateStorageDealID()
 
-			err := proposals.Set(id, &deal.Proposal)
-			if err != nil {
+			if err := proposals.Set(id, &deal.Proposal); err != nil {
 				rt.Abortf(exitcode.ErrIllegalState, "set deal: %v", err)
 			}
 
-			if err = dbp.Put(client, id); err != nil {
-				rt.Abortf(exitcode.ErrIllegalState, "set client deal id: %v", err)
-			}
-			if err = dbp.Put(provider, id); err != nil {
-				rt.Abortf(exitcode.ErrIllegalState, "set provider deal id: %v", err)
+			if err := dbp.Put(deal.Proposal.StartEpoch, id); err != nil {
+				rt.Abortf(exitcode.ErrIllegalState, "set deal in ops set: %v", err)
 			}
 
 			newDealIds = append(newDealIds, id)
@@ -254,12 +239,10 @@ func (a Actor) PublishStorageDeals(rt Runtime, params *PublishStorageDealsParams
 			rt.Abortf(exitcode.ErrIllegalState, "failed to flush deal ids map: %w", err)
 		}
 
-		st.DealIDsByParty = dipc
+		st.DealOpsByEpoch = dipc
 		return nil
 	})
 
-	_, code := rt.Send(builtin.BurntFundsActorAddr, builtin.MethodSend, nil, amountSlashedTotal)
-	builtin.RequireSuccess(rt, code, "failed to burn funds")
 	return &PublishStorageDealsReturn{newDealIds}
 }
 
@@ -426,78 +409,62 @@ func (a Actor) OnMinerSectorsTerminate(rt Runtime, params *OnMinerSectorsTermina
 	return nil
 }
 
-type HandleExpiredDealsParams struct {
-	Deals []abi.DealID // TODO: RLE
-}
+func (a Actor) CronTick(rt Runtime, params *adt.EmptyValue) *adt.EmptyValue {
+	rt.ValidateImmediateCallerIs(builtin.CronActorAddr)
+	amountSlashed := big.Zero()
 
-func (a Actor) HandleExpiredDeals(rt Runtime, params *HandleExpiredDealsParams) *adt.EmptyValue {
-	rt.ValidateImmediateCallerType(builtin.CallerTypesSignable...)
-	var slashed abi.TokenAmount
 	var st State
 	rt.State().Transaction(&st, func() interface{} {
-		slashed = st.updatePendingDealStates(rt, params.Deals, rt.CurrEpoch())
-		return nil
-	})
+		dbe, err := AsSetMultimap(adt.AsStore(rt), st.DealOpsByEpoch)
+		if err != nil {
+			rt.Abortf(exitcode.ErrIllegalState, "failed to load deal opts set: %s", err)
+		}
 
-	// TODO: award some small portion of slashed to caller as incentive
+		updatesNeeded := make(map[abi.ChainEpoch][]abi.DealID)
 
-	_, code := rt.Send(builtin.BurntFundsActorAddr, builtin.MethodSend, nil, slashed)
-	builtin.RequireSuccess(rt, code, "failed to burn funds")
-	return nil
-}
-
-type HandleInitTimeoutDealsParams struct {
-	Deals []abi.DealID // TODO: RLE
-}
-
-func (a Actor) HandleInitTimeoutDeals(rt Runtime, params *HandleInitTimeoutDealsParams) *adt.EmptyValue {
-	rt.ValidateImmediateCallerType(builtin.CallerTypesSignable...)
-	var st State
-	var verifiedDeals []*DealProposal
-	slashedAmount := rt.State().Transaction(&st, func() interface{} {
-		slashed := abi.NewTokenAmount(0)
-		for _, dealID := range params.Deals {
-			deal := st.mustGetDeal(rt, dealID)
-			state := st.mustGetDealState(rt, dealID)
-
-			// Deal has not been activated.
-			if state.SectorStartEpoch == epochUndefined {
-				// Now is after StartEpoch when the Deal should have been activated, hence clean up.
-				if rt.CurrEpoch() > deal.StartEpoch {
-					// Store VerifiedDeal to restore bytes for VerifiedClient.
-					if deal.VerifiedDeal {
-						verifiedDeals = append(verifiedDeals, deal)
-					}
-					newlySlashed := st.processDealInitTimedOut(rt, dealID)
-					big.Add(slashed, newlySlashed)
-				} else {
-					// All deals must have timed out.
-					rt.Abortf(exitcode.ErrIllegalArgument, "not all deals have timed out: %d", dealID)
+		for i := st.LastCron; i <= rt.CurrEpoch(); i++ {
+			if err := dbe.ForEach(i, func(deal abi.DealID) error {
+				slashAmount, nextEpoch := st.updatePendingDealState(rt, deal, rt.CurrEpoch())
+				if !slashAmount.IsZero() {
+					amountSlashed = big.Add(amountSlashed, slashAmount)
 				}
+
+				if nextEpoch != 0 {
+					Assert(nextEpoch <= rt.CurrEpoch())
+
+					updatesNeeded[nextEpoch] = append(updatesNeeded[nextEpoch], deal)
+				}
+
+				return nil
+			}); err != nil {
+				rt.Abortf(exitcode.ErrIllegalState, "failed to iterate deals for epoch: %s", err)
+			}
+			if err := dbe.RemoveAll(i); err != nil {
+				rt.Abortf(exitcode.ErrIllegalState, "failed to delete deals from set: %s", err)
 			}
 		}
 
-		return &slashed
-	}).(abi.TokenAmount)
+		// NB: its okay that we're doing a 'random' golang map iteration here
+		// because HAMTs and AMTs are insertion order independent, the same set of
+		// data inserted will always produce the same structure, no matter the order
+		for epoch, deals := range updatesNeeded {
+			if err := dbe.PutMany(epoch, deals); err != nil {
+				rt.Abortf(exitcode.ErrIllegalState, "failed to reinsert deal IDs into epoch set: %s", err)
+			}
+		}
 
-	// TODO: award some small portion of slashed to caller as incentive
+		ndbec, err := dbe.Root()
+		if err != nil {
+			rt.Abortf(exitcode.ErrIllegalState, "failed to get root of deals by epoch set: %s", err)
+		}
 
-	// Restore verified dataset allowance for verified clients.
-	for _, deal := range verifiedDeals {
-		_, code := rt.Send(
-			builtin.VerifiedRegistryActorAddr,
-			builtin.MethodsVerifiedRegistry.RestoreBytes,
-			&verifreg.RestoreBytesParams{
-				Address:  deal.Client,
-				DealSize: big.NewIntUnsigned(uint64(deal.PieceSize)),
-			},
-			abi.NewTokenAmount(0),
-		)
-		builtin.RequireSuccess(rt, code, "failed to restore bytes for verified client: %v", deal.Client)
-	}
+		st.DealOpsByEpoch = ndbec
 
-	_, code := rt.Send(builtin.BurntFundsActorAddr, builtin.MethodSend, nil, slashedAmount)
-	builtin.RequireSuccess(rt, code, "failed to burn funds")
+		return nil
+	})
+
+	_, e := rt.Send(builtin.BurntFundsActorAddr, 0, nil, amountSlashed)
+	builtin.RequireSuccess(rt, e, "expected send to burnt funds actor to succeed")
 	return nil
 }
 

--- a/actors/builtin/market/market_state.go
+++ b/actors/builtin/market/market_state.go
@@ -14,6 +14,8 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
 )
 
+const DealUpdatesInterval = 100
+
 const epochUndefined = abi.ChainEpoch(-1)
 
 // Market mutations
@@ -37,7 +39,8 @@ type State struct {
 	NextID abi.DealID
 
 	// Metadata cached for efficient iteration over deals.
-	DealIDsByParty cid.Cid // SetMultimap, HAMT[addr]Set
+	DealOpsByEpoch cid.Cid // SetMultimap, HAMT[epoch]Set
+	LastCron       abi.ChainEpoch
 }
 
 func ConstructState(emptyArrayCid, emptyMapCid, emptyMSetCid cid.Cid) *State {
@@ -47,7 +50,7 @@ func ConstructState(emptyArrayCid, emptyMapCid, emptyMSetCid cid.Cid) *State {
 		EscrowTable:    emptyMapCid,
 		LockedTable:    emptyMapCid,
 		NextID:         abi.DealID(0),
-		DealIDsByParty: emptyMSetCid,
+		DealOpsByEpoch: emptyMSetCid,
 	}
 }
 
@@ -55,43 +58,9 @@ func ConstructState(emptyArrayCid, emptyMapCid, emptyMSetCid cid.Cid) *State {
 // Deal state operations
 ////////////////////////////////////////////////////////////////////////////////
 
-func (st *State) updatePendingDealStatesForParty(rt Runtime, addr addr.Address) (amountSlashedTotal abi.TokenAmount) {
-	// For consistency with HandleExpiredDeals, only process updates up to the end of the _previous_ epoch.
-	epoch := rt.CurrEpoch() - 1
+func (st *State) updatePendingDealState(rt Runtime, dealID abi.DealID, epoch abi.ChainEpoch) (abi.TokenAmount, abi.ChainEpoch) {
+	amountSlashed := abi.NewTokenAmount(0)
 
-	dbp, err := AsSetMultimap(adt.AsStore(rt), st.DealIDsByParty)
-	if err != nil {
-		rt.Abortf(exitcode.ErrIllegalState, "failed to load dead ids set: %s", err)
-	}
-
-	var extractedDealIDs []abi.DealID
-	err = dbp.ForEach(addr, func(id abi.DealID) error {
-		extractedDealIDs = append(extractedDealIDs, id)
-		return nil
-	})
-	if err != nil {
-		rt.Abortf(exitcode.ErrIllegalState, "foreach error %v", err)
-	}
-
-	amountSlashedTotal = st.updatePendingDealStates(rt, extractedDealIDs, epoch)
-	return
-}
-
-func (st *State) updatePendingDealStates(rt Runtime, dealIDs []abi.DealID, epoch abi.ChainEpoch) abi.TokenAmount {
-	amountSlashedTotal := abi.NewTokenAmount(0)
-
-	for _, dealID := range dealIDs {
-		amountSlashedTotal = big.Add(amountSlashedTotal, st.updatePendingDealState(rt, dealID, epoch))
-	}
-
-	return amountSlashedTotal
-}
-
-// TODO: This does waaaay too many redundant hamt reads
-func (st *State) updatePendingDealState(rt Runtime, dealID abi.DealID, epoch abi.ChainEpoch) (amountSlashed abi.TokenAmount) {
-	amountSlashed = abi.NewTokenAmount(0)
-
-	deal := st.mustGetDeal(rt, dealID)
 	state := st.mustGetDealState(rt, dealID)
 
 	everUpdated := state.LastUpdatedEpoch != epochUndefined
@@ -99,20 +68,18 @@ func (st *State) updatePendingDealState(rt Runtime, dealID abi.DealID, epoch abi
 
 	Assert(!everUpdated || (state.LastUpdatedEpoch <= epoch)) // if the deal was ever updated, make sure it didn't happen in the future
 
-	if state.LastUpdatedEpoch == epoch { // TODO: This looks fishy, check all places that set LastUpdatedEpoch
-		return
-	}
+	deal := st.mustGetDeal(rt, dealID)
 
 	if state.SectorStartEpoch == epochUndefined {
 		// Not yet appeared in proven sector; check for timeout.
 		if epoch > deal.StartEpoch {
-			return st.processDealInitTimedOut(rt, dealID)
+			return st.processDealInitTimedOut(rt, dealID, deal, state), 0
 		}
-		return
+		return amountSlashed, 0
 	}
 
 	if deal.StartEpoch > epoch {
-		return
+		return amountSlashed, 0
 	}
 
 	dealEnd := deal.EndEpoch
@@ -151,14 +118,20 @@ func (st *State) updatePendingDealState(rt Runtime, dealID abi.DealID, epoch abi
 		st.slashBalance(rt, deal.Provider, amountSlashed)
 
 		st.deleteDeal(rt, dealID)
-		return
+		return amountSlashed, 0
 	}
 
 	if epoch >= deal.EndEpoch {
 		st.processDealExpired(rt, dealID)
-		return
+		return amountSlashed, 0
 	}
 
+	next := epoch + DealUpdatesInterval
+	if next > deal.EndEpoch {
+		next = deal.EndEpoch
+	}
+
+	// TODO: can we avoid having this field?
 	state.LastUpdatedEpoch = epoch
 
 	st.mutateDealStates(rt, func(states *DealMetaArray) {
@@ -166,7 +139,8 @@ func (st *State) updatePendingDealState(rt Runtime, dealID abi.DealID, epoch abi
 			rt.Abortf(exitcode.ErrPlaceholder, "failed to get deal: %v", err)
 		}
 	})
-	return
+
+	return amountSlashed, next
 }
 
 func (st *State) mutateDealStates(rt Runtime, f func(*DealMetaArray)) {
@@ -202,38 +176,17 @@ func (st *State) mutateDealProposals(rt Runtime, f func(*DealArray)) {
 }
 
 func (st *State) deleteDeal(rt Runtime, dealID abi.DealID) {
-
-	var dealP *DealProposal
 	st.mutateDealProposals(rt, func(proposals *DealArray) {
-		p, err := proposals.Get(dealID)
-		if err != nil {
-			rt.Abortf(exitcode.ErrIllegalState, "failed to get deal before deleting it: %s", err)
-		}
-		dealP = p
-
 		if err := proposals.Delete(uint64(dealID)); err != nil {
 			rt.Abortf(exitcode.ErrPlaceholder, "failed to delete deal: %v", err)
 		}
-	})
-
-	st.MutateDealIDs(rt, func(dbp *SetMultimap) error {
-		if err := dbp.Remove(dealP.Client, dealID); err != nil {
-			rt.Abortf(exitcode.ErrIllegalState, "failed to delete deal by client address from DealIDsByParty: %v", err)
-		}
-		if err := dbp.Remove(dealP.Provider, dealID); err != nil {
-			rt.Abortf(exitcode.ErrIllegalState, "failed to delete deal by provider address from DealIDsByParty: %v", err)
-		}
-		return nil
 	})
 }
 
 // Deal start deadline elapsed without appearing in a proven sector.
 // Delete deal, slash a portion of provider's collateral, and unlock remaining collaterals
 // for both provider and client.
-func (st *State) processDealInitTimedOut(rt Runtime, dealID abi.DealID) (amountSlashed abi.TokenAmount) {
-	deal := st.mustGetDeal(rt, dealID)
-	state := st.mustGetDealState(rt, dealID)
-
+func (st *State) processDealInitTimedOut(rt Runtime, dealID abi.DealID, deal *DealProposal, state *DealState) (amountSlashed abi.TokenAmount) {
 	Assert(state.SectorStartEpoch == epochUndefined)
 
 	st.unlockBalance(rt, deal.Client, deal.ClientBalanceRequirement())
@@ -353,6 +306,7 @@ func (st *State) maybeLockBalance(rt Runtime, addr addr.Address, amount abi.Toke
 	})
 }
 
+// TODO: all these balance table mutations need to happen at the top level and be batched (no flushing after each!)
 func (st *State) unlockBalance(rt Runtime, addr addr.Address, amount abi.TokenAmount) {
 	Assert(amount.GreaterThanEqual(big.Zero()))
 
@@ -511,7 +465,7 @@ func dealGetPaymentRemaining(deal *DealProposal, epoch abi.ChainEpoch) abi.Token
 }
 
 func (st *State) MutateDealIDs(rt Runtime, f func(dbp *SetMultimap) error) {
-	dbp, err := AsSetMultimap(adt.AsStore(rt), st.DealIDsByParty)
+	dbp, err := AsSetMultimap(adt.AsStore(rt), st.DealOpsByEpoch)
 	if err != nil {
 		rt.Abortf(exitcode.ErrIllegalState, "failed to load deal ids map: %s", err)
 	}
@@ -525,5 +479,5 @@ func (st *State) MutateDealIDs(rt Runtime, f func(dbp *SetMultimap) error) {
 		rt.Abortf(exitcode.ErrIllegalState, "failed to flush deal ids map: %w", err)
 	}
 
-	st.DealIDsByParty = dipc
+	st.DealOpsByEpoch = dipc
 }

--- a/actors/builtin/market/market_state.go
+++ b/actors/builtin/market/market_state.go
@@ -82,7 +82,7 @@ func (st *State) updatePendingDealState(rt Runtime, dealID abi.DealID, epoch abi
 	if state.SectorStartEpoch == epochUndefined {
 		// Not yet appeared in proven sector; check for timeout.
 		if epoch > deal.StartEpoch {
-			return st.processDealInitTimedOut(rt, dealID, deal, state), 0
+			return st.processDealInitTimedOut(rt, dealID, deal, state), epochUndefined
 		}
 		// This should not be able to happen
 		return amountSlashed, epochUndefined
@@ -478,22 +478,4 @@ func dealGetPaymentRemaining(deal *DealProposal, epoch abi.ChainEpoch) abi.Token
 	Assert(durationRemaining > 0)
 
 	return big.Mul(big.NewInt(int64(durationRemaining)), deal.StoragePricePerEpoch)
-}
-
-func (st *State) MutateDealIDs(rt Runtime, f func(dbp *SetMultimap) error) {
-	dbp, err := AsSetMultimap(adt.AsStore(rt), st.DealOpsByEpoch)
-	if err != nil {
-		rt.Abortf(exitcode.ErrIllegalState, "failed to load deal ids map: %s", err)
-	}
-
-	if err := f(dbp); err != nil {
-		rt.Abortf(exitcode.ErrIllegalState, "failed to manipulate dead ids map: %s", err)
-	}
-
-	dipc, err := dbp.Root()
-	if err != nil {
-		rt.Abortf(exitcode.ErrIllegalState, "failed to flush deal ids map: %w", err)
-	}
-
-	st.DealOpsByEpoch = dipc
 }

--- a/actors/builtin/market/market_state.go
+++ b/actors/builtin/market/market_state.go
@@ -64,8 +64,11 @@ func (st *State) updatePendingDealState(rt Runtime, dealID abi.DealID, epoch abi
 		rt.Abortf(exitcode.ErrIllegalState, "get state state: %v", err)
 	}
 
-	state, err := states.Get(dealID)
+	state, found, err := states.Get(dealID)
 	if err != nil {
+		rt.Abortf(exitcode.ErrIllegalState, "failed to get deal: %d", dealID)
+	}
+	if !found {
 		return abi.NewTokenAmount(0), epochUndefined
 	}
 
@@ -423,9 +426,13 @@ func (st *State) mustGetDealState(rt Runtime, dealID abi.DealID) *DealState {
 	if err != nil {
 		rt.Abortf(exitcode.ErrIllegalState, "get state state: %v", err)
 	}
-	state, err := states.Get(dealID)
+	state, found, err := states.Get(dealID)
 	if err != nil {
 		rt.Abortf(exitcode.ErrIllegalState, "get state state: %v", err)
+	}
+
+	if !found {
+		rt.Abortf(exitcode.ErrIllegalState, "deal %d not found", dealID)
 	}
 
 	return state

--- a/actors/builtin/market/market_state.go
+++ b/actors/builtin/market/market_state.go
@@ -49,6 +49,7 @@ func ConstructState(emptyArrayCid, emptyMapCid, emptyMSetCid cid.Cid) *State {
 		LockedTable:    emptyMapCid,
 		NextID:         abi.DealID(0),
 		DealOpsByEpoch: emptyMSetCid,
+		LastCron:       abi.ChainEpoch(-1),
 	}
 }
 

--- a/actors/builtin/market/market_test.go
+++ b/actors/builtin/market/market_test.go
@@ -80,6 +80,7 @@ func TestMarketActor(t *testing.T) {
 		assert.Equal(t, emptyMap, state.LockedTable)
 		assert.Equal(t, abi.DealID(0), state.NextID)
 		assert.Equal(t, emptyMultiMap, state.DealOpsByEpoch)
+		assert.Equal(t, abi.ChainEpoch(-1), state.LastCron)
 	})
 
 	t.Run("AddBalance", func(t *testing.T) {

--- a/actors/builtin/market/market_test.go
+++ b/actors/builtin/market/market_test.go
@@ -79,7 +79,7 @@ func TestMarketActor(t *testing.T) {
 		assert.Equal(t, emptyMap, state.EscrowTable)
 		assert.Equal(t, emptyMap, state.LockedTable)
 		assert.Equal(t, abi.DealID(0), state.NextID)
-		assert.Equal(t, emptyMultiMap, state.DealIDsByParty)
+		assert.Equal(t, emptyMultiMap, state.DealOpsByEpoch)
 	})
 
 	t.Run("AddBalance", func(t *testing.T) {

--- a/actors/builtin/market/policy.go
+++ b/actors/builtin/market/policy.go
@@ -2,6 +2,9 @@ package market
 
 import "github.com/filecoin-project/specs-actors/actors/abi"
 
+// DealUpdatesInterval is the number of blocks between payouts for deals
+const DealUpdatesInterval = 100
+
 // Bounds (inclusive) on deal duration
 func dealDurationBounds(size abi.PaddedPieceSize) (min abi.ChainEpoch, max abi.ChainEpoch) {
 	return abi.ChainEpoch(0), abi.ChainEpoch(10000) // PARAM_FINISH

--- a/actors/builtin/market/set_multimap.go
+++ b/actors/builtin/market/set_multimap.go
@@ -3,7 +3,6 @@ package market
 import (
 	"reflect"
 
-	"github.com/filecoin-project/go-address"
 	cid "github.com/ipfs/go-cid"
 	errors "github.com/pkg/errors"
 	cbg "github.com/whyrusleeping/cbor-gen"
@@ -38,9 +37,9 @@ func (mm *SetMultimap) Root() (cid.Cid, error) {
 	return mm.mp.Root()
 }
 
-func (mm *SetMultimap) Put(key address.Address, v abi.DealID) error {
+func (mm *SetMultimap) Put(epoch abi.ChainEpoch, v abi.DealID) error {
 	// Load the hamt under key, or initialize a new empty one if not found.
-	k := adt.AddrKey(key)
+	k := adt.UIntKey(uint64(epoch))
 	set, found, err := mm.get(k)
 	if err != nil {
 		return err
@@ -51,7 +50,7 @@ func (mm *SetMultimap) Put(key address.Address, v abi.DealID) error {
 
 	// Add to the set.
 	if err = set.Put(dealKey(v)); err != nil {
-		return errors.Wrapf(err, "failed to add key to set %v", key)
+		return errors.Wrapf(err, "failed to add key to set %v", epoch)
 	}
 
 	src, err := set.Root()
@@ -67,40 +66,40 @@ func (mm *SetMultimap) Put(key address.Address, v abi.DealID) error {
 	return nil
 }
 
-// Removes a value for a key.
-func (mm *SetMultimap) Remove(key address.Address, v abi.DealID) error {
-	k := adt.AddrKey(key)
-	// Load the set under key, or initialize a new empty one if not found.
+func (mm *SetMultimap) PutMany(epoch abi.ChainEpoch, vs []abi.DealID) error {
+	// Load the hamt under key, or initialize a new empty one if not found.
+	k := adt.UIntKey(uint64(epoch))
 	set, found, err := mm.get(k)
 	if err != nil {
 		return err
 	}
 	if !found {
-		return nil
+		set = adt.MakeEmptySet(mm.store)
 	}
 
-	// Append to the set.
-	if err = set.Delete(dealKey(v)); err != nil {
-		return errors.Wrapf(err, "failed to remove set key %v", key)
+	// Add to the set.
+	for _, v := range vs {
+		if err = set.Put(dealKey(v)); err != nil {
+			return errors.Wrapf(err, "failed to add key to set %v", epoch)
+		}
 	}
 
-	// Store the new set root under key.
 	src, err := set.Root()
 	if err != nil {
 		return xerrors.Errorf("failed to flush set root: %w", err)
 	}
-
+	// Store the new set root under key.
 	newSetRoot := cbg.CborCid(src)
 	err = mm.mp.Put(k, &newSetRoot)
 	if err != nil {
-		return errors.Wrapf(err, "failed to store set root")
+		return errors.Wrapf(err, "failed to store set")
 	}
 	return nil
 }
 
 // Removes all values for a key.
-func (mm *SetMultimap) RemoveAll(key address.Address) error {
-	err := mm.mp.Delete(adt.AddrKey(key))
+func (mm *SetMultimap) RemoveAll(key abi.ChainEpoch) error {
+	err := mm.mp.Delete(adt.UIntKey(uint64(key)))
 	if err != nil {
 		return xerrors.Errorf("failed to delete set key %v: %w", key, err)
 	}
@@ -108,8 +107,8 @@ func (mm *SetMultimap) RemoveAll(key address.Address) error {
 }
 
 // Iterates all entries for a key, iteration halts if the function returns an error.
-func (mm *SetMultimap) ForEach(key address.Address, fn func(id abi.DealID) error) error {
-	set, found, err := mm.get(adt.AddrKey(key))
+func (mm *SetMultimap) ForEach(epoch abi.ChainEpoch, fn func(id abi.DealID) error) error {
+	set, found, err := mm.get(adt.UIntKey(uint64(epoch)))
 	if err != nil {
 		return err
 	}

--- a/actors/builtin/market/types.go
+++ b/actors/builtin/market/types.go
@@ -71,20 +71,20 @@ func (t *DealMetaArray) Root() (cid.Cid, error) {
 }
 
 // Gets the deal for a key. The entry must have been previously initialized.
-func (t *DealMetaArray) Get(id abi.DealID) (*DealState, error) {
+func (t *DealMetaArray) Get(id abi.DealID) (*DealState, bool, error) {
 	var value DealState
 	found, err := t.Array.Get(uint64(id), &value)
 	if err != nil {
-		return nil, err // The errors from Map carry good information, no need to wrap here.
+		return nil, false, err // The errors from Map carry good information, no need to wrap here.
 	}
 	if !found {
 		return &DealState{
 			SectorStartEpoch: epochUndefined,
 			LastUpdatedEpoch: epochUndefined,
 			SlashEpoch:       epochUndefined,
-		}, nil
+		}, false, nil
 	}
-	return &value, nil
+	return &value, true, nil
 }
 
 func (t *DealMetaArray) Set(k abi.DealID, value *DealState) error {

--- a/actors/builtin/methods.go
+++ b/actors/builtin/methods.go
@@ -56,13 +56,12 @@ var MethodsMarket = struct {
 	Constructor                    abi.MethodNum
 	AddBalance                     abi.MethodNum
 	WithdrawBalance                abi.MethodNum
-	HandleExpiredDeals             abi.MethodNum
 	PublishStorageDeals            abi.MethodNum
 	VerifyDealsOnSectorProveCommit abi.MethodNum
 	OnMinerSectorsTerminate        abi.MethodNum
 	ComputeDataCommitment          abi.MethodNum
-	HandleInitTimeoutDeals         abi.MethodNum
-}{MethodConstructor, 2, 3, 4, 5, 6, 7, 8, 9}
+	CronTick                       abi.MethodNum
+}{MethodConstructor, 2, 3, 4, 5, 6, 7, 8}
 
 var MethodsPower = struct {
 	Constructor              abi.MethodNum

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -151,8 +151,6 @@ func main() {
 		market.VerifyDealsOnSectorProveCommitReturn{},
 		market.ComputeDataCommitmentParams{},
 		market.OnMinerSectorsTerminateParams{},
-		market.HandleExpiredDealsParams{},
-		market.HandleInitTimeoutDealsParams{},
 		// method returns
 		market.PublishStorageDealsReturn{},
 		// other types

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/filecoin-project/go-address v0.0.2-0.20200218010043-eb9bb40ed5be
-	github.com/filecoin-project/go-amt-ipld/v2 v2.0.1-0.20200131012142-05d80eeccc5e
+	github.com/filecoin-project/go-amt-ipld/v2 v2.0.1-0.20200424220931-6263827e49f2
 	github.com/filecoin-project/go-bitfield v0.0.0-20200416002808-b3ee67ec9060
 	github.com/gopherjs/gopherjs v0.0.0-20190812055157-5d271430af9f // indirect
 	github.com/ipfs/go-block-format v0.0.2

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/filecoin-project/go-address v0.0.2-0.20200218010043-eb9bb40ed5be h1:TooKBwR/g8jG0hZ3lqe9S5sy2vTUcLOZLlz3M5wGn2E=
 github.com/filecoin-project/go-address v0.0.2-0.20200218010043-eb9bb40ed5be/go.mod h1:SAOwJoakQ8EPjwNIsiakIQKsoKdkcbx8U3IapgCg9R0=
-github.com/filecoin-project/go-amt-ipld/v2 v2.0.1-0.20200131012142-05d80eeccc5e h1:IOoff6yAZSJ5zHCPY2jzGNwQYQU6ygsRVe/cSnJrY+o=
-github.com/filecoin-project/go-amt-ipld/v2 v2.0.1-0.20200131012142-05d80eeccc5e/go.mod h1:boRtQhzmxNocrMxOXo1NYn4oUc1NGvR8tEa79wApNXg=
 github.com/filecoin-project/go-amt-ipld/v2 v2.0.1-0.20200424220931-6263827e49f2 h1:jamfsxfK0Q9yCMHt8MPWx7Aa/O9k2Lve8eSc6FILYGQ=
 github.com/filecoin-project/go-amt-ipld/v2 v2.0.1-0.20200424220931-6263827e49f2/go.mod h1:boRtQhzmxNocrMxOXo1NYn4oUc1NGvR8tEa79wApNXg=
 github.com/filecoin-project/go-bitfield v0.0.0-20200416002808-b3ee67ec9060 h1:/3qjGMn6ukXgZJHsIbuwGL7ipla8DOV3uHZDBJkBYfU=

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/filecoin-project/go-address v0.0.2-0.20200218010043-eb9bb40ed5be h1:T
 github.com/filecoin-project/go-address v0.0.2-0.20200218010043-eb9bb40ed5be/go.mod h1:SAOwJoakQ8EPjwNIsiakIQKsoKdkcbx8U3IapgCg9R0=
 github.com/filecoin-project/go-amt-ipld/v2 v2.0.1-0.20200131012142-05d80eeccc5e h1:IOoff6yAZSJ5zHCPY2jzGNwQYQU6ygsRVe/cSnJrY+o=
 github.com/filecoin-project/go-amt-ipld/v2 v2.0.1-0.20200131012142-05d80eeccc5e/go.mod h1:boRtQhzmxNocrMxOXo1NYn4oUc1NGvR8tEa79wApNXg=
+github.com/filecoin-project/go-amt-ipld/v2 v2.0.1-0.20200424220931-6263827e49f2 h1:jamfsxfK0Q9yCMHt8MPWx7Aa/O9k2Lve8eSc6FILYGQ=
+github.com/filecoin-project/go-amt-ipld/v2 v2.0.1-0.20200424220931-6263827e49f2/go.mod h1:boRtQhzmxNocrMxOXo1NYn4oUc1NGvR8tEa79wApNXg=
 github.com/filecoin-project/go-bitfield v0.0.0-20200416002808-b3ee67ec9060 h1:/3qjGMn6ukXgZJHsIbuwGL7ipla8DOV3uHZDBJkBYfU=
 github.com/filecoin-project/go-bitfield v0.0.0-20200416002808-b3ee67ec9060/go.mod h1:iodsLxOFZnqKtjj2zkgqzoGNrv6vUqj69AT/J8DKXEw=
 github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03 h1:2pMXdBnCiXjfCYx/hLqFxccPoqsSveQFxVLvNxy9bus=


### PR DESCRIPTION
This should accomplish the same thing, except now payments for storage deals only happen once every hundred blocks or so (not bucketed though, otherwise that would create hot spots)