### PR TITLE
Add ChargeGas method to Runtime

### DIFF
--- a/actors/runtime/runtime.go
+++ b/actors/runtime/runtime.go
@@ -95,6 +95,13 @@ type Runtime interface {
 
 	// Starts a new tracing span. The span must be End()ed explicitly, typically with a deferred invocation.
 	StartSpan(name string) TraceSpan
+
+	// ChargeGas charges specified amount of `gas` for execution.
+	// `name` provides information about gas charging point
+	// `virtual` sets virtual amount of gas to charge, this amount is not counted
+	// toward execution cost. This functionality is used for observing global changes
+	// in total gas charged if amount of gas charged was to be changed.
+	ChargeGas(name string, gas int64, virtual int64)
 }
 
 // Store defines the storage module exposed to actors.

--- a/support/mock/mockrt.go
+++ b/support/mock/mockrt.go
@@ -808,6 +808,8 @@ func (rt *Runtime) failTestNow(msg string, args ...interface{}) {
 	rt.t.FailNow()
 }
 
+func (rt *Runtime) ChargeGas(_ string, _, _ int64) {}
+
 type ReturnWrapper struct {
 	V runtime.CBORMarshaler
 }


### PR DESCRIPTION
It will be used in the current effort of setting sane values for gas.
Gas is split into compute gas and storage gas to allow better analisys
of computation time in relation to gas.
Both gas types are latter combined into one and this is charged for the
execution.

Virtual gas is added for observing how changes to gas numbers affect
the balance without affecting the stateroot of the chain.