### PR TITLE
Fractional network time

### DIFF
--- a/actors/abi/primitives.go
+++ b/actors/abi/primitives.go
@@ -14,6 +14,9 @@ import (
 // Epoch number of the chain state, which acts as a proxy for time within the VM.
 type ChainEpoch int64
 
+// Fractional representation of NetworkTime with an implicit denominator of (2^MintingInputFixedPoint).
+type NetworkTime big.Int
+
 func (e ChainEpoch) String() string {
 	return strconv.FormatInt(int64(e), 10)
 }

--- a/actors/abi/primitives.go
+++ b/actors/abi/primitives.go
@@ -15,7 +15,7 @@ import (
 type ChainEpoch int64
 
 // Fractional representation of NetworkTime with an implicit denominator of (2^MintingInputFixedPoint).
-type NetworkTime big.Int
+type NetworkTime = big.Int
 
 func (e ChainEpoch) String() string {
 	return strconv.FormatInt(int64(e), 10)

--- a/actors/abi/primitives.go
+++ b/actors/abi/primitives.go
@@ -14,9 +14,6 @@ import (
 // Epoch number of the chain state, which acts as a proxy for time within the VM.
 type ChainEpoch int64
 
-// Fractional representation of NetworkTime with an implicit denominator of (2^MintingInputFixedPoint).
-type NetworkTime = big.Int
-
 func (e ChainEpoch) String() string {
 	return strconv.FormatInt(int64(e), 10)
 }

--- a/actors/builtin/reward/reward_actor.go
+++ b/actors/builtin/reward/reward_actor.go
@@ -99,7 +99,7 @@ func (a Actor) LastPerEpochReward(rt vmr.Runtime, _ *adt.EmptyValue) *abi.TokenA
 }
 
 // Updates the simple/baseline supply state and last epoch reward with computation for for a single epoch.
-func (a Actor) computePerEpochReward(st *State, clockTime abi.ChainEpoch, networkTime big.Int, ticketCount int64) abi.TokenAmount {
+func (a Actor) computePerEpochReward(st *State, clockTime abi.ChainEpoch, networkTime abi.NetworkTime, ticketCount int64) abi.TokenAmount {
 	// TODO: PARAM_FINISH
 	newSimpleSupply := mintingFunction(SimpleTotal, big.Lsh(big.NewInt(int64(clockTime)), MintingInputFixedPoint))
 	newBaselineSupply := mintingFunction(BaselineTotal, networkTime)
@@ -125,11 +125,11 @@ func (a Actor) newBaselinePower(st *State, rewardEpochsPaid abi.ChainEpoch) abi.
 	return big.NewInt(baselinePower)
 }
 
-func (a Actor) getEffectiveNetworkTime(st *State, cumsumBaseline abi.Spacetime, cumsumRealized abi.Spacetime) big.Int {
+func (a Actor) getEffectiveNetworkTime(st *State, cumsumBaseline abi.Spacetime, cumsumRealized abi.Spacetime) abi.NetworkTime {
 	// TODO: this function depends on the final baseline
 	// EffectiveNetworkTime is a fractional input with an implicit denominator of (2^MintingInputFixedPoint).
 	// realizedCumsum is thus left shifted by MintingInputFixedPoint before converted into a FixedPoint fraction
-	// through division (which an inverse function for the integral of the baseline).
+	// through division (which is an inverse function for the integral of the baseline).
 	realizedCumsum := big.Min(cumsumBaseline, cumsumRealized)
 	return big.Div(big.Lsh(realizedCumsum, MintingInputFixedPoint), big.NewInt(baselinePower))
 }

--- a/actors/builtin/reward/reward_actor.go
+++ b/actors/builtin/reward/reward_actor.go
@@ -99,7 +99,7 @@ func (a Actor) LastPerEpochReward(rt vmr.Runtime, _ *adt.EmptyValue) *abi.TokenA
 }
 
 // Updates the simple/baseline supply state and last epoch reward with computation for for a single epoch.
-func (a Actor) computePerEpochReward(st *State, clockTime abi.ChainEpoch, networkTime abi.NetworkTime, ticketCount int64) abi.TokenAmount {
+func (a Actor) computePerEpochReward(st *State, clockTime abi.ChainEpoch, networkTime NetworkTime, ticketCount int64) abi.TokenAmount {
 	// TODO: PARAM_FINISH
 	newSimpleSupply := mintingFunction(SimpleTotal, big.Lsh(big.NewInt(int64(clockTime)), MintingInputFixedPoint))
 	newBaselineSupply := mintingFunction(BaselineTotal, networkTime)
@@ -125,7 +125,7 @@ func (a Actor) newBaselinePower(st *State, rewardEpochsPaid abi.ChainEpoch) abi.
 	return big.NewInt(baselinePower)
 }
 
-func (a Actor) getEffectiveNetworkTime(st *State, cumsumBaseline abi.Spacetime, cumsumRealized abi.Spacetime) abi.NetworkTime {
+func (a Actor) getEffectiveNetworkTime(st *State, cumsumBaseline abi.Spacetime, cumsumRealized abi.Spacetime) NetworkTime {
 	// TODO: this function depends on the final baseline
 	// EffectiveNetworkTime is a fractional input with an implicit denominator of (2^MintingInputFixedPoint).
 	// realizedCumsum is thus left shifted by MintingInputFixedPoint before converted into a FixedPoint fraction

--- a/actors/builtin/reward/reward_state.go
+++ b/actors/builtin/reward/reward_state.go
@@ -12,7 +12,7 @@ type State struct {
 	RealizedPower        abi.StoragePower
 	CumsumBaseline       abi.Spacetime
 	CumsumRealized       abi.Spacetime
-	EffectiveNetworkTime abi.ChainEpoch
+	EffectiveNetworkTime big.Int
 
 	SimpleSupply   abi.TokenAmount // current supply
 	BaselineSupply abi.TokenAmount // current supply
@@ -39,7 +39,7 @@ func ConstructState() *State {
 		RealizedPower:        big.Zero(),
 		CumsumBaseline:       big.Zero(),
 		CumsumRealized:       big.Zero(),
-		EffectiveNetworkTime: abi.ChainEpoch(int64(0)),
+		EffectiveNetworkTime: big.Zero(),
 
 		SimpleSupply:       big.Zero(),
 		BaselineSupply:     big.Zero(),
@@ -240,8 +240,7 @@ func taylorSeriesExpansion(lambdaNum big.Int, lambdaDen big.Int, t big.Int) big.
 //   number, and right-shift down by MintingOutputFixedPoint. This convenience
 //   wrapper implements those conventions. However, it does NOT implement
 //   left-shifting the input by the MintingInputFixedPoint, because baseline
-//   minting will (soon) actually supply a fractional input, so this would only
-//   be used for simple minting.
+//   minting will actually supply a fractional input.
 func mintingFunction(factor big.Int, t big.Int) big.Int {
 	return big.Rsh(big.Mul(factor, taylorSeriesExpansion(LambdaNum, LambdaDen, t)), MintingOutputFixedPoint)
 }

--- a/actors/builtin/reward/reward_state.go
+++ b/actors/builtin/reward/reward_state.go
@@ -7,12 +7,15 @@ import (
 	adt "github.com/filecoin-project/specs-actors/actors/util/adt"
 )
 
+// Fractional representation of NetworkTime with an implicit denominator of (2^MintingInputFixedPoint).
+type NetworkTime = big.Int
+
 type State struct {
 	BaselinePower        abi.StoragePower
 	RealizedPower        abi.StoragePower
 	CumsumBaseline       abi.Spacetime
 	CumsumRealized       abi.Spacetime
-	EffectiveNetworkTime abi.NetworkTime
+	EffectiveNetworkTime NetworkTime
 
 	SimpleSupply   abi.TokenAmount // current supply
 	BaselineSupply abi.TokenAmount // current supply

--- a/actors/builtin/reward/reward_state.go
+++ b/actors/builtin/reward/reward_state.go
@@ -12,7 +12,7 @@ type State struct {
 	RealizedPower        abi.StoragePower
 	CumsumBaseline       abi.Spacetime
 	CumsumRealized       abi.Spacetime
-	EffectiveNetworkTime big.Int
+	EffectiveNetworkTime abi.NetworkTime
 
 	SimpleSupply   abi.TokenAmount // current supply
 	BaselineSupply abi.TokenAmount // current supply


### PR DESCRIPTION
Update NetworkTime to be a fraction with an implicit denominator of (2^MintingInputFixedPoint) and fix integer division error when baseline reward is only minted when a unit of baseline power is met.