### PR TITLE
fix bugs in miner vesting

### DIFF
--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -823,15 +823,15 @@ func (st *State) UnlockUnvestedFunds(store adt.Store, currEpoch abi.ChainEpoch, 
 		if amountUnlocked.LessThan(target) {
 			if k >= int64(currEpoch) {
 				unlockAmount := big.Min(big.Sub(target, amountUnlocked), lockedEntry)
-
-				lockedEntry = big.Sub(lockedEntry, unlockAmount)
-				if err := vestingFunds.Set(uint64(k), &lockedEntry); err != nil {
-					return err
-				}
 				amountUnlocked = big.Add(amountUnlocked, unlockAmount)
+				lockedEntry = big.Sub(lockedEntry, unlockAmount)
 
 				if lockedEntry.IsZero() {
 					toDelete = append(toDelete, uint64(k))
+				} else {
+					if err = vestingFunds.Set(uint64(k), &lockedEntry); err != nil {
+						return err
+					}
 				}
 			}
 			return nil

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -798,6 +798,7 @@ func (st *State) AddLockedFunds(store adt.Store, currEpoch abi.ChainEpoch, vesti
 	if err != nil {
 		return err
 	}
+	st.LockedFunds = big.Add(st.LockedFunds, vestingSum)
 
 	return nil
 }

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -822,8 +822,12 @@ func (st *State) UnlockUnvestedFunds(store adt.Store, currEpoch abi.ChainEpoch, 
 	err = vestingFunds.ForEach(&lockedEntry, func(k int64) error {
 		if amountUnlocked.LessThan(target) {
 			if k >= int64(currEpoch) {
-				unlockAmount := big.Max(big.Sub(target, amountUnlocked), lockedEntry)
+				unlockAmount := big.Min(big.Sub(target, amountUnlocked), lockedEntry)
+
 				lockedEntry = big.Sub(lockedEntry, unlockAmount)
+				if err := vestingFunds.Set(uint64(k), &lockedEntry); err != nil {
+					return err
+				}
 				amountUnlocked = big.Add(amountUnlocked, unlockAmount)
 
 				if lockedEntry.IsZero() {

--- a/actors/builtin/miner/miner_state_test.go
+++ b/actors/builtin/miner/miner_state_test.go
@@ -420,6 +420,26 @@ func TestVestingFunds_AddLockedFunds(t *testing.T) {
 
 }
 
+func TestVestingFundsStore(t *testing.T) {
+	harness := constructStateHarness(t, abi.ChainEpoch(0))
+	vspec := &miner.VestSpec{
+		InitialDelay: 0,
+		VestPeriod:   1,
+		StepDuration: 1,
+		Quantization: 1,
+	}
+
+	vestStart := abi.ChainEpoch(10)
+	vestSum := abi.NewTokenAmount(100)
+
+	harness.addLockedFunds(vestStart, vestSum, vspec)
+	unvestedFunds := harness.unlockUnvestedFunds(vestStart, abi.NewTokenAmount(49))
+	assert.Equal(t, abi.NewTokenAmount(49), unvestedFunds)
+
+	vestedFunds := harness.unlockVestedFunds(vestStart + 2)
+	assert.Equal(t, abi.NewTokenAmount(51), vestedFunds)
+}
+
 type stateHarness struct {
 	t testing.TB
 

--- a/actors/builtin/miner/miner_state_test.go
+++ b/actors/builtin/miner/miner_state_test.go
@@ -398,11 +398,54 @@ func TestPostSubmissionsBitfield(t *testing.T) {
 	})
 }
 
+func TestVestingFunds_AddLockedFunds(t *testing.T) {
+	t.Run("LockedFunds increases with sequential calls", func(t *testing.T) {
+		harness := constructStateHarness(t, abi.ChainEpoch(0))
+		vspec := &miner.VestSpec{
+			InitialDelay: 0,
+			VestPeriod:   1,
+			StepDuration: 1,
+			Quantization: 1,
+		}
+
+		vestStart := abi.ChainEpoch(10)
+		vestSum := abi.NewTokenAmount(100)
+
+		harness.addLockedFunds(vestStart, vestSum, vspec)
+		assert.Equal(t, vestSum, harness.s.LockedFunds)
+
+		harness.addLockedFunds(vestStart, vestSum, vspec)
+		assert.Equal(t, big.Mul(vestSum, big.NewInt(2)), harness.s.LockedFunds)
+	})
+
+}
+
 type stateHarness struct {
 	t testing.TB
 
 	s     *miner.State
 	store adt.Store
+}
+
+//
+// Vesting Store
+//
+
+func (h *stateHarness) addLockedFunds(epoch abi.ChainEpoch, sum abi.TokenAmount, spec *miner.VestSpec) {
+	err := h.s.AddLockedFunds(h.store, epoch, sum, spec)
+	require.NoError(h.t, err)
+}
+
+func (h *stateHarness) unlockUnvestedFunds(epoch abi.ChainEpoch, target abi.TokenAmount) abi.TokenAmount {
+	amount, err := h.s.UnlockUnvestedFunds(h.store, epoch, target)
+	require.NoError(h.t, err)
+	return amount
+}
+
+func (h *stateHarness) unlockVestedFunds(epoch abi.ChainEpoch) abi.TokenAmount {
+	amount, err := h.s.UnlockVestedFunds(h.store, epoch)
+	require.NoError(h.t, err)
+	return amount
 }
 
 //
@@ -647,4 +690,3 @@ func newSectorPreCommitInfo(sectorNo abi.SectorNumber, sealed cid.Cid) *miner.Se
 		Expiration:      sectorExpiration,
 	}
 }
-

--- a/actors/builtin/miner/miner_state_test.go
+++ b/actors/builtin/miner/miner_state_test.go
@@ -433,11 +433,11 @@ func TestVestingFundsStore(t *testing.T) {
 	vestSum := abi.NewTokenAmount(100)
 
 	harness.addLockedFunds(vestStart, vestSum, vspec)
-	unvestedFunds := harness.unlockUnvestedFunds(vestStart, abi.NewTokenAmount(49))
-	assert.Equal(t, abi.NewTokenAmount(49), unvestedFunds)
+	unlocked := harness.unlockUnvestedFunds(vestStart, abi.NewTokenAmount(49))
+	assert.Equal(t, abi.NewTokenAmount(49), unlocked)
 
-	vestedFunds := harness.unlockVestedFunds(vestStart + 2)
-	assert.Equal(t, abi.NewTokenAmount(51), vestedFunds)
+	vested := harness.unlockVestedFunds(vestStart + 2)
+	assert.Equal(t, abi.NewTokenAmount(51), vested)
 }
 
 type stateHarness struct {


### PR DESCRIPTION
fix: bug in miner LockedFunds and add test
- LockedFunds was not updated when AddLockedFunds was called.

fix: bug in UnlockUnvestedFunds and add test
- unlockAmount was incorrectly caluculated such that entries were
negative and never removed from vestingStore.
- vestingFunds was not updated when its entires changes.