### PR TITLE
Move pledge calculation from power to miner actor

### DIFF
--- a/actors/builtin/methods.go
+++ b/actors/builtin/methods.go
@@ -68,13 +68,13 @@ var MethodsPower = struct {
 	Constructor              abi.MethodNum
 	CreateMiner              abi.MethodNum
 	DeleteMiner              abi.MethodNum
-	OnSectorProveCommit      abi.MethodNum
 	UpdateClaimedPower       abi.MethodNum
 	EnrollCronEvent          abi.MethodNum
 	OnEpochTickEnd           abi.MethodNum
 	UpdatePledgeTotal        abi.MethodNum
 	OnConsensusFault         abi.MethodNum
 	SubmitPoRepForBulkVerify abi.MethodNum
+	CurrentTotalPower        abi.MethodNum
 }{MethodConstructor, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 
 var MethodsMiner = struct {

--- a/actors/builtin/miner/monies.go
+++ b/actors/builtin/miner/monies.go
@@ -1,0 +1,26 @@
+package miner
+
+import (
+	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/specs-actors/actors/abi/big"
+)
+
+// Computes the pledge requirement for committing new quality-adjusted power to the network, given the current
+// total power, total pledge commitment, epoch block reward, and circulating token supply.
+// In plain language, the pledge requirement is a multiple of the block reward expected to be earned by the
+// newly-committed power, holding the per-epoch block reward constant (though in reality it will change over time).
+// The network total pledge and circulating supply parameters are currently unused, but may be included in a
+// future calculation.
+func InitialPledgeForPower(newQAPower abi.StoragePower, networkQAPower abi.StoragePower, networkTotalPledge abi.TokenAmount, epochTargetReward abi.TokenAmount, networkCirculatingSupply abi.TokenAmount) abi.TokenAmount {
+	// Details here are still subject to change.
+	// PARAM_FINISH
+	// https://github.com/filecoin-project/specs-actors/issues/468
+	_ = networkCirculatingSupply // TODO: ce use this
+	_ = networkTotalPledge       // TODO: ce use this
+
+	if networkQAPower.IsZero() {
+		return epochTargetReward
+	}
+	return big.Div(big.Mul(newQAPower, epochTargetReward), networkQAPower)
+}
+

--- a/actors/builtin/power/cbor_gen.go
+++ b/actors/builtin/power/cbor_gen.go
@@ -717,63 +717,6 @@ func (t *EnrollCronEventParams) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
-func (t *OnSectorProveCommitParams) MarshalCBOR(w io.Writer) error {
-	if t == nil {
-		_, err := w.Write(cbg.CborNull)
-		return err
-	}
-	if _, err := w.Write([]byte{130}); err != nil {
-		return err
-	}
-
-	// t.RawBytePower (big.Int) (struct)
-	if err := t.RawBytePower.MarshalCBOR(w); err != nil {
-		return err
-	}
-
-	// t.QualityAdjustedPower (big.Int) (struct)
-	if err := t.QualityAdjustedPower.MarshalCBOR(w); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (t *OnSectorProveCommitParams) UnmarshalCBOR(r io.Reader) error {
-	br := cbg.GetPeeker(r)
-
-	maj, extra, err := cbg.CborReadHeader(br)
-	if err != nil {
-		return err
-	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
-	}
-
-	if extra != 2 {
-		return fmt.Errorf("cbor input had wrong number of fields")
-	}
-
-	// t.RawBytePower (big.Int) (struct)
-
-	{
-
-		if err := t.RawBytePower.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.RawBytePower: %w", err)
-		}
-
-	}
-	// t.QualityAdjustedPower (big.Int) (struct)
-
-	{
-
-		if err := t.QualityAdjustedPower.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.QualityAdjustedPower: %w", err)
-		}
-
-	}
-	return nil
-}
-
 func (t *UpdateClaimedPowerParams) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
@@ -882,6 +825,77 @@ func (t *CreateMinerReturn) UnmarshalCBOR(r io.Reader) error {
 
 		if err := t.RobustAddress.UnmarshalCBOR(br); err != nil {
 			return xerrors.Errorf("unmarshaling t.RobustAddress: %w", err)
+		}
+
+	}
+	return nil
+}
+
+func (t *CurrentTotalPowerReturn) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write([]byte{131}); err != nil {
+		return err
+	}
+
+	// t.RawBytePower (big.Int) (struct)
+	if err := t.RawBytePower.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.QualityAdjPower (big.Int) (struct)
+	if err := t.QualityAdjPower.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.PledgeCollateral (big.Int) (struct)
+	if err := t.PledgeCollateral.MarshalCBOR(w); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *CurrentTotalPowerReturn) UnmarshalCBOR(r io.Reader) error {
+	br := cbg.GetPeeker(r)
+
+	maj, extra, err := cbg.CborReadHeader(br)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 3 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.RawBytePower (big.Int) (struct)
+
+	{
+
+		if err := t.RawBytePower.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.RawBytePower: %w", err)
+		}
+
+	}
+	// t.QualityAdjPower (big.Int) (struct)
+
+	{
+
+		if err := t.QualityAdjPower.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.QualityAdjPower: %w", err)
+		}
+
+	}
+	// t.PledgeCollateral (big.Int) (struct)
+
+	{
+
+		if err := t.PledgeCollateral.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.PledgeCollateral: %w", err)
 		}
 
 	}

--- a/actors/builtin/power/policy.go
+++ b/actors/builtin/power/policy.go
@@ -2,7 +2,6 @@ package power
 
 import (
 	abi "github.com/filecoin-project/specs-actors/actors/abi"
-	big "github.com/filecoin-project/specs-actors/actors/abi/big"
 )
 
 // Minimum number of registered miners for the minimum miner size limit to effectively limit consensus power.
@@ -10,13 +9,3 @@ const ConsensusMinerMinMiners = 3
 
 // Minimum power of an individual miner to meet the threshold for leader election.
 var ConsensusMinerMinPower = abi.NewStoragePower(1 << 40) // PARAM_FINISH
-
-func InitialPledgeForWeight(qapower abi.StoragePower, totqapower abi.StoragePower, circSupply abi.TokenAmount, totalPledge abi.TokenAmount, perEpochReward abi.TokenAmount) abi.TokenAmount {
-	// Details here are still subject to change.
-	// PARAM_FINISH
-	// https://github.com/filecoin-project/specs-actors/issues/468
-	_ = circSupply  // TODO: ce use this
-	_ = totalPledge // TODO: ce use this
-
-	return big.Div(big.Mul(qapower, perEpochReward), totqapower)
-}

--- a/actors/runtime/runtime.go
+++ b/actors/runtime/runtime.go
@@ -78,6 +78,14 @@ type Runtime interface {
 	// Provides the system call interface.
 	Syscalls() Syscalls
 
+	// Returns the total token supply in circulation at the beginning of the current epoch.
+	// The circulating supply is the sum of:
+	// - rewards emitted by the reward actor,
+	// - funds vested from lock-ups in the genesis state,
+	// less the sum of:
+	// - funds burnt,
+	// - pledge collateral locked in storage miner actors (recorded in the storage power actor)
+	// - deal collateral locked by the storage market actor
 	TotalFilCircSupply() abi.TokenAmount
 
 	// Provides a Go context for use by HAMT, etc.

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -126,10 +126,10 @@ func main() {
 		power.CreateMinerParams{},
 		power.DeleteMinerParams{},
 		power.EnrollCronEventParams{},
-		power.OnSectorProveCommitParams{},
 		power.UpdateClaimedPowerParams{},
 		// method returns
 		power.CreateMinerReturn{},
+		power.CurrentTotalPowerReturn{},
 		// other types
 		power.MinerConstructorParams{},
 		power.SectorStorageWeightDesc{},

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/warpfork/go-wish v0.0.0-20190328234359-8b3e70f8e830 // indirect
 	github.com/whyrusleeping/cbor-gen v0.0.0-20200414195334-429a0b5e922e
-	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect
+	golang.org/x/crypto v0.0.0-20200115085410-6d4e4cb37c7d // indirect
 	golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456 // indirect
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
 )

--- a/go.sum
+++ b/go.sum
@@ -134,8 +134,8 @@ golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8 h1:1wopBVtVdWnn03fZelqdXTqk7U7zPQCb+T4rbU9ZEoU=
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 h1:ObdrDkeb4kJdCP557AjRjq69pTHfNouLtWZG7j9rPN8=
-golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20200115085410-6d4e4cb37c7d h1:2+ZP7EfsZV7Vvmx3TIqSlSzATMkTAKqM14YGFPoSKjI=
+golang.org/x/crypto v0.0.0-20200115085410-6d4e4cb37c7d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20190227160552-c95aed5357e7/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=

--- a/support/mock/builder.go
+++ b/support/mock/builder.go
@@ -19,13 +19,14 @@ type RuntimeBuilder struct {
 // Initializes a new builder with a receiving actor address.
 func NewBuilder(ctx context.Context, receiver addr.Address) *RuntimeBuilder {
 	m := &Runtime{
-		ctx:         ctx,
-		epoch:       0,
-		receiver:    receiver,
-		caller:      addr.Address{},
-		callerType:  cid.Undef,
-		miner:       addr.Address{},
-		idAddresses: make(map[addr.Address]addr.Address),
+		ctx:               ctx,
+		epoch:             0,
+		receiver:          receiver,
+		caller:            addr.Address{},
+		callerType:        cid.Undef,
+		miner:             addr.Address{},
+		idAddresses:       make(map[addr.Address]addr.Address),
+		circulatingSupply: abi.NewTokenAmount(0),
 
 		state:    cid.Undef,
 		store:    make(map[cid.Cid][]byte),


### PR DESCRIPTION
The miner actor can compute pledge amounts, which simplifies some interactions with the power actor. This PR avoids calling the reward actor for every sector.

Note that there's more simplification and batching now possible than I tried to realise in this PR, and things will also change when the pledge calculation moves to PreCommitSector, as the pre-commit deposit.

Fixes #489. FYI @zixuanzh 