### PR TITLE
Fix the 32GiB Window PoSt partition size again

### DIFF
--- a/actors/abi/sector.go
+++ b/actors/abi/sector.go
@@ -122,7 +122,7 @@ func (p RegisteredProof) WindowPoStPartitionSectors() (uint64, error) {
 	// See https://github.com/filecoin-project/rust-fil-proofs/blob/master/filecoin-proofs/src/constants.rs#L85
 	switch sp {
 	case RegisteredProof_StackedDRG32GiBSeal:
-		return 2049, nil
+		return 2349, nil
 	case RegisteredProof_StackedDRG2KiBSeal:
 		return 2, nil
 	case RegisteredProof_StackedDRG8MiBSeal:


### PR DESCRIPTION
First fixed in #332 but then broken again by my typo in #336.