### PR TITLE
Refactor RegisteredProof to agree with proofs API.

### DIFF
--- a/actors/abi/cbor_gen.go
+++ b/actors/abi/cbor_gen.go
@@ -160,12 +160,12 @@ func (t *SectorInfo) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.RegisteredProof (abi.RegisteredProof) (int64)
-	if t.RegisteredProof >= 0 {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.RegisteredProof))); err != nil {
+	if t.RegisteredSealProof >= 0 {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.RegisteredSealProof))); err != nil {
 			return err
 		}
 	} else {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.RegisteredProof)-1)); err != nil {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.RegisteredSealProof)-1)); err != nil {
 			return err
 		}
 	}
@@ -223,7 +223,7 @@ func (t *SectorInfo) UnmarshalCBOR(r io.Reader) error {
 			return fmt.Errorf("wrong type for int64 field: %d", maj)
 		}
 
-		t.RegisteredProof = RegisteredProof(extraI)
+		t.RegisteredSealProof = RegisteredSealProof(extraI)
 	}
 	// t.SectorNumber (abi.SectorNumber) (uint64)
 
@@ -263,13 +263,13 @@ func (t *SealVerifyInfo) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.RegisteredProof (abi.RegisteredProof) (int64)
-	if t.RegisteredProof >= 0 {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.RegisteredProof))); err != nil {
+	// t.RegisteredSealProof (abi.RegisteredProof) (int64)
+	if t.RegisteredSealProof >= 0 {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.RegisteredSealProof))); err != nil {
 			return err
 		}
 	} else {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.RegisteredProof)-1)); err != nil {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.RegisteredSealProof)-1)); err != nil {
 			return err
 		}
 	}
@@ -382,7 +382,7 @@ func (t *SealVerifyInfo) UnmarshalCBOR(r io.Reader) error {
 			return fmt.Errorf("wrong type for int64 field: %d", maj)
 		}
 
-		t.RegisteredProof = RegisteredProof(extraI)
+		t.RegisteredSealProof = RegisteredSealProof(extraI)
 	}
 	// t.SectorID (abi.SectorID) (struct)
 
@@ -514,12 +514,12 @@ func (t *PoStProof) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.RegisteredProof (abi.RegisteredProof) (int64)
-	if t.RegisteredProof >= 0 {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.RegisteredProof))); err != nil {
+	if t.RegisteredPoStProof >= 0 {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.RegisteredPoStProof))); err != nil {
 			return err
 		}
 	} else {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.RegisteredProof)-1)); err != nil {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.RegisteredPoStProof)-1)); err != nil {
 			return err
 		}
 	}
@@ -576,7 +576,7 @@ func (t *PoStProof) UnmarshalCBOR(r io.Reader) error {
 			return fmt.Errorf("wrong type for int64 field: %d", maj)
 		}
 
-		t.RegisteredProof = RegisteredProof(extraI)
+		t.RegisteredPoStProof = RegisteredPoStProof(extraI)
 	}
 	// t.ProofBytes ([]uint8) (slice)
 

--- a/actors/abi/cbor_gen.go
+++ b/actors/abi/cbor_gen.go
@@ -159,13 +159,13 @@ func (t *SectorInfo) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.RegisteredProof (abi.RegisteredProof) (int64)
-	if t.RegisteredSealProof >= 0 {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.RegisteredSealProof))); err != nil {
+	// t.SealProof (abi.RegisteredProof) (int64)
+	if t.SealProof >= 0 {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.SealProof))); err != nil {
 			return err
 		}
 	} else {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.RegisteredSealProof)-1)); err != nil {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.SealProof)-1)); err != nil {
 			return err
 		}
 	}
@@ -223,7 +223,7 @@ func (t *SectorInfo) UnmarshalCBOR(r io.Reader) error {
 			return fmt.Errorf("wrong type for int64 field: %d", maj)
 		}
 
-		t.RegisteredSealProof = RegisteredSealProof(extraI)
+		t.SealProof = RegisteredSealProof(extraI)
 	}
 	// t.SectorNumber (abi.SectorNumber) (uint64)
 
@@ -264,12 +264,12 @@ func (t *SealVerifyInfo) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.RegisteredSealProof (abi.RegisteredProof) (int64)
-	if t.RegisteredSealProof >= 0 {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.RegisteredSealProof))); err != nil {
+	if t.SealProof >= 0 {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.SealProof))); err != nil {
 			return err
 		}
 	} else {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.RegisteredSealProof)-1)); err != nil {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.SealProof)-1)); err != nil {
 			return err
 		}
 	}
@@ -382,7 +382,7 @@ func (t *SealVerifyInfo) UnmarshalCBOR(r io.Reader) error {
 			return fmt.Errorf("wrong type for int64 field: %d", maj)
 		}
 
-		t.RegisteredSealProof = RegisteredSealProof(extraI)
+		t.SealProof = RegisteredSealProof(extraI)
 	}
 	// t.SectorID (abi.SectorID) (struct)
 
@@ -514,12 +514,12 @@ func (t *PoStProof) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.RegisteredProof (abi.RegisteredProof) (int64)
-	if t.RegisteredPoStProof >= 0 {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.RegisteredPoStProof))); err != nil {
+	if t.PoStProof >= 0 {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.PoStProof))); err != nil {
 			return err
 		}
 	} else {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.RegisteredPoStProof)-1)); err != nil {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.PoStProof)-1)); err != nil {
 			return err
 		}
 	}
@@ -576,7 +576,7 @@ func (t *PoStProof) UnmarshalCBOR(r io.Reader) error {
 			return fmt.Errorf("wrong type for int64 field: %d", maj)
 		}
 
-		t.RegisteredPoStProof = RegisteredPoStProof(extraI)
+		t.PoStProof = RegisteredPoStProof(extraI)
 	}
 	// t.ProofBytes ([]uint8) (slice)
 

--- a/actors/abi/sector.go
+++ b/actors/abi/sector.go
@@ -109,16 +109,16 @@ func (p RegisteredPoStProof) RegisteredSealProof() (RegisteredSealProof, error) 
 
 func (p RegisteredSealProof) SectorSize() (SectorSize, error) {
 	switch p {
-	case RegisteredSealProof_StackedDrg64GiBV1:
-		return 2 * (32 << 30), nil
-	case RegisteredSealProof_StackedDrg32GiBV1:
-		return 32 << 30, nil
 	case RegisteredSealProof_StackedDrg2KiBV1:
 		return 2 << 10, nil
 	case RegisteredSealProof_StackedDrg8MiBV1:
 		return 8 << 20, nil
 	case RegisteredSealProof_StackedDrg512MiBV1:
 		return 512 << 20, nil
+	case RegisteredSealProof_StackedDrg32GiBV1:
+		return 32 << 30, nil
+	case RegisteredSealProof_StackedDrg64GiBV1:
+		return 2 * (32 << 30), nil
 	default:
 		return 0, errors.Errorf("unsupported proof type: %v", p)
 	}
@@ -184,18 +184,6 @@ func (p RegisteredSealProof) RegisteredWinningPoStProof() (RegisteredPoStProof, 
 	}
 }
 
-// RegisteredWinningPoStProof produces the PoSt-specific RegisteredProof corresponding
-// to the receiving RegisteredProof.
-func (p RegisteredPoStProof) RegisteredWinningPoStProof() (RegisteredPoStProof, error) {
-	// Resolve to seal proof and then compute Winning PoSt from that.
-	sp, err := p.RegisteredSealProof()
-	if err != nil {
-		return 0, err
-	}
-	return sp.RegisteredWinningPoStProof()
-}
-
-
 // RegisteredWindowPoStProof produces the PoSt-specific RegisteredProof corresponding
 // to the receiving RegisteredProof.
 func (p RegisteredSealProof) RegisteredWindowPoStProof() (RegisteredPoStProof, error) {
@@ -215,17 +203,6 @@ func (p RegisteredSealProof) RegisteredWindowPoStProof() (RegisteredPoStProof, e
 	}
 }
 
-// RegisteredWindowPoStProof produces the PoSt-specific RegisteredProof corresponding
-// to the receiving RegisteredProof.
-func (p RegisteredPoStProof) RegisteredWindowPoStProof() (RegisteredPoStProof, error) {
-	// Resolve to seal proof and then compute Window PoSt from that.
-	sp, err := p.RegisteredSealProof()
-	if err != nil {
-		return 0, err
-	}
-	return sp.RegisteredWindowPoStProof()
-}
-
 ///
 /// Sealing
 ///
@@ -235,9 +212,8 @@ type InteractiveSealRandomness Randomness
 
 // Information needed to verify a seal proof.
 type SealVerifyInfo struct {
-	RegisteredSealProof
+	SealProof             RegisteredSealProof
 	SectorID
-
 	DealIDs               []DealID
 	Randomness            SealRandomness
 	InteractiveRandomness InteractiveSealRandomness
@@ -254,13 +230,13 @@ type PoStRandomness Randomness
 
 // Information about a sector necessary for PoSt verification.
 type SectorInfo struct {
-	RegisteredSealProof // RegisteredProof used when sealing - needs to be mapped to PoSt registered proof when used to verify a PoSt
+	SealProof       RegisteredSealProof // RegisteredProof used when sealing - needs to be mapped to PoSt registered proof when used to verify a PoSt
 	SectorNumber    SectorNumber
 	SealedCID       cid.Cid // CommR
 }
 
 type PoStProof struct {
-	RegisteredPoStProof
+	PoStProof  RegisteredPoStProof
 	ProofBytes []byte
 }
 

--- a/actors/abi/sector.go
+++ b/actors/abi/sector.go
@@ -64,99 +64,152 @@ func NewStoragePower(n int64) StoragePower {
 	return big.NewInt(n)
 }
 
+type RegisteredProof = int64
+
 // This ordering, defines mappings to UInt in a way which MUST never change.
-type RegisteredProof int64
-
+type RegisteredSealProof RegisteredProof
 const (
-	RegisteredProof_StackedDRG32GiBSeal  = RegisteredProof(1)
-	RegisteredProof_StackedDRG32GiBPoSt  = RegisteredProof(2) // No longer used
-	RegisteredProof_StackedDRG2KiBSeal   = RegisteredProof(3)
-	RegisteredProof_StackedDRG2KiBPoSt   = RegisteredProof(4) // No longer used
-	RegisteredProof_StackedDRG8MiBSeal   = RegisteredProof(5)
-	RegisteredProof_StackedDRG8MiBPoSt   = RegisteredProof(6) // No longer used
-	RegisteredProof_StackedDRG512MiBSeal = RegisteredProof(7)
-	RegisteredProof_StackedDRG512MiBPoSt = RegisteredProof(8) // No longer used
-
-	RegisteredProof_StackedDRG2KiBWinningPoSt = RegisteredProof(9)
-	RegisteredProof_StackedDRG2KiBWindowPoSt  = RegisteredProof(10)
-
-	RegisteredProof_StackedDRG8MiBWinningPoSt = RegisteredProof(11)
-	RegisteredProof_StackedDRG8MiBWindowPoSt  = RegisteredProof(12)
-
-	RegisteredProof_StackedDRG512MiBWinningPoSt = RegisteredProof(13)
-	RegisteredProof_StackedDRG512MiBWindowPoSt  = RegisteredProof(14)
-
-	RegisteredProof_StackedDRG32GiBWinningPoSt = RegisteredProof(15)
-	RegisteredProof_StackedDRG32GiBWindowPoSt  = RegisteredProof(16)
-
-	RegisteredProof_StackedDRG64GiBSeal = RegisteredProof(17)
-
-	RegisteredProof_StackedDRG64GiBWinningPoSt = RegisteredProof(18)
-	RegisteredProof_StackedDRG64GiBWindowPoSt  = RegisteredProof(19)
+	RegisteredSealProof_StackedDrg2KiBV1 = RegisteredSealProof(0);
+	RegisteredSealProof_StackedDrg8MiBV1 = RegisteredSealProof(1);
+	RegisteredSealProof_StackedDrg512MiBV1 = RegisteredSealProof(2);
+	RegisteredSealProof_StackedDrg32GiBV1 = RegisteredSealProof(3);
+	RegisteredSealProof_StackedDrg64GiBV1 = RegisteredSealProof(4);
 )
 
-func (p RegisteredProof) SectorSize() (SectorSize, error) {
-	// Resolve to seal proof and then compute size from that.
-	sp, err := p.RegisteredSealProof()
-	if err != nil {
-		return 0, err
+type RegisteredPoStProof RegisteredProof
+const(
+ 	RegisteredPoStProof_StackedDrgWinning2KiBV1 = RegisteredPoStProof(0);
+   	RegisteredPoStProof_StackedDrgWinning8MiBV1 = RegisteredPoStProof(1);
+	RegisteredPoStProof_StackedDrgWinning512MiBV1 = RegisteredPoStProof(2);
+	RegisteredPoStProof_StackedDrgWinning32GiBV1 = RegisteredPoStProof(3);
+	RegisteredPoStProof_StackedDrgWinning64GiBV1 = RegisteredPoStProof(4);
+	RegisteredPoStProof_StackedDrgWindow2KiBV1 = RegisteredPoStProof(5);
+	RegisteredPoStProof_StackedDrgWindow8MiBV1 = RegisteredPoStProof(6);
+	RegisteredPoStProof_StackedDrgWindow512MiBV1 = RegisteredPoStProof(7);
+	RegisteredPoStProof_StackedDrgWindow32GiBV1 = RegisteredPoStProof(8);
+	RegisteredPoStProof_StackedDrgWindow64GiBV1 = RegisteredPoStProof(9);
+)
+
+func (p RegisteredPoStProof) RegisteredSealProof() (RegisteredSealProof, error) {
+	switch p {
+ 	case RegisteredPoStProof_StackedDrgWinning2KiBV1, RegisteredPoStProof_StackedDrgWindow2KiBV1:
+		return RegisteredSealProof_StackedDrg2KiBV1, nil
+   	case RegisteredPoStProof_StackedDrgWinning8MiBV1, RegisteredPoStProof_StackedDrgWindow8MiBV1:
+		return RegisteredSealProof_StackedDrg8MiBV1, nil
+	case RegisteredPoStProof_StackedDrgWinning512MiBV1, RegisteredPoStProof_StackedDrgWindow512MiBV1:
+		return RegisteredSealProof_StackedDrg512MiBV1, nil
+	case RegisteredPoStProof_StackedDrgWinning32GiBV1, RegisteredPoStProof_StackedDrgWindow32GiBV1:
+		return RegisteredSealProof_StackedDrg32GiBV1, nil
+	case RegisteredPoStProof_StackedDrgWinning64GiBV1, RegisteredPoStProof_StackedDrgWindow64GiBV1:
+		return RegisteredSealProof_StackedDrg64GiBV1, nil
+	default:
+		return 0, errors.Errorf("unsupported PoSt proof type: %v", p)
 	}
-	switch sp {
-	case RegisteredProof_StackedDRG64GiBSeal:
+}
+
+func (p RegisteredSealProof) SectorSize() (SectorSize, error) {
+	switch p {
+	case RegisteredSealProof_StackedDrg64GiBV1:
 		return 2 * (32 << 30), nil
-	case RegisteredProof_StackedDRG32GiBSeal:
+	case RegisteredSealProof_StackedDrg32GiBV1:
 		return 32 << 30, nil
-	case RegisteredProof_StackedDRG2KiBSeal:
+	case RegisteredSealProof_StackedDrg2KiBV1:
 		return 2 << 10, nil
-	case RegisteredProof_StackedDRG8MiBSeal:
+	case RegisteredSealProof_StackedDrg8MiBV1:
 		return 8 << 20, nil
-	case RegisteredProof_StackedDRG512MiBSeal:
+	case RegisteredSealProof_StackedDrg512MiBV1:
 		return 512 << 20, nil
 	default:
 		return 0, errors.Errorf("unsupported proof type: %v", p)
 	}
 }
 
-// Returns the partition size, in sectors, associated with a proof type.
-// The partition size is the number of sectors proven in a single PoSt proof.
-func (p RegisteredProof) WindowPoStPartitionSectors() (uint64, error) {
+func (p RegisteredPoStProof) SectorSize() (SectorSize, error) {
 	// Resolve to seal proof and then compute size from that.
 	sp, err := p.RegisteredSealProof()
 	if err != nil {
 		return 0, err
 	}
+	return sp.SectorSize()
+}
+
+// Returns the partition size, in sectors, associated with a proof type.
+// The partition size is the number of sectors proved in a single PoSt proof.
+func (p RegisteredSealProof) WindowPoStPartitionSectors() (uint64, error) {
 	// These numbers must match those used by the proofs library.
 	// See https://github.com/filecoin-project/rust-fil-proofs/blob/master/filecoin-proofs/src/constants.rs#L85
-	switch sp {
-	case RegisteredProof_StackedDRG64GiBSeal:
+	switch p {
+	case RegisteredSealProof_StackedDrg64GiBV1:
 		return 2300, nil
-	case RegisteredProof_StackedDRG32GiBSeal:
+	case RegisteredSealProof_StackedDrg32GiBV1:
 		return 2349, nil
-	case RegisteredProof_StackedDRG2KiBSeal:
+	case RegisteredSealProof_StackedDrg2KiBV1:
 		return 2, nil
-	case RegisteredProof_StackedDRG8MiBSeal:
+	case RegisteredSealProof_StackedDrg8MiBV1:
 		return 2, nil
-	case RegisteredProof_StackedDRG512MiBSeal:
+	case RegisteredSealProof_StackedDrg512MiBV1:
 		return 2, nil
 	default:
 		return 0, errors.Errorf("unsupported proof type: %v", p)
 	}
 }
 
+// Returns the partition size, in sectors, associated with a proof type.
+// The partition size is the number of sectors proved in a single PoSt proof.
+func (p RegisteredPoStProof) WindowPoStPartitionSectors() (uint64, error) {
+	// Resolve to seal proof and then compute size from that.
+	sp, err := p.RegisteredSealProof()
+	if err != nil {
+		return 0, err
+	}
+	return sp.WindowPoStPartitionSectors()
+}
+
 // RegisteredWinningPoStProof produces the PoSt-specific RegisteredProof corresponding
 // to the receiving RegisteredProof.
-func (p RegisteredProof) RegisteredWinningPoStProof() (RegisteredProof, error) {
+func (p RegisteredSealProof) RegisteredWinningPoStProof() (RegisteredPoStProof, error) {
 	switch p {
-	case RegisteredProof_StackedDRG64GiBSeal, RegisteredProof_StackedDRG64GiBWindowPoSt, RegisteredProof_StackedDRG64GiBWinningPoSt:
-		return RegisteredProof_StackedDRG64GiBWinningPoSt, nil
-	case RegisteredProof_StackedDRG32GiBSeal, RegisteredProof_StackedDRG32GiBWindowPoSt, RegisteredProof_StackedDRG32GiBWinningPoSt:
-		return RegisteredProof_StackedDRG32GiBWinningPoSt, nil
-	case RegisteredProof_StackedDRG2KiBSeal, RegisteredProof_StackedDRG2KiBWindowPoSt, RegisteredProof_StackedDRG2KiBWinningPoSt:
-		return RegisteredProof_StackedDRG2KiBWinningPoSt, nil
-	case RegisteredProof_StackedDRG8MiBSeal, RegisteredProof_StackedDRG8MiBWindowPoSt, RegisteredProof_StackedDRG8MiBWinningPoSt:
-		return RegisteredProof_StackedDRG8MiBWinningPoSt, nil
-	case RegisteredProof_StackedDRG512MiBSeal, RegisteredProof_StackedDRG512MiBWindowPoSt, RegisteredProof_StackedDRG512MiBWinningPoSt:
-		return RegisteredProof_StackedDRG512MiBWinningPoSt, nil
+	case RegisteredSealProof_StackedDrg64GiBV1:
+		return RegisteredPoStProof_StackedDrgWinning64GiBV1, nil
+	case RegisteredSealProof_StackedDrg32GiBV1:
+		return RegisteredPoStProof_StackedDrgWinning32GiBV1, nil
+	case RegisteredSealProof_StackedDrg2KiBV1:
+		return RegisteredPoStProof_StackedDrgWinning2KiBV1, nil
+	case RegisteredSealProof_StackedDrg8MiBV1:
+		return RegisteredPoStProof_StackedDrgWinning8MiBV1, nil
+	case RegisteredSealProof_StackedDrg512MiBV1:
+		return RegisteredPoStProof_StackedDrgWinning512MiBV1, nil
+	default:
+		return 0, errors.Errorf("unsupported mapping from %+v to PoSt-specific RegisteredProof", p)
+	}
+}
+
+// RegisteredWinningPoStProof produces the PoSt-specific RegisteredProof corresponding
+// to the receiving RegisteredProof.
+func (p RegisteredPoStProof) RegisteredWinningPoStProof() (RegisteredPoStProof, error) {
+	// Resolve to seal proof and then compute Winning PoSt from that.
+	sp, err := p.RegisteredSealProof()
+	if err != nil {
+		return 0, err
+	}
+	return sp.RegisteredWinningPoStProof()
+}
+
+
+// RegisteredWindowPoStProof produces the PoSt-specific RegisteredProof corresponding
+// to the receiving RegisteredProof.
+func (p RegisteredSealProof) RegisteredWindowPoStProof() (RegisteredPoStProof, error) {
+	switch p {
+	case RegisteredSealProof_StackedDrg64GiBV1:
+		return RegisteredPoStProof_StackedDrgWindow64GiBV1, nil
+	case RegisteredSealProof_StackedDrg32GiBV1:
+		return RegisteredPoStProof_StackedDrgWindow32GiBV1, nil
+	case RegisteredSealProof_StackedDrg2KiBV1:
+		return RegisteredPoStProof_StackedDrgWindow2KiBV1, nil
+	case RegisteredSealProof_StackedDrg8MiBV1:
+		return RegisteredPoStProof_StackedDrgWindow8MiBV1, nil
+	case RegisteredSealProof_StackedDrg512MiBV1:
+		return RegisteredPoStProof_StackedDrgWindow512MiBV1, nil
 	default:
 		return 0, errors.Errorf("unsupported mapping from %+v to PoSt-specific RegisteredProof", p)
 	}
@@ -164,40 +217,13 @@ func (p RegisteredProof) RegisteredWinningPoStProof() (RegisteredProof, error) {
 
 // RegisteredWindowPoStProof produces the PoSt-specific RegisteredProof corresponding
 // to the receiving RegisteredProof.
-func (p RegisteredProof) RegisteredWindowPoStProof() (RegisteredProof, error) {
-	switch p {
-	case RegisteredProof_StackedDRG64GiBSeal, RegisteredProof_StackedDRG64GiBWinningPoSt, RegisteredProof_StackedDRG64GiBWindowPoSt:
-		return RegisteredProof_StackedDRG64GiBWindowPoSt, nil
-	case RegisteredProof_StackedDRG32GiBSeal, RegisteredProof_StackedDRG32GiBWinningPoSt, RegisteredProof_StackedDRG32GiBWindowPoSt:
-		return RegisteredProof_StackedDRG32GiBWindowPoSt, nil
-	case RegisteredProof_StackedDRG2KiBSeal, RegisteredProof_StackedDRG2KiBWinningPoSt, RegisteredProof_StackedDRG2KiBWindowPoSt:
-		return RegisteredProof_StackedDRG2KiBWindowPoSt, nil
-	case RegisteredProof_StackedDRG8MiBSeal, RegisteredProof_StackedDRG8MiBWinningPoSt, RegisteredProof_StackedDRG8MiBWindowPoSt:
-		return RegisteredProof_StackedDRG8MiBWindowPoSt, nil
-	case RegisteredProof_StackedDRG512MiBSeal, RegisteredProof_StackedDRG512MiBWinningPoSt, RegisteredProof_StackedDRG512MiBWindowPoSt:
-		return RegisteredProof_StackedDRG512MiBWindowPoSt, nil
-	default:
-		return 0, errors.Errorf("unsupported mapping from %+v to PoSt-specific RegisteredProof", p)
+func (p RegisteredPoStProof) RegisteredWindowPoStProof() (RegisteredPoStProof, error) {
+	// Resolve to seal proof and then compute Window PoSt from that.
+	sp, err := p.RegisteredSealProof()
+	if err != nil {
+		return 0, err
 	}
-}
-
-// RegisteredSealProof produces the seal-specific RegisteredProof corresponding
-// to the receiving RegisteredProof.
-func (p RegisteredProof) RegisteredSealProof() (RegisteredProof, error) {
-	switch p {
-	case RegisteredProof_StackedDRG64GiBSeal, RegisteredProof_StackedDRG64GiBWindowPoSt, RegisteredProof_StackedDRG64GiBWinningPoSt:
-		return RegisteredProof_StackedDRG64GiBSeal, nil
-	case RegisteredProof_StackedDRG32GiBSeal, RegisteredProof_StackedDRG32GiBPoSt, RegisteredProof_StackedDRG32GiBWindowPoSt, RegisteredProof_StackedDRG32GiBWinningPoSt:
-		return RegisteredProof_StackedDRG32GiBSeal, nil
-	case RegisteredProof_StackedDRG2KiBSeal, RegisteredProof_StackedDRG2KiBPoSt, RegisteredProof_StackedDRG2KiBWindowPoSt, RegisteredProof_StackedDRG2KiBWinningPoSt:
-		return RegisteredProof_StackedDRG2KiBSeal, nil
-	case RegisteredProof_StackedDRG8MiBSeal, RegisteredProof_StackedDRG8MiBPoSt, RegisteredProof_StackedDRG8MiBWindowPoSt, RegisteredProof_StackedDRG8MiBWinningPoSt:
-		return RegisteredProof_StackedDRG8MiBSeal, nil
-	case RegisteredProof_StackedDRG512MiBSeal, RegisteredProof_StackedDRG512MiBPoSt, RegisteredProof_StackedDRG512MiBWindowPoSt, RegisteredProof_StackedDRG512MiBWinningPoSt:
-		return RegisteredProof_StackedDRG512MiBSeal, nil
-	default:
-		return 0, errors.Errorf("unsupported mapping from %+v to seal-specific RegisteredProof", p)
-	}
+	return sp.RegisteredWindowPoStProof()
 }
 
 ///
@@ -209,7 +235,7 @@ type InteractiveSealRandomness Randomness
 
 // Information needed to verify a seal proof.
 type SealVerifyInfo struct {
-	RegisteredProof
+	RegisteredSealProof
 	SectorID
 
 	DealIDs               []DealID
@@ -228,13 +254,13 @@ type PoStRandomness Randomness
 
 // Information about a sector necessary for PoSt verification.
 type SectorInfo struct {
-	RegisteredProof // RegisteredProof used when sealing - needs to be mapped to PoSt registered proof when used to verify a PoSt
+	RegisteredSealProof // RegisteredProof used when sealing - needs to be mapped to PoSt registered proof when used to verify a PoSt
 	SectorNumber    SectorNumber
 	SealedCID       cid.Cid // CommR
 }
 
 type PoStProof struct {
-	RegisteredProof
+	RegisteredPoStProof
 	ProofBytes []byte
 }
 

--- a/actors/builtin/market/cbor_gen.go
+++ b/actors/builtin/market/cbor_gen.go
@@ -509,7 +509,7 @@ func (t *ComputeDataCommitmentParams) MarshalCBOR(w io.Writer) error {
 		}
 	}
 
-	// t.SectorType (abi.RegisteredProof) (int64)
+	// t.SectorType (abi.RegisteredSealProof) (int64)
 	if t.SectorType >= 0 {
 		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.SectorType))); err != nil {
 			return err
@@ -593,7 +593,7 @@ func (t *ComputeDataCommitmentParams) UnmarshalCBOR(r io.Reader) error {
 			return fmt.Errorf("wrong type for int64 field: %d", maj)
 		}
 
-		t.SectorType = abi.RegisteredProof(extraI)
+		t.SectorType = abi.RegisteredSealProof(extraI)
 	}
 	return nil
 }

--- a/actors/builtin/market/market_actor.go
+++ b/actors/builtin/market/market_actor.go
@@ -335,7 +335,7 @@ func (a Actor) VerifyDealsOnSectorProveCommit(rt Runtime, params *VerifyDealsOnS
 
 type ComputeDataCommitmentParams struct {
 	DealIDs    []abi.DealID
-	SectorType abi.RegisteredProof
+	SectorType abi.RegisteredSealProof
 }
 
 func (a Actor) ComputeDataCommitment(rt Runtime, params *ComputeDataCommitmentParams) *cbg.CborCid {

--- a/actors/builtin/miner/cbor_gen.go
+++ b/actors/builtin/miner/cbor_gen.go
@@ -784,12 +784,12 @@ func (t *SectorPreCommitInfo) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.RegisteredProof (abi.RegisteredProof) (int64)
-	if t.RegisteredSealProof >= 0 {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.RegisteredSealProof))); err != nil {
+	if t.SealProof >= 0 {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.SealProof))); err != nil {
 			return err
 		}
 	} else {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.RegisteredSealProof)-1)); err != nil {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.SealProof)-1)); err != nil {
 			return err
 		}
 	}
@@ -882,7 +882,7 @@ func (t *SectorPreCommitInfo) UnmarshalCBOR(r io.Reader) error {
 			return fmt.Errorf("wrong type for int64 field: %d", maj)
 		}
 
-		t.RegisteredSealProof = abi.RegisteredSealProof(extraI)
+		t.SealProof = abi.RegisteredSealProof(extraI)
 	}
 	// t.SectorNumber (abi.SectorNumber) (uint64)
 

--- a/actors/builtin/miner/cbor_gen.go
+++ b/actors/builtin/miner/cbor_gen.go
@@ -574,7 +574,7 @@ func (t *MinerInfo) UnmarshalCBOR(r io.Reader) error {
 			return fmt.Errorf("wrong type for int64 field: %d", maj)
 		}
 
-		t.SealProofType = abi.RegisteredProof(extraI)
+		t.SealProofType = abi.RegisteredSealProof(extraI)
 	}
 	// t.SectorSize (abi.SectorSize) (uint64)
 
@@ -784,12 +784,12 @@ func (t *SectorPreCommitInfo) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.RegisteredProof (abi.RegisteredProof) (int64)
-	if t.RegisteredProof >= 0 {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.RegisteredProof))); err != nil {
+	if t.RegisteredSealProof >= 0 {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.RegisteredSealProof))); err != nil {
 			return err
 		}
 	} else {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.RegisteredProof)-1)); err != nil {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.RegisteredSealProof)-1)); err != nil {
 			return err
 		}
 	}
@@ -859,7 +859,7 @@ func (t *SectorPreCommitInfo) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
-	// t.RegisteredProof (abi.RegisteredProof) (int64)
+	// t.RegisteredProof (abi.RegisteredSealProof) (int64)
 	{
 		maj, extra, err := cbg.CborReadHeader(br)
 		var extraI int64
@@ -882,7 +882,7 @@ func (t *SectorPreCommitInfo) UnmarshalCBOR(r io.Reader) error {
 			return fmt.Errorf("wrong type for int64 field: %d", maj)
 		}
 
-		t.RegisteredProof = abi.RegisteredProof(extraI)
+		t.RegisteredSealProof = abi.RegisteredSealProof(extraI)
 	}
 	// t.SectorNumber (abi.SectorNumber) (uint64)
 

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -324,7 +324,7 @@ func (a Actor) PreCommitSector(rt Runtime, params *SectorPreCommitInfo) *adt.Emp
 	if params.SealRandEpoch >= rt.CurrEpoch() {
 		rt.Abortf(exitcode.ErrIllegalArgument, "seal challenge epoch %v must be before now %v", params.SealRandEpoch, rt.CurrEpoch())
 	}
-	challengeEarliest := sealChallengeEarliest(rt.CurrEpoch(), params.RegisteredProof)
+	challengeEarliest := sealChallengeEarliest(rt.CurrEpoch(), params.RegisteredSealProof)
 	if params.SealRandEpoch < challengeEarliest {
 		// The subsequent commitment proof can't possibly be accepted because the seal challenge will be deemed
 		// too old. Note that passing this check doesn't guarantee the proof will be soon enough, depending on
@@ -336,7 +336,7 @@ func (a Actor) PreCommitSector(rt Runtime, params *SectorPreCommitInfo) *adt.Emp
 	var st State
 	newlyVestedAmount := rt.State().Transaction(&st, func() interface{} {
 		rt.ValidateImmediateCallerIs(st.Info.Worker)
-		if params.RegisteredProof != st.Info.SealProofType {
+		if params.RegisteredSealProof != st.Info.SealProofType {
 			rt.Abortf(exitcode.ErrIllegalArgument, "wrong proof type")
 		}
 
@@ -396,9 +396,9 @@ func (a Actor) PreCommitSector(rt Runtime, params *SectorPreCommitInfo) *adt.Emp
 		Sectors:   bf,
 	}
 
-	msd, ok := MaxSealDuration[params.RegisteredProof]
+	msd, ok := MaxSealDuration[params.RegisteredSealProof]
 	if !ok {
-		rt.Abortf(exitcode.ErrIllegalArgument, "no max seal duration set for proof type: %d", params.RegisteredProof)
+		rt.Abortf(exitcode.ErrIllegalArgument, "no max seal duration set for proof type: %d", params.RegisteredSealProof)
 	}
 
 	expiryBound := rt.CurrEpoch() + msd + 1
@@ -427,9 +427,9 @@ func (a Actor) ProveCommitSector(rt Runtime, params *ProveCommitSectorParams) *a
 		rt.Abortf(exitcode.ErrNotFound, "no precommitted sector %v", sectorNo)
 	}
 
-	msd, ok := MaxSealDuration[precommit.Info.RegisteredProof]
+	msd, ok := MaxSealDuration[precommit.Info.RegisteredSealProof]
 	if !ok {
-		rt.Abortf(exitcode.ErrIllegalState, "no max seal duration for proof type: %d", precommit.Info.RegisteredProof)
+		rt.Abortf(exitcode.ErrIllegalState, "no max seal duration for proof type: %d", precommit.Info.RegisteredSealProof)
 	}
 	proveCommitDue := precommit.PreCommitEpoch + msd
 	if rt.CurrEpoch() > proveCommitDue {
@@ -444,7 +444,7 @@ func (a Actor) ProveCommitSector(rt Runtime, params *ProveCommitSectorParams) *a
 		Proof:            params.Proof,
 		DealIDs:          precommit.Info.DealIDs,
 		SectorNumber:     precommit.Info.SectorNumber,
-		RegisteredProof:  precommit.Info.RegisteredProof,
+		RegisteredSealProof:  precommit.Info.RegisteredSealProof,
 	})
 
 	_, code := rt.Send(
@@ -1574,7 +1574,7 @@ func verifyWindowedPost(rt Runtime, challengeEpoch abi.ChainEpoch, sectors []*Se
 type SealVerifyStuff struct {
 	SealedCID        cid.Cid        // CommR
 	InteractiveEpoch abi.ChainEpoch // Used to derive the interactive PoRep challenge.
-	abi.RegisteredProof
+	abi.RegisteredSealProof
 	Proof   []byte
 	DealIDs []abi.DealID
 	abi.SectorNumber
@@ -1587,12 +1587,12 @@ func getVerifyInfo(rt Runtime, params *SealVerifyStuff) *abi.SealVerifyInfo {
 	}
 
 	// Check randomness.
-	challengeEarliest := sealChallengeEarliest(rt.CurrEpoch(), params.RegisteredProof)
+	challengeEarliest := sealChallengeEarliest(rt.CurrEpoch(), params.RegisteredSealProof)
 	if params.SealRandEpoch < challengeEarliest {
 		rt.Abortf(exitcode.ErrIllegalArgument, "seal epoch %v too old, expected >= %v", params.SealRandEpoch, challengeEarliest)
 	}
 
-	commD := requestUnsealedSectorCID(rt, params.RegisteredProof, params.DealIDs)
+	commD := requestUnsealedSectorCID(rt, params.RegisteredSealProof, params.DealIDs)
 
 	minerActorID, err := addr.IDFromAddress(rt.Message().Receiver())
 	AssertNoError(err) // Runtime always provides ID-addresses
@@ -1605,7 +1605,7 @@ func getVerifyInfo(rt Runtime, params *SealVerifyStuff) *abi.SealVerifyInfo {
 	svInfoInteractiveRandomness := rt.GetRandomness(crypto.DomainSeparationTag_InteractiveSealChallengeSeed, params.InteractiveEpoch, buf.Bytes())
 
 	return &abi.SealVerifyInfo{
-		RegisteredProof: params.RegisteredProof,
+		RegisteredSealProof: params.RegisteredSealProof,
 		SectorID: abi.SectorID{
 			Miner:  abi.ActorID(minerActorID),
 			Number: params.SectorNumber,
@@ -1620,7 +1620,7 @@ func getVerifyInfo(rt Runtime, params *SealVerifyStuff) *abi.SealVerifyInfo {
 }
 
 // Requests the storage market actor compute the unsealed sector CID from a sector's deals.
-func requestUnsealedSectorCID(rt Runtime, proofType abi.RegisteredProof, dealIDs []abi.DealID) cid.Cid {
+func requestUnsealedSectorCID(rt Runtime, proofType abi.RegisteredSealProof, dealIDs []abi.DealID) cid.Cid {
 	ret, code := rt.Send(
 		builtin.StorageMarketActorAddr,
 		builtin.MethodsMarket.ComputeDataCommitment,
@@ -1818,7 +1818,7 @@ func unlockPenalty(st *State, store adt.Store, currEpoch abi.ChainEpoch, sectors
 }
 
 // The oldest seal challenge epoch that will be accepted in the current epoch.
-func sealChallengeEarliest(currEpoch abi.ChainEpoch, proof abi.RegisteredProof) abi.ChainEpoch {
+func sealChallengeEarliest(currEpoch abi.ChainEpoch, proof abi.RegisteredSealProof) abi.ChainEpoch {
 	return currEpoch - ChainFinalityish - MaxSealDuration[proof]
 }
 

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -324,7 +324,7 @@ func (a Actor) PreCommitSector(rt Runtime, params *SectorPreCommitInfo) *adt.Emp
 	if params.SealRandEpoch >= rt.CurrEpoch() {
 		rt.Abortf(exitcode.ErrIllegalArgument, "seal challenge epoch %v must be before now %v", params.SealRandEpoch, rt.CurrEpoch())
 	}
-	challengeEarliest := sealChallengeEarliest(rt.CurrEpoch(), params.RegisteredSealProof)
+	challengeEarliest := sealChallengeEarliest(rt.CurrEpoch(), params.SealProof)
 	if params.SealRandEpoch < challengeEarliest {
 		// The subsequent commitment proof can't possibly be accepted because the seal challenge will be deemed
 		// too old. Note that passing this check doesn't guarantee the proof will be soon enough, depending on
@@ -336,7 +336,7 @@ func (a Actor) PreCommitSector(rt Runtime, params *SectorPreCommitInfo) *adt.Emp
 	var st State
 	newlyVestedAmount := rt.State().Transaction(&st, func() interface{} {
 		rt.ValidateImmediateCallerIs(st.Info.Worker)
-		if params.RegisteredSealProof != st.Info.SealProofType {
+		if params.SealProof != st.Info.SealProofType {
 			rt.Abortf(exitcode.ErrIllegalArgument, "wrong proof type")
 		}
 
@@ -396,9 +396,9 @@ func (a Actor) PreCommitSector(rt Runtime, params *SectorPreCommitInfo) *adt.Emp
 		Sectors:   bf,
 	}
 
-	msd, ok := MaxSealDuration[params.RegisteredSealProof]
+	msd, ok := MaxSealDuration[params.SealProof]
 	if !ok {
-		rt.Abortf(exitcode.ErrIllegalArgument, "no max seal duration set for proof type: %d", params.RegisteredSealProof)
+		rt.Abortf(exitcode.ErrIllegalArgument, "no max seal duration set for proof type: %d", params.SealProof)
 	}
 
 	expiryBound := rt.CurrEpoch() + msd + 1
@@ -427,9 +427,9 @@ func (a Actor) ProveCommitSector(rt Runtime, params *ProveCommitSectorParams) *a
 		rt.Abortf(exitcode.ErrNotFound, "no precommitted sector %v", sectorNo)
 	}
 
-	msd, ok := MaxSealDuration[precommit.Info.RegisteredSealProof]
+	msd, ok := MaxSealDuration[precommit.Info.SealProof]
 	if !ok {
-		rt.Abortf(exitcode.ErrIllegalState, "no max seal duration for proof type: %d", precommit.Info.RegisteredSealProof)
+		rt.Abortf(exitcode.ErrIllegalState, "no max seal duration for proof type: %d", precommit.Info.SealProof)
 	}
 	proveCommitDue := precommit.PreCommitEpoch + msd
 	if rt.CurrEpoch() > proveCommitDue {
@@ -444,7 +444,7 @@ func (a Actor) ProveCommitSector(rt Runtime, params *ProveCommitSectorParams) *a
 		Proof:            params.Proof,
 		DealIDs:          precommit.Info.DealIDs,
 		SectorNumber:     precommit.Info.SectorNumber,
-		RegisteredSealProof:  precommit.Info.RegisteredSealProof,
+		RegisteredSealProof:        precommit.Info.SealProof,
 	})
 
 	_, code := rt.Send(
@@ -1605,7 +1605,7 @@ func getVerifyInfo(rt Runtime, params *SealVerifyStuff) *abi.SealVerifyInfo {
 	svInfoInteractiveRandomness := rt.GetRandomness(crypto.DomainSeparationTag_InteractiveSealChallengeSeed, params.InteractiveEpoch, buf.Bytes())
 
 	return &abi.SealVerifyInfo{
-		RegisteredSealProof: params.RegisteredSealProof,
+		SealProof: params.RegisteredSealProof,
 		SectorID: abi.SectorID{
 			Miner:  abi.ActorID(minerActorID),
 			Number: params.SectorNumber,

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -119,7 +119,7 @@ type WorkerKeyChange struct {
 }
 
 type SectorPreCommitInfo struct {
-	RegisteredSealProof abi.RegisteredSealProof
+	SealProof abi.RegisteredSealProof
 	SectorNumber    abi.SectorNumber
 	SealedCID       cid.Cid // CommR
 	SealRandEpoch   abi.ChainEpoch
@@ -1015,7 +1015,7 @@ func (st *State) AssertBalanceInvariants(balance abi.TokenAmount) {
 
 func (s *SectorOnChainInfo) AsSectorInfo() abi.SectorInfo {
 	return abi.SectorInfo{
-		RegisteredSealProof: s.Info.RegisteredSealProof,
+		SealProof:       s.Info.SealProof,
 		SectorNumber:    s.Info.SectorNumber,
 		SealedCID:       s.Info.SealedCID,
 	}

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -102,7 +102,7 @@ type MinerInfo struct {
 	Multiaddrs []abi.Multiaddrs
 
 	// The proof type used by this miner for sealing sectors.
-	SealProofType abi.RegisteredProof
+	SealProofType abi.RegisteredSealProof
 
 	// Amount of space in each sector committed by this miner.
 	// This is computed from the proof type and represented here redundantly.
@@ -119,7 +119,7 @@ type WorkerKeyChange struct {
 }
 
 type SectorPreCommitInfo struct {
-	RegisteredProof abi.RegisteredProof
+	RegisteredSealProof abi.RegisteredSealProof
 	SectorNumber    abi.SectorNumber
 	SealedCID       cid.Cid // CommR
 	SealRandEpoch   abi.ChainEpoch
@@ -141,11 +141,7 @@ type SectorOnChainInfo struct {
 }
 
 func ConstructState(emptyArrayCid, emptyMapCid, emptyDeadlinesCid cid.Cid, ownerAddr, workerAddr addr.Address,
-	peerId abi.PeerID, multiaddrs []abi.Multiaddrs, proofType abi.RegisteredProof, periodStart abi.ChainEpoch) (*State, error) {
-	sealProofType, err := proofType.RegisteredSealProof()
-	if err != nil {
-		return nil, fmt.Errorf("no seal proof for proof type %d: %w", sealProofType, err)
-	}
+	peerId abi.PeerID, multiaddrs []abi.Multiaddrs, sealProofType abi.RegisteredSealProof, periodStart abi.ChainEpoch) (*State, error) {
 	sectorSize, err := sealProofType.SectorSize()
 	if err != nil {
 		return nil, fmt.Errorf("no sector size for seal proof type %d: %w", sealProofType, err)
@@ -1019,7 +1015,7 @@ func (st *State) AssertBalanceInvariants(balance abi.TokenAmount) {
 
 func (s *SectorOnChainInfo) AsSectorInfo() abi.SectorInfo {
 	return abi.SectorInfo{
-		RegisteredProof: s.Info.RegisteredProof,
+		RegisteredSealProof: s.Info.RegisteredSealProof,
 		SectorNumber:    s.Info.SectorNumber,
 		SealedCID:       s.Info.SealedCID,
 	}

--- a/actors/builtin/miner/miner_state_test.go
+++ b/actors/builtin/miner/miner_state_test.go
@@ -999,7 +999,7 @@ const (
 // returns a unique SectorPreCommitInfo with each invocation with SectorNumber set to `sectorNo`.
 func newSectorPreCommitInfo(sectorNo abi.SectorNumber, sealed cid.Cid) *miner.SectorPreCommitInfo {
 	return &miner.SectorPreCommitInfo{
-		RegisteredSealProof: abi.RegisteredSealProof_StackedDrg32GiBV1,
+		SealProof:       abi.RegisteredSealProof_StackedDrg32GiBV1,
 		SectorNumber:    sectorNo,
 		SealedCID:       sealed,
 		SealRandEpoch:   sectorSealRandEpochValue,

--- a/actors/builtin/miner/miner_state_test.go
+++ b/actors/builtin/miner/miner_state_test.go
@@ -950,7 +950,7 @@ func constructStateHarness(t *testing.T, periodBoundary abi.ChainEpoch) *stateHa
 	// state field init
 	owner := tutils.NewBLSAddr(t, 1)
 	worker := tutils.NewBLSAddr(t, 2)
-	state, err := miner.ConstructState(emptyArray, emptyMap, emptyDeadlinesCid, owner, worker, abi.PeerID("peer"), testMultiaddrs, abi.RegisteredProof_StackedDRG2KiBSeal, periodBoundary)
+	state, err := miner.ConstructState(emptyArray, emptyMap, emptyDeadlinesCid, owner, worker, abi.PeerID("peer"), testMultiaddrs, abi.RegisteredSealProof_StackedDrg2KiBV1, periodBoundary)
 	require.NoError(t, err)
 
 	// assert NewSectors bitfield was constructed correctly (empty)
@@ -999,7 +999,7 @@ const (
 // returns a unique SectorPreCommitInfo with each invocation with SectorNumber set to `sectorNo`.
 func newSectorPreCommitInfo(sectorNo abi.SectorNumber, sealed cid.Cid) *miner.SectorPreCommitInfo {
 	return &miner.SectorPreCommitInfo{
-		RegisteredProof: abi.RegisteredProof_StackedDRG32GiBPoSt,
+		RegisteredSealProof: abi.RegisteredSealProof_StackedDrg32GiBV1,
 		SectorNumber:    sectorNo,
 		SealedCID:       sealed,
 		SealRandEpoch:   sectorSealRandEpochValue,

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -170,7 +170,7 @@ func TestCommitments(t *testing.T) {
 		// Bad seal proof type
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			pc := makePreCommit(114, challengeEpoch, deadline.PeriodEnd())
-			pc.RegisteredSealProof = abi.RegisteredSealProof_StackedDrg8MiBV1
+			pc.SealProof = abi.RegisteredSealProof_StackedDrg8MiBV1
 			actor.preCommitSector(rt, pc, big.Zero())
 		})
 
@@ -216,7 +216,7 @@ func TestCommitments(t *testing.T) {
 		rt.Reset()
 
 		// Too late.
-		rt.SetEpoch(precommitEpoch + miner.MaxSealDuration[precommit.RegisteredSealProof] + 1)
+		rt.SetEpoch(precommitEpoch + miner.MaxSealDuration[precommit.SealProof] + 1)
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			actor.proveCommitSector(rt, precommit, precommitEpoch, makeProveCommit(sectorNo), proveCommitConf{})
 		})
@@ -562,7 +562,7 @@ func (h *actorHarness) preCommitSector(rt *mock.Runtime, params *miner.SectorPre
 		err := eventPayload.MarshalCBOR(&buf)
 		require.NoError(h.t, err)
 		cronParams := power.EnrollCronEventParams{
-			EventEpoch: rt.Epoch() + miner.MaxSealDuration[params.RegisteredSealProof] + 1,
+			EventEpoch: rt.Epoch() + miner.MaxSealDuration[params.SealProof] + 1,
 			Payload:    buf.Bytes(),
 		}
 		rt.ExpectSend(builtin.StoragePowerActorAddr, builtin.MethodsPower.EnrollCronEvent, &cronParams, big.Zero(), nil, exitcode.Ok)
@@ -593,7 +593,7 @@ func (h *actorHarness) proveCommitSector(rt *mock.Runtime, precommit *miner.Sect
 	{
 		cdcParams := market.ComputeDataCommitmentParams{
 			DealIDs:    precommit.DealIDs,
-			SectorType: precommit.RegisteredSealProof,
+			SectorType: precommit.SealProof,
 		}
 		rt.ExpectSend(builtin.StorageMarketActorAddr, builtin.MethodsMarket.ComputeDataCommitment, &cdcParams, big.Zero(), &commd, exitcode.Ok)
 	}
@@ -613,7 +613,7 @@ func (h *actorHarness) proveCommitSector(rt *mock.Runtime, precommit *miner.Sect
 				Number: precommit.SectorNumber,
 			},
 			SealedCID:             precommit.SealedCID,
-			RegisteredSealProof:       precommit.RegisteredSealProof,
+			SealProof:             precommit.SealProof,
 			Proof:                 params.Proof,
 			DealIDs:               precommit.DealIDs,
 			Randomness:            sealRand,
@@ -639,7 +639,7 @@ func (h *actorHarness) proveCommitSector(rt *mock.Runtime, precommit *miner.Sect
 		rt.ExpectSend(builtin.StorageMarketActorAddr, builtin.MethodsMarket.VerifyDealsOnSectorProveCommit, &vdParams, big.Zero(), &vdRet, conf.verifyDealsExit)
 	}
 	{
-		sectorSize, err := precommit.RegisteredSealProof.SectorSize()
+		sectorSize, err := precommit.SealProof.SectorSize()
 		require.NoError(h.t, err)
 		pcParams := power.OnSectorProveCommitParams{Weight: power.SectorStorageWeightDesc{
 			SectorSize:         sectorSize,
@@ -702,7 +702,7 @@ func (h *actorHarness) submitWindowPost(rt *mock.Runtime, deadline *miner.Deadli
 
 	proofs := make([]abi.PoStProof, 1) // Number of proofs doesn't depend on partition count
 	for i := range proofs {
-		proofs[i].RegisteredPoStProof = registeredPoStProof
+		proofs[i].PoStProof  = registeredPoStProof
 		proofs[i].ProofBytes = []byte(fmt.Sprintf("proof%d", i))
 	}
 	challengeRand := abi.SealRandomness([]byte{10, 11, 12, 13})
@@ -721,7 +721,7 @@ func (h *actorHarness) submitWindowPost(rt *mock.Runtime, deadline *miner.Deadli
 		proofInfos := make([]abi.SectorInfo, len(infos))
 		for i, ci := range infos {
 			proofInfos[i] = abi.SectorInfo{
-				RegisteredSealProof: ci.Info.RegisteredSealProof,
+				SealProof:       ci.Info.SealProof,
 				SectorNumber:    ci.Info.SectorNumber,
 				SealedCID:       ci.Info.SealedCID,
 			}
@@ -848,7 +848,7 @@ func makeProvingPeriodCronEventParams(t testing.TB, epoch abi.ChainEpoch) *power
 
 func makePreCommit(sectorNo abi.SectorNumber, challenge, expiration abi.ChainEpoch) *miner.SectorPreCommitInfo {
 	return &miner.SectorPreCommitInfo{
-		RegisteredSealProof: abi.RegisteredSealProof_StackedDrg2KiBV1,
+		SealProof:       abi.RegisteredSealProof_StackedDrg2KiBV1,
 		SectorNumber:    sectorNo,
 		SealedCID:       tutil.MakeCID("commr"),
 		SealRandEpoch:   challenge,

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -50,19 +50,19 @@ const NewSectorsPerPeriodMax = 128 << 10
 const ChainFinalityish = abi.ChainEpoch(900) // PARAM_FINISH
 
 // List of proof types which can be used when creating new miner actors
-var SupportedProofTypes = map[abi.RegisteredProof]struct{}{
-	abi.RegisteredProof_StackedDRG32GiBSeal: {},
-	abi.RegisteredProof_StackedDRG64GiBSeal: {},
+var SupportedProofTypes = map[abi.RegisteredSealProof]struct{}{
+	abi.RegisteredSealProof_StackedDrg32GiBV1: {},
+	abi.RegisteredSealProof_StackedDrg64GiBV1: {},
 }
 
 // Maximum duration to allow for the sealing process for seal algorithms.
 // Dependent on algorithm and sector size
-var MaxSealDuration = map[abi.RegisteredProof]abi.ChainEpoch{
-	abi.RegisteredProof_StackedDRG32GiBSeal:  abi.ChainEpoch(10000), // PARAM_FINISH
-	abi.RegisteredProof_StackedDRG2KiBSeal:   abi.ChainEpoch(10000),
-	abi.RegisteredProof_StackedDRG8MiBSeal:   abi.ChainEpoch(10000),
-	abi.RegisteredProof_StackedDRG512MiBSeal: abi.ChainEpoch(10000),
-	abi.RegisteredProof_StackedDRG64GiBSeal:  abi.ChainEpoch(10000),
+var MaxSealDuration = map[abi.RegisteredSealProof]abi.ChainEpoch{
+	abi.RegisteredSealProof_StackedDrg32GiBV1:  abi.ChainEpoch(10000), // PARAM_FINISH
+	abi.RegisteredSealProof_StackedDrg2KiBV1:   abi.ChainEpoch(10000),
+	abi.RegisteredSealProof_StackedDrg8MiBV1:   abi.ChainEpoch(10000),
+	abi.RegisteredSealProof_StackedDrg512MiBV1: abi.ChainEpoch(10000),
+	abi.RegisteredSealProof_StackedDrg64GiBV1:  abi.ChainEpoch(10000),
 }
 
 // Number of epochs between publishing the precommit and when the challenge for interactive PoRep is drawn

--- a/actors/builtin/power/cbor_gen.go
+++ b/actors/builtin/power/cbor_gen.go
@@ -515,7 +515,7 @@ func (t *CreateMinerParams) UnmarshalCBOR(r io.Reader) error {
 			return fmt.Errorf("wrong type for int64 field: %d", maj)
 		}
 
-		t.SealProofType = abi.RegisteredProof(extraI)
+		t.SealProofType = abi.RegisteredSealProof(extraI)
 	}
 	// t.Peer ([]uint8) (slice)
 
@@ -1247,7 +1247,7 @@ func (t *MinerConstructorParams) UnmarshalCBOR(r io.Reader) error {
 			return fmt.Errorf("wrong type for int64 field: %d", maj)
 		}
 
-		t.SealProofType = abi.RegisteredProof(extraI)
+		t.SealProofType = abi.RegisteredSealProof(extraI)
 	}
 	// t.PeerId ([]uint8) (slice)
 

--- a/actors/builtin/power/power_actor.go
+++ b/actors/builtin/power/power_actor.go
@@ -56,7 +56,7 @@ var _ abi.Invokee = Actor{}
 type MinerConstructorParams struct {
 	OwnerAddr     addr.Address
 	WorkerAddr    addr.Address
-	SealProofType abi.RegisteredProof
+	SealProofType abi.RegisteredSealProof
 	PeerId        abi.PeerID
 	Multiaddrs    []abi.Multiaddrs
 }
@@ -92,7 +92,7 @@ func (a Actor) Constructor(rt Runtime, _ *adt.EmptyValue) *adt.EmptyValue {
 type CreateMinerParams struct {
 	Owner         addr.Address
 	Worker        addr.Address
-	SealProofType abi.RegisteredProof
+	SealProofType abi.RegisteredSealProof
 	Peer          abi.PeerID
 	Multiaddrs    []abi.Multiaddrs
 }

--- a/actors/builtin/power/power_test.go
+++ b/actors/builtin/power/power_test.go
@@ -43,7 +43,7 @@ func TestConstruction(t *testing.T) {
 		rt := builder.Build(t)
 		actor.constructAndVerify(rt)
 
-		actor.createMiner(rt, owner, owner, miner, actr, abi.PeerID("miner"), []abi.Multiaddrs{{1}}, abi.RegisteredProof_StackedDRG2KiBSeal, abi.NewTokenAmount(10))
+		actor.createMiner(rt, owner, owner, miner, actr, abi.PeerID("miner"), []abi.Multiaddrs{{1}}, abi.RegisteredSealProof_StackedDrg2KiBV1, abi.NewTokenAmount(10))
 
 		var st power.State
 		rt.GetState(&st)
@@ -191,7 +191,7 @@ func (h *spActorHarness) constructAndVerify(rt *mock.Runtime) {
 }
 
 func (h *spActorHarness) createMiner(rt *mock.Runtime, owner, worker, miner, robust addr.Address, peer abi.PeerID,
-	multiaddrs []abi.Multiaddrs, sealProofType abi.RegisteredProof, value abi.TokenAmount) {
+	multiaddrs []abi.Multiaddrs, sealProofType abi.RegisteredSealProof, value abi.TokenAmount) {
 	createMinerParams := &power.CreateMinerParams{
 		Owner:         owner,
 		Worker:        worker,
@@ -230,7 +230,7 @@ func (h *spActorHarness) enrollCronEvent(rt *mock.Runtime, miner addr.Address, e
 	rt.Verify()
 }
 
-func initCreateMinerBytes(t testing.TB, owner, worker addr.Address, peer abi.PeerID, multiaddrs []abi.Multiaddrs, sealProofType abi.RegisteredProof) []byte {
+func initCreateMinerBytes(t testing.TB, owner, worker addr.Address, peer abi.PeerID, multiaddrs []abi.Multiaddrs, sealProofType abi.RegisteredSealProof) []byte {
 	params := &power.MinerConstructorParams{
 		OwnerAddr:     owner,
 		WorkerAddr:    worker,

--- a/actors/runtime/runtime.go
+++ b/actors/runtime/runtime.go
@@ -116,7 +116,7 @@ type Syscalls interface {
 	// Hashes input data using blake2b with 256 bit output.
 	HashBlake2b(data []byte) [32]byte
 	// Computes an unsealed sector CID (CommD) from its constituent piece CIDs (CommPs) and sizes.
-	ComputeUnsealedSectorCID(reg abi.RegisteredProof, pieces []abi.PieceInfo) (cid.Cid, error)
+	ComputeUnsealedSectorCID(reg abi.RegisteredSealProof, pieces []abi.PieceInfo) (cid.Cid, error)
 	// Verifies a sector seal proof.
 	VerifySeal(vi abi.SealVerifyInfo) error
 

--- a/support/mock/mockrt.go
+++ b/support/mock/mockrt.go
@@ -446,7 +446,7 @@ func (rt *Runtime) HashBlake2b(data []byte) [32]byte {
 	return rt.hashfunc(data)
 }
 
-func (rt *Runtime) ComputeUnsealedSectorCID(reg abi.RegisteredProof, pieces []abi.PieceInfo) (cid.Cid, error) {
+func (rt *Runtime) ComputeUnsealedSectorCID(reg abi.RegisteredSealProof, pieces []abi.PieceInfo) (cid.Cid, error) {
 	panic("implement me")
 }
 


### PR DESCRIPTION
As of https://github.com/filecoin-project/rust-filecoin-proofs-api/pull/24, the actual enumerated values of registered seal proofs are significant to the protocol. In order to emphasize the non-arbitrary nature of these types/values, and to simplify keeping them in lockstep through the repos, I would like to mirror the types as closely as possible. I consulted @laser and mentioned my intention to @anorth before undertaking this.

To support this work, we will need a third PR — this one in filecoin-ffi. Hopefully once `specs-actors` and `rust-filecoin-proofs-api` are in sync, the job of adapting between them will be simpler. So that code will need some refactoring, hopefully to something more straightforward than currently exists.

I will leave this PR in draft until the work in `filecoin-ffi` is done (depending on this branch). Review can begin prior to that, though. I am not very familiar with `specs-actors`, so it's entirely possible that I overlooked something important while making these changes. I did not intentionally change anything that wasn't required to make tests pass after making the intended changes in `sector.go`.