### PR TITLE
Change WPoStPartitionSectors to 2349

### DIFF
--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -23,7 +23,7 @@ const WPoStChallengeWindow = abi.ChainEpoch(1800 / EpochDurationSeconds) // Half
 const WPoStPeriodDeadlines = uint64(WPoStProvingPeriod / WPoStChallengeWindow)
 
 // The maximum number of sectors in a single window PoSt proof.
-const WPoStPartitionSectors = uint64(2350)
+const WPoStPartitionSectors = uint64(2349)
 
 // The maximum number of partitions that may be submitted in a single message.
 // This bounds the size of a list/set of sector numbers that might be instantiated to process a submission.


### PR DESCRIPTION
I think this change is required to match a number [hardcoded in in rust-fil-proofs](https://github.com/filecoin-project/rust-fil-proofs/blob/13cdfbb204e7a7c161bcb4cf787b0d2154c57b12/filecoin-proofs/src/constants.rs#L95). Without this change, I'm pretty sure proofs will fail to validate since the wrong sector information will be passed.

The linked code is alarming in a few ways:
- it suggests that this number is specific to sector size, which is big news to me and invalidates the implemented Window PoSt code for sectors other than 32GiB
- is has a value of `2` for 512GiB sectors, which doesn't seem motivated by any technical reason but is pretty unworkable for practical networks.

cc @dignifiedquire @porcuquine 