### PR TITLE
Change WPoSt deadline duration to 40 minutes

### DIFF
--- a/actors/builtin/miner/cbor_gen.go
+++ b/actors/builtin/miner/cbor_gen.go
@@ -616,7 +616,7 @@ func (t *Deadlines) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.Due ([24]*bitfield.BitField) (array)
+	// t.Due ([36]*bitfield.BitField) (array)
 	if len(t.Due) > cbg.MaxLength {
 		return xerrors.Errorf("Slice value in field t.Due was too long")
 	}
@@ -647,7 +647,7 @@ func (t *Deadlines) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
-	// t.Due ([24]*bitfield.BitField) (array)
+	// t.Due ([36]*bitfield.BitField) (array)
 
 	maj, extra, err = cbg.CborReadHeader(br)
 	if err != nil {
@@ -662,11 +662,11 @@ func (t *Deadlines) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("expected cbor array")
 	}
 
-	if extra != 24 {
-		return fmt.Errorf("expected array to have 24 elements")
+	if extra != 36 {
+		return fmt.Errorf("expected array to have 36 elements")
 	}
 
-	t.Due = [24]*bitfield.BitField{}
+	t.Due = [36]*bitfield.BitField{}
 
 	for i := 0; i < int(extra); i++ {
 

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -12,7 +12,7 @@ import (
 const WPoStProvingPeriod = abi.ChainEpoch(builtin.EpochsInDay) // 24 hours
 
 // The duration of a deadline's challenge window, the period before a deadline when the challenge is available.
-const WPoStChallengeWindow = abi.ChainEpoch(3600 / builtin.EpochDurationSeconds) // An hour (=24 per day)
+const WPoStChallengeWindow = abi.ChainEpoch(40*60 / builtin.EpochDurationSeconds) // Half an hour (=48 per day)
 
 // The number of non-overlapping PoSt deadlines in each proving period.
 const WPoStPeriodDeadlines = uint64(WPoStProvingPeriod / WPoStChallengeWindow)

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -12,7 +12,7 @@ import (
 const WPoStProvingPeriod = abi.ChainEpoch(builtin.EpochsInDay) // 24 hours
 
 // The duration of a deadline's challenge window, the period before a deadline when the challenge is available.
-const WPoStChallengeWindow = abi.ChainEpoch(40*60 / builtin.EpochDurationSeconds) // Half an hour (=48 per day)
+const WPoStChallengeWindow = abi.ChainEpoch(40*60 / builtin.EpochDurationSeconds) // 40 minutes (36 per day)
 
 // The number of non-overlapping PoSt deadlines in each proving period.
 const WPoStPeriodDeadlines = uint64(WPoStProvingPeriod / WPoStChallengeWindow)


### PR DESCRIPTION
We believe proofs are now fast enough again that a ~half-hour~ 40 minute deadline duration is reasonable.

See #373 where this was changed to an hour.