### PR TITLE
Bug/sector expiry checks new expiry is valid

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -361,13 +361,7 @@ func (a Actor) PreCommitSector(rt Runtime, params *SectorPreCommitInfo) *adt.Emp
 			}
 		}
 
-		// Check expiry is exactly *the epoch before* the start of a proving period.
-		periodOffset := st.ProvingPeriodStart % WPoStProvingPeriod
-		expiryOffset := (params.Expiration + 1) % WPoStProvingPeriod
-		if expiryOffset != periodOffset {
-			rt.Abortf(exitcode.ErrIllegalArgument, "invalid expiration %d, must be immediately before proving period boundary %d mod %d",
-				params.Expiration, periodOffset, WPoStProvingPeriod)
-		}
+		validateExpiration(st, params.Expiration, rt)
 
 		newlyVestedFund, err := st.UnlockVestedFunds(store, rt.CurrEpoch())
 		availableBalance := st.GetAvailableBalance(rt.CurrentBalance())
@@ -608,6 +602,8 @@ func (a Actor) ExtendSectorExpiration(rt Runtime, params *ExtendSectorExpiration
 	var st State
 	rt.State().Readonly(&st)
 	rt.ValidateImmediateCallerIs(st.Info.Worker)
+
+	validateExpiration(st, params.NewExpiration, rt)
 
 	store := adt.AsStore(rt)
 	sectorNo := params.SectorNumber
@@ -1221,6 +1217,16 @@ func computeFaultsFromMissingPoSts(st *State, deadlines *Deadlines, sinceDeadlin
 		return nil, nil, fmt.Errorf("failed to union failed recovery groups: %w", err)
 	}
 	return
+}
+
+// Check expiry is exactly *the epoch before* the start of a proving period.
+func validateExpiration(st State, expiration abi.ChainEpoch, rt Runtime) {
+	periodOffset := st.ProvingPeriodStart % WPoStProvingPeriod
+	expiryOffset := (expiration + 1) % WPoStProvingPeriod
+	if expiryOffset != periodOffset {
+		rt.Abortf(exitcode.ErrIllegalArgument, "invalid expiration %d, must be immediately before proving period boundary %d mod %d",
+			expiration, periodOffset, WPoStProvingPeriod)
+	}
 }
 
 // Removes and returns sector numbers that expire at or before an epoch.

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -361,7 +361,7 @@ func (a Actor) PreCommitSector(rt Runtime, params *SectorPreCommitInfo) *adt.Emp
 			}
 		}
 
-		validateExpiration(st, params.Expiration, rt)
+		validateExpiration(rt, &st, params.Expiration)
 
 		newlyVestedFund, err := st.UnlockVestedFunds(store, rt.CurrEpoch())
 		availableBalance := st.GetAvailableBalance(rt.CurrentBalance())
@@ -603,7 +603,7 @@ func (a Actor) ExtendSectorExpiration(rt Runtime, params *ExtendSectorExpiration
 	rt.State().Readonly(&st)
 	rt.ValidateImmediateCallerIs(st.Info.Worker)
 
-	validateExpiration(st, params.NewExpiration, rt)
+	validateExpiration(rt, &st, params.NewExpiration)
 
 	store := adt.AsStore(rt)
 	sectorNo := params.SectorNumber
@@ -1220,7 +1220,7 @@ func computeFaultsFromMissingPoSts(st *State, deadlines *Deadlines, sinceDeadlin
 }
 
 // Check expiry is exactly *the epoch before* the start of a proving period.
-func validateExpiration(st State, expiration abi.ChainEpoch, rt Runtime) {
+func validateExpiration(rt Runtime, st *State, expiration abi.ChainEpoch) {
 	periodOffset := st.ProvingPeriodStart % WPoStProvingPeriod
 	expiryOffset := (expiration + 1) % WPoStProvingPeriod
 	if expiryOffset != periodOffset {

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -397,9 +397,20 @@ func TestExtendSectorExpiration(t *testing.T) {
 		WithHasher(fixedHasher(uint64(periodOffset))).
 		WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID)
 
-	t.Run("rejects negative extension", func(t *testing.T) {
-		rt, _, _, sector := setupExtension(t, builder, actor, periodOffset)
+	rt := builder.Build(t)
+	actor.constructAndVerify(rt, periodOffset)
+	precommitEpoch := abi.ChainEpoch(1)
+	rt.SetEpoch(precommitEpoch)
+	st := getState(rt)
+	deadline := st.DeadlineInfo(rt.Epoch())
+	expiration := deadline.PeriodEnd() + 10*miner.WPoStProvingPeriod
+	sectorInfo := actor.commitAndProveSectors(rt, 1, expiration, big.Zero())
 
+	sector, found, err := getState(rt).GetSector(rt.AdtStore(), sectorInfo[0].SectorNumber)
+	require.NoError(t, err)
+	require.True(t, found)
+
+	t.Run("rejects negative extension", func(t *testing.T) {
 		// attempt to shorten epoch
 		newExpiration := sector.Info.Expiration - abi.ChainEpoch(miner.WPoStProvingPeriod)
 		params := &miner.ExtendSectorExpirationParams{
@@ -412,9 +423,7 @@ func TestExtendSectorExpiration(t *testing.T) {
 		})
 	})
 
-	t.Run("rejects extention to invalid epoch", func(t *testing.T) {
-		rt, _, _, sector := setupExtension(t, builder, actor, periodOffset)
-
+	t.Run("rejects extension to invalid epoch", func(t *testing.T) {
 		// attempt to extend to an epoch that is not a multiple of the proving period + the commit epoch
 		extension := 42*miner.WPoStProvingPeriod + 1
 		newExpiration := sector.Info.Expiration - abi.ChainEpoch(extension)
@@ -429,8 +438,6 @@ func TestExtendSectorExpiration(t *testing.T) {
 	})
 
 	t.Run("updates expiration with valid params", func(t *testing.T) {
-		rt, st, expiration, sector := setupExtension(t, builder, actor, periodOffset)
-
 		extension := uint64(42 * miner.WPoStProvingPeriod)
 		newExpiration := sector.Info.Expiration + abi.ChainEpoch(extension)
 		params := &miner.ExtendSectorExpirationParams{
@@ -461,22 +468,6 @@ func TestExtendSectorExpiration(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, exists)
 	})
-}
-
-func setupExtension(t *testing.T, b *mock.RuntimeBuilder, a *actorHarness, periodOffset abi.ChainEpoch) (*mock.Runtime, *miner.State, abi.ChainEpoch, *miner.SectorOnChainInfo) {
-	rt := b.Build(t)
-	a.constructAndVerify(rt, periodOffset)
-	precommitEpoch := abi.ChainEpoch(1)
-	rt.SetEpoch(precommitEpoch)
-	st := getState(rt)
-	deadline := st.DeadlineInfo(rt.Epoch())
-	expiration := deadline.PeriodEnd() + 10*miner.WPoStProvingPeriod
-	sectorInfo := a.commitAndProveSectors(rt, 1, expiration, big.Zero())
-
-	sector, found, err := getState(rt).GetSector(rt.AdtStore(), sectorInfo[0].SectorNumber)
-	require.NoError(t, err)
-	require.True(t, found)
-	return rt, st, expiration, sector
 }
 
 type actorHarness struct {
@@ -721,14 +712,19 @@ func (h *actorHarness) submitWindowPost(rt *mock.Runtime, deadline *miner.Deadli
 }
 
 func (h *actorHarness) extendSector(rt *mock.Runtime, sector *miner.SectorOnChainInfo, extension uint64, params *miner.ExtendSectorExpirationParams) {
+	rt.Reset()
 	rt.SetCaller(h.worker, builtin.AccountActorCodeID)
 	rt.ExpectValidateCallerAddr(h.worker)
 
 	st := getState(rt)
 
 	storageWeightDescPrev := miner.AsStorageWeightDesc(st.Info.SectorSize, sector)
-	storageWeightDescNew := *storageWeightDescPrev
-	storageWeightDescNew.Duration += abi.ChainEpoch(extension)
+	storageWeightDescNew := power.SectorStorageWeightDesc{
+		SectorSize:         storageWeightDescPrev.SectorSize,
+		Duration:           storageWeightDescPrev.Duration + abi.ChainEpoch(extension),
+		DealWeight:         storageWeightDescPrev.DealWeight,
+		VerifiedDealWeight: storageWeightDescPrev.VerifiedDealWeight,
+	}
 
 	rt.ExpectSend(builtin.StoragePowerActorAddr,
 		builtin.MethodsPower.OnSectorModifyWeightDesc,


### PR DESCRIPTION
closes #394

### Motivation

Expiration for a sector must be set to the epoch before the proving period start. This is validated in `PreCommitSector`, but not in `ExtendSectorExpiration`.

### Proposed Changes

1. Execute the same validation in `ExtendSectorExpiration` by extracting it as a function in `miner.Actor`.
2. Test.