### PR TITLE
Load balance new sectors to less-full partitions

### DIFF
--- a/actors/builtin/miner/deadlines.go
+++ b/actors/builtin/miner/deadlines.go
@@ -239,7 +239,7 @@ func AssignNewSectors(deadlines *Deadlines, partitionSize uint64, newSectors []u
 
 	sortDeadlines := func() {
 		// Order deadline indexes by corresponding partition count (then secondarily by index) to form a queue.
-		sort.Slice(dlIdxs, func(i, j int) bool {
+		sort.SliceStable(dlIdxs, func(i, j int) bool {
 			idxI, idxJ := dlIdxs[i], dlIdxs[j]
 			countI, countJ := deadlinePartitionCounts[idxI], deadlinePartitionCounts[idxJ]
 			if countI == countJ {

--- a/actors/builtin/miner/deadlines.go
+++ b/actors/builtin/miner/deadlines.go
@@ -2,6 +2,8 @@ package miner
 
 import (
 	"fmt"
+	"math"
+	"sort"
 
 	"github.com/filecoin-project/specs-actors/actors/abi"
 )
@@ -175,6 +177,14 @@ func ComputePartitionsSectors(d *Deadlines, partitionSize uint64, deadlineIndex 
 // When multiple partitions share the minimal sector count, one is chosen at random (from a seed).
 func AssignNewSectors(deadlines *Deadlines, partitionSize uint64, newSectors []uint64, seed abi.Randomness) error {
 	nextNewSector := uint64(0)
+	// The first deadline is left empty since it's more difficult for a miner to orchestrate proofs. 
+	// The set of sectors due at the deadline isn't known until the proving period actually starts and any
+	// new sectors are assigned to it (here).
+	// Practically, a miner must also wait for some probabilistic finality after that before beginning proof
+	// calculations. 
+	// It's left empty so a miner has at least one challenge duration to prepare for proving after new sectors
+	// are assigned.
+	firstAssignableDeadline := uint64(1)
 
 	// Assigns up to `count` sectors to `deadline` and advances `nextNewSector`.
 	assignToDeadline := func(count uint64, deadline uint64) error {
@@ -191,9 +201,13 @@ func AssignNewSectors(deadlines *Deadlines, partitionSize uint64, newSectors []u
 	// Iterate deadlines and fill any partial partitions. There's no great advantage to filling more- or less-
 	// full ones first, so they're filled in sequence order.
 	// Meanwhile, record the partition count at each deadline.
-	// leaving first Window PoSt proving deadline empty
 	deadlinePartitionCounts := make([]uint64, WPoStPeriodDeadlines)
-	for i := uint64(1); i < WPoStPeriodDeadlines && nextNewSector < uint64(len(newSectors)); i++ {
+	for i := uint64(0); i < WPoStPeriodDeadlines && nextNewSector < uint64(len(newSectors)); i++ {
+		if i < firstAssignableDeadline {
+			// Mark unassignable deadlines as "full" so nothing more will be assigned.
+			deadlinePartitionCounts[i] = math.MaxUint64
+			continue
+		}
 		partitionCount, sectorCount, err := DeadlineCount(deadlines, partitionSize, i)
 		if err != nil {
 			return fmt.Errorf("failed to count sectors in partition %d: %w", i, err)
@@ -209,18 +223,45 @@ func AssignNewSectors(deadlines *Deadlines, partitionSize uint64, newSectors []u
 		}
 	}
 
-	// While there remain new sectors to assign, fill a new partition at each deadline in round-robin fashion.
-	// TODO WPOST (follow-up): fill less-full deadlines first, randomize when equally full.
-	targetDeadline := uint64(1)
+	// While there remain new sectors to assign, fill a new partition in one of the deadlines that is least full.
+	// Do this by maintaining a slice of deadline indexes sorted by partition count.
+	// Shuffling this slice to re-sort as weights change is O(n^2).
+	// For a large number of partitions, a heap would be the way to do this in O(n*log n), but for small numbers
+	// is probably overkill.
+	// A miner onboarding a monumental 1EiB of 32GiB sectors uniformly throughout a year will fill 40 partitions
+	// per proving period (40^2=1600). With 64GiB sectors, half that (20^2=400).
+	// TODO: randomize assignment among equally-full deadlines https://github.com/filecoin-project/specs-actors/issues/432
+
+	dlIdxs := make([]uint64, WPoStPeriodDeadlines)
+	for i := range dlIdxs {
+		dlIdxs[i] = uint64(i)
+	}
+
+	sortDeadlines := func() {
+		// Order deadline indexes by corresponding partition count (then secondarily by index) to form a queue.
+		sort.Slice(dlIdxs, func(i, j int) bool {
+			idxI, idxJ := dlIdxs[i], dlIdxs[j]
+			countI, countJ := deadlinePartitionCounts[idxI], deadlinePartitionCounts[idxJ]
+			if countI == countJ {
+				return idxI < idxJ
+			}
+			return countI < countJ
+		})
+	}
+
+	sortDeadlines()
 	for nextNewSector < uint64(len(newSectors)) {
+		// Assign a full partition to the least-full deadline.
+		targetDeadline := dlIdxs[0]
 		err := assignToDeadline(partitionSize, targetDeadline)
 		if err != nil {
 			return err
 		}
-		targetDeadline = (targetDeadline + 1) % WPoStPeriodDeadlines
-		if targetDeadline == 0 {
-			targetDeadline++
-		}
+		deadlinePartitionCounts[targetDeadline]++
+		// Re-sort the queue.
+		// Only the first element has changed, the remainder is still sorted, so with an insertion-sort under
+		// the hood this will be linear.
+		sortDeadlines()
 	}
 	return nil
 }

--- a/actors/builtin/miner/deadlines_test.go
+++ b/actors/builtin/miner/deadlines_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
 )
 
-const partSize = uint64(1000)
-
 func TestProvingPeriodDeadlines(t *testing.T) {
 	PP := miner.WPoStProvingPeriod
 	CW := miner.WPoStChallengeWindow
@@ -154,8 +152,10 @@ func makeDeadline(currEpoch, periodStart abi.ChainEpoch, index uint64, deadlineO
 }
 
 func TestPartitionsForDeadline(t *testing.T) {
+	const partSize = uint64(1000)
+
 	t.Run("empty deadlines", func(t *testing.T) {
-		dl := deadlineWithSectors(t, [miner.WPoStPeriodDeadlines]uint64{})
+		dl := buildDeadlines(t, []uint64{})
 		firstIndex, sectorCount, err := miner.PartitionsForDeadline(dl, partSize, 0)
 		require.NoError(t, err)
 		assert.Equal(t, uint64(0), firstIndex)
@@ -168,7 +168,7 @@ func TestPartitionsForDeadline(t *testing.T) {
 	})
 
 	t.Run("single sector at first deadline", func(t *testing.T) {
-		dl := deadlineWithSectors(t, [miner.WPoStPeriodDeadlines]uint64{1})
+		dl := buildDeadlines(t, []uint64{1})
 		firstIndex, sectorCount, err := miner.PartitionsForDeadline(dl, partSize, 0)
 		require.NoError(t, err)
 		assert.Equal(t, uint64(0), firstIndex)
@@ -186,7 +186,7 @@ func TestPartitionsForDeadline(t *testing.T) {
 	})
 
 	t.Run("single sector at non-first deadline", func(t *testing.T) {
-		dl := deadlineWithSectors(t, [miner.WPoStPeriodDeadlines]uint64{0, 1})
+		dl := buildDeadlines(t, []uint64{0, 1})
 		firstIndex, sectorCount, err := miner.PartitionsForDeadline(dl, partSize, 0)
 		require.NoError(t, err)
 		assert.Equal(t, uint64(0), firstIndex)
@@ -209,7 +209,7 @@ func TestPartitionsForDeadline(t *testing.T) {
 	})
 
 	t.Run("deadlines with one full partitions", func(t *testing.T) {
-		dl := deadlinesWithFullPartitions(t, 1)
+		dl := NewDeadlinesBuilder(t).addToAll(partSize).Deadlines
 		firstIndex, sectorCount, err := miner.PartitionsForDeadline(dl, partSize, 0)
 		require.NoError(t, err)
 		assert.Equal(t, uint64(0), firstIndex)
@@ -227,7 +227,7 @@ func TestPartitionsForDeadline(t *testing.T) {
 	})
 
 	t.Run("partial partitions", func(t *testing.T) {
-		dl := deadlineWithSectors(t, [miner.WPoStPeriodDeadlines]uint64{
+		dl := buildDeadlines(t, []uint64{
 			0: partSize - 1,
 			1: partSize,
 			2: partSize - 2,
@@ -257,7 +257,7 @@ func TestPartitionsForDeadline(t *testing.T) {
 	})
 
 	t.Run("multiple partitions", func(t *testing.T) {
-		dl := deadlineWithSectors(t, [miner.WPoStPeriodDeadlines]uint64{
+		dl := buildDeadlines(t, []uint64{
 			0: partSize,       // 1 partition 1 total
 			1: partSize * 2,   // 2 partitions 3 total
 			2: partSize*4 - 1, // 4 partitions 7 total
@@ -304,9 +304,11 @@ func TestPartitionsForDeadline(t *testing.T) {
 }
 
 func TestComputePartitionsSectors(t *testing.T) {
+	const partSize = uint64(1000)
+
 	t.Run("no partitions due at empty deadline", func(t *testing.T) {
 		dls := miner.ConstructDeadlines()
-		dls.Due[1] = bf(0, 1)
+		dls.Due[1] = bfSeq(0, 1)
 
 		// No partitions at deadline 0
 		_, err := miner.ComputePartitionsSectors(dls, partSize, 0, []uint64{0})
@@ -322,55 +324,55 @@ func TestComputePartitionsSectors(t *testing.T) {
 	})
 	t.Run("single sector", func(t *testing.T) {
 		dls := miner.ConstructDeadlines()
-		dls.Due[1] = bf(0, 1)
+		dls.Due[1] = bfSeq(0, 1)
 		partitions, err := miner.ComputePartitionsSectors(dls, partSize, 1, []uint64{0})
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(partitions))
-		assertBfEqual(t, bf(0, 1), partitions[0])
+		assertBfEqual(t, bfSeq(0, 1), partitions[0])
 	})
 	t.Run("full partition", func(t *testing.T) {
 		dls := miner.ConstructDeadlines()
-		dls.Due[10] = bf(1234, partSize)
+		dls.Due[10] = bfSeq(1234, partSize)
 		partitions, err := miner.ComputePartitionsSectors(dls, partSize, 10, []uint64{0})
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(partitions))
-		assertBfEqual(t, bf(1234, partSize), partitions[0])
+		assertBfEqual(t, bfSeq(1234, partSize), partitions[0])
 	})
 	t.Run("full plus partial partition", func(t *testing.T) {
 		dls := miner.ConstructDeadlines()
-		dls.Due[10] = bf(5555, partSize+1)
+		dls.Due[10] = bfSeq(5555, partSize+1)
 		partitions, err := miner.ComputePartitionsSectors(dls, partSize, 10, []uint64{0}) // First partition
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(partitions))
-		assertBfEqual(t, bf(5555, partSize), partitions[0])
+		assertBfEqual(t, bfSeq(5555, partSize), partitions[0])
 
 		partitions, err = miner.ComputePartitionsSectors(dls, partSize, 10, []uint64{1}) // Second partition
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(partitions))
-		assertBfEqual(t, bf(5555+partSize, 1), partitions[0])
+		assertBfEqual(t, bfSeq(5555+partSize, 1), partitions[0])
 
 		partitions, err = miner.ComputePartitionsSectors(dls, partSize, 10, []uint64{0, 1}) // Both partitions
 		require.NoError(t, err)
 		assert.Equal(t, 2, len(partitions))
-		assertBfEqual(t, bf(5555, partSize), partitions[0])
-		assertBfEqual(t, bf(5555+partSize, 1), partitions[1])
+		assertBfEqual(t, bfSeq(5555, partSize), partitions[0])
+		assertBfEqual(t, bfSeq(5555+partSize, 1), partitions[1])
 	})
 	t.Run("multiple partitions", func(t *testing.T) {
 		dls := miner.ConstructDeadlines()
-		dls.Due[1] = bf(0, 3*partSize+1)
+		dls.Due[1] = bfSeq(0, 3*partSize+1)
 		partitions, err := miner.ComputePartitionsSectors(dls, partSize, 1, []uint64{0, 1, 2, 3})
 		require.NoError(t, err)
 		assert.Equal(t, 4, len(partitions))
-		assertBfEqual(t, bf(0, partSize), partitions[0])
-		assertBfEqual(t, bf(1*partSize, partSize), partitions[1])
-		assertBfEqual(t, bf(2*partSize, partSize), partitions[2])
-		assertBfEqual(t, bf(3*partSize, 1), partitions[3])
+		assertBfEqual(t, bfSeq(0, partSize), partitions[0])
+		assertBfEqual(t, bfSeq(1*partSize, partSize), partitions[1])
+		assertBfEqual(t, bfSeq(2*partSize, partSize), partitions[2])
+		assertBfEqual(t, bfSeq(3*partSize, 1), partitions[3])
 	})
 	t.Run("partitions numbered across deadlines", func(t *testing.T) {
 		dls := miner.ConstructDeadlines()
-		dls.Due[1] = bf(0, 3*partSize+1)
-		dls.Due[3] = bf(3*partSize+1, 1)
-		dls.Due[5] = bf(3*partSize+1+1, 2*partSize)
+		dls.Due[1] = bfSeq(0, 3*partSize+1)
+		dls.Due[3] = bfSeq(3*partSize+1, 1)
+		dls.Due[5] = bfSeq(3*partSize+1+1, 2*partSize)
 
 		partitions, err := miner.ComputePartitionsSectors(dls, partSize, 1, []uint64{0, 1, 2, 3})
 		require.NoError(t, err)
@@ -379,13 +381,13 @@ func TestComputePartitionsSectors(t *testing.T) {
 		partitions, err = miner.ComputePartitionsSectors(dls, partSize, 3, []uint64{4})
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(partitions))
-		assertBfEqual(t, bf(3*partSize+1, 1), partitions[0])
+		assertBfEqual(t, bfSeq(3*partSize+1, 1), partitions[0])
 
 		partitions, err = miner.ComputePartitionsSectors(dls, partSize, 5, []uint64{5, 6})
 		require.NoError(t, err)
 		assert.Equal(t, 2, len(partitions))
-		assertBfEqual(t, bf(3*partSize+1+1, partSize), partitions[0])
-		assertBfEqual(t, bf(3*partSize+1+1+partSize, partSize), partitions[1])
+		assertBfEqual(t, bfSeq(3*partSize+1+1, partSize), partitions[0])
+		assertBfEqual(t, bfSeq(3*partSize+1+1+partSize, partSize), partitions[1])
 
 		// Mismatched deadline/partition pairs
 		_, err = miner.ComputePartitionsSectors(dls, partSize, 1, []uint64{4})
@@ -407,6 +409,109 @@ func TestComputePartitionsSectors(t *testing.T) {
 	})
 }
 
+func TestAssignNewSectors(t *testing.T) {
+	partSize := uint64(4)
+	seed := abi.Randomness([]byte{})
+
+	assign := func(deadlines *miner.Deadlines, sectors []uint64) *miner.Deadlines {
+		require.NoError(t, miner.AssignNewSectors(deadlines, partSize, sectors, seed))
+		return deadlines
+	}
+
+	t.Run("initial assignment", func(t *testing.T) {
+		{
+			deadlines := assign(miner.ConstructDeadlines(), seq(0, 0))
+			NewDeadlinesBuilder(t).verify(deadlines)
+		}
+		{
+			deadlines := assign(miner.ConstructDeadlines(), seq(0, 1))
+			NewDeadlinesBuilder(t, 0, 1).verify(deadlines)
+		}
+		{
+			deadlines := assign(miner.ConstructDeadlines(), seq(0, 15))
+			NewDeadlinesBuilder(t, 0, 4, 4, 4, 3).verify(deadlines)
+		}
+		{
+			deadlines := assign(miner.ConstructDeadlines(), seq(0, (miner.WPoStPeriodDeadlines-1)*partSize+1))
+			NewDeadlinesBuilder(t).addToAllFrom(1, partSize).addTo(1, 1).verify(deadlines)
+		}
+	})
+	t.Run("incremental assignment", func(t *testing.T) {
+		{
+			// Add one sector at a time.
+			deadlines := NewDeadlinesBuilder(t, 0, 1).Deadlines
+			assign(deadlines, seq(1, 1))
+			NewDeadlinesBuilder(t, 0, 2).verify(deadlines)
+			assign(deadlines, seq(2, 1))
+			NewDeadlinesBuilder(t, 0, 3).verify(deadlines)
+			assign(deadlines, seq(3, 1))
+			NewDeadlinesBuilder(t, 0, 4).verify(deadlines)
+			assign(deadlines, seq(4, 1))
+			NewDeadlinesBuilder(t, 0, 4, 1).verify(deadlines)
+		}
+		{
+			// Add one partition at a time.
+			deadlines := miner.ConstructDeadlines()
+			assign(deadlines, seq(0, 4))
+			NewDeadlinesBuilder(t, 0, 4).verify(deadlines)
+			assign(deadlines, seq(4, 4))
+			NewDeadlinesBuilder(t, 0, 4, 4).verify(deadlines)
+			assign(deadlines, seq(2*4, 4))
+			NewDeadlinesBuilder(t, 0, 4, 4, 4).verify(deadlines)
+			assign(deadlines, seq(3*4, 4))
+			NewDeadlinesBuilder(t, 0, 4, 4, 4, 4).verify(deadlines)
+		}
+		{
+			// Add lots
+			deadlines := miner.ConstructDeadlines()
+			assign(deadlines, seq(0, 2*partSize+1))
+			NewDeadlinesBuilder(t, 0, partSize, partSize, 1).verify(deadlines)
+			assign(deadlines, seq(2*partSize+1, partSize))
+			NewDeadlinesBuilder(t, 0, partSize, partSize, partSize, 1).verify(deadlines)
+		}
+	})
+	t.Run("fill partial partitions first", func(t *testing.T) {
+		{
+			b := NewDeadlinesBuilder(t, 0, 4, 3, 1)
+			deadlines := assign(b.Deadlines, seq(b.NextSectorIdx, 4))
+
+			NewDeadlinesBuilder(t, 0, 4, 3, 1).
+				addTo(2, 1). // Fill the first partial partition
+				addTo(3, 3). // Fill the next partial partition
+				verify(deadlines)
+		}
+		{
+			b := NewDeadlinesBuilder(t, 0, 9, 8, 7, 4, 1)
+			deadlines := assign(b.Deadlines, seq(b.NextSectorIdx, 7))
+
+			NewDeadlinesBuilder(t, 0, 9, 8, 7, 4, 1).
+				addTo(1, 3). // Fill the first partial partition, in deadline 1
+				addTo(3, 1). // Fill the next partial partition
+				addTo(5, 3). // Fill the final partial partition
+				verify(deadlines)
+		}
+	})
+	t.Run("fill less full deadlines first", func(t *testing.T) {
+		{
+			b := NewDeadlinesBuilder(t, 0, 12, 4, 4, 8).
+				addToAllFrom(5, 100) // Fill  trailing deadlines so we can just use the first few.
+			deadlines := b.Deadlines
+			assign(deadlines, seq(b.NextSectorIdx, 20))
+
+			NewDeadlinesBuilder(t, 0, 12, 4, 4, 8).
+				addToAllFrom(5, 100).
+				addTo(2, 4).
+				addTo(3, 4).
+				addTo(2, 4).
+				addTo(3, 4).
+				addTo(4, 4).
+				verify(deadlines)
+		}
+	})
+	// TODO: a final test including partial and full partitions that exercises both filling the partials first,
+	// then prioritising the less full deadlines.
+}
+
 //
 // Deadlines Utils
 //
@@ -419,21 +524,29 @@ func assertBfEqual(t *testing.T, expected, actual *bitfield.BitField) {
 	assert.Equal(t, ex, ac)
 }
 
-// Creates a bitfield with a contiguous run of `count` values from `first.
-func bf(first uint64, count uint64) *abi.BitField {
+func assertDeadlinesEqual(t *testing.T, expected, actual *miner.Deadlines) {
+	for i := range expected.Due {
+		ex, err := expected.Due[i].All(1 << 20)
+		require.NoError(t, err)
+		ac, err := actual.Due[i].All(1 << 20)
+		require.NoError(t, err)
+		assert.Equal(t, ex, ac, "mismatched deadlines at index %d", i)
+	}
+}
+
+// Creates a bitfield with a sequence of `count` values from `first.
+func bfSeq(first uint64, count uint64) *abi.BitField {
+	values := seq(first, count)
+	return bitfield.NewFromSet(values)
+}
+
+// Creates a slice of integers with a sequence of `count` values from `first.
+func seq(first uint64, count uint64) []uint64 {
 	values := make([]uint64, count)
 	for i := range values {
 		values[i] = first + uint64(i)
 	}
-	return bitfield.NewFromSet(values)
-}
-
-func deadlinesWithFullPartitions(t *testing.T, n uint64) *miner.Deadlines {
-	gen := [miner.WPoStPeriodDeadlines]uint64{}
-	for i := range gen {
-		gen[i] = partSize * n
-	}
-	return deadlineWithSectors(t, gen)
+	return values
 }
 
 // accepts an array were the value at each index indicates how many sectors are in the partition of the returned Deadlines
@@ -443,17 +556,57 @@ func deadlinesWithFullPartitions(t *testing.T, n uint64) *miner.Deadlines {
 // 42 sectors at deadlineIdx 1
 // 89 sectors at deadlineIdx 2
 // 0  sectors at deadlineIdx 3-47
-func deadlineWithSectors(t *testing.T, gen [miner.WPoStPeriodDeadlines]uint64) *miner.Deadlines {
-	// ensure there are no duplicate sectors across partitions
-	var sectorIdx uint64
-	dls := miner.ConstructDeadlines()
-	for partition, numSectors := range gen {
-		var sectors []uint64
-		for i := uint64(0); i < numSectors; i++ {
-			sectors = append(sectors, sectorIdx)
-			sectorIdx++
-		}
-		require.NoError(t, dls.AddToDeadline(uint64(partition), sectors...))
+func buildDeadlines(t *testing.T, gen []uint64) *miner.Deadlines {
+	return NewDeadlinesBuilder(t).addToFrom(0, gen...).Deadlines
+}
+
+// A builder for initialising a Deadlines with sectors assigned.
+type DeadlinesBuilder struct {
+	Deadlines     *miner.Deadlines
+	NextSectorIdx uint64
+	t             *testing.T
+}
+
+// Creates a new builder with, with optional initial sector counts.
+func NewDeadlinesBuilder(t *testing.T, counts ...uint64) *DeadlinesBuilder {
+	b := &DeadlinesBuilder{miner.ConstructDeadlines(), 0, t}
+	b.addToFrom(0, counts...)
+	return b
+}
+
+// Assigns count new sectors to deadline idx.
+func (b *DeadlinesBuilder) addTo(idx uint64, count uint64) *DeadlinesBuilder {
+	nums := seq(b.NextSectorIdx, count)
+	b.NextSectorIdx += count
+	require.NoError(b.t, b.Deadlines.AddToDeadline(idx, nums...))
+	return b
+}
+
+// Assigns counts[i] new sectors to deadlines sequentially from first.
+func (b *DeadlinesBuilder) addToFrom(first uint64, counts ...uint64) *DeadlinesBuilder {
+	for i, c := range counts {
+		b.addTo(first+uint64(i), c)
 	}
-	return dls
+	return b
+}
+
+// Assigns count new sectors to every deadline.
+func (b *DeadlinesBuilder) addToAll(count uint64) *DeadlinesBuilder {
+	for i := range b.Deadlines.Due {
+		b.addTo(uint64(i), count)
+	}
+	return b
+}
+
+// Assigns count new sectors to every deadline from first until the last.
+func (b *DeadlinesBuilder) addToAllFrom(first uint64, count uint64) *DeadlinesBuilder {
+	for i := first; i < miner.WPoStPeriodDeadlines; i++ {
+		b.addTo(i, count)
+	}
+	return b
+}
+
+// Verifies that deadlines match this builder as expected values.
+func (b *DeadlinesBuilder) verify(actual *miner.Deadlines) {
+	assertDeadlinesEqual(b.t, b.Deadlines, actual)
 }

--- a/actors/builtin/miner/deadlines_test.go
+++ b/actors/builtin/miner/deadlines_test.go
@@ -567,7 +567,7 @@ type DeadlinesBuilder struct {
 	t             *testing.T
 }
 
-// Creates a new builder with, with optional initial sector counts.
+// Creates a new builder, with optional initial sector counts.
 func NewDeadlinesBuilder(t *testing.T, counts ...uint64) *DeadlinesBuilder {
 	b := &DeadlinesBuilder{miner.ConstructDeadlines(), 0, t}
 	b.addToFrom(0, counts...)


### PR DESCRIPTION
Fixes the assignment of new sectors to deadlines to open new partitions in one of the least-full deadlines, rather than a simple round robin always starting from the first (which led the first deadline to get ~all the sectors in practice).

See discussion in the comments about efficiency trade-offs made.

Closes #409, closes #402.