### PR TITLE
DeadlineInfo handles expired proving period

### DIFF
--- a/actors/builtin/miner/deadlines_test.go
+++ b/actors/builtin/miner/deadlines_test.go
@@ -116,6 +116,19 @@ func TestProvingPeriodDeadlines(t *testing.T) {
 		assertDeadlineInfo(t, 2+2*CW, initialPPStart+PP, 0, initialPPStart+PP)
 		assertDeadlineInfo(t, 2+2*CW+1, initialPPStart+PP, 0, initialPPStart+PP)
 	})
+
+	t.Run("period expired", func(t *testing.T) {
+		offset := abi.ChainEpoch(1)
+		d := miner.ComputeProvingPeriodDeadline(offset, offset+miner.WPoStProvingPeriod)
+		assert.True(t, d.PeriodStarted())
+		assert.True(t, d.PeriodElapsed())
+		assert.Equal(t, miner.WPoStPeriodDeadlines, d.Index)
+		assert.False(t, d.IsOpen())
+		assert.True(t, d.HasElapsed())
+		assert.True(t, d.FaultCutoffPassed())
+		assert.Equal(t, offset+miner.WPoStProvingPeriod-1, d.PeriodEnd())
+		assert.Equal(t, offset+miner.WPoStProvingPeriod, d.NextPeriodStart())
+	})
 }
 
 func assertDeadlineInfo(t *testing.T, current, periodStart abi.ChainEpoch, expectedIndex uint64, expectedDeadlineOpen abi.ChainEpoch) *miner.DeadlineInfo {


### PR DESCRIPTION
This provides a `PeriodElapsed()` predicate and fixes the other ones to indicate that no challenge window is open after a proving period has elapsed and before the proving period start has been updated to the next period.

Also changes assertions from using a too-high deadline index into errors.