### PR TITLE
Restructure weight and power calculations to be callable from outside

### DIFF
--- a/actors/builtin/market/policy.go
+++ b/actors/builtin/market/policy.go
@@ -2,6 +2,7 @@ package market
 
 import (
 	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/specs-actors/actors/abi/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 )
 
@@ -30,4 +31,12 @@ func dealClientCollateralBounds(pieceSize abi.PaddedPieceSize, duration abi.Chai
 // Penalty to provider deal collateral if the deadline expires before sector commitment.
 func collateralPenaltyForDealActivationMissed(providerCollateral abi.TokenAmount) abi.TokenAmount {
 	return providerCollateral // PARAM_FINISH
+}
+
+// Computes the weight for a deal proposal, which is a function of its size and duration.
+func DealWeight(proposal *DealProposal) abi.DealWeight {
+	dealDuration := big.NewInt(int64(proposal.Duration()))
+	dealSize := big.NewIntUnsigned(uint64(proposal.PieceSize))
+	dealSpaceTime := big.Mul(dealDuration, dealSize)
+	return dealSpaceTime
 }


### PR DESCRIPTION
Miner operators need to compute the initial pledge for a sector before attempting to (prove-) commit it. The pledge calculation logic was previously buried inside power actor methods and so Lotus goes through some [gymnastics involving simulating side-effecting actor messages](https://github.com/filecoin-project/lotus/blob/741825a04ee11b5ef68f32a7aee3608fca99911e/node/impl/full/state.go#L685) to the market and power actor in order to get at the expected pledge amount.

#489 moved the pledge amount calculation from the power actor to the miner, so that method won't work any more. This PR rearranges the code to export some free functions with which a miner operator can make the calculations directly (after plucking some values like the LastEpochBlockReward and TotalPower from the state). This is an API-breaking change for nodes, but with the intention to make a much easier API.

After this, instead of simulating the messages, Lotus should:
- Load the reward actor and power actor state to get the block reward and power constants
- Call `market.ValidateDealsForActivation()` to get the deal weight for deals in the precommit
- Call `miner.QAPowerForWeight()` with the weights to calculate the power the sector will have
- Call `miner.InitialPledgeForPower()` with the power and network values to calculate the pledge

Note that the pledge calculation is set to move from ProveCommitSector to PreCommitSector, where it will be the pre-commit deposit (#424) so the point at which the node needs to invoke this will shortly change too.

Closes #420