### PR TITLE
puppet type and method for failed marshal to cbor

### DIFF
--- a/actors/puppet/puppet.go
+++ b/actors/puppet/puppet.go
@@ -1,14 +1,18 @@
 package puppet
 
 import (
+	"fmt"
+	"io"
+
 	addr "github.com/filecoin-project/go-address"
+	"github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+
 	abi "github.com/filecoin-project/specs-actors/actors/abi"
 	builtin "github.com/filecoin-project/specs-actors/actors/builtin"
 	runtime "github.com/filecoin-project/specs-actors/actors/runtime"
 	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 	adt "github.com/filecoin-project/specs-actors/actors/util/adt"
-	"github.com/ipfs/go-cid"
-	mh "github.com/multiformats/go-multihash"
 )
 
 // The Puppet Actor exists to aid testing the runtime and environment in which it's embedded. It provides direct access
@@ -20,6 +24,7 @@ func (a Actor) Exports() []interface{} {
 	return []interface{}{
 		builtin.MethodConstructor: a.Constructor,
 		2:                         a.Send,
+		3:                         a.SendMarshalCBORFailure,
 	}
 }
 
@@ -62,6 +67,31 @@ func (a Actor) Send(rt runtime.Runtime, params *SendParams) *SendReturn {
 	}
 }
 
+func (a Actor) SendMarshalCBORFailure(rt runtime.Runtime, params *SendParams) *SendReturn {
+	rt.ValidateImmediateCallerAcceptAny()
+	ret, code := rt.Send(
+		params.To,
+		params.Method,
+		&FailToMarshalCBOR{},
+		params.Value,
+	)
+	var out runtime.CBORBytes
+	if err := ret.Into(&out); err != nil {
+		rt.Abortf(exitcode.ErrIllegalState, "failed to unmarshal send return: %v", err)
+	}
+	return &SendReturn{
+		Return: out,
+		Code:   code,
+	}
+}
+
+type FailToMarshalCBOR struct {
+}
+
+func (t *FailToMarshalCBOR) MarshalCBOR(w io.Writer) error {
+	return fmt.Errorf("failed to marshal cbor")
+}
+
 type State struct{}
 
 func init() {
@@ -77,6 +107,7 @@ func init() {
 var PuppetActorCodeID cid.Cid
 
 var MethodsPuppet = struct {
-	Constructor abi.MethodNum
-	Send        abi.MethodNum
-}{builtin.MethodConstructor, 2}
+	Constructor            abi.MethodNum
+	Send                   abi.MethodNum
+	SendMarshalCBORFailuer abi.MethodNum
+}{builtin.MethodConstructor, 2, 3}


### PR DESCRIPTION
Implement a method on the puppet actor that sends parameters that always fail to marshal to CBOR.