### PR TITLE
Change ExpectedLeadersPerEpoch to a const

### DIFF
--- a/actors/builtin/network.go
+++ b/actors/builtin/network.go
@@ -16,8 +16,8 @@ const EpochsInHour = SecondsInHour / EpochDurationSeconds
 const EpochsInDay = SecondsInDay / EpochDurationSeconds
 const EpochsInYear = SecondsInYear / EpochDurationSeconds
 
-// The expected number of block producers in each epoch.
-var ExpectedLeadersPerEpoch = int64(5)
+// ExpectedLeadersPerEpoch is the expected number of block producers in each epoch.
+const ExpectedLeadersPerEpoch = 5
 
 func init() {
 	//noinspection GoBoolExpressions


### PR DESCRIPTION
Just switch to see why it was a var, and figured might as well PR in even though very trivial change