### PR TITLE
Power actor proceeds after failure of cron callback.

### DIFF
--- a/actors/builtin/power/power_actor.go
+++ b/actors/builtin/power/power_actor.go
@@ -428,18 +428,19 @@ func (a Actor) processDeferredCronEvents(rt Runtime) error {
 		}
 
 		st.LastEpochTick = rtEpoch
-
 		return nil
 	})
 
 	for _, event := range cronEvents {
-		_, code := rt.Send(
+		_, _ = rt.Send(
 			event.MinerAddr,
 			builtin.MethodsMiner.OnDeferredCronEvent,
 			vmr.CBORBytes(event.CallbackPayload),
 			abi.NewTokenAmount(0),
 		)
-		builtin.RequireSuccess(rt, code, "failed to defer cron event")
+		// The exit code is ignored. If a callback fails, this actor continues to invoke other callbacks
+		// and persists state removing the failed event from the event queue. It won't be tried again.
+		// A log message would really help here, though.
 	}
 	return nil
 }

--- a/actors/builtin/power/power_state.go
+++ b/actors/builtin/power/power_state.go
@@ -182,12 +182,7 @@ func (st *State) loadCronEvents(store adt.Store, epoch abi.ChainEpoch) ([]CronEv
 	var events []CronEvent
 	var ev CronEvent
 	err = mmap.ForEach(epochKey(epoch), &ev, func(i int64) error {
-		// Ignore events for defunct miners.
-		if _, found, err := st.getClaim(store, ev.MinerAddr); err != nil {
-			return errors.Wrapf(err, "failed to find claimed power for %v for cron event", ev.MinerAddr)
-		} else if found {
-			events = append(events, ev)
-		}
+		events = append(events, ev)
 		return nil
 	})
 	return events, err


### PR DESCRIPTION
This behaviour is worth paying attention to. We don't expect miner cron callbacks to abort, ever. Previously the signal was very loud when they did. Now the network will proceed, but it'll be easy to miss this unexpected and probably-major error.

(This PR doesn't fix the miner cron, which fails to handle being invoked after its scheduled round, if it was scheduled on a null).