### PR TITLE
Change min miner power from 10TiB to 1TiB for testnet-2

### DIFF
--- a/actors/builtin/power/policy.go
+++ b/actors/builtin/power/policy.go
@@ -11,7 +11,7 @@ import (
 const ConsensusMinerMinMiners = 3
 
 // Minimum power of an individual miner to meet the threshold for leader election.
-var ConsensusMinerMinPower = abi.NewStoragePower(10 << 40) // PARAM_FINISH
+var ConsensusMinerMinPower = abi.NewStoragePower(1 << 40) // PARAM_FINISH
 
 var BaseMultiplier = big.NewInt(10)                // PARAM_FINISH
 var DealWeightMultiplier = big.NewInt(11)          // PARAM_FINISH


### PR DESCRIPTION
We can patch this at runtime in each impl, but it'll be way less confusing for other operators if the code has the right value.