### PR TITLE
Store proving period start in state explicitly and fix cron to handle invocation off expected schedule

### DIFF
--- a/actors/builtin/miner/deadlines.go
+++ b/actors/builtin/miner/deadlines.go
@@ -49,7 +49,7 @@ func (d *DeadlineInfo) NextPeriodStart() abi.ChainEpoch {
 func ComputeProvingPeriodDeadline(periodStart, currEpoch abi.ChainEpoch) *DeadlineInfo {
 	periodProgress := currEpoch - periodStart
 	deadlineIdx := uint64(periodProgress / WPoStChallengeWindow)
-	if deadlineIdx < 0 { // Period not yet started.
+	if periodProgress < 0 { // Period not yet started.
 		deadlineIdx = 0
 	}
 	deadlineOpen := periodStart + (abi.ChainEpoch(deadlineIdx) * WPoStChallengeWindow)

--- a/actors/builtin/miner/deadlines.go
+++ b/actors/builtin/miner/deadlines.go
@@ -21,6 +21,10 @@ type DeadlineInfo struct {
 	FaultCutoff  abi.ChainEpoch // First epoch at which a fault declaration is rejected (< Open).
 }
 
+func (d *DeadlineInfo) PeriodStarted() bool {
+	return d.CurrentEpoch >= d.PeriodStart
+}
+
 func (d *DeadlineInfo) IsOpen() bool {
 	return d.CurrentEpoch >= d.Open && d.CurrentEpoch < d.Close
 }
@@ -41,22 +45,13 @@ func (d *DeadlineInfo) NextPeriodStart() abi.ChainEpoch {
 	return d.PeriodStart + WPoStProvingPeriod
 }
 
-// Returns the epoch that starts the current proving period, the current deadline index,
-// and whether the proving period starts on or after epoch 0 (i.e. is a whole period).
-// The proving period start is the largest number <= the current epoch that has remainder mod WPoStProvingPeriod
-// equal to ProvingPeriodBoundary.
-// The period start can be negative during the first WPoStProvingPeriod of the chain, indicated by a `false` final result value.
-func ComputeProvingPeriodDeadline(boundary abi.ChainEpoch, currEpoch abi.ChainEpoch) (*DeadlineInfo, bool) {
-	currModulus := currEpoch % WPoStProvingPeriod
-	var periodProgress abi.ChainEpoch // How far ahead is currEpoch from previous boundary.
-	if currModulus >= boundary {
-		periodProgress = currModulus - boundary
-	} else {
-		periodProgress = WPoStProvingPeriod - (boundary - currModulus)
-	}
-
-	periodStart := currEpoch - periodProgress
+// Returns deadline-related calculations for a proving period start and current epoch.
+func ComputeProvingPeriodDeadline(periodStart, currEpoch abi.ChainEpoch) *DeadlineInfo {
+	periodProgress := currEpoch - periodStart
 	deadlineIdx := uint64(periodProgress / WPoStChallengeWindow)
+	if deadlineIdx < 0 { // Period not yet started.
+		deadlineIdx = 0
+	}
 	deadlineOpen := periodStart + (abi.ChainEpoch(deadlineIdx) * WPoStChallengeWindow)
 
 	return &DeadlineInfo{
@@ -67,7 +62,7 @@ func ComputeProvingPeriodDeadline(boundary abi.ChainEpoch, currEpoch abi.ChainEp
 		Close:        deadlineOpen + WPoStChallengeWindow,
 		Challenge:    deadlineOpen - WPoStChallengeLookback,
 		FaultCutoff:  deadlineOpen - FaultDeclarationCutoff,
-	}, periodStart >= 0
+	}
 }
 
 // Computes the first partition index and number of sectors for a deadline.

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -96,18 +96,19 @@ func (a Actor) Constructor(rt Runtime, params *ConstructorParams) *adt.EmptyValu
 	emptyDeadlines := ConstructDeadlines()
 	emptyDeadlinesCid := rt.Store().Put(emptyDeadlines)
 
-	ppBoundary, err := assignProvingPeriodBoundary(rt.Message().Receiver(), rt.CurrEpoch(), rt.Syscalls().HashBlake2b)
-	builtin.RequireNoErr(rt, err, exitcode.ErrSerialization, "failed to assign proving period boundary")
+	currEpoch := rt.CurrEpoch()
+	offset, err := assignProvingPeriodOffset(rt.Message().Receiver(), currEpoch, rt.Syscalls().HashBlake2b)
+	builtin.RequireNoErr(rt, err, exitcode.ErrSerialization, "failed to assign proving period offset")
+	periodStart := nextProvingPeriodStart(currEpoch, offset)
+	Assert(periodStart > currEpoch)
 
-	state := ConstructState(emptyArray, emptyMap, emptyDeadlinesCid, owner, worker, params.PeerId, params.SectorSize, ppBoundary)
+	state := ConstructState(emptyArray, emptyMap, emptyDeadlinesCid, owner, worker, params.PeerId, params.SectorSize, periodStart)
 	rt.State().Create(state)
 
-	// Register cron callback for epoch before the next proving period starts.
-	deadline, _ := state.DeadlineInfo(rt.CurrEpoch())
-	enrollCronEvent(rt, deadline.PeriodEnd(), &CronEventPayload{
+	// Register cron callback for epoch before the first proving period starts.
+	enrollCronEvent(rt, periodStart-1, &CronEventPayload{
 		EventType: CronEventProvingPeriod,
 	})
-
 	return nil
 }
 
@@ -209,13 +210,9 @@ func (a Actor) SubmitWindowedPoSt(rt Runtime, params *SubmitWindowedPoStParams) 
 	rt.State().Transaction(&st, func() interface{} {
 		rt.ValidateImmediateCallerIs(st.Info.Worker)
 
-		// Every epoch is during some deadline's challenge window.
-		// Rather than require it in the parameters, compute it from the current epoch.
-		// If the submission was intended for a different window, the partitions won't match and it will be rejected.
-		deadline, fullPeriod := st.DeadlineInfo(currEpoch)
-		if !fullPeriod {
-			// A miner is exempt from PoSt until the first full proving period begins after chain genesis.
-			rt.Abortf(exitcode.ErrIllegalState, "invalid proving period: %v", deadline.PeriodStart)
+		deadline := st.DeadlineInfo(currEpoch)
+		if !deadline.PeriodStarted() {
+			rt.Abortf(exitcode.ErrIllegalArgument, "proving period %d not yet open at %d", deadline.PeriodStart, currEpoch)
 		}
 		if params.Deadline != deadline.Index {
 			rt.Abortf(exitcode.ErrIllegalArgument, "invalid deadline %d at epoch %d, expected %d",
@@ -352,10 +349,11 @@ func (a Actor) PreCommitSector(rt Runtime, params *SectorPreCommitInfo) *adt.Emp
 		}
 
 		// Check expiry is exactly *the epoch before* the start of a proving period.
-		expiryMod := (params.Expiration + 1) % WPoStProvingPeriod
-		if expiryMod != st.Info.ProvingPeriodBoundary {
-			rt.Abortf(exitcode.ErrIllegalArgument, "invalid expiration %d, must be on proving period boundary %d mod %d",
-				params.Expiration, st.Info.ProvingPeriodBoundary, WPoStProvingPeriod)
+		periodOffset := st.ProvingPeriodStart % WPoStProvingPeriod
+		expiryOffset := (params.Expiration + 1) % WPoStProvingPeriod
+		if expiryOffset != periodOffset {
+			rt.Abortf(exitcode.ErrIllegalArgument, "invalid expiration %d, must be immediately before proving period boundary %d mod %d",
+				params.Expiration, periodOffset, WPoStProvingPeriod)
 		}
 
 		newlyVestedFund, err := st.UnlockVestedFunds(store, rt.CurrEpoch())
@@ -651,9 +649,7 @@ func (a Actor) DeclareFaults(rt Runtime, params *DeclareFaultsParams) *adt.Empty
 	rt.State().Transaction(&st, func() interface{} {
 		rt.ValidateImmediateCallerIs(st.Info.Worker)
 
-		// The proving period start may be negative for low epochs, but all the arithmetic should work out
-		// correctly in order to declare faults for an upcoming deadline or the next period.
-		deadline, _ := st.DeadlineInfo(currEpoch)
+		deadline := st.DeadlineInfo(currEpoch)
 		deadlines, err := st.LoadDeadlines(adt.AsStore(rt))
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deadlines")
 
@@ -688,9 +684,9 @@ func (a Actor) DeclareFaults(rt Runtime, params *DeclareFaultsParams) *adt.Empty
 			if contains {
 				// This could happen if attempting to declare a fault for a deadline that's already passed,
 				// detected and added to Faults above.
-				// Wait for the fault detection at proving period end, or submit again omitting deadlines that have
-				// passed.
-				// Alternatively, we could subtract the detected faults from new faults.
+				// The miner must for the fault detection at proving period end, or submit again omitting
+				// sectors in deadlines that have passed.
+				// Alternatively, we could subtract the just-detected faults from new faults.
 				rt.Abortf(exitcode.ErrIllegalArgument, "attempted to re-declare fault")
 			}
 
@@ -745,7 +741,7 @@ func (a Actor) DeclareFaultsRecovered(rt Runtime, params *DeclareFaultsRecovered
 	rt.State().Transaction(&st, func() interface{} {
 		rt.ValidateImmediateCallerIs(st.Info.Worker)
 
-		deadline, _ := st.DeadlineInfo(currEpoch)
+		deadline := st.DeadlineInfo(currEpoch)
 		deadlines, err := st.LoadDeadlines(adt.AsStore(rt))
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deadlines")
 
@@ -911,16 +907,21 @@ func (a Actor) OnDeferredCronEvent(rt Runtime, payload *CronEventPayload) *adt.E
 // Utility functions & helpers
 ////////////////////////////////////////////////////////////////////////////////
 
+// Invoked at the end of each proving period, at the end of the epoch before the next one starts.
 func handleProvingPeriod(rt Runtime) {
 	store := adt.AsStore(rt)
 	var st State
-	currEpoch := rt.CurrEpoch()
+	// Note: because the cron actor is not invoked on epochs with empty tipsets, the current epoch is not necessarily
+	// exactly the final epoch of the period; it may be slightly later (i.e. in the subsequent period).
+	// Further, this method is invoked once *before* the first proving period starts, after the actor is first
+	// constructed; this is detected by !deadline.PeriodStarted().
+	// Use deadline.PeriodEnd() rather than rt.CurrEpoch unless certain of the desired semantics.
 	var deadline *DeadlineInfo
-	var fullPeriod bool
 	{
 		// Vest locked funds.
+		// This happens first so that any subsequent penalties are taken from locked pledge, rather than free funds.
 		newlyVestedAmount := rt.State().Transaction(&st, func() interface{} {
-			newlyVestedFund, err := st.UnlockVestedFunds(store, currEpoch)
+			newlyVestedFund, err := st.UnlockVestedFunds(store, rt.CurrEpoch())
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to vest funds")
 			return newlyVestedFund
 		}).(abi.TokenAmount)
@@ -931,14 +932,14 @@ func handleProvingPeriod(rt Runtime) {
 	{
 		// Detect and penalize missing proofs.
 		var detectedFaultSectors []*SectorOnChainInfo
+		currEpoch := rt.CurrEpoch()
 		penalty := big.Zero()
 		rt.State().Transaction(&st, func() interface{} {
-			deadline, fullPeriod = st.DeadlineInfo(currEpoch)
-			AssertMsg(currEpoch == deadline.PeriodEnd(), "proving period cron at epoch %d, period ends at %d", currEpoch, deadline.PeriodEnd())
-			if fullPeriod { // Skip checking faults on the first, incomplete period.
+			deadline = st.DeadlineInfo(currEpoch)
+			if deadline.PeriodStarted() { // Skip checking faults on the first, incomplete period.
 				deadlines, err := st.LoadDeadlines(store)
 				builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deadlines")
-				detectedFaultSectors, penalty = checkMissingPoStFaults(rt, &st, store, deadlines, deadline.PeriodStart, WPoStPeriodDeadlines, currEpoch)
+				detectedFaultSectors, penalty = checkMissingPoStFaults(rt, &st, store, deadlines, deadline.PeriodStart, WPoStPeriodDeadlines, deadline.PeriodEnd())
 			}
 			return nil
 		})
@@ -953,7 +954,7 @@ func handleProvingPeriod(rt Runtime) {
 		var expiredSectors *abi.BitField
 		var err error
 		rt.State().Transaction(&st, func() interface{} {
-			expiredSectors, err = popSectorExpirations(&st, store, currEpoch)
+			expiredSectors, err = popSectorExpirations(&st, store, deadline.PeriodEnd())
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load expired sectors")
 			return nil
 		})
@@ -968,7 +969,7 @@ func handleProvingPeriod(rt Runtime) {
 		var ongoingFaultPenalty abi.TokenAmount
 		var err error
 		rt.State().Transaction(&st, func() interface{} {
-			expiredFaults, ongoingFaults, err = popExpiredFaults(&st, store, currEpoch-FaultMaxAge)
+			expiredFaults, ongoingFaults, err = popExpiredFaults(&st, store, deadline.PeriodEnd()-FaultMaxAge)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load fault epochs")
 
 			// Load info for ongoing faults.
@@ -977,7 +978,7 @@ func handleProvingPeriod(rt Runtime) {
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load fault sectors")
 
 			// Unlock penalty for ongoing faults.
-			ongoingFaultPenalty, err = unlockPenalty(&st, store, currEpoch, ongoingFaultInfos, pledgePenaltyForSectorDeclaredFault)
+			ongoingFaultPenalty, err = unlockPenalty(&st, store, deadline.PeriodEnd(), ongoingFaultInfos, pledgePenaltyForSectorDeclaredFault)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to charge fault fee")
 			return nil
 		})
@@ -997,7 +998,7 @@ func handleProvingPeriod(rt Runtime) {
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to expand new sectors")
 
 			if len(newSectors) > 0 {
-				assignmentSeed := rt.GetRandomness(crypto.DomainSeparationTag_WindowedPoStDeadlineAssignment, currEpoch-1, nil)
+				assignmentSeed := rt.GetRandomness(crypto.DomainSeparationTag_WindowedPoStDeadlineAssignment, deadline.PeriodEnd()-1, nil)
 				err = AssignNewSectors(deadlines, newSectors, assignmentSeed)
 				builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to assign new sectors to deadlines")
 
@@ -1009,12 +1010,17 @@ func handleProvingPeriod(rt Runtime) {
 			// Reset PoSt submissions for next period.
 			err = st.ClearPoStSubmissions()
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to clear PoSt submissions")
+
+			// Set new proving period start.
+			if deadline.PeriodStarted() {
+				st.ProvingPeriodStart = st.ProvingPeriodStart + WPoStProvingPeriod
+			}
 			return nil
 		})
 	}
 
 	// Schedule cron callback for next period
-	nextPeriodEnd := deadline.PeriodEnd() + WPoStProvingPeriod
+	nextPeriodEnd := st.ProvingPeriodStart + WPoStProvingPeriod - 1
 	enrollCronEvent(rt, nextPeriodEnd, &CronEventPayload{
 		EventType: CronEventProvingPeriod,
 	})
@@ -1586,29 +1592,46 @@ func notifyPledgeChanged(rt Runtime, pledgeDelta abi.TokenAmount) {
 	}
 }
 
-// Assigns proving period boundary randomly in the range [0, WPoStProvingPeriod) by hashing
+// Assigns proving period offset randomly in the range [0, WPoStProvingPeriod) by hashing
 // the actor's address and current epoch.
-func assignProvingPeriodBoundary(myAddr addr.Address, currEpoch abi.ChainEpoch, hash func(data []byte) [32]byte) (abi.ChainEpoch, error) {
-	ppBoundarySeed := bytes.Buffer{}
-	err := myAddr.MarshalCBOR(&ppBoundarySeed)
+func assignProvingPeriodOffset(myAddr addr.Address, currEpoch abi.ChainEpoch, hash func(data []byte) [32]byte) (abi.ChainEpoch, error) {
+	offsetSeed := bytes.Buffer{}
+	err := myAddr.MarshalCBOR(&offsetSeed)
 	if err != nil {
 		return 0, fmt.Errorf("failed to serialize address: %w", err)
 	}
 
-	err = binary.Write(&ppBoundarySeed, binary.BigEndian, currEpoch)
+	err = binary.Write(&offsetSeed, binary.BigEndian, currEpoch)
 	if err != nil {
 		return 0, fmt.Errorf("failed to serialize epoch: %w", err)
 	}
 
-	digest := hash(ppBoundarySeed.Bytes())
-	var ppBoundary uint64
-	err = binary.Read(bytes.NewBuffer(digest[:]), binary.BigEndian, &ppBoundary)
+	digest := hash(offsetSeed.Bytes())
+	var offset uint64
+	err = binary.Read(bytes.NewBuffer(digest[:]), binary.BigEndian, &offset)
 	if err != nil {
 		return 0, fmt.Errorf("failed to interpret digest: %w", err)
 	}
 
-	ppBoundary = ppBoundary % uint64(WPoStProvingPeriod)
-	return abi.ChainEpoch(ppBoundary), nil
+	offset = offset % uint64(WPoStProvingPeriod)
+	return abi.ChainEpoch(offset), nil
+}
+
+// Computes the epoch at which a proving period should start such that it is greater than the current epoch, and
+// has a defined offset from being an exact multiple of WPoStProvingPeriod.
+// A miner is exempt from Winow PoSt until the first full proving period starts.
+func nextProvingPeriodStart(currEpoch abi.ChainEpoch, offset abi.ChainEpoch) abi.ChainEpoch {
+	currModulus := currEpoch % WPoStProvingPeriod
+	var periodProgress abi.ChainEpoch // How far ahead is currEpoch from previous offset boundary.
+	if currModulus >= offset {
+		periodProgress = currModulus - offset
+	} else {
+		periodProgress = WPoStProvingPeriod - (offset - currModulus)
+	}
+
+	periodStart := currEpoch - periodProgress + WPoStProvingPeriod
+	Assert(periodStart > currEpoch)
+	return periodStart
 }
 
 // Checks that a fault or recovery declaration of sectors at a specific deadline is valid and not within

--- a/actors/builtin/miner/miner_internal_test.go
+++ b/actors/builtin/miner/miner_internal_test.go
@@ -16,12 +16,12 @@ func TestAssignProvingPeriodBoundary(t *testing.T) {
 	startEpoch := abi.ChainEpoch(1)
 
 	// ensure the values are different for different addresses
-	b1, err := assignProvingPeriodBoundary(addr1, startEpoch, blake2b.Sum256)
+	b1, err := assignProvingPeriodOffset(addr1, startEpoch, blake2b.Sum256)
 	assert.NoError(t, err)
 	assert.True(t, b1 >= 0)
 	assert.True(t, b1 < WPoStProvingPeriod)
 
-	b2, err := assignProvingPeriodBoundary(addr2, startEpoch, blake2b.Sum256)
+	b2, err := assignProvingPeriodOffset(addr2, startEpoch, blake2b.Sum256)
 	assert.NoError(t, err)
 	assert.True(t, b2 >= 0)
 	assert.True(t, b2 < WPoStProvingPeriod)
@@ -30,9 +30,63 @@ func TestAssignProvingPeriodBoundary(t *testing.T) {
 
 	// Ensure boundaries are always less than a proving period.
 	for i := 0; i < 10_000; i++ {
-		boundary, err := assignProvingPeriodBoundary(addr1, abi.ChainEpoch(i), blake2b.Sum256)
+		boundary, err := assignProvingPeriodOffset(addr1, abi.ChainEpoch(i), blake2b.Sum256)
 		assert.NoError(t, err)
 		assert.True(t, boundary >= 0)
 		assert.True(t, boundary < WPoStProvingPeriod)
 	}
 }
+
+func TestNextProvingPeriodStart(t *testing.T) {
+	// At epoch zero...
+	curr := e(0)
+	// ... with offset zero, the first period start skips one period ahead, ...
+	assert.Equal(t, WPoStProvingPeriod, nextProvingPeriodStart(curr, 0))
+
+	// ... and all non-zero offsets are simple.
+	assert.Equal(t, e(1), nextProvingPeriodStart(curr, 1))
+	assert.Equal(t, e(10), nextProvingPeriodStart(curr, 10))
+	assert.Equal(t, WPoStProvingPeriod-1, nextProvingPeriodStart(curr, WPoStProvingPeriod-1))
+
+	// At epoch 1, offsets 0 and 1 start a long way forward, but offsets 2 and later start soon.
+	curr = 1
+	assert.Equal(t, WPoStProvingPeriod, nextProvingPeriodStart(curr, 0))
+	assert.Equal(t, WPoStProvingPeriod+1, nextProvingPeriodStart(curr, 1))
+	assert.Equal(t, e(2), nextProvingPeriodStart(curr, 2))
+	assert.Equal(t, e(3), nextProvingPeriodStart(curr, 3))
+	assert.Equal(t, WPoStProvingPeriod-1, nextProvingPeriodStart(curr, WPoStProvingPeriod-1))
+
+	// An arbitrary mid-period epoch.
+	curr = 123
+	assert.Equal(t, WPoStProvingPeriod, nextProvingPeriodStart(curr, 0))
+	assert.Equal(t, WPoStProvingPeriod+1, nextProvingPeriodStart(curr, 1))
+	assert.Equal(t, WPoStProvingPeriod+122, nextProvingPeriodStart(curr, 122))
+	assert.Equal(t, WPoStProvingPeriod+123, nextProvingPeriodStart(curr, 123))
+	assert.Equal(t, e(124), nextProvingPeriodStart(curr, 124))
+	assert.Equal(t, WPoStProvingPeriod-1, nextProvingPeriodStart(curr, WPoStProvingPeriod-1))
+
+	// The final epoch in the chain's first full period
+	curr = WPoStProvingPeriod-1
+	assert.Equal(t, WPoStProvingPeriod, nextProvingPeriodStart(curr, 0))
+	assert.Equal(t, WPoStProvingPeriod+1, nextProvingPeriodStart(curr, 1))
+	assert.Equal(t, WPoStProvingPeriod+2, nextProvingPeriodStart(curr, 2))
+	assert.Equal(t, WPoStProvingPeriod+WPoStProvingPeriod-2, nextProvingPeriodStart(curr, WPoStProvingPeriod-2))
+	assert.Equal(t, WPoStProvingPeriod+WPoStProvingPeriod-1, nextProvingPeriodStart(curr, WPoStProvingPeriod-1))
+
+	// Into the chain's second period
+	curr = WPoStProvingPeriod
+	assert.Equal(t, 2*WPoStProvingPeriod, nextProvingPeriodStart(curr, 0))
+	assert.Equal(t, WPoStProvingPeriod+1, nextProvingPeriodStart(curr, 1))
+	assert.Equal(t, WPoStProvingPeriod+2, nextProvingPeriodStart(curr, 2))
+	assert.Equal(t, WPoStProvingPeriod+WPoStProvingPeriod-1, nextProvingPeriodStart(curr, WPoStProvingPeriod-1))
+
+	curr = WPoStProvingPeriod+234
+	assert.Equal(t, 2*WPoStProvingPeriod, nextProvingPeriodStart(curr, 0))
+	assert.Equal(t, 2*WPoStProvingPeriod+1, nextProvingPeriodStart(curr, 1))
+	assert.Equal(t, 2*WPoStProvingPeriod+233, nextProvingPeriodStart(curr, 233))
+	assert.Equal(t, 2*WPoStProvingPeriod+234, nextProvingPeriodStart(curr, 234))
+	assert.Equal(t, WPoStProvingPeriod+235, nextProvingPeriodStart(curr, 235))
+	assert.Equal(t, WPoStProvingPeriod+WPoStProvingPeriod-1, nextProvingPeriodStart(curr, WPoStProvingPeriod-1))
+}
+
+type e = abi.ChainEpoch

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -39,6 +39,15 @@ type State struct {
 	// Information for all proven and not-yet-expired sectors.
 	Sectors cid.Cid // Array, AMT[SectorNumber]SectorOnChainInfo (sparse)
 
+	// The first epoch in this miner's current proving period. This is the first epoch in which a PoSt for a
+	// partition at the miner's first deadline may arrive. Alternatively, it is after the last epoch at which
+	// a PoSt for the previous window is valid.
+	// Always greater than zero, his may be greater than the current epoch for genesis miners in the first
+	// WPoStProvingPeriod epochs of the chain; the epochs before the first proving period starts are exempt from Window
+	// PoSt requirements.
+	// Updated at the end of every period by a power actor cron event.
+	ProvingPeriodStart abi.ChainEpoch
+
 	// Sector numbers prove-committed since period start, to be added to Deadlines at next proving period boundary.
 	NewSectors *abi.BitField
 
@@ -87,11 +96,6 @@ type MinerInfo struct {
 
 	// Amount of space in each sector committed to the network by this miner.
 	SectorSize abi.SectorSize
-
-	// The offset of this miner's proving period from zero.
-	// An un-changing number in range [0, proving period).
-	// A miner's current proving period start is the highest multiple of this boundary <= the current epoch.
-	ProvingPeriodBoundary abi.ChainEpoch
 }
 
 type PeerID peer.ID
@@ -124,15 +128,14 @@ type SectorOnChainInfo struct {
 }
 
 func ConstructState(emptyArrayCid, emptyMapCid, emptyDeadlinesCid cid.Cid, ownerAddr, workerAddr addr.Address,
-	peerId peer.ID, sectorSize abi.SectorSize, periodBoundary abi.ChainEpoch) *State {
+	peerId peer.ID, sectorSize abi.SectorSize, periodStart abi.ChainEpoch) *State {
 	return &State{
 		Info: MinerInfo{
-			Owner:                 ownerAddr,
-			Worker:                workerAddr,
-			PendingWorkerKey:      nil,
-			PeerId:                peerId,
-			SectorSize:            sectorSize,
-			ProvingPeriodBoundary: periodBoundary,
+			Owner:            ownerAddr,
+			Worker:           workerAddr,
+			PendingWorkerKey: nil,
+			PeerId:           peerId,
+			SectorSize:       sectorSize,
 		},
 
 		PreCommitDeposits: abi.NewTokenAmount(0),
@@ -141,6 +144,7 @@ func ConstructState(emptyArrayCid, emptyMapCid, emptyDeadlinesCid cid.Cid, owner
 
 		PreCommittedSectors: emptyMapCid,
 		Sectors:             emptyArrayCid,
+		ProvingPeriodStart:  periodStart,
 		NewSectors:          abi.NewBitField(),
 		SectorExpirations:   emptyArrayCid,
 		Deadlines:           emptyDeadlinesCid,
@@ -159,9 +163,9 @@ func (st *State) GetSectorSize() abi.SectorSize {
 	return st.Info.SectorSize
 }
 
-// Computes the current proving period and deadline, and whether that period is whole.
-func (st *State) DeadlineInfo(currEpoch abi.ChainEpoch) (*DeadlineInfo, bool) {
-	return ComputeProvingPeriodDeadline(st.Info.ProvingPeriodBoundary, currEpoch)
+// Returns deadline calculations for the current proving period.
+func (st *State) DeadlineInfo(currEpoch abi.ChainEpoch) *DeadlineInfo {
+	return ComputeProvingPeriodDeadline(st.ProvingPeriodStart, currEpoch)
 }
 
 func (st *State) GetSectorCount(store adt.Store) (uint64, error) {


### PR DESCRIPTION
Handling the possibility of the cron callback coming after the scheduled epoch means we can no longer infer the proving period from the current epoch. Instead, it's stored in state and updated for each new period. This does make some things more directly observable from the state, at least.

Apologies @magik6k that this may require tweaks to the wpost worker integration.