### PR TITLE
Fix seal proof type in miner actor and parameterize WPoSt partition size by it

### DIFF
--- a/actors/abi/sector.go
+++ b/actors/abi/sector.go
@@ -110,6 +110,30 @@ func (p RegisteredProof) SectorSize() (SectorSize, error) {
 	}
 }
 
+// Returns the partition size, in sectors, associated with a proof type.
+// The partition size is the number of sectors proven in a single PoSt proof.
+func (p RegisteredProof) WindowPoStPartitionSectors() (uint64, error) {
+	// Resolve to seal proof and then compute size from that.
+	sp, err := p.RegisteredSealProof()
+	if err != nil {
+		return 0, err
+	}
+	// These numbers must match those used by the proofs library.
+	// See https://github.com/filecoin-project/rust-fil-proofs/blob/master/filecoin-proofs/src/constants.rs#L85
+	switch sp {
+	case RegisteredProof_StackedDRG32GiBSeal:
+		return 2049, nil
+	case RegisteredProof_StackedDRG2KiBSeal:
+		return 2, nil
+	case RegisteredProof_StackedDRG8MiBSeal:
+		return 2, nil
+	case RegisteredProof_StackedDRG512MiBSeal:
+		return 2, nil
+	default:
+		return 0, errors.Errorf("unsupported proof type: %v", p)
+	}
+}
+
 // RegisteredWinningPoStProof produces the PoSt-specific RegisteredProof corresponding
 // to the receiving RegisteredProof.
 func (p RegisteredProof) RegisteredWinningPoStProof() (RegisteredProof, error) {

--- a/actors/builtin/miner/deadlines_test.go
+++ b/actors/builtin/miner/deadlines_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
 )
 
-const partSize = miner.WPoStPartitionSectors
+const partSize = uint64(1000)
 
 func TestProvingPeriodDeadlines(t *testing.T) {
 	PP := miner.WPoStProvingPeriod
@@ -143,12 +143,12 @@ func makeDeadline(currEpoch, periodStart abi.ChainEpoch, index uint64, deadlineO
 func TestPartitionsForDeadline(t *testing.T) {
 	t.Run("empty deadlines", func(t *testing.T) {
 		dl := deadlineWithSectors(t, [miner.WPoStPeriodDeadlines]uint64{})
-		firstIndex, sectorCount, err := miner.PartitionsForDeadline(dl, 0)
+		firstIndex, sectorCount, err := miner.PartitionsForDeadline(dl, partSize, 0)
 		require.NoError(t, err)
 		assert.Equal(t, uint64(0), firstIndex)
 		assert.Equal(t, uint64(0), sectorCount)
 
-		firstIndex, sectorCount, err = miner.PartitionsForDeadline(dl, miner.WPoStPeriodDeadlines-1)
+		firstIndex, sectorCount, err = miner.PartitionsForDeadline(dl, partSize, miner.WPoStPeriodDeadlines-1)
 		require.NoError(t, err)
 		assert.Equal(t, uint64(0), firstIndex)
 		assert.Equal(t, uint64(0), sectorCount)
@@ -156,17 +156,17 @@ func TestPartitionsForDeadline(t *testing.T) {
 
 	t.Run("single sector at first deadline", func(t *testing.T) {
 		dl := deadlineWithSectors(t, [miner.WPoStPeriodDeadlines]uint64{1})
-		firstIndex, sectorCount, err := miner.PartitionsForDeadline(dl, 0)
+		firstIndex, sectorCount, err := miner.PartitionsForDeadline(dl, partSize, 0)
 		require.NoError(t, err)
 		assert.Equal(t, uint64(0), firstIndex)
 		assert.Equal(t, uint64(1), sectorCount)
 
-		firstIndex, sectorCount, err = miner.PartitionsForDeadline(dl, 1)
+		firstIndex, sectorCount, err = miner.PartitionsForDeadline(dl, partSize, 1)
 		require.NoError(t, err)
 		assert.Equal(t, uint64(1), firstIndex)
 		assert.Zero(t, sectorCount)
 
-		firstIndex, sectorCount, err = miner.PartitionsForDeadline(dl, miner.WPoStPeriodDeadlines-1)
+		firstIndex, sectorCount, err = miner.PartitionsForDeadline(dl, partSize, miner.WPoStPeriodDeadlines-1)
 		require.NoError(t, err)
 		assert.Equal(t, uint64(1), firstIndex)
 		assert.Zero(t, sectorCount)
@@ -174,22 +174,22 @@ func TestPartitionsForDeadline(t *testing.T) {
 
 	t.Run("single sector at non-first deadline", func(t *testing.T) {
 		dl := deadlineWithSectors(t, [miner.WPoStPeriodDeadlines]uint64{0, 1})
-		firstIndex, sectorCount, err := miner.PartitionsForDeadline(dl, 0)
+		firstIndex, sectorCount, err := miner.PartitionsForDeadline(dl, partSize, 0)
 		require.NoError(t, err)
 		assert.Equal(t, uint64(0), firstIndex)
 		assert.Equal(t, uint64(0), sectorCount)
 
-		firstIndex, sectorCount, err = miner.PartitionsForDeadline(dl, 1)
+		firstIndex, sectorCount, err = miner.PartitionsForDeadline(dl, partSize, 1)
 		require.NoError(t, err)
 		assert.Equal(t, uint64(0), firstIndex)
 		assert.Equal(t, uint64(1), sectorCount)
 
-		firstIndex, sectorCount, err = miner.PartitionsForDeadline(dl, 2)
+		firstIndex, sectorCount, err = miner.PartitionsForDeadline(dl, partSize, 2)
 		require.NoError(t, err)
 		assert.Equal(t, uint64(1), firstIndex)
 		assert.Equal(t, uint64(0), sectorCount)
 
-		firstIndex, sectorCount, err = miner.PartitionsForDeadline(dl, miner.WPoStPeriodDeadlines-1)
+		firstIndex, sectorCount, err = miner.PartitionsForDeadline(dl, partSize, miner.WPoStPeriodDeadlines-1)
 		require.NoError(t, err)
 		assert.Equal(t, uint64(1), firstIndex)
 		assert.Equal(t, uint64(0), sectorCount)
@@ -197,17 +197,17 @@ func TestPartitionsForDeadline(t *testing.T) {
 
 	t.Run("deadlines with one full partitions", func(t *testing.T) {
 		dl := deadlinesWithFullPartitions(t, 1)
-		firstIndex, sectorCount, err := miner.PartitionsForDeadline(dl, 0)
+		firstIndex, sectorCount, err := miner.PartitionsForDeadline(dl, partSize, 0)
 		require.NoError(t, err)
 		assert.Equal(t, uint64(0), firstIndex)
 		assert.Equal(t, partSize, sectorCount)
 
-		firstIndex, sectorCount, err = miner.PartitionsForDeadline(dl, 1)
+		firstIndex, sectorCount, err = miner.PartitionsForDeadline(dl, partSize, 1)
 		require.NoError(t, err)
 		assert.Equal(t, uint64(1), firstIndex)
 		assert.Equal(t, partSize, sectorCount)
 
-		firstIndex, sectorCount, err = miner.PartitionsForDeadline(dl, miner.WPoStPeriodDeadlines-1)
+		firstIndex, sectorCount, err = miner.PartitionsForDeadline(dl, partSize, miner.WPoStPeriodDeadlines-1)
 		require.NoError(t, err)
 		assert.Equal(t, miner.WPoStPeriodDeadlines-1, firstIndex)
 		assert.Equal(t, partSize, sectorCount)
@@ -222,22 +222,22 @@ func TestPartitionsForDeadline(t *testing.T) {
 			4: partSize - 3,
 			5: partSize,
 		})
-		firstIndex, sectorCount, err := miner.PartitionsForDeadline(dl, 0)
+		firstIndex, sectorCount, err := miner.PartitionsForDeadline(dl, partSize, 0)
 		require.NoError(t, err)
 		assert.Equal(t, uint64(0), firstIndex)
 		assert.Equal(t, partSize-1, sectorCount)
 
-		firstIndex, sectorCount, err = miner.PartitionsForDeadline(dl, 1)
+		firstIndex, sectorCount, err = miner.PartitionsForDeadline(dl, partSize, 1)
 		require.NoError(t, err)
 		assert.Equal(t, uint64(1), firstIndex)
 		assert.Equal(t, partSize, sectorCount)
 
-		firstIndex, sectorCount, err = miner.PartitionsForDeadline(dl, 2)
+		firstIndex, sectorCount, err = miner.PartitionsForDeadline(dl, partSize, 2)
 		require.NoError(t, err)
 		assert.Equal(t, uint64(2), firstIndex)
 		assert.Equal(t, partSize-2, sectorCount)
 
-		firstIndex, sectorCount, err = miner.PartitionsForDeadline(dl, 5)
+		firstIndex, sectorCount, err = miner.PartitionsForDeadline(dl, partSize, 5)
 		require.NoError(t, err)
 		assert.Equal(t, uint64(5), firstIndex)
 		assert.Equal(t, partSize, sectorCount)
@@ -253,37 +253,37 @@ func TestPartitionsForDeadline(t *testing.T) {
 			5: partSize * 9,   // 9 partitions 30 total
 		})
 
-		firstIndex, sectorCount, err := miner.PartitionsForDeadline(dl, 0)
+		firstIndex, sectorCount, err := miner.PartitionsForDeadline(dl, partSize, 0)
 		require.NoError(t, err)
 		assert.Equal(t, uint64(0), firstIndex)
 		assert.Equal(t, partSize, sectorCount)
 
-		firstIndex, sectorCount, err = miner.PartitionsForDeadline(dl, 1)
+		firstIndex, sectorCount, err = miner.PartitionsForDeadline(dl, partSize, 1)
 		require.NoError(t, err)
 		assert.Equal(t, uint64(1), firstIndex)
 		assert.Equal(t, partSize*2, sectorCount)
 
-		firstIndex, sectorCount, err = miner.PartitionsForDeadline(dl, 2)
+		firstIndex, sectorCount, err = miner.PartitionsForDeadline(dl, partSize, 2)
 		require.NoError(t, err)
 		assert.Equal(t, uint64(3), firstIndex)
 		assert.Equal(t, partSize*4-1, sectorCount)
 
-		firstIndex, sectorCount, err = miner.PartitionsForDeadline(dl, 3)
+		firstIndex, sectorCount, err = miner.PartitionsForDeadline(dl, partSize, 3)
 		require.NoError(t, err)
 		assert.Equal(t, uint64(7), firstIndex)
 		assert.Equal(t, partSize*6, sectorCount)
 
-		firstIndex, sectorCount, err = miner.PartitionsForDeadline(dl, 4)
+		firstIndex, sectorCount, err = miner.PartitionsForDeadline(dl, partSize, 4)
 		require.NoError(t, err)
 		assert.Equal(t, uint64(13), firstIndex)
 		assert.Equal(t, partSize*8-1, sectorCount)
 
-		firstIndex, sectorCount, err = miner.PartitionsForDeadline(dl, 5)
+		firstIndex, sectorCount, err = miner.PartitionsForDeadline(dl, partSize, 5)
 		require.NoError(t, err)
 		assert.Equal(t, uint64(21), firstIndex)
 		assert.Equal(t, partSize*9, sectorCount)
 
-		firstIndex, sectorCount, err = miner.PartitionsForDeadline(dl, miner.WPoStPeriodDeadlines-1)
+		firstIndex, sectorCount, err = miner.PartitionsForDeadline(dl, partSize, miner.WPoStPeriodDeadlines-1)
 		require.NoError(t, err)
 		assert.Equal(t, uint64(30), firstIndex)
 		assert.Equal(t, uint64(0), sectorCount)
@@ -296,21 +296,21 @@ func TestComputePartitionsSectors(t *testing.T) {
 		dls.Due[1] = bf(0, 1)
 
 		// No partitions at deadline 0
-		_, err := miner.ComputePartitionsSectors(dls, 0, []uint64{0})
+		_, err := miner.ComputePartitionsSectors(dls, partSize, 0, []uint64{0})
 		require.Error(t, err)
 
 		// No partitions at deadline 2
-		_, err = miner.ComputePartitionsSectors(dls, 2, []uint64{0})
+		_, err = miner.ComputePartitionsSectors(dls, partSize, 2, []uint64{0})
 		require.Error(t, err)
-		_, err = miner.ComputePartitionsSectors(dls, 2, []uint64{1})
+		_, err = miner.ComputePartitionsSectors(dls, partSize, 2, []uint64{1})
 		require.Error(t, err)
-		_, err = miner.ComputePartitionsSectors(dls, 2, []uint64{2})
+		_, err = miner.ComputePartitionsSectors(dls, partSize, 2, []uint64{2})
 		require.Error(t, err)
 	})
 	t.Run("single sector", func(t *testing.T) {
 		dls := miner.ConstructDeadlines()
 		dls.Due[1] = bf(0, 1)
-		partitions, err := miner.ComputePartitionsSectors(dls, 1, []uint64{0})
+		partitions, err := miner.ComputePartitionsSectors(dls, partSize, 1, []uint64{0})
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(partitions))
 		assertBfEqual(t, bf(0, 1), partitions[0])
@@ -318,7 +318,7 @@ func TestComputePartitionsSectors(t *testing.T) {
 	t.Run("full partition", func(t *testing.T) {
 		dls := miner.ConstructDeadlines()
 		dls.Due[10] = bf(1234, partSize)
-		partitions, err := miner.ComputePartitionsSectors(dls, 10, []uint64{0})
+		partitions, err := miner.ComputePartitionsSectors(dls, partSize, 10, []uint64{0})
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(partitions))
 		assertBfEqual(t, bf(1234, partSize), partitions[0])
@@ -326,17 +326,17 @@ func TestComputePartitionsSectors(t *testing.T) {
 	t.Run("full plus partial partition", func(t *testing.T) {
 		dls := miner.ConstructDeadlines()
 		dls.Due[10] = bf(5555, partSize+1)
-		partitions, err := miner.ComputePartitionsSectors(dls, 10, []uint64{0}) // First partition
+		partitions, err := miner.ComputePartitionsSectors(dls, partSize, 10, []uint64{0}) // First partition
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(partitions))
 		assertBfEqual(t, bf(5555, partSize), partitions[0])
 
-		partitions, err = miner.ComputePartitionsSectors(dls, 10, []uint64{1}) // Second partition
+		partitions, err = miner.ComputePartitionsSectors(dls, partSize, 10, []uint64{1}) // Second partition
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(partitions))
 		assertBfEqual(t, bf(5555+partSize, 1), partitions[0])
 
-		partitions, err = miner.ComputePartitionsSectors(dls, 10, []uint64{0, 1}) // Both partitions
+		partitions, err = miner.ComputePartitionsSectors(dls, partSize, 10, []uint64{0, 1}) // Both partitions
 		require.NoError(t, err)
 		assert.Equal(t, 2, len(partitions))
 		assertBfEqual(t, bf(5555, partSize), partitions[0])
@@ -345,7 +345,7 @@ func TestComputePartitionsSectors(t *testing.T) {
 	t.Run("multiple partitions", func(t *testing.T) {
 		dls := miner.ConstructDeadlines()
 		dls.Due[1] = bf(0, 3*partSize+1)
-		partitions, err := miner.ComputePartitionsSectors(dls, 1, []uint64{0, 1, 2, 3})
+		partitions, err := miner.ComputePartitionsSectors(dls, partSize, 1, []uint64{0, 1, 2, 3})
 		require.NoError(t, err)
 		assert.Equal(t, 4, len(partitions))
 		assertBfEqual(t, bf(0, partSize), partitions[0])
@@ -359,37 +359,37 @@ func TestComputePartitionsSectors(t *testing.T) {
 		dls.Due[3] = bf(3*partSize+1, 1)
 		dls.Due[5] = bf(3*partSize+1+1, 2*partSize)
 
-		partitions, err := miner.ComputePartitionsSectors(dls, 1, []uint64{0, 1, 2, 3})
+		partitions, err := miner.ComputePartitionsSectors(dls, partSize, 1, []uint64{0, 1, 2, 3})
 		require.NoError(t, err)
 		assert.Equal(t, 4, len(partitions))
 
-		partitions, err = miner.ComputePartitionsSectors(dls, 3, []uint64{4})
+		partitions, err = miner.ComputePartitionsSectors(dls, partSize, 3, []uint64{4})
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(partitions))
 		assertBfEqual(t, bf(3*partSize+1, 1), partitions[0])
 
-		partitions, err = miner.ComputePartitionsSectors(dls, 5, []uint64{5, 6})
+		partitions, err = miner.ComputePartitionsSectors(dls, partSize, 5, []uint64{5, 6})
 		require.NoError(t, err)
 		assert.Equal(t, 2, len(partitions))
 		assertBfEqual(t, bf(3*partSize+1+1, partSize), partitions[0])
 		assertBfEqual(t, bf(3*partSize+1+1+partSize, partSize), partitions[1])
 
 		// Mismatched deadline/partition pairs
-		_, err = miner.ComputePartitionsSectors(dls, 1, []uint64{4})
+		_, err = miner.ComputePartitionsSectors(dls, partSize, 1, []uint64{4})
 		require.Error(t, err)
-		_, err = miner.ComputePartitionsSectors(dls, 2, []uint64{4})
+		_, err = miner.ComputePartitionsSectors(dls, partSize, 2, []uint64{4})
 		require.Error(t, err)
-		_, err = miner.ComputePartitionsSectors(dls, 3, []uint64{0})
+		_, err = miner.ComputePartitionsSectors(dls, partSize, 3, []uint64{0})
 		require.Error(t, err)
-		_, err = miner.ComputePartitionsSectors(dls, 3, []uint64{3})
+		_, err = miner.ComputePartitionsSectors(dls, partSize, 3, []uint64{3})
 		require.Error(t, err)
-		_, err = miner.ComputePartitionsSectors(dls, 3, []uint64{5})
+		_, err = miner.ComputePartitionsSectors(dls, partSize, 3, []uint64{5})
 		require.Error(t, err)
-		_, err = miner.ComputePartitionsSectors(dls, 4, []uint64{5})
+		_, err = miner.ComputePartitionsSectors(dls, partSize, 4, []uint64{5})
 		require.Error(t, err)
-		_, err = miner.ComputePartitionsSectors(dls, 5, []uint64{0})
+		_, err = miner.ComputePartitionsSectors(dls, partSize, 5, []uint64{0})
 		require.Error(t, err)
-		_, err = miner.ComputePartitionsSectors(dls, 5, []uint64{7})
+		_, err = miner.ComputePartitionsSectors(dls, partSize, 5, []uint64{7})
 		require.Error(t, err)
 	})
 }

--- a/actors/builtin/miner/miner_state_test.go
+++ b/actors/builtin/miner/miner_state_test.go
@@ -950,7 +950,8 @@ func constructStateHarness(t *testing.T, periodBoundary abi.ChainEpoch) *stateHa
 	// state field init
 	owner := tutils.NewBLSAddr(t, 1)
 	worker := tutils.NewBLSAddr(t, 2)
-	state := miner.ConstructState(emptyArray, emptyMap, emptyDeadlinesCid, owner, worker, "peer", SectorSize, periodBoundary)
+	state, err := miner.ConstructState(emptyArray, emptyMap, emptyDeadlinesCid, owner, worker, "peer", abi.RegisteredProof_StackedDRG2KiBSeal, periodBoundary)
+	require.NoError(t, err)
 
 	// assert NewSectors bitfield was constructed correctly (empty)
 	newSectorsCount, err := state.NewSectors.Count()

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -36,8 +36,6 @@ func init() {
 	testPid = pid
 }
 
-const SectorSize = abi.SectorSize(32 << 20)
-
 func TestExports(t *testing.T) {
 	mock.CheckActorExports(t, miner.Actor{})
 }
@@ -58,10 +56,10 @@ func TestConstruction(t *testing.T) {
 	t.Run("simple construction", func(t *testing.T) {
 		rt := builder.Build(t)
 		params := miner.ConstructorParams{
-			OwnerAddr:  owner,
-			WorkerAddr: worker,
-			SectorSize: SectorSize,
-			PeerId:     testPid,
+			OwnerAddr:     owner,
+			WorkerAddr:    worker,
+			SealProofType: abi.RegisteredProof_StackedDRG2KiBSeal,
+			PeerId:        testPid,
 		}
 
 		provingPeriodStart := abi.ChainEpoch(2386) // This is just set from running the code.
@@ -80,7 +78,9 @@ func TestConstruction(t *testing.T) {
 		assert.Equal(t, params.OwnerAddr, st.Info.Owner)
 		assert.Equal(t, params.WorkerAddr, st.Info.Worker)
 		assert.Equal(t, params.PeerId, st.Info.PeerId)
-		assert.Equal(t, params.SectorSize, st.Info.SectorSize)
+		assert.Equal(t, abi.RegisteredProof_StackedDRG2KiBSeal, st.Info.SealProofType)
+		assert.Equal(t, abi.SectorSize(2048), st.Info.SectorSize)
+		assert.Equal(t, uint64(2), st.Info.WindowPoStPartitionSectors)
 		assert.Equal(t, provingPeriodStart, st.ProvingPeriodStart)
 
 		assert.Equal(t, big.Zero(), st.PreCommitDeposits)
@@ -237,10 +237,10 @@ func newHarness(t testing.TB, owner, worker, key addr.Address) *actorHarness {
 
 func (h *actorHarness) constructAndVerify(rt *mock.Runtime, provingPeriodStart abi.ChainEpoch) {
 	params := miner.ConstructorParams{
-		OwnerAddr:  h.owner,
-		WorkerAddr: h.worker,
-		SectorSize: SectorSize,
-		PeerId:     testPid,
+		OwnerAddr:     h.owner,
+		WorkerAddr:    h.worker,
+		SealProofType: abi.RegisteredProof_StackedDRG2KiBSeal,
+		PeerId:        testPid,
 	}
 
 	rt.ExpectValidateCallerAddr(builtin.InitActorAddr)

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -22,13 +22,6 @@ const WPoStChallengeWindow = abi.ChainEpoch(1800 / EpochDurationSeconds) // Half
 // The number of non-overlapping PoSt deadlines in each proving period.
 const WPoStPeriodDeadlines = uint64(WPoStProvingPeriod / WPoStChallengeWindow)
 
-// The maximum number of sectors in a single window PoSt proof.
-const WPoStPartitionSectors = uint64(2349)
-
-// The maximum number of partitions that may be submitted in a single message.
-// This bounds the size of a list/set of sector numbers that might be instantiated to process a submission.
-const WPoStMessagePartitionsMax = 100_000 / WPoStPartitionSectors
-
 func init() {
 	// Check that the challenge windows divide the proving period evenly.
 	if WPoStProvingPeriod%WPoStChallengeWindow != 0 {
@@ -45,7 +38,15 @@ func init() {
 const SectorsMax = 32 << 20 // PARAM_FINISH
 
 // The maximum number of proving partitions a miner can have simultaneously active.
-const PartitionsMax = (SectorsMax / WPoStPartitionSectors) + WPoStPeriodDeadlines
+func activePartitionsMax(partitionSectorCount uint64) uint64 {
+	return (SectorsMax / partitionSectorCount) + WPoStPeriodDeadlines
+}
+
+// The maximum number of partitions that may be submitted in a single message.
+// This bounds the size of a list/set of sector numbers that might be instantiated to process a submission.
+func windowPoStMessagePartitionsMax(partitionSectorCount uint64) uint64 {
+	return 100_000 / partitionSectorCount
+}
 
 // The maximum number of new sectors that may be staged by a miner during a single proving period.
 const NewSectorsPerPeriodMax = 128 << 10

--- a/actors/builtin/power/cbor_gen.go
+++ b/actors/builtin/power/cbor_gen.go
@@ -377,10 +377,15 @@ func (t *CreateMinerParams) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.SectorSize (abi.SectorSize) (uint64)
-
-	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.SectorSize))); err != nil {
-		return err
+	// t.SealProofType (abi.RegisteredProof) (int64)
+	if t.SealProofType >= 0 {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.SealProofType))); err != nil {
+			return err
+		}
+	} else {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.SealProofType)-1)); err != nil {
+			return err
+		}
 	}
 
 	// t.Peer (peer.ID) (string)
@@ -430,19 +435,30 @@ func (t *CreateMinerParams) UnmarshalCBOR(r io.Reader) error {
 		}
 
 	}
-	// t.SectorSize (abi.SectorSize) (uint64)
-
+	// t.SealProofType (abi.RegisteredProof) (int64)
 	{
-
-		maj, extra, err = cbg.CborReadHeader(br)
+		maj, extra, err := cbg.CborReadHeader(br)
+		var extraI int64
 		if err != nil {
 			return err
 		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
+		switch maj {
+		case cbg.MajUnsignedInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 positive overflow")
+			}
+		case cbg.MajNegativeInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 negative oveflow")
+			}
+			extraI = -1 - extraI
+		default:
+			return fmt.Errorf("wrong type for int64 field: %d", maj)
 		}
-		t.SectorSize = abi.SectorSize(extra)
 
+		t.SealProofType = abi.RegisteredProof(extraI)
 	}
 	// t.Peer (peer.ID) (string)
 
@@ -1022,10 +1038,15 @@ func (t *MinerConstructorParams) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.SectorSize (abi.SectorSize) (uint64)
-
-	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.SectorSize))); err != nil {
-		return err
+	// t.SealProofType (abi.RegisteredProof) (int64)
+	if t.SealProofType >= 0 {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.SealProofType))); err != nil {
+			return err
+		}
+	} else {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.SealProofType)-1)); err != nil {
+			return err
+		}
 	}
 
 	// t.PeerId (peer.ID) (string)
@@ -1075,19 +1096,30 @@ func (t *MinerConstructorParams) UnmarshalCBOR(r io.Reader) error {
 		}
 
 	}
-	// t.SectorSize (abi.SectorSize) (uint64)
-
+	// t.SealProofType (abi.RegisteredProof) (int64)
 	{
-
-		maj, extra, err = cbg.CborReadHeader(br)
+		maj, extra, err := cbg.CborReadHeader(br)
+		var extraI int64
 		if err != nil {
 			return err
 		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
+		switch maj {
+		case cbg.MajUnsignedInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 positive overflow")
+			}
+		case cbg.MajNegativeInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 negative oveflow")
+			}
+			extraI = -1 - extraI
+		default:
+			return fmt.Errorf("wrong type for int64 field: %d", maj)
 		}
-		t.SectorSize = abi.SectorSize(extra)
 
+		t.SealProofType = abi.RegisteredProof(extraI)
 	}
 	// t.PeerId (peer.ID) (string)
 

--- a/actors/builtin/power/power_actor.go
+++ b/actors/builtin/power/power_actor.go
@@ -52,10 +52,10 @@ var _ abi.Invokee = Actor{}
 // Storage miner actor constructor params are defined here so the power actor can send them to the init actor
 // to instantiate miners.
 type MinerConstructorParams struct {
-	OwnerAddr  addr.Address
-	WorkerAddr addr.Address
-	SectorSize abi.SectorSize
-	PeerId     peer.ID
+	OwnerAddr     addr.Address
+	WorkerAddr    addr.Address
+	SealProofType abi.RegisteredProof
+	PeerId        peer.ID
 }
 
 type SectorStorageWeightDesc struct {
@@ -83,10 +83,10 @@ func (a Actor) Constructor(rt Runtime, _ *adt.EmptyValue) *adt.EmptyValue {
 }
 
 type CreateMinerParams struct {
-	Owner      addr.Address
-	Worker     addr.Address
-	SectorSize abi.SectorSize
-	Peer       peer.ID
+	Owner         addr.Address
+	Worker        addr.Address
+	SealProofType abi.RegisteredProof
+	Peer          peer.ID
 }
 
 type CreateMinerReturn struct {
@@ -98,10 +98,10 @@ func (a Actor) CreateMiner(rt Runtime, params *CreateMinerParams) *CreateMinerRe
 	rt.ValidateImmediateCallerType(builtin.CallerTypesSignable...)
 
 	ctorParams := MinerConstructorParams{
-		OwnerAddr:  params.Owner,
-		WorkerAddr: params.Worker,
-		SectorSize: params.SectorSize,
-		PeerId:     params.Peer,
+		OwnerAddr:     params.Owner,
+		WorkerAddr:    params.Worker,
+		SealProofType: params.SealProofType,
+		PeerId:        params.Peer,
 	}
 	ctorParamBuf := new(bytes.Buffer)
 	err := ctorParams.MarshalCBOR(ctorParamBuf)


### PR DESCRIPTION
This is part of the way to #335. The registered proof types in all the sector states and messages are now redundant.

FYI @magik6k, @acruikshank