### PR TITLE
Fix nil verified deal weight

### DIFF
--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -977,9 +977,10 @@ func (s *SectorOnChainInfo) AsSectorInfo() abi.SectorInfo {
 
 func AsStorageWeightDesc(sectorSize abi.SectorSize, sectorInfo *SectorOnChainInfo) *power.SectorStorageWeightDesc {
 	return &power.SectorStorageWeightDesc{
-		SectorSize: sectorSize,
-		DealWeight: sectorInfo.DealWeight,
-		Duration:   sectorInfo.Info.Expiration - sectorInfo.ActivationEpoch,
+		SectorSize:         sectorSize,
+		DealWeight:         sectorInfo.DealWeight,
+		VerifiedDealWeight: sectorInfo.VerifiedDealWeight,
+		Duration:           sectorInfo.Info.Expiration - sectorInfo.ActivationEpoch,
 	}
 }
 


### PR DESCRIPTION
This was found in production.

I haven't gone to effort to cement this with regression tests because this whole SectoStorageWeightDesc and back-and-forth with the power actor is technical debt holdover from when the power actor owned these calculations, and I intend to remove most of it.

Closes #359, https://github.com/filecoin-project/go-filecoin/issues/4094