### PR TITLE
Document issues for existing TODOs

### DIFF
--- a/actors/abi/bitfield.go
+++ b/actors/abi/bitfield.go
@@ -21,7 +21,7 @@ func BitFieldUnion(bfs ...*BitField) (*BitField, error) {
 	if len(bfs) == 0 {
 		return NewBitField(), nil
 	}
-	// TODO: optimize me
+	// TODO: optimize me: https://github.com/filecoin-project/specs-actors/issues/460
 	for len(bfs) > 1 {
 		var next []*BitField
 		for i := 0; i < len(bfs); i += 2 {

--- a/actors/builtin/market/market_actor.go
+++ b/actors/builtin/market/market_actor.go
@@ -402,7 +402,7 @@ func (a Actor) OnMinerSectorsTerminate(rt Runtime, params *OnMinerSectorsTermina
 
 			// Note: we do not perform the balance transfers here, but rather simply record the flag
 			// to indicate that processDealSlashed should be called when the deferred state computation
-			// is performed. // TODO: Do that here
+			// is performed. // TODO: Do that here. https://github.com/filecoin-project/specs-actors/issues/462
 
 			state.SlashEpoch = rt.CurrEpoch()
 
@@ -486,6 +486,7 @@ func (a Actor) CronTick(rt Runtime, params *adt.EmptyValue) *adt.EmptyValue {
 					Assert(nextEpoch > rt.CurrEpoch())
 
 					// TODO: can we avoid having this field?
+					// https://github.com/filecoin-project/specs-actors/issues/463
 					state.LastUpdatedEpoch = rt.CurrEpoch()
 
 					if err := states.Set(dealID, state); err != nil {

--- a/actors/builtin/market/market_state.go
+++ b/actors/builtin/market/market_state.go
@@ -289,6 +289,7 @@ func (st *State) maybeLockBalance(rt Runtime, addr addr.Address, amount abi.Toke
 }
 
 // TODO: all these balance table mutations need to happen at the top level and be batched (no flushing after each!)
+// https://github.com/filecoin-project/specs-actors/issues/464
 func (st *State) unlockBalance(lt *adt.BalanceTable, addr addr.Address, amount abi.TokenAmount) error {
 	Assert(amount.GreaterThanEqual(big.Zero()))
 

--- a/actors/builtin/market/market_test.go
+++ b/actors/builtin/market/market_test.go
@@ -294,6 +294,7 @@ func TestMarketActor(t *testing.T) {
 
 		// TODO: withdraws limited by slashing
 		// TODO: withdraws limited by locked balance
+		// https://github.com/filecoin-project/specs-actors/issues/465
 	})
 }
 

--- a/actors/builtin/methods.go
+++ b/actors/builtin/methods.go
@@ -9,6 +9,7 @@ const (
 	MethodConstructor = abi.MethodNum(1)
 
 	// TODO fin: remove this once canonical method numbers are finalized
+	// https://github.com/filecoin-project/specs-actors/issues/461
 	MethodPlaceholder = abi.MethodNum(1 << 30)
 )
 

--- a/actors/builtin/miner/deadlines_test.go
+++ b/actors/builtin/miner/deadlines_test.go
@@ -510,6 +510,7 @@ func TestAssignNewSectors(t *testing.T) {
 	})
 	// TODO: a final test including partial and full partitions that exercises both filling the partials first,
 	// then prioritising the less full deadlines.
+	// https://github.com/filecoin-project/specs-actors/issues/439
 }
 
 //

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -1341,7 +1341,7 @@ func checkPrecommitExpiry(rt Runtime, sectors *abi.BitField) {
 }
 
 // TODO: red flag that this method is potentially super expensive
-// https://github.com/filecoin-project/specs-actors/issues/411
+// https://github.com/filecoin-project/specs-actors/issues/483
 func terminateSectors(rt Runtime, sectorNos *abi.BitField, terminationType power.SectorTermination) {
 	empty, err := sectorNos.IsEmpty()
 	if err != nil {
@@ -1516,7 +1516,7 @@ func requestTerminateDeals(rt Runtime, dealIDs []abi.DealID) {
 func requestTerminateAllDeals(rt Runtime, st *State) {
 	// TODO: red flag this is an ~unbounded computation.
 	// Transform into an idempotent partial computation that can be progressed on each invocation.
-	// https://github.com/filecoin-project/specs-actors/issues/411
+	// https://github.com/filecoin-project/specs-actors/issues/483
 	dealIds := []abi.DealID{}
 	if err := st.ForEachSector(adt.AsStore(rt), func(sector *SectorOnChainInfo) {
 		dealIds = append(dealIds, sector.Info.DealIDs...)

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -249,6 +249,7 @@ func (a Actor) SubmitWindowedPoSt(rt Runtime, params *SubmitWindowedPoStParams) 
 		verifyPledgeMeetsInitialRequirements(rt, &st)
 
 		// TODO WPOST (follow-up): process Skipped as faults
+		// https://github.com/filecoin-project/specs-actors/issues/410
 
 		// Work out which sectors are due in the declared partitions at this deadline.
 		partitionsSectors, err := ComputePartitionsSectors(deadlines, partitionSize, currDeadline.Index, params.Partitions)
@@ -475,6 +476,7 @@ func (a Actor) ConfirmSectorProofsValid(rt Runtime, params *builtin.ConfirmSecto
 		// Check (and activate) storage deals associated to sector. Abort if checks failed.
 		// return DealWeight for the deal set in the sector
 		// TODO: we should batch these calls...
+		// https://github.com/filecoin-project/specs-actors/issues/474
 		var dealWeights market.VerifyDealsOnSectorProveCommitReturn
 		ret, code := rt.Send(
 			builtin.StorageMarketActorAddr,
@@ -495,6 +497,7 @@ func (a Actor) ConfirmSectorProofsValid(rt Runtime, params *builtin.ConfirmSecto
 		// initially, can we just do this while we're there?
 		// We can probably return the right information from this call to the caller, so it can update there
 		// TODO: we should batch these calls...
+		// https://github.com/filecoin-project/specs-actors/issues/475
 		var initialPledge abi.TokenAmount
 		ret, code = rt.Send(
 			builtin.StoragePowerActorAddr,

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -517,6 +517,7 @@ func (a Actor) ConfirmSectorProofsValid(rt Runtime, params *builtin.ConfirmSecto
 
 		// Add sector and pledge lock-up to miner state
 		// TODO: do this all at once after the loop
+		// https://github.com/filecoin-project/specs-actors/issues/476
 		newlyVestedAmount := rt.State().Transaction(&st, func() interface{} {
 			newlyVestedFund, err := st.UnlockVestedFunds(store, rt.CurrEpoch())
 			if err != nil {
@@ -1063,6 +1064,7 @@ func handleProvingPeriod(rt Runtime) {
 
 			// Load info for ongoing faults.
 			// TODO: this is potentially super expensive for a large miner with ongoing faults
+			// https://github.com/filecoin-project/specs-actors/issues/411
 			ongoingFaultInfos, err := st.LoadSectorInfos(store, ongoingFaults)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load fault sectors")
 
@@ -1154,6 +1156,7 @@ func processMissingPoStFaults(rt Runtime, st *State, store adt.Store, deadlines 
 
 	// Load info for sectors.
 	// TODO: this is potentially super expensive for a large miner failing to submit proofs.
+	// https://github.com/filecoin-project/specs-actors/issues/411
 	detectedFaultSectors, err := st.LoadSectorInfos(store, detectedFaults)
 	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load fault sectors")
 	failedRecoverySectors, err := st.LoadSectorInfos(store, failedRecoveries)
@@ -1170,6 +1173,7 @@ func processMissingPoStFaults(rt Runtime, st *State, store adt.Store, deadlines 
 func computeFaultsFromMissingPoSts(st *State, deadlines *Deadlines, sinceDeadline, beforeDeadline uint64) (detectedFaults, failedRecoveries *abi.BitField, err error) {
 	// TODO: Iterating this bitfield and keeping track of what partitions we're expecting could remove the
 	// need to expand this into a potentially-giant map. But it's tricksy.
+	// https://github.com/filecoin-project/specs-actors/issues/477
 	partitionSize := st.Info.WindowPoStPartitionSectors
 	submissions, err := st.PostSubmissions.AllMap(activePartitionsMax(partitionSize))
 	if err != nil {
@@ -1337,6 +1341,7 @@ func checkPrecommitExpiry(rt Runtime, sectors *abi.BitField) {
 }
 
 // TODO: red flag that this method is potentially super expensive
+// https://github.com/filecoin-project/specs-actors/issues/411
 func terminateSectors(rt Runtime, sectorNos *abi.BitField, terminationType power.SectorTermination) {
 	empty, err := sectorNos.IsEmpty()
 	if err != nil {
@@ -1405,6 +1410,7 @@ func terminateSectors(rt Runtime, sectorNos *abi.BitField, terminationType power
 
 	// End any fault state before terminating sector power.
 	// TODO: could we compress the three calls to power actor into one sector termination call?
+	// https://github.com/filecoin-project/specs-actors/issues/478
 	requestEndFaults(rt, st.Info.SectorSize, faultySectors)
 	requestTerminateDeals(rt, dealIDs)
 	requestTerminatePower(rt, terminationType, st.Info.SectorSize, allSectors)
@@ -1510,6 +1516,7 @@ func requestTerminateDeals(rt Runtime, dealIDs []abi.DealID) {
 func requestTerminateAllDeals(rt Runtime, st *State) {
 	// TODO: red flag this is an ~unbounded computation.
 	// Transform into an idempotent partial computation that can be progressed on each invocation.
+	// https://github.com/filecoin-project/specs-actors/issues/411
 	dealIds := []abi.DealID{}
 	if err := st.ForEachSector(adt.AsStore(rt), func(sector *SectorOnChainInfo) {
 		dealIds = append(dealIds, sector.Info.DealIDs...)
@@ -1661,6 +1668,7 @@ func commitWorkerKeyChange(rt Runtime) *adt.EmptyValue {
 // Verifies that the total locked balance exceeds the sum of sector initial pledges.
 func verifyPledgeMeetsInitialRequirements(rt Runtime, st *State) {
 	// TODO WPOST (follow-up): implement this
+	// https://github.com/filecoin-project/specs-actors/issues/415
 }
 
 // Resolves an address to an ID address and verifies that it is address of an account or multisig actor.

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -24,6 +24,7 @@ import (
 type State struct {
 	// Information not related to sectors.
 	// TODO: this should be a cid of the miner Info struct so it's not re-written when other fields change.
+	// https://github.com/filecoin-project/specs-actors/issues/422
 	Info MinerInfo
 
 	PreCommitDeposits abi.TokenAmount // Total funds locked as PreCommitDeposits

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -135,6 +135,7 @@ func TestControlAddresses(t *testing.T) {
 	})
 
 	// TODO: test changing worker (with delay), changing peer id
+	// https://github.com/filecoin-project/specs-actors/issues/479
 }
 
 // Test for sector precommitment and proving.
@@ -225,6 +226,7 @@ func TestCommitments(t *testing.T) {
 		// TODO: too early to prove sector
 		// TODO: seal rand epoch too old
 		// TODO: commitment expires before proof
+		// https://github.com/filecoin-project/specs-actors/issues/479
 
 		// Set the right epoch for all following tests
 		rt.SetEpoch(precommitEpoch + miner.PreCommitChallengeDelay + 1)
@@ -247,6 +249,7 @@ func TestCommitments(t *testing.T) {
 
 		// Invalid seal proof
 		/* TODO: how should this test work?
+		// https://github.com/filecoin-project/specs-actors/issues/479
 		rt.ExpectAbort(exitcode.ErrIllegalState, func() {
 			actor.proveCommitSector(rt, precommit, precommitEpoch, makeProveCommit(sectorNo), proveCommitConf{
 				verifySealErr: fmt.Errorf("for testing"),

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -30,6 +30,7 @@ func init() {
 // The maximum number of sectors that a miner can have simultaneously active.
 // This also bounds the number of faults that can be declared, etc.
 // TODO raise this number, carefully
+// https://github.com/filecoin-project/specs-actors/issues/470
 const SectorsMax = 32 << 20 // PARAM_FINISH
 
 // The maximum number of proving partitions a miner can have simultaneously active.

--- a/actors/builtin/paych/paych_test.go
+++ b/actors/builtin/paych/paych_test.go
@@ -523,8 +523,6 @@ func TestActor_UpdateChannelStateSettling(t *testing.T) {
 }
 
 func TestActor_UpdateChannelStateSecretPreimage(t *testing.T) {
-	// TODO: constructing the mock runtime outside of the t.Run calls below is invalid, results in use of
-	// the wrong testing.T.
 	t.Run("Succeeds with correct secret", func(t *testing.T) {
 		rt, actor, sv := requireCreateChannelWithLanes(t, context.Background(), 1)
 		var st State

--- a/actors/builtin/power/policy.go
+++ b/actors/builtin/power/policy.go
@@ -46,6 +46,7 @@ func QAPowerForWeight(weight *SectorStorageWeightDesc) abi.StoragePower {
 func InitialPledgeForWeight(qapower abi.StoragePower, totqapower abi.StoragePower, circSupply abi.TokenAmount, totalPledge abi.TokenAmount, perEpochReward abi.TokenAmount) abi.TokenAmount {
 	// Details here are still subject to change.
 	// PARAM_FINISH
+	// https://github.com/filecoin-project/specs-actors/issues/468
 	_ = circSupply  // TODO: ce use this
 	_ = totalPledge // TODO: ce use this
 

--- a/actors/builtin/power/power_actor.go
+++ b/actors/builtin/power/power_actor.go
@@ -217,7 +217,7 @@ func (a Actor) OnSectorProveCommit(rt Runtime, params *OnSectorProveCommitParams
 
 type OnSectorTerminateParams struct {
 	TerminationType SectorTermination
-	Weights         []SectorStorageWeightDesc // TODO: replace with power if it can be computed by miner, https://github.com/filecoin-project/specs-actors/issues/466
+	Weights         []SectorStorageWeightDesc // TODO: replace with power if it can be computed by miner, https://github.com/filecoin-project/specs-actors/issues/419
 }
 
 func (a Actor) OnSectorTerminate(rt Runtime, params *OnSectorTerminateParams) *adt.EmptyValue {

--- a/actors/builtin/power/power_actor.go
+++ b/actors/builtin/power/power_actor.go
@@ -217,7 +217,7 @@ func (a Actor) OnSectorProveCommit(rt Runtime, params *OnSectorProveCommitParams
 
 type OnSectorTerminateParams struct {
 	TerminationType SectorTermination
-	Weights         []SectorStorageWeightDesc // TODO: replace with power if it can be computed by miner
+	Weights         []SectorStorageWeightDesc // TODO: replace with power if it can be computed by miner, https://github.com/filecoin-project/specs-actors/issues/466
 }
 
 func (a Actor) OnSectorTerminate(rt Runtime, params *OnSectorTerminateParams) *adt.EmptyValue {
@@ -238,7 +238,7 @@ func (a Actor) OnSectorTerminate(rt Runtime, params *OnSectorTerminateParams) *a
 }
 
 type OnFaultBeginParams struct {
-	Weights []SectorStorageWeightDesc // TODO: replace with power if it can be computed by miner
+	Weights []SectorStorageWeightDesc // TODO: replace with power if it can be computed by miner, https://github.com/filecoin-project/specs-actors/issues/466
 }
 
 func (a Actor) OnFaultBegin(rt Runtime, params *OnFaultBeginParams) *adt.EmptyValue {
@@ -256,7 +256,7 @@ func (a Actor) OnFaultBegin(rt Runtime, params *OnFaultBeginParams) *adt.EmptyVa
 }
 
 type OnFaultEndParams struct {
-	Weights []SectorStorageWeightDesc // TODO: replace with power if it can be computed by miner
+	Weights []SectorStorageWeightDesc // TODO: replace with power if it can be computed by miner, https://github.com/filecoin-project/specs-actors/issues/466
 }
 
 func (a Actor) OnFaultEnd(rt Runtime, params *OnFaultEndParams) *adt.EmptyValue {
@@ -276,7 +276,7 @@ func (a Actor) OnFaultEnd(rt Runtime, params *OnFaultEndParams) *adt.EmptyValue 
 }
 
 type OnSectorModifyWeightDescParams struct {
-	PrevWeight SectorStorageWeightDesc // TODO: replace with power if it can be computed by miner
+	PrevWeight SectorStorageWeightDesc // TODO: replace with power if it can be computed by miner, https://github.com/filecoin-project/specs-actors/issues/466
 	NewWeight  SectorStorageWeightDesc
 }
 
@@ -401,6 +401,7 @@ func (a Actor) SubmitPoRepForBulkVerify(rt Runtime, sealInfo *abi.SealVerifyInfo
 	minerAddr := rt.Message().Caller()
 
 	// TODO: charge a LOT of gas
+	// https://github.com/filecoin-project/specs-actors/issues/442
 	var st State
 	rt.State().Transaction(&st, func() interface{} {
 		store := adt.AsStore(rt)

--- a/actors/builtin/reward/reward_actor.go
+++ b/actors/builtin/reward/reward_actor.go
@@ -35,9 +35,9 @@ func (a Actor) Constructor(rt vmr.Runtime, _ *adt.EmptyValue) *adt.EmptyValue {
 }
 
 type AwardBlockRewardParams struct {
-	Miner       address.Address
-	Penalty     abi.TokenAmount // penalty for including bad messages in a block
-	GasReward   abi.TokenAmount // gas reward from all gas fees in a block
+	Miner     address.Address
+	Penalty   abi.TokenAmount // penalty for including bad messages in a block
+	GasReward abi.TokenAmount // gas reward from all gas fees in a block
 }
 
 // Awards a reward to a block producer.

--- a/support/mock/mockrt.go
+++ b/support/mock/mockrt.go
@@ -800,7 +800,6 @@ func (rt *Runtime) failTestNow(msg string, args ...interface{}) {
 }
 
 func (rt *Runtime) TotalFilCircSupply() abi.TokenAmount {
-	// https://github.com/filecoin-project/specs-actors/issues/467
 	panic("todo crypto econ")
 }
 

--- a/support/mock/mockrt.go
+++ b/support/mock/mockrt.go
@@ -800,6 +800,7 @@ func (rt *Runtime) failTestNow(msg string, args ...interface{}) {
 }
 
 func (rt *Runtime) TotalFilCircSupply() abi.TokenAmount {
+	// https://github.com/filecoin-project/specs-actors/issues/467
 	panic("todo crypto econ")
 }
 


### PR DESCRIPTION
Adding github issue links for all TODOs in the code.  I defaulted to filing an issue for every TODO even though some appear to be easy and maybe an issue is overkill.  If some TODOs are totally done let me know and I'll close down and remove from PR.

Please search for appearances of issue 411 in this patch and verify that this issue is correctly scoped to cover the 4 instances where it is linked.  It seemed ok but I don't understand the scaling problem well enough to know if we should file distinct issues for separate TODOs.

Closes #412

