### PR TITLE
Unify sector power accounting methods

### DIFF
--- a/actors/builtin/methods.go
+++ b/actors/builtin/methods.go
@@ -69,16 +69,13 @@ var MethodsPower = struct {
 	CreateMiner              abi.MethodNum
 	DeleteMiner              abi.MethodNum
 	OnSectorProveCommit      abi.MethodNum
-	OnSectorTerminate        abi.MethodNum
-	OnFaultBegin             abi.MethodNum
-	OnFaultEnd               abi.MethodNum
-	OnSectorModifyWeightDesc abi.MethodNum
+	UpdateClaimedPower       abi.MethodNum
 	EnrollCronEvent          abi.MethodNum
 	OnEpochTickEnd           abi.MethodNum
 	UpdatePledgeTotal        abi.MethodNum
 	OnConsensusFault         abi.MethodNum
 	SubmitPoRepForBulkVerify abi.MethodNum
-}{MethodConstructor, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13}
+}{MethodConstructor, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 
 var MethodsMiner = struct {
 	Constructor              abi.MethodNum

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -301,14 +301,10 @@ func (a Actor) SubmitWindowedPoSt(rt Runtime, params *SubmitWindowedPoStParams) 
 		return nil
 	})
 
-	// Remove power for new faults, and burn penalties.
-	requestBeginFaults(rt, st.Info.SectorSize, detectedFaultSectors)
+	// Restore power for recovered sectors. Remove power for new faults.
+	requestUpdateSectorPower(rt, st.Info.SectorSize, recoveredSectors, detectedFaultSectors)
+	// Burn penalties.
 	burnFundsAndNotifyPledgeChange(rt, penalty)
-
-	// Restore power for recovered sectors.
-	if len(recoveredSectors) > 0 {
-		requestEndFaults(rt, st.Info.SectorSize, recoveredSectors)
-	}
 	return nil
 }
 
@@ -621,16 +617,14 @@ func (a Actor) ExtendSectorExpiration(rt Runtime, params *ExtendSectorExpiration
 
 	newSector := *oldSector
 	newSector.Info.Expiration = params.NewExpiration
-	rawBytePower := big.NewIntUnsigned(uint64(st.Info.SectorSize))
+	qaPowerDelta := big.Sub(QAPowerForSector(st.Info.SectorSize, &newSector), QAPowerForSector(st.Info.SectorSize, oldSector))
 
 	_, code := rt.Send(
 		builtin.StoragePowerActorAddr,
-		builtin.MethodsPower.OnSectorModifyWeightDesc,
-		&power.OnSectorModifyWeightDescParams{
-			PrevRawBytePower:         rawBytePower,
-			NewRawBytePower:          rawBytePower,
-			PrevQualityAdjustedPower: QAPowerForSector(st.Info.SectorSize, oldSector),
-			NewQualityAdjustedPower:  QAPowerForSector(st.Info.SectorSize, &newSector),
+		builtin.MethodsPower.UpdateClaimedPower,
+		&power.UpdateClaimedPowerParams{
+			RawByteDelta:         big.Zero(), // Sector size has not changed
+			QualityAdjustedDelta: qaPowerDelta,
 		},
 		abi.NewTokenAmount(0),
 	)
@@ -780,7 +774,7 @@ func (a Actor) DeclareFaults(rt Runtime, params *DeclareFaultsParams) *adt.Empty
 	})
 
 	// Remove power for new faulty sectors.
-	requestBeginFaults(rt, st.Info.SectorSize, append(detectedFaultSectors, declaredFaultSectors...))
+	requestUpdateSectorPower(rt, st.Info.SectorSize, nil, append(detectedFaultSectors, declaredFaultSectors...))
 	burnFundsAndNotifyPledgeChange(rt, penalty)
 
 	return nil
@@ -848,7 +842,7 @@ func (a Actor) DeclareFaultsRecovered(rt Runtime, params *DeclareFaultsRecovered
 	})
 
 	// Remove power for new faulty sectors.
-	requestBeginFaults(rt, st.Info.SectorSize, detectedFaultSectors)
+	requestUpdateSectorPower(rt, st.Info.SectorSize, nil, detectedFaultSectors)
 	burnFundsAndNotifyPledgeChange(rt, penalty)
 
 	// Power is not restored yet, but when the recovered sectors are successfully PoSted.
@@ -1027,7 +1021,7 @@ func handleProvingPeriod(rt Runtime) {
 		})
 
 		// Remove power for new faults, and burn penalties.
-		requestBeginFaults(rt, st.Info.SectorSize, detectedFaultSectors)
+		requestUpdateSectorPower(rt, st.Info.SectorSize, nil, detectedFaultSectors)
 		burnFundsAndNotifyPledgeChange(rt, penalty)
 	}
 
@@ -1401,12 +1395,11 @@ func terminateSectors(rt Runtime, sectorNos *abi.BitField, terminationType power
 		return nil
 	})
 
-	// End any fault state before terminating sector power.
-	// TODO: could we compress the three calls to power actor into one sector termination call?
+	// TODO: could we compress the multiple calls to power actor into one sector termination call?
 	// https://github.com/filecoin-project/specs-actors/issues/478
-	requestEndFaults(rt, st.Info.SectorSize, faultySectors)
+	// Copmute the power delta as if recovering all the currently-faulty sectors before terminating all of them.
+	requestUpdateSectorPower(rt, st.Info.SectorSize, faultySectors, allSectors)
 	requestTerminateDeals(rt, dealIDs)
-	requestTerminatePower(rt, st.Info.SectorSize, allSectors)
 
 	burnFundsAndNotifyPledgeChange(rt, penalty)
 }
@@ -1451,40 +1444,23 @@ func enrollCronEvent(rt Runtime, eventEpoch abi.ChainEpoch, callbackPayload *Cro
 	builtin.RequireSuccess(rt, code, "failed to enroll cron event")
 }
 
-func requestBeginFaults(rt Runtime, sectorSize abi.SectorSize, sectors []*SectorOnChainInfo) {
-	if len(sectors) == 0 {
+func requestUpdateSectorPower(rt Runtime, sectorSize abi.SectorSize, sectorsAdded, sectorsRemoved []*SectorOnChainInfo) {
+	if len(sectorsAdded)+len(sectorsRemoved) == 0 {
 		return
 	}
-	rawBytePower, qaPower := powerForSectors(sectorSize, sectors)
+	addRawPower, addQAPower := powerForSectors(sectorSize, sectorsAdded)
+	remRawPower, remQAPower := powerForSectors(sectorSize, sectorsRemoved)
 
 	_, code := rt.Send(
 		builtin.StoragePowerActorAddr,
-		builtin.MethodsPower.OnFaultBegin,
-		&power.OnFaultBeginParams{
-			RawBytePower:         rawBytePower,
-			QualityAdjustedPower: qaPower,
+		builtin.MethodsPower.UpdateClaimedPower,
+		&power.UpdateClaimedPowerParams{
+			RawByteDelta:         big.Sub(addRawPower, remRawPower),
+			QualityAdjustedDelta: big.Sub(addQAPower, remQAPower),
 		},
 		abi.NewTokenAmount(0),
 	)
-	builtin.RequireSuccess(rt, code, "failed to request faults %v", sectors)
-}
-
-func requestEndFaults(rt Runtime, sectorSize abi.SectorSize, sectors []*SectorOnChainInfo) {
-	if len(sectors) == 0 {
-		return
-	}
-	rawBytePower, qaPower := powerForSectors(sectorSize, sectors)
-
-	_, code := rt.Send(
-		builtin.StoragePowerActorAddr,
-		builtin.MethodsPower.OnFaultEnd,
-		&power.OnFaultEndParams{
-			RawBytePower:         rawBytePower,
-			QualityAdjustedPower: qaPower,
-		},
-		abi.NewTokenAmount(0),
-	)
-	builtin.RequireSuccess(rt, code, "failed to request end faults %v", sectors)
+	builtin.RequireSuccess(rt, code, "failed to update power for sectors added %v, removed %v", sectorsAdded, sectorsRemoved)
 }
 
 func requestTerminateDeals(rt Runtime, dealIDs []abi.DealID) {
@@ -1514,24 +1490,6 @@ func requestTerminateAllDeals(rt Runtime, st *State) {
 	}
 
 	requestTerminateDeals(rt, dealIds)
-}
-
-func requestTerminatePower(rt Runtime, sectorSize abi.SectorSize, sectors []*SectorOnChainInfo) {
-	if len(sectors) == 0 {
-		return
-	}
-	rawBytePower, qaPower := powerForSectors(sectorSize, sectors)
-
-	_, code := rt.Send(
-		builtin.StoragePowerActorAddr,
-		builtin.MethodsPower.OnSectorTerminate,
-		&power.OnSectorTerminateParams{
-			RawBytePower:         rawBytePower,
-			QualityAdjustedPower: qaPower,
-		},
-		abi.NewTokenAmount(0),
-	)
-	builtin.RequireSuccess(rt, code, "failed to terminate sector power, sectors %v", sectors)
 }
 
 func verifyWindowedPost(rt Runtime, challengeEpoch abi.ChainEpoch, sectors []*SectorOnChainInfo, proofs []abi.PoStProof) {

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -1397,7 +1397,7 @@ func terminateSectors(rt Runtime, sectorNos *abi.BitField, terminationType power
 
 	// TODO: could we compress the multiple calls to power actor into one sector termination call?
 	// https://github.com/filecoin-project/specs-actors/issues/478
-	// Copmute the power delta as if recovering all the currently-faulty sectors before terminating all of them.
+	// Compute the power delta as if recovering all the currently-faulty sectors before terminating all of them.
 	requestUpdateSectorPower(rt, st.Info.SectorSize, faultySectors, allSectors)
 	requestTerminateDeals(rt, dealIDs)
 

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -807,17 +807,15 @@ func (h *actorHarness) extendSector(rt *mock.Runtime, sector *miner.SectorOnChai
 	rt.ExpectValidateCallerAddr(h.worker)
 
 	st := getState(rt)
-	rawBytePower := big.NewIntUnsigned(uint64(st.Info.SectorSize))
 	newSector := *sector
 	newSector.Info.Expiration += extension
+	qaDelta := big.Sub(miner.QAPowerForSector(st.Info.SectorSize, &newSector), miner.QAPowerForSector(st.Info.SectorSize, sector))
 
 	rt.ExpectSend(builtin.StoragePowerActorAddr,
-		builtin.MethodsPower.OnSectorModifyWeightDesc,
-		&power.OnSectorModifyWeightDescParams{
-			PrevRawBytePower:         rawBytePower,
-			NewRawBytePower:          rawBytePower,
-			PrevQualityAdjustedPower: miner.QAPowerForSector(st.Info.SectorSize, sector),
-			NewQualityAdjustedPower:  miner.QAPowerForSector(st.Info.SectorSize, &newSector),
+		builtin.MethodsPower.UpdateClaimedPower,
+		&power.UpdateClaimedPowerParams{
+			RawByteDelta:         big.Zero(),
+			QualityAdjustedDelta: qaDelta,
 		},
 		abi.NewTokenAmount(0),
 		nil,

--- a/actors/builtin/power/cbor_gen.go
+++ b/actors/builtin/power/cbor_gen.go
@@ -717,148 +717,6 @@ func (t *EnrollCronEventParams) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
-func (t *OnSectorTerminateParams) MarshalCBOR(w io.Writer) error {
-	if t == nil {
-		_, err := w.Write(cbg.CborNull)
-		return err
-	}
-	if _, err := w.Write([]byte{130}); err != nil {
-		return err
-	}
-
-	// t.RawBytePower (big.Int) (struct)
-	if err := t.RawBytePower.MarshalCBOR(w); err != nil {
-		return err
-	}
-
-	// t.QualityAdjustedPower (big.Int) (struct)
-	if err := t.QualityAdjustedPower.MarshalCBOR(w); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (t *OnSectorTerminateParams) UnmarshalCBOR(r io.Reader) error {
-	br := cbg.GetPeeker(r)
-
-	maj, extra, err := cbg.CborReadHeader(br)
-	if err != nil {
-		return err
-	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
-	}
-
-	if extra != 2 {
-		return fmt.Errorf("cbor input had wrong number of fields")
-	}
-
-	// t.RawBytePower (big.Int) (struct)
-
-	{
-
-		if err := t.RawBytePower.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.RawBytePower: %w", err)
-		}
-
-	}
-	// t.QualityAdjustedPower (big.Int) (struct)
-
-	{
-
-		if err := t.QualityAdjustedPower.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.QualityAdjustedPower: %w", err)
-		}
-
-	}
-	return nil
-}
-
-func (t *OnSectorModifyWeightDescParams) MarshalCBOR(w io.Writer) error {
-	if t == nil {
-		_, err := w.Write(cbg.CborNull)
-		return err
-	}
-	if _, err := w.Write([]byte{132}); err != nil {
-		return err
-	}
-
-	// t.PrevRawBytePower (big.Int) (struct)
-	if err := t.PrevRawBytePower.MarshalCBOR(w); err != nil {
-		return err
-	}
-
-	// t.NewRawBytePower (big.Int) (struct)
-	if err := t.NewRawBytePower.MarshalCBOR(w); err != nil {
-		return err
-	}
-
-	// t.PrevQualityAdjustedPower (big.Int) (struct)
-	if err := t.PrevQualityAdjustedPower.MarshalCBOR(w); err != nil {
-		return err
-	}
-
-	// t.NewQualityAdjustedPower (big.Int) (struct)
-	if err := t.NewQualityAdjustedPower.MarshalCBOR(w); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (t *OnSectorModifyWeightDescParams) UnmarshalCBOR(r io.Reader) error {
-	br := cbg.GetPeeker(r)
-
-	maj, extra, err := cbg.CborReadHeader(br)
-	if err != nil {
-		return err
-	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
-	}
-
-	if extra != 4 {
-		return fmt.Errorf("cbor input had wrong number of fields")
-	}
-
-	// t.PrevRawBytePower (big.Int) (struct)
-
-	{
-
-		if err := t.PrevRawBytePower.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.PrevRawBytePower: %w", err)
-		}
-
-	}
-	// t.NewRawBytePower (big.Int) (struct)
-
-	{
-
-		if err := t.NewRawBytePower.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.NewRawBytePower: %w", err)
-		}
-
-	}
-	// t.PrevQualityAdjustedPower (big.Int) (struct)
-
-	{
-
-		if err := t.PrevQualityAdjustedPower.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.PrevQualityAdjustedPower: %w", err)
-		}
-
-	}
-	// t.NewQualityAdjustedPower (big.Int) (struct)
-
-	{
-
-		if err := t.NewQualityAdjustedPower.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.NewQualityAdjustedPower: %w", err)
-		}
-
-	}
-	return nil
-}
-
 func (t *OnSectorProveCommitParams) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
@@ -916,7 +774,7 @@ func (t *OnSectorProveCommitParams) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
-func (t *OnFaultBeginParams) MarshalCBOR(w io.Writer) error {
+func (t *UpdateClaimedPowerParams) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
@@ -925,19 +783,19 @@ func (t *OnFaultBeginParams) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.RawBytePower (big.Int) (struct)
-	if err := t.RawBytePower.MarshalCBOR(w); err != nil {
+	// t.RawByteDelta (big.Int) (struct)
+	if err := t.RawByteDelta.MarshalCBOR(w); err != nil {
 		return err
 	}
 
-	// t.QualityAdjustedPower (big.Int) (struct)
-	if err := t.QualityAdjustedPower.MarshalCBOR(w); err != nil {
+	// t.QualityAdjustedDelta (big.Int) (struct)
+	if err := t.QualityAdjustedDelta.MarshalCBOR(w); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (t *OnFaultBeginParams) UnmarshalCBOR(r io.Reader) error {
+func (t *UpdateClaimedPowerParams) UnmarshalCBOR(r io.Reader) error {
 	br := cbg.GetPeeker(r)
 
 	maj, extra, err := cbg.CborReadHeader(br)
@@ -952,78 +810,21 @@ func (t *OnFaultBeginParams) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
-	// t.RawBytePower (big.Int) (struct)
+	// t.RawByteDelta (big.Int) (struct)
 
 	{
 
-		if err := t.RawBytePower.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.RawBytePower: %w", err)
+		if err := t.RawByteDelta.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.RawByteDelta: %w", err)
 		}
 
 	}
-	// t.QualityAdjustedPower (big.Int) (struct)
+	// t.QualityAdjustedDelta (big.Int) (struct)
 
 	{
 
-		if err := t.QualityAdjustedPower.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.QualityAdjustedPower: %w", err)
-		}
-
-	}
-	return nil
-}
-
-func (t *OnFaultEndParams) MarshalCBOR(w io.Writer) error {
-	if t == nil {
-		_, err := w.Write(cbg.CborNull)
-		return err
-	}
-	if _, err := w.Write([]byte{130}); err != nil {
-		return err
-	}
-
-	// t.RawBytePower (big.Int) (struct)
-	if err := t.RawBytePower.MarshalCBOR(w); err != nil {
-		return err
-	}
-
-	// t.QualityAdjustedPower (big.Int) (struct)
-	if err := t.QualityAdjustedPower.MarshalCBOR(w); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (t *OnFaultEndParams) UnmarshalCBOR(r io.Reader) error {
-	br := cbg.GetPeeker(r)
-
-	maj, extra, err := cbg.CborReadHeader(br)
-	if err != nil {
-		return err
-	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
-	}
-
-	if extra != 2 {
-		return fmt.Errorf("cbor input had wrong number of fields")
-	}
-
-	// t.RawBytePower (big.Int) (struct)
-
-	{
-
-		if err := t.RawBytePower.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.RawBytePower: %w", err)
-		}
-
-	}
-	// t.QualityAdjustedPower (big.Int) (struct)
-
-	{
-
-		if err := t.QualityAdjustedPower.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.QualityAdjustedPower: %w", err)
+		if err := t.QualityAdjustedDelta.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.QualityAdjustedDelta: %w", err)
 		}
 
 	}

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -126,11 +126,8 @@ func main() {
 		power.CreateMinerParams{},
 		power.DeleteMinerParams{},
 		power.EnrollCronEventParams{},
-		power.OnSectorTerminateParams{},
-		power.OnSectorModifyWeightDescParams{},
 		power.OnSectorProveCommitParams{},
-		power.OnFaultBeginParams{},
-		power.OnFaultEndParams{},
+		power.UpdateClaimedPowerParams{},
 		// method returns
 		power.CreateMinerReturn{},
 		// other types


### PR DESCRIPTION
Deletes redundant power actor exported methods that are left over from when much more logic lived in the power actor.

- [x] Rebase after #488 lands

FYI @magik6k. Closes #487.