### PR TITLE
Fix/wdpost proof len

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -195,9 +195,10 @@ type SubmitWindowedPoStParams struct {
 
 // Invoked by miner's worker address to submit their fallback post
 func (a Actor) SubmitWindowedPoSt(rt Runtime, params *SubmitWindowedPoStParams) *adt.EmptyValue {
-	proofNum := len(params.Proofs[0].ProofBytes) / WdPoStSingleProofLen
-	if len(params.Partitions) != len(params.Proofs) {
-		rt.Abortf(exitcode.ErrIllegalArgument, "proof count %d must match partition count %d", proofNum, len(params.Partitions))
+	proofPartitions := proofPartitionCount(params.Proofs)
+
+	if len(params.Partitions) != proofPartitions {
+		rt.Abortf(exitcode.ErrIllegalArgument, "proof count %d must match partition count %d", proofPartitions, len(params.Partitions))
 	}
 
 	currEpoch := rt.CurrEpoch()

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -195,8 +195,9 @@ type SubmitWindowedPoStParams struct {
 
 // Invoked by miner's worker address to submit their fallback post
 func (a Actor) SubmitWindowedPoSt(rt Runtime, params *SubmitWindowedPoStParams) *adt.EmptyValue {
+	proofNum := len(params.Proofs[0].ProofBytes) / WdPoStSingleProofLen
 	if len(params.Partitions) != len(params.Proofs) {
-		rt.Abortf(exitcode.ErrIllegalArgument, "proof count %d must match partition count %", len(params.Proofs), len(params.Partitions))
+		rt.Abortf(exitcode.ErrIllegalArgument, "proof count %d must match partition count %d", proofNum, len(params.Partitions))
 	}
 
 	currEpoch := rt.CurrEpoch()

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -157,3 +157,12 @@ func rewardForConsensusSlashReport(elapsedEpoch abi.ChainEpoch, collateral abi.T
 	denom := big.Mul(slasherShareDenominator, consensusFaultReporterInitialShare.denominator)
 	return big.Min(big.Div(num, denom), big.Div(big.Mul(collateral, maxReporterShareNum), maxReporterShareDen))
 }
+
+func proofPartitionCount(proofs []abi.PoStProof) int {
+	partitions := 0
+	for _, proof := range proofs {
+		partitions += len(proof.ProofBytes) / WdPoStSingleProofLen
+	}
+
+	return partitions
+}

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -8,6 +8,9 @@ import (
 	builtin "github.com/filecoin-project/specs-actors/actors/builtin"
 )
 
+// single proof byte length for wdpost
+const WdPoStSingleProofLen = 192
+
 // The period over which all a miner's active sectors will be challenged.
 const WPoStProvingPeriod = abi.ChainEpoch(builtin.EpochsInDay) // 24 hours
 


### PR DESCRIPTION
Based on changes from https://github.com/filecoin-project/specs-actors/pull/361, after getting input from @dignifiedquire, this seems to be the correct way to count proven partitions 