### PR TITLE
Revert "add cc upgrade to precommit (#398)"

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -348,20 +348,10 @@ func (a Actor) PreCommitSector(rt Runtime, params *SectorPreCommitInfo) *adt.Emp
 			rt.Abortf(exitcode.ErrIllegalArgument, "sector %v already precommitted", params.SectorNumber)
 		}
 
-		if sectorInfo, found, err := st.GetSector(store, params.SectorNumber); err != nil {
+		if found, err := st.HasSectorNo(store, params.SectorNumber); err != nil {
 			rt.Abortf(exitcode.ErrIllegalState, "failed to check sector %v: %v", params.SectorNumber, err)
 		} else if found {
-			if len(sectorInfo.Info.DealIDs) > 0 {
-				// Sector has been previously committed and proven with deals.
-				rt.Abortf(exitcode.ErrIllegalArgument, "sector %v already committed with deals", params.SectorNumber)
-			} else {
-				// Committed Capacity sector upgrade.
-				// The unexpired sector info remains in the state until ProveCommitSector overwrites it with the
-				// new activation epoch, expiration, deals etc.
-				if params.Expiration < sectorInfo.Info.Expiration {
-					rt.Abortf(exitcode.ErrIllegalArgument, "upgraded sector %v expires before original expiration", params.SectorNumber)
-				}
-			}
+			rt.Abortf(exitcode.ErrIllegalArgument, "sector %v already committed", params.SectorNumber)
 		}
 
 		validateExpiration(rt, &st, params.Expiration)


### PR DESCRIPTION
This reverts commit fb8781b093e434b1b7c26570f6be2af743e42199.

This commit introduced a number of problems, now described in the linked PR. Fixes #430.

We'll re-implement committed-capacity upgrades with a different approach (#485).

FYI @zixuanzh 