### PR TITLE
miner actor does not get randomness from future

### DIFF
--- a/support/mock/mockrt.go
+++ b/support/mock/mockrt.go
@@ -221,6 +221,12 @@ func (rt *Runtime) GetRandomness(tag crypto.DomainSeparationTag, epoch abi.Chain
 	if len(rt.expectRandomness) == 0 {
 		rt.failTestNow("unexpected call to get randomness for tag %v, epoch %v", tag, epoch)
 	}
+
+	if epoch > rt.epoch {
+		rt.failTestNow("attempt to get randomness from future\n"+
+			"         requested epoch: %d greater than current epoch %d\n", epoch, rt.epoch)
+	}
+
 	exp := rt.expectRandomness[0]
 	if tag != exp.tag || epoch != exp.epoch || !bytes.Equal(entropy, exp.entropy) {
 		rt.failTest("unexpected get randomness\n"+


### PR DESCRIPTION
closes #406

### Motivation

In the first proving period, the miner actor may attempt to retrieve randomness from the future when it handles the proving period cron task. In this case it should retrieve the randomness from the current epoch minus a lookback.

### Proposed Changes

1. Set the randomness epoch to be the min of of the proving period end and the current epoch - `ElectionLookback`. It is unclear whether this deserves a new constant or not. The thinking is that whatever would cause us to change `ElectionLookback` would drive us to change this value as well, so we might as well reuse it.
2. Add a test that runs `handleProvingPeriod` in scenarios where the miner would have required randomness from the future and another where it would get it from the proving period end.
3. Add the ability for the actor harness to submit PoSt on deadlines so we can run `handleProvingPeriod` with sectors in proving periods other than the first without incurring faults. This is a bit heavyweight for this test, but I suspect we'll need it later.