### PR TITLE
Move sector quality and power calculations into miner actor

### DIFF
--- a/actors/abi/cbor_gen.go
+++ b/actors/abi/cbor_gen.go
@@ -159,7 +159,7 @@ func (t *SectorInfo) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.SealProof (abi.RegisteredProof) (int64)
+	// t.SealProof (abi.RegisteredSealProof) (int64)
 	if t.SealProof >= 0 {
 		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.SealProof))); err != nil {
 			return err
@@ -200,7 +200,7 @@ func (t *SectorInfo) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
-	// t.RegisteredProof (abi.RegisteredProof) (int64)
+	// t.SealProof (abi.RegisteredSealProof) (int64)
 	{
 		maj, extra, err := cbg.CborReadHeader(br)
 		var extraI int64
@@ -263,7 +263,7 @@ func (t *SealVerifyInfo) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.RegisteredSealProof (abi.RegisteredProof) (int64)
+	// t.SealProof (abi.RegisteredSealProof) (int64)
 	if t.SealProof >= 0 {
 		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.SealProof))); err != nil {
 			return err
@@ -359,7 +359,7 @@ func (t *SealVerifyInfo) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
-	// t.RegisteredProof (abi.RegisteredProof) (int64)
+	// t.SealProof (abi.RegisteredSealProof) (int64)
 	{
 		maj, extra, err := cbg.CborReadHeader(br)
 		var extraI int64
@@ -513,7 +513,7 @@ func (t *PoStProof) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.RegisteredProof (abi.RegisteredProof) (int64)
+	// t.PoStProof (abi.RegisteredPoStProof) (int64)
 	if t.PoStProof >= 0 {
 		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.PoStProof))); err != nil {
 			return err
@@ -553,7 +553,7 @@ func (t *PoStProof) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
-	// t.RegisteredProof (abi.RegisteredProof) (int64)
+	// t.PoStProof (abi.RegisteredPoStProof) (int64)
 	{
 		maj, extra, err := cbg.CborReadHeader(br)
 		var extraI int64

--- a/actors/builtin/market/cbor_gen.go
+++ b/actors/builtin/market/cbor_gen.go
@@ -570,7 +570,7 @@ func (t *ComputeDataCommitmentParams) UnmarshalCBOR(r io.Reader) error {
 		t.DealIDs[i] = abi.DealID(val)
 	}
 
-	// t.SectorType (abi.RegisteredProof) (int64)
+	// t.SectorType (abi.RegisteredSealProof) (int64)
 	{
 		maj, extra, err := cbg.CborReadHeader(br)
 		var extraI int64

--- a/actors/builtin/miner/cbor_gen.go
+++ b/actors/builtin/miner/cbor_gen.go
@@ -411,7 +411,7 @@ func (t *MinerInfo) MarshalCBOR(w io.Writer) error {
 		}
 	}
 
-	// t.SealProofType (abi.RegisteredProof) (int64)
+	// t.SealProofType (abi.RegisteredSealProof) (int64)
 	if t.SealProofType >= 0 {
 		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.SealProofType))); err != nil {
 			return err
@@ -551,7 +551,7 @@ func (t *MinerInfo) UnmarshalCBOR(r io.Reader) error {
 		}
 	}
 
-	// t.SealProofType (abi.RegisteredProof) (int64)
+	// t.SealProofType (abi.RegisteredSealProof) (int64)
 	{
 		maj, extra, err := cbg.CborReadHeader(br)
 		var extraI int64
@@ -783,7 +783,7 @@ func (t *SectorPreCommitInfo) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.RegisteredProof (abi.RegisteredProof) (int64)
+	// t.SealProof (abi.RegisteredSealProof) (int64)
 	if t.SealProof >= 0 {
 		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.SealProof))); err != nil {
 			return err
@@ -859,7 +859,7 @@ func (t *SectorPreCommitInfo) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
-	// t.RegisteredProof (abi.RegisteredSealProof) (int64)
+	// t.SealProof (abi.RegisteredSealProof) (int64)
 	{
 		maj, extra, err := cbg.CborReadHeader(br)
 		var extraI int64

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -12,7 +12,6 @@ import (
 
 	abi "github.com/filecoin-project/specs-actors/actors/abi"
 	big "github.com/filecoin-project/specs-actors/actors/abi/big"
-	power "github.com/filecoin-project/specs-actors/actors/builtin/power"
 	. "github.com/filecoin-project/specs-actors/actors/util"
 	adt "github.com/filecoin-project/specs-actors/actors/util/adt"
 )
@@ -1044,15 +1043,6 @@ func (s *SectorOnChainInfo) AsSectorInfo() abi.SectorInfo {
 		SealProof:    s.Info.SealProof,
 		SectorNumber: s.Info.SectorNumber,
 		SealedCID:    s.Info.SealedCID,
-	}
-}
-
-func AsStorageWeightDesc(sectorSize abi.SectorSize, sectorInfo *SectorOnChainInfo) *power.SectorStorageWeightDesc {
-	return &power.SectorStorageWeightDesc{
-		SectorSize:         sectorSize,
-		DealWeight:         sectorInfo.DealWeight,
-		VerifiedDealWeight: sectorInfo.VerifiedDealWeight,
-		Duration:           sectorInfo.Info.Expiration - sectorInfo.ActivationEpoch,
 	}
 }
 

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -6,6 +6,7 @@ import (
 	abi "github.com/filecoin-project/specs-actors/actors/abi"
 	big "github.com/filecoin-project/specs-actors/actors/abi/big"
 	builtin "github.com/filecoin-project/specs-actors/actors/builtin"
+	. "github.com/filecoin-project/specs-actors/actors/util"
 )
 
 // The period over which all a miner's active sectors will be challenged.
@@ -86,6 +87,38 @@ const FaultMaxAge = WPoStProvingPeriod*14 - 1
 
 // Staging period for a miner worker key change.
 const WorkerKeyChangeDelay = 2 * ElectionLookback // PARAM_FINISH
+
+var QualityBaseMultiplier = big.NewInt(10)         // PARAM_FINISH
+var DealWeightMultiplier = big.NewInt(11)          // PARAM_FINISH
+var VerifiedDealWeightMultiplier = big.NewInt(100) // PARAM_FINISH
+const SectorQualityPrecision = 20
+
+// DealWeight and VerifiedDealWeight are spacetime occupied by regular deals and verified deals in a sector.
+// Sum of DealWeight and VerifiedDealWeight should be less than or equal to total SpaceTime of a sector.
+// Sectors full of VerifiedDeals will have a SectorQuality of VerifiedDealWeightMultiplier/QualityBaseMultiplier.
+// Sectors full of Deals will have a SectorQuality of DealWeightMultiplier/QualityBaseMultiplier.
+// Sectors with neither will have a SectorQuality of QualityBaseMultiplier/QualityBaseMultiplier.
+// SectorQuality of a sector is a weighted average of multipliers based on their propotions.
+func QualityForSector(sectorSize abi.SectorSize, sector *SectorOnChainInfo) abi.SectorQuality {
+	duration := sector.Info.Expiration - sector.ActivationEpoch
+	sectorSpaceTime := big.Mul(big.NewIntUnsigned(uint64(sectorSize)), big.NewInt(int64(duration)))
+	totalDealSpaceTime := big.Add(sector.DealWeight, sector.VerifiedDealWeight)
+	Assert(sectorSpaceTime.GreaterThanEqual(totalDealSpaceTime))
+
+	weightedBaseSpaceTime := big.Mul(big.Sub(sectorSpaceTime, totalDealSpaceTime), QualityBaseMultiplier)
+	weightedDealSpaceTime := big.Mul(sector.DealWeight, DealWeightMultiplier)
+	weightedVerifiedSpaceTime := big.Mul(sector.VerifiedDealWeight, VerifiedDealWeightMultiplier)
+	weightedSumSpaceTime := big.Add(weightedBaseSpaceTime, big.Add(weightedDealSpaceTime, weightedVerifiedSpaceTime))
+	scaledUpWeightedSumSpaceTime := big.Lsh(weightedSumSpaceTime, SectorQualityPrecision)
+
+	return big.Div(big.Div(scaledUpWeightedSumSpaceTime, sectorSpaceTime), QualityBaseMultiplier)
+}
+
+// Returns the quality-adjusted power for a sector.
+func QAPowerForSector(size abi.SectorSize, sector *SectorOnChainInfo) abi.StoragePower {
+	qual := QualityForSector(size, sector)
+	return big.Rsh(big.Mul(big.NewIntUnsigned(uint64(size)), qual), SectorQualityPrecision)
+}
 
 // Deposit per sector required at pre-commitment, refunded after the commitment is proven (else burned).
 func precommitDeposit(sectorSize abi.SectorSize, duration abi.ChainEpoch) abi.TokenAmount {

--- a/actors/builtin/power/policy.go
+++ b/actors/builtin/power/policy.go
@@ -3,8 +3,6 @@ package power
 import (
 	abi "github.com/filecoin-project/specs-actors/actors/abi"
 	big "github.com/filecoin-project/specs-actors/actors/abi/big"
-
-	. "github.com/filecoin-project/specs-actors/actors/util"
 )
 
 // Minimum number of registered miners for the minimum miner size limit to effectively limit consensus power.
@@ -12,36 +10,6 @@ const ConsensusMinerMinMiners = 3
 
 // Minimum power of an individual miner to meet the threshold for leader election.
 var ConsensusMinerMinPower = abi.NewStoragePower(1 << 40) // PARAM_FINISH
-
-var BaseMultiplier = big.NewInt(10)                // PARAM_FINISH
-var DealWeightMultiplier = big.NewInt(11)          // PARAM_FINISH
-var VerifiedDealWeightMultiplier = big.NewInt(100) // PARAM_FINISH
-const SectorQualityPrecision = 20
-
-// DealWeight and VerifiedDealWeight are spacetime occupied by regular deals and verified deals in a sector.
-// Sum of DealWeight and VerifiedDealWeight should be less than or equal to total SpaceTime of a sector.
-// Sectors full of VerifiedDeals will have a SectorQuality of VerifiedDealWeightMultiplier/BaseMultiplier.
-// Sectors full of Deals will have a SectorQuality of DealWeightMultiplier/BaseMultiplier.
-// Sectors with neither will have a SectorQuality of BaseMultiplier/BaseMultiplier.
-// SectorQuality of a sector is a weighted average of multipliers based on their propotions.
-func SectorQualityFromWeight(weight *SectorStorageWeightDesc) abi.SectorQuality {
-	sectorSpaceTime := big.Mul(big.NewInt(int64(weight.SectorSize)), big.NewInt(int64(weight.Duration)))
-	totalDealSpaceTime := big.Add(weight.DealWeight, weight.VerifiedDealWeight)
-	Assert(sectorSpaceTime.GreaterThanEqual(totalDealSpaceTime))
-
-	weightedBaseSpaceTime := big.Mul(big.Sub(sectorSpaceTime, totalDealSpaceTime), BaseMultiplier)
-	weightedDealSpaceTime := big.Mul(weight.DealWeight, DealWeightMultiplier)
-	weightedVerifiedSpaceTime := big.Mul(weight.VerifiedDealWeight, VerifiedDealWeightMultiplier)
-	weightedSumSpaceTime := big.Add(weightedBaseSpaceTime, big.Add(weightedDealSpaceTime, weightedVerifiedSpaceTime))
-	scaledUpWeightedSumSpaceTime := big.Lsh(weightedSumSpaceTime, SectorQualityPrecision)
-
-	return big.Div(big.Div(scaledUpWeightedSumSpaceTime, sectorSpaceTime), BaseMultiplier)
-}
-
-func QAPowerForWeight(weight *SectorStorageWeightDesc) abi.StoragePower {
-	qual := SectorQualityFromWeight(weight)
-	return big.Rsh(big.Mul(big.NewInt(int64(weight.SectorSize)), qual), SectorQualityPrecision)
-}
 
 func InitialPledgeForWeight(qapower abi.StoragePower, totqapower abi.StoragePower, circSupply abi.TokenAmount, totalPledge abi.TokenAmount, perEpochReward abi.TokenAmount) abi.TokenAmount {
 	// Details here are still subject to change.

--- a/actors/builtin/shared.go
+++ b/actors/builtin/shared.go
@@ -11,6 +11,13 @@ import (
 
 ///// Code shared by multiple built-in actors. /////
 
+// Aborts with an ErrIllegalArgument if predicate is not true.
+func RequireParam(rt runtime.Runtime, predicate bool, msg string, args ...interface{}) {
+	if !predicate {
+		rt.Abortf(exitcode.ErrIllegalArgument, msg, args...)
+	}
+}
+
 // Propagates a failed send by aborting the current method with the same exit code.
 func RequireSuccess(rt runtime.Runtime, e exitcode.ExitCode, msg string, args ...interface{}) {
 	if !e.IsSuccess() {


### PR DESCRIPTION
The calculation of sector quality and power was once in the power actor, but has no need to be. Moving the calculations to the miner actor simplifies the interactions.

- Removed `SectorStorageWeightDesc` struct
- Moved quality and power calculation functions to miner, in terms of `SectorOnChainInfo`
- Use power quantities rather than weight desc in parameters to power-accounting methods

Closes #419