### PR TITLE
Terminate all miner deals when a consensus fault is detected

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -910,7 +910,7 @@ func (a Actor) ReportConsensusFault(rt Runtime, params *ReportConsensusFaultPara
 	}
 
 	// Reward reporter with a share of the miner's current balance.
-	slasherReward := rewardForConsensusSlashReport(faultAge, rt.CurrentBalance())
+	slasherReward := RewardForConsensusSlashReport(faultAge, rt.CurrentBalance())
 	_, code := rt.Send(reporter, builtin.MethodSend, nil, slasherReward)
 	builtin.RequireSuccess(rt, code, "failed to reward reporter")
 

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -909,27 +909,14 @@ func (a Actor) ReportConsensusFault(rt Runtime, params *ReportConsensusFaultPara
 		rt.Abortf(exitcode.ErrIllegalArgument, "invalid fault epoch %v ahead of current %v", fault.Epoch, rt.CurrEpoch())
 	}
 
-	var st State
-	rt.State().Readonly(&st)
-
-	// Notify power actor with lock-up total being removed.
-	_, code := rt.Send(
-		builtin.StoragePowerActorAddr,
-		builtin.MethodsPower.OnConsensusFault,
-		&st.LockedFunds,
-		abi.NewTokenAmount(0),
-	)
-	builtin.RequireSuccess(rt, code, "failed to notify power actor on consensus fault")
-
-	// TODO: terminate deals with market actor, https://github.com/filecoin-project/specs-actors/issues/279
-
 	// Reward reporter with a share of the miner's current balance.
 	slasherReward := rewardForConsensusSlashReport(faultAge, rt.CurrentBalance())
-	_, code = rt.Send(reporter, builtin.MethodSend, nil, slasherReward)
+	_, code := rt.Send(reporter, builtin.MethodSend, nil, slasherReward)
 	builtin.RequireSuccess(rt, code, "failed to reward reporter")
 
-	// Delete the actor and burn all remaining funds
-	rt.DeleteActor(builtin.BurntFundsActorAddr)
+	// kill power, close deals and burn funds
+	terminateMiner(rt)
+
 	return nil
 }
 
@@ -1598,6 +1585,26 @@ func getVerifyInfo(rt Runtime, params *SealVerifyStuff) *abi.SealVerifyInfo {
 		SealedCID:             params.SealedCID,
 		UnsealedCID:           commD,
 	}
+}
+
+// Closes down this miner by erasing its power, terminating all its deals and burning its funds
+func terminateMiner(rt Runtime) {
+	var st State
+	rt.State().Readonly(&st)
+
+	// Notify power actor with lock-up total being removed.
+	_, code := rt.Send(
+		builtin.StoragePowerActorAddr,
+		builtin.MethodsPower.OnConsensusFault,
+		&st.LockedFunds,
+		abi.NewTokenAmount(0),
+	)
+	builtin.RequireSuccess(rt, code, "failed to notify power actor on consensus fault")
+
+	requestTerminateAllDeals(rt, &st)
+
+	// Delete the actor and burn all remaining funds
+	rt.DeleteActor(builtin.BurntFundsActorAddr)
 }
 
 // Requests the storage market actor compute the unsealed sector CID from a sector's deals.

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -647,6 +647,7 @@ func TestReportConsensusFault(t *testing.T) {
 		WithActorType(owner, builtin.AccountActorCodeID).
 		WithActorType(worker, builtin.AccountActorCodeID).
 		WithHasher(fixedHasher(uint64(periodOffset))).
+		WithBalance(abi.NewTokenAmount(1<<50), abi.NewTokenAmount(0)).
 		WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID)
 
 	rt := builder.Build(t)

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -885,7 +885,7 @@ func (h *actorHarness) commitAndProveSectors(rt *mock.Runtime, n int, expiration
 			sectorDealIDs = dealIDs[i]
 		}
 		precommit := makePreCommit(sectorNo, precommitEpoch-1, expiration, sectorDealIDs)
-		h.preCommitSector(rt, precommit, big.Zero(), abi.NewStoragePower(int64(networkPower)))
+		h.preCommitSector(rt, precommit, abi.NewStoragePower(int64(networkPower)), big.Zero())
 		precommits[i] = precommit
 		h.nextSectorNo++
 	}
@@ -1099,10 +1099,11 @@ func (h *actorHarness) reportConsensusFault(rt *mock.Runtime, from addr.Address,
 	}, nil)
 
 	// slash reward
-	rt.ExpectSend(from, builtin.MethodSend, nil, big.Zero(), nil, exitcode.Ok)
+	reward := miner.RewardForConsensusSlashReport(1, rt.Balance())
+	rt.ExpectSend(from, builtin.MethodSend, nil, reward, nil, exitcode.Ok)
 
 	// power termination
-	lockedFunds := abi.NewTokenAmount(0)
+	lockedFunds := getState(rt).LockedFunds
 	rt.ExpectSend(builtin.StoragePowerActorAddr, builtin.MethodsPower.OnConsensusFault, &lockedFunds, abi.NewTokenAmount(0), nil, exitcode.Ok)
 
 	// expect every deal to be closed out

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -1088,7 +1088,6 @@ func (h *actorHarness) extendSector(rt *mock.Runtime, sector *miner.SectorOnChai
 }
 
 func (h *actorHarness) reportConsensusFault(rt *mock.Runtime, from addr.Address, params *miner.ReportConsensusFaultParams, dealIDs []abi.DealID) {
-	rt.Reset()
 	rt.SetCaller(from, builtin.AccountActorCodeID)
 	rt.ExpectValidateCallerType(builtin.CallerTypesSignable...)
 
@@ -1115,6 +1114,7 @@ func (h *actorHarness) reportConsensusFault(rt *mock.Runtime, from addr.Address,
 	rt.ExpectDeleteActor(builtin.BurntFundsActorAddr)
 
 	rt.Call(h.a.ReportConsensusFault, params)
+	rt.Verify()
 }
 
 func (h *actorHarness) onProvingPeriodCron(rt *mock.Runtime, expectedEnrollment abi.ChainEpoch, newSectors bool, randEpoch abi.ChainEpoch) {

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"github.com/filecoin-project/specs-actors/actors/runtime"
 	"testing"
 
 	addr "github.com/filecoin-project/go-address"
@@ -165,7 +166,7 @@ func TestCommitments(t *testing.T) {
 
 		// Make a good commitment for the proof to target.
 		sectorNo := abi.SectorNumber(100)
-		precommit := makePreCommit(sectorNo, precommitEpoch-1, deadline.PeriodEnd())
+		precommit := makePreCommit(sectorNo, precommitEpoch-1, deadline.PeriodEnd(), nil)
 		actor.preCommitSector(rt, precommit, networkPower, big.Zero())
 
 		// assert precommit exists and meets expectations
@@ -234,17 +235,17 @@ func TestCommitments(t *testing.T) {
 		challengeEpoch := precommitEpoch - 1
 
 		// Good commitment.
-		actor.preCommitSector(rt, makePreCommit(100, challengeEpoch, deadline.PeriodEnd()), networkPower, big.Zero())
+		actor.preCommitSector(rt, makePreCommit(100, challengeEpoch, deadline.PeriodEnd(), nil), networkPower, big.Zero())
 
 		// Duplicate sector ID
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
-			actor.preCommitSector(rt, makePreCommit(100, challengeEpoch, deadline.PeriodEnd()), networkPower, big.Zero())
+			actor.preCommitSector(rt, makePreCommit(100, challengeEpoch, deadline.PeriodEnd(), nil), networkPower, big.Zero())
 		})
 		rt.Reset()
 
 		// Bad seal proof type
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
-			pc := makePreCommit(114, challengeEpoch, deadline.PeriodEnd())
+			pc := makePreCommit(114, challengeEpoch, deadline.PeriodEnd(), nil)
 			pc.SealProof = abi.RegisteredSealProof_StackedDrg8MiBV1
 			actor.preCommitSector(rt, pc, networkPower, big.Zero())
 		})
@@ -253,21 +254,21 @@ func TestCommitments(t *testing.T) {
 		// Expires at current epoch
 		rt.SetEpoch(deadline.PeriodEnd())
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
-			actor.preCommitSector(rt, makePreCommit(111, challengeEpoch, deadline.PeriodEnd()), networkPower, big.Zero())
+			actor.preCommitSector(rt, makePreCommit(111, challengeEpoch, deadline.PeriodEnd(), nil), networkPower, big.Zero())
 		})
 		rt.Reset()
 
 		// Expires before current epoch
 		rt.SetEpoch(deadline.PeriodEnd() + 1)
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
-			actor.preCommitSector(rt, makePreCommit(112, challengeEpoch, deadline.PeriodEnd()), networkPower, big.Zero())
+			actor.preCommitSector(rt, makePreCommit(112, challengeEpoch, deadline.PeriodEnd(), nil), networkPower, big.Zero())
 		})
 		rt.Reset()
 
 		// Expires not on period end
 		rt.SetEpoch(precommitEpoch)
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
-			actor.preCommitSector(rt, makePreCommit(113, challengeEpoch, deadline.PeriodEnd()-1), networkPower, big.Zero())
+			actor.preCommitSector(rt, makePreCommit(113, challengeEpoch, deadline.PeriodEnd()-1, nil), networkPower, big.Zero())
 		})
 
 		// TODO: test insufficient funds when the precommit deposit is set above zero
@@ -285,7 +286,7 @@ func TestCommitments(t *testing.T) {
 
 		// Make a good commitment for the proof to target.
 		sectorNo := abi.SectorNumber(100)
-		precommit := makePreCommit(sectorNo, precommitEpoch-1, deadline.PeriodEnd())
+		precommit := makePreCommit(sectorNo, precommitEpoch-1, deadline.PeriodEnd(), nil)
 		actor.preCommitSector(rt, precommit, networkPower, big.Zero())
 
 		// Sector pre-commitment missing.
@@ -374,7 +375,7 @@ func TestWindowPost(t *testing.T) {
 		partitionSize := st.Info.WindowPoStPartitionSectors
 		deadline := st.DeadlineInfo(rt.Epoch())
 		expiration := deadline.PeriodEnd() + 100*miner.WPoStProvingPeriod
-		_ = actor.commitAndProveSectors(rt, 1, expiration, 1<<50)
+		_ = actor.commitAndProveSectors(rt, 1, expiration, 1<<50, nil)
 
 		// Skip to end of proving period, cron adds sectors to proving set.
 		deadline = st.DeadlineInfo(rt.Epoch())
@@ -466,7 +467,7 @@ func TestProvingPeriodCron(t *testing.T) {
 		actor.constructAndVerify(rt, periodOffset)
 		st := getState(rt)
 
-		sectorInfo := actor.commitAndProveSectors(rt, 1, periodOffset+100*miner.WPoStProvingPeriod-1, 1<<50)
+		sectorInfo := actor.commitAndProveSectors(rt, 1, periodOffset+100*miner.WPoStProvingPeriod-1, 1<<50, nil)
 
 		// Flag new sectors to trigger request for randomness
 		rt.Transaction(st, func() interface{} {
@@ -514,7 +515,7 @@ func TestDeclareFaults(t *testing.T) {
 		actor.constructAndVerify(rt, periodOffset)
 		expiration := 100*miner.WPoStProvingPeriod + periodOffset - 1
 		sectorNumber := actor.nextSectorNo
-		actor.commitAndProveSectors(rt, 1, expiration, 1<<50)
+		actor.commitAndProveSectors(rt, 1, expiration, 1<<50, nil)
 
 		// Skip to end of proving period, cron adds sectors to proving set.
 		st := getState(rt)
@@ -560,7 +561,7 @@ func TestExtendSectorExpiration(t *testing.T) {
 		st := getState(rt)
 		deadline := st.DeadlineInfo(rt.Epoch())
 		expiration := deadline.PeriodEnd() + 100*miner.WPoStProvingPeriod
-		sectorInfo := actor.commitAndProveSectors(rt, 1, expiration, 0)
+		sectorInfo := actor.commitAndProveSectors(rt, 1, expiration, 0, nil)
 
 		sector, found, err := getState(rt).GetSector(rt.AdtStore(), sectorInfo[0].SectorNumber)
 		require.NoError(t, err)
@@ -634,6 +635,43 @@ func TestExtendSectorExpiration(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, exists)
 	})
+}
+
+func TestReportConsensusFault(t *testing.T) {
+	owner := tutil.NewIDAddr(t, 100)
+	worker := tutil.NewIDAddr(t, 101)
+	workerKey := tutil.NewBLSAddr(t, 0)
+	actor := newHarness(t, tutil.NewIDAddr(t, 1000), owner, worker, workerKey)
+	periodOffset := abi.ChainEpoch(100)
+	builder := mock.NewBuilder(context.Background(), actor.receiver).
+		WithActorType(owner, builtin.AccountActorCodeID).
+		WithActorType(worker, builtin.AccountActorCodeID).
+		WithHasher(fixedHasher(uint64(periodOffset))).
+		WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID)
+
+	rt := builder.Build(t)
+	actor.constructAndVerify(rt, periodOffset)
+	precommitEpoch := abi.ChainEpoch(1)
+	rt.SetEpoch(precommitEpoch)
+	st := getState(rt)
+	deadline := st.DeadlineInfo(rt.Epoch())
+	expiration := deadline.PeriodEnd() + 10*miner.WPoStProvingPeriod
+	dealIDs := [][]abi.DealID{{1, 2}, {3, 4}}
+	sectorInfo := actor.commitAndProveSectors(rt, 2, expiration, 1<<50, dealIDs)
+	_ = sectorInfo
+
+	params := &miner.ReportConsensusFaultParams{
+		BlockHeader1:     nil,
+		BlockHeader2:     nil,
+		BlockHeaderExtra: nil,
+	}
+
+	// miner should send a single call to terminate the deals for all its sectors
+	allDeals := []abi.DealID{}
+	for _, ids := range dealIDs {
+		allDeals = append(allDeals, ids...)
+	}
+	actor.reportConsensusFault(rt, addr.TestAddress, params, allDeals)
 }
 
 type actorHarness struct {
@@ -834,14 +872,18 @@ func (h *actorHarness) proveCommitSector(rt *mock.Runtime, precommit *miner.Sect
 
 // Pre-commits and then proves a number of sectors.
 // The runtime epoch will be moved forward to the epoch of commitment proofs.
-func (h *actorHarness) commitAndProveSectors(rt *mock.Runtime, n int, expiration abi.ChainEpoch, networkPower uint64) []*miner.SectorPreCommitInfo {
+func (h *actorHarness) commitAndProveSectors(rt *mock.Runtime, n int, expiration abi.ChainEpoch, networkPower uint64, dealIDs [][]abi.DealID) []*miner.SectorPreCommitInfo {
 	precommitEpoch := rt.Epoch()
 	precommits := make([]*miner.SectorPreCommitInfo, n)
 
 	// Precommit
 	for i := 0; i < n; i++ {
 		sectorNo := h.nextSectorNo
-		precommit := makePreCommit(sectorNo, precommitEpoch-1, expiration)
+		var sectorDealIDs []abi.DealID
+		if dealIDs != nil {
+			sectorDealIDs = dealIDs[i]
+		}
+		precommit := makePreCommit(sectorNo, precommitEpoch-1, expiration, sectorDealIDs)
 		h.preCommitSector(rt, precommit, big.Zero(), abi.NewStoragePower(int64(networkPower)))
 		precommits[i] = precommit
 		h.nextSectorNo++
@@ -1044,6 +1086,35 @@ func (h *actorHarness) extendSector(rt *mock.Runtime, sector *miner.SectorOnChai
 	rt.Call(h.a.ExtendSectorExpiration, params)
 }
 
+func (h *actorHarness) reportConsensusFault(rt *mock.Runtime, from addr.Address, params *miner.ReportConsensusFaultParams, dealIDs []abi.DealID) {
+	rt.Reset()
+	rt.SetCaller(from, builtin.AccountActorCodeID)
+	rt.ExpectValidateCallerType(builtin.CallerTypesSignable...)
+
+	rt.ExpectVerifyConsensusFault(params.BlockHeader1, params.BlockHeader2, params.BlockHeaderExtra, &runtime.ConsensusFault{
+		Target: h.receiver,
+		Epoch:  rt.Epoch() - 1,
+		Type:   runtime.ConsensusFaultDoubleForkMining,
+	}, nil)
+
+	// slash reward
+	rt.ExpectSend(from, builtin.MethodSend, nil, big.Zero(), nil, exitcode.Ok)
+
+	// power termination
+	lockedFunds := abi.NewTokenAmount(0)
+	rt.ExpectSend(builtin.StoragePowerActorAddr, builtin.MethodsPower.OnConsensusFault, &lockedFunds, abi.NewTokenAmount(0), nil, exitcode.Ok)
+
+	// expect every deal to be closed out
+	rt.ExpectSend(builtin.StorageMarketActorAddr, builtin.MethodsMarket.OnMinerSectorsTerminate, &market.OnMinerSectorsTerminateParams{
+		DealIDs: dealIDs,
+	}, abi.NewTokenAmount(0), nil, exitcode.Ok)
+
+	// expect actor to be deleted
+	rt.ExpectDeleteActor(builtin.BurntFundsActorAddr)
+
+	rt.Call(h.a.ReportConsensusFault, params)
+}
+
 func (h *actorHarness) onProvingPeriodCron(rt *mock.Runtime, expectedEnrollment abi.ChainEpoch, newSectors bool, randEpoch abi.ChainEpoch) {
 	rt.ExpectValidateCallerAddr(builtin.StoragePowerActorAddr)
 	if newSectors {
@@ -1083,13 +1154,13 @@ func makeProvingPeriodCronEventParams(t testing.TB, epoch abi.ChainEpoch) *power
 	}
 }
 
-func makePreCommit(sectorNo abi.SectorNumber, challenge, expiration abi.ChainEpoch) *miner.SectorPreCommitInfo {
+func makePreCommit(sectorNo abi.SectorNumber, challenge, expiration abi.ChainEpoch, dealIDs []abi.DealID) *miner.SectorPreCommitInfo {
 	return &miner.SectorPreCommitInfo{
 		SealProof:     abi.RegisteredSealProof_StackedDrg2KiBV1,
 		SectorNumber:  sectorNo,
 		SealedCID:     tutil.MakeCID("commr"),
 		SealRandEpoch: challenge,
-		DealIDs:       nil,
+		DealIDs:       dealIDs,
 		Expiration:    expiration,
 	}
 }

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -167,7 +167,7 @@ var PledgeVestingSpec = VestSpec{
 	Quantization: 12 * builtin.EpochsInHour,               // 12 hours for testnet, PARAM_FINISH
 }
 
-func rewardForConsensusSlashReport(elapsedEpoch abi.ChainEpoch, collateral abi.TokenAmount) abi.TokenAmount {
+func RewardForConsensusSlashReport(elapsedEpoch abi.ChainEpoch, collateral abi.TokenAmount) abi.TokenAmount {
 	// PARAM_FINISH
 	// var growthRate = SLASHER_SHARE_GROWTH_RATE_NUM / SLASHER_SHARE_GROWTH_RATE_DENOM
 	// var multiplier = growthRate^elapsedEpoch

--- a/support/mock/mockrt.go
+++ b/support/mock/mockrt.go
@@ -325,12 +325,13 @@ func (rt *Runtime) DeleteActor(addr addr.Address) {
 		rt.Abortf(exitcode.SysErrorIllegalActor, "side-effect within transaction")
 	}
 	if rt.expectDeleteActor == nil {
-		rt.failTestNow("Unexpected call to delete actor")
+		rt.failTestNow("unexpected call to delete actor %s", addr.String())
 	}
 
 	if *rt.expectDeleteActor != addr {
-		rt.failTestNow("Attempt to delete wrong actor. Expected %s, got %s.", rt.expectDeleteActor.String(), addr.String())
+		rt.failTestNow("attempt to delete wrong actor. Expected %s, got %s.", rt.expectDeleteActor.String(), addr.String())
 	}
+	rt.expectDeleteActor = nil
 }
 
 func (rt *Runtime) TotalFilCircSupply() abi.TokenAmount {
@@ -735,6 +736,9 @@ func (rt *Runtime) Verify() {
 	}
 	if rt.expectVerifySeal != nil {
 		rt.failTest("missing expected verify seal with %v", rt.expectVerifySeal.seal)
+	}
+	if rt.expectDeleteActor != nil {
+		rt.failTest("missing expected delete actor with address %s", rt.expectDeleteActor.String())
 	}
 
 	rt.Reset()

--- a/support/mock/mockrt.go
+++ b/support/mock/mockrt.go
@@ -540,7 +540,10 @@ func (rt *Runtime) VerifyConsensusFault(h1, h2, extra []byte) (*runtime.Consensu
 		}
 	}
 
-	return rt.expectVerifyConsensusFault.Fault, rt.expectVerifyConsensusFault.Err
+	fault := rt.expectVerifyConsensusFault.Fault
+	err := rt.expectVerifyConsensusFault.Err
+	rt.expectVerifyConsensusFault = nil
+	return fault, err
 }
 
 ///// Trace span implementation /////
@@ -736,6 +739,9 @@ func (rt *Runtime) Verify() {
 	}
 	if rt.expectVerifySeal != nil {
 		rt.failTest("missing expected verify seal with %v", rt.expectVerifySeal.seal)
+	}
+	if rt.expectVerifyConsensusFault != nil {
+		rt.failTest("missing expected verify consensus fault")
 	}
 	if rt.expectDeleteActor != nil {
 		rt.failTest("missing expected delete actor with address %s", rt.expectDeleteActor.String())


### PR DESCRIPTION
closes #279

### Motivation

When a miner is deleted due to a consensus fault, all of it's deals need to be properly terminated.

### Changes in this PR

1. Extract the miner termination logic out of `ReportConsensusFault` into a new `terminateMiner` method.
2. Call `requestTerminateAllDeals` from within that method.
3. Add a method to call `ReportConsensusFault` within the miner test actor harness.
4. Add logic to expect a `VerifyConsensusFault` and `DeleteActor` to the mock runtime.
5. Add the ability to specify deal IDs when creating sectors for miner tests so that we can observe the deal termination logic.
6. Add happy path test for `ReportConsensusFault` that confirms that it sends a `OnMinerSectorsTerminate` message to the storage market actor whose params contain every deal id referenced by all the miner's sectors.

### Work left to be done

1. Issue #279 requests that deal ids also be removed when a miner is removed voluntarily or in response to a storage fault. The logic for these cases does not seem to exist, but can use the new `terminateMiner` function when they do.
2. There are TODOs in the code base suggesting the `requestTerminateAllDeals` method could be too expensive to run. The proposed alternative did not seem sufficiently specified to deal with in this PR.