### PR TITLE
Don't clear recovery declarations for future deadlines on PP boundary cron

### DIFF
--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -78,12 +78,11 @@ type State struct {
 	// The presence of a partition number indicates on-time PoSt received.
 	PostSubmissions *abi.BitField
 
-	// The index of the last deadline for which faults have been detected and processed, in the range
-	// [0, WPoStProvingPeriodDeadlines). The proving period cron handler will always set this to
-	// WPoStProvingPeriodDeadlines-1, representing the whole period having been processed,
-	// but eager processing on fault/recovery declarations or PoSt may set a smaller number, indicating partial
-	// progress, from which subsequent processing should continue.
-	// FIXME comment
+	// The index of the next deadline for which faults should been detected and processed (after it's closed).
+	// The proving period cron handler will always reset this to 0, for the subsequent period.
+	// Eager fault detection processing on fault/recovery declarations or PoSt may set a smaller number,
+	// indicating partial progress, from which subsequent processing should continue.
+	// In the range [0, WPoStProvingPeriodDeadlines).
 	NextDeadlineToProcessFaults uint64
 }
 

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -77,6 +77,14 @@ type State struct {
 	// Records successful PoSt submission in the current proving period by partition number.
 	// The presence of a partition number indicates on-time PoSt received.
 	PostSubmissions *abi.BitField
+
+	// The index of the last deadline for which faults have been detected and processed, in the range
+	// [0, WPoStProvingPeriodDeadlines). The proving period cron handler will always set this to
+	// WPoStProvingPeriodDeadlines-1, representing the whole period having been processed,
+	// but eager processing on fault/recovery declarations or PoSt may set a smaller number, indicating partial
+	// progress, from which subsequent processing should continue.
+	// FIXME comment
+	NextDeadlineToProcessFaults uint64
 }
 
 type MinerInfo struct {


### PR DESCRIPTION
Fixes the erroneous clearing of declared recoveries during the proving period cron (or other detect-faults hooks). See the linked issue for background.

I'm painfully aware that this behaviour doesn't have unit tests yet.

Fixes #387