### PR TITLE
Resolve key addresses to ID addresses in multisig validation

### DIFF
--- a/actors/builtin/multisig/multisig_actor.go
+++ b/actors/builtin/multisig/multisig_actor.go
@@ -417,36 +417,27 @@ func (a Actor) approveTransaction(rt vmr.Runtime, txnID TxnID, proposalHash []by
 }
 
 func isSigner(rt vmr.Runtime, st *State, address addr.Address) bool {
-	candidateIdAddr := address
-	if candidateIdAddr.Protocol() != addr.ID {
-		idAddr, found := rt.ResolveAddress(candidateIdAddr)
-		if found {
-			candidateIdAddr = idAddr
-		}
-	}
+	candidateResolved := resolve(rt,address)
 
-	for i, ap := range st.Signers {
-		if address == ap {
+	for _, ap := range st.Signers {
+		signerResolved := resolve(rt, ap)
+		if signerResolved ==  candidateResolved {
 			return true
-		}
-
-		switch ap.Protocol() {
-		case addr.ID:
-			if candidateIdAddr == ap {
-				return true
-			}
-		default:
-			idAddr, found := rt.ResolveAddress(ap)
-			if found {
-				st.Signers[i] = idAddr
-				if idAddr == candidateIdAddr {
-					return true
-				}
-			}
 		}
 	}
 
 	return false
+}
+
+func resolve(rt vmr.Runtime, address addr.Address) addr.Address {
+	resolved := address
+	if resolved.Protocol() != addr.ID {
+		idAddr, found := rt.ResolveAddress(resolved)
+		if found {
+			resolved = idAddr
+		}
+	}
+	return resolved
 }
 
 // Computes a digest of a proposed transaction. This digest is used to confirm identity of the transaction

--- a/actors/builtin/multisig/multisig_actor.go
+++ b/actors/builtin/multisig/multisig_actor.go
@@ -421,7 +421,7 @@ func isSigner(rt vmr.Runtime, st *State, address addr.Address) bool {
 
 	for _, ap := range st.Signers {
 		signerResolved := resolve(rt, ap)
-		if signerResolved ==  candidateResolved {
+		if signerResolved == candidateResolved {
 			return true
 		}
 	}

--- a/actors/builtin/multisig/multisig_state.go
+++ b/actors/builtin/multisig/multisig_state.go
@@ -33,15 +33,6 @@ func (st *State) AmountLocked(elapsedEpoch abi.ChainEpoch) abi.TokenAmount {
 	return big.Mul(unitLocked, big.Sub(big.NewInt(int64(st.UnlockDuration)), big.NewInt(int64(elapsedEpoch))))
 }
 
-func (st *State) isSigner(party address.Address) bool {
-	for _, ap := range st.Signers {
-		if party == ap {
-			return true
-		}
-	}
-	return false
-}
-
 // return nil if MultiSig maintains required locked balance after spending the amount, else return an error.
 func (st *State) assertAvailable(currBalance abi.TokenAmount, amountToSpend abi.TokenAmount, currEpoch abi.ChainEpoch) error {
 	if amountToSpend.LessThan(big.Zero()) {

--- a/actors/builtin/multisig/multisig_state.go
+++ b/actors/builtin/multisig/multisig_state.go
@@ -12,6 +12,10 @@ import (
 )
 
 type State struct {
+	// Signers may be either public-key or actor ID-addresses. The ID address is canonical, but doesn't exist
+	// for a public key that has not yet received a message on chain.
+	// If any signer address is a public-key address, it will be resolved to an ID address and persisted
+	// in this state when the address is used.
 	Signers               []address.Address
 	NumApprovalsThreshold uint64
 	NextTxnID             TxnID


### PR DESCRIPTION
We currently allow the approved signers of a multisig to not be ID addresses. However, when we try to validate that a caller is an approved signer, we only have the ID address of the caller. This causes an issue when checking if a caller is an approved signer.

We probably *don't* want to enforce that approved signers must be ID addresses, since these signers might not be registered at the time of multisig creation.

This PR changes the `isSigner` method to (attempt to) resolve any non-ID addresses in the approved signers, and to replace a non-ID address if this resolution is successful. 