### PR TITLE
track pending deal proposals to ensure deals can't be duplicately published

### DIFF
--- a/actors/builtin/market/cbor_gen.go
+++ b/actors/builtin/market/cbor_gen.go
@@ -18,7 +18,7 @@ func (t *State) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{135}); err != nil {
+	if _, err := w.Write([]byte{136}); err != nil {
 		return err
 	}
 
@@ -32,6 +32,12 @@ func (t *State) MarshalCBOR(w io.Writer) error {
 
 	if err := cbg.WriteCid(w, t.States); err != nil {
 		return xerrors.Errorf("failed to write cid field t.States: %w", err)
+	}
+
+	// t.PendingProposals (cid.Cid) (struct)
+
+	if err := cbg.WriteCid(w, t.PendingProposals); err != nil {
+		return xerrors.Errorf("failed to write cid field t.PendingProposals: %w", err)
 	}
 
 	// t.EscrowTable (cid.Cid) (struct)
@@ -82,7 +88,7 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 7 {
+	if extra != 8 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -108,6 +114,18 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 		}
 
 		t.States = c
+
+	}
+	// t.PendingProposals (cid.Cid) (struct)
+
+	{
+
+		c, err := cbg.ReadCid(br)
+		if err != nil {
+			return xerrors.Errorf("failed to read cid field t.PendingProposals: %w", err)
+		}
+
+		t.PendingProposals = c
 
 	}
 	// t.EscrowTable (cid.Cid) (struct)
@@ -903,7 +921,7 @@ func (t *DealProposal) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{138}); err != nil {
+	if _, err := w.Write([]byte{139}); err != nil {
 		return err
 	}
 
@@ -931,6 +949,18 @@ func (t *DealProposal) MarshalCBOR(w io.Writer) error {
 
 	// t.Provider (address.Address) (struct)
 	if err := t.Provider.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.Label (string) (string)
+	if len(t.Label) > cbg.MaxLength {
+		return xerrors.Errorf("Value in field t.Label was too long")
+	}
+
+	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajTextString, uint64(len(t.Label)))); err != nil {
+		return err
+	}
+	if _, err := w.Write([]byte(t.Label)); err != nil {
 		return err
 	}
 
@@ -984,7 +1014,7 @@ func (t *DealProposal) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 10 {
+	if extra != 11 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -1048,6 +1078,16 @@ func (t *DealProposal) UnmarshalCBOR(r io.Reader) error {
 			return xerrors.Errorf("unmarshaling t.Provider: %w", err)
 		}
 
+	}
+	// t.Label (string) (string)
+
+	{
+		sval, err := cbg.ReadString(br)
+		if err != nil {
+			return err
+		}
+
+		t.Label = string(sval)
 	}
 	// t.StartEpoch (abi.ChainEpoch) (int64)
 	{

--- a/actors/builtin/market/deal.go
+++ b/actors/builtin/market/deal.go
@@ -1,8 +1,11 @@
 package market
 
 import (
+	"bytes"
+
 	addr "github.com/filecoin-project/go-address"
 	cid "github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
 
 	abi "github.com/filecoin-project/specs-actors/actors/abi"
 	big "github.com/filecoin-project/specs-actors/actors/abi/big"
@@ -23,6 +26,9 @@ type DealProposal struct {
 	VerifiedDeal bool
 	Client       addr.Address
 	Provider     addr.Address
+
+	// Label is an arbitrary client chosen label to apply to the deal
+	Label string
 
 	// Nominal start epoch. Deal payment is linear between StartEpoch and EndEpoch,
 	// with total amount StoragePricePerEpoch * (EndEpoch - StartEpoch).
@@ -56,6 +62,26 @@ func (p *DealProposal) ClientBalanceRequirement() abi.TokenAmount {
 
 func (p *DealProposal) ProviderBalanceRequirement() abi.TokenAmount {
 	return p.ProviderCollateral
+}
+
+func (p *DealProposal) Cid() (cid.Cid, error) {
+	buf := new(bytes.Buffer)
+	if err := p.MarshalCBOR(buf); err != nil {
+		return cid.Undef, err
+	}
+	b := buf.Bytes()
+
+	mhType := uint64(mh.BLAKE2B_MIN + 31)
+	mhLen := -1
+
+	hash, err := mh.Sum(b, mhType, mhLen)
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	c := cid.NewCidV1(cid.DagCBOR, hash)
+
+	return c, nil
 }
 
 type DealState struct {

--- a/actors/builtin/market/market_state.go
+++ b/actors/builtin/market/market_state.go
@@ -26,6 +26,10 @@ type State struct {
 	Proposals cid.Cid // AMT[DealID]DealProposal
 	States    cid.Cid // AMT[DealID]DealState
 
+	// PendingProposals tracks proposals that have not yet reached their deal start date.
+	// We track them here to ensure that miners can't publish the same deal proposal twice
+	PendingProposals cid.Cid // HAMT[DealCid]DealProposal
+
 	// Total amount held in escrow, indexed by actor address (including both locked and unlocked amounts).
 	EscrowTable cid.Cid // BalanceTable
 
@@ -43,13 +47,14 @@ type State struct {
 
 func ConstructState(emptyArrayCid, emptyMapCid, emptyMSetCid cid.Cid) *State {
 	return &State{
-		Proposals:      emptyArrayCid,
-		States:         emptyArrayCid,
-		EscrowTable:    emptyMapCid,
-		LockedTable:    emptyMapCid,
-		NextID:         abi.DealID(0),
-		DealOpsByEpoch: emptyMSetCid,
-		LastCron:       abi.ChainEpoch(-1),
+		Proposals:        emptyArrayCid,
+		States:           emptyArrayCid,
+		PendingProposals: emptyMapCid,
+		EscrowTable:      emptyMapCid,
+		LockedTable:      emptyMapCid,
+		NextID:           abi.DealID(0),
+		DealOpsByEpoch:   emptyMSetCid,
+		LastCron:         abi.ChainEpoch(-1),
 	}
 }
 

--- a/actors/builtin/market/market_test.go
+++ b/actors/builtin/market/market_test.go
@@ -1,6 +1,7 @@
 package market_test
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
@@ -12,11 +13,22 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/builtin/market"
 	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
+	"github.com/filecoin-project/specs-actors/actors/crypto"
+	"github.com/filecoin-project/specs-actors/actors/runtime"
 	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
 	"github.com/filecoin-project/specs-actors/support/mock"
 	tutil "github.com/filecoin-project/specs-actors/support/testing"
 )
+
+func mustCbor(o runtime.CBORMarshaler) []byte {
+	buf := new(bytes.Buffer)
+	if err := o.MarshalCBOR(buf); err != nil {
+		panic(err)
+	}
+
+	return buf.Bytes()
+}
 
 func TestExports(t *testing.T) {
 	mock.CheckActorExports(t, market.Actor{})
@@ -296,6 +308,114 @@ func TestMarketActor(t *testing.T) {
 		// TODO: withdraws limited by locked balance
 		// https://github.com/filecoin-project/specs-actors/issues/465
 	})
+}
+
+func basicMarketSetup(t *testing.T, ma, owner, provider, worker, client address.Address) (*mock.Runtime, *marketActorTestHarness) {
+	builder := mock.NewBuilder(context.Background(), ma).
+		WithCaller(builtin.SystemActorAddr, builtin.InitActorCodeID).
+		WithActorType(owner, builtin.AccountActorCodeID).
+		WithActorType(worker, builtin.AccountActorCodeID).
+		WithActorType(provider, builtin.StorageMinerActorCodeID).
+		WithActorType(client, builtin.AccountActorCodeID)
+
+	rt := builder.Build(t)
+
+	actor := marketActorTestHarness{t: t}
+	actor.constructAndVerify(rt)
+
+	return rt, &actor
+}
+
+func mkDealProposal(client, prov address.Address) market.DealProposal {
+	return market.DealProposal{
+		PieceCID:  tutil.MakeCID("a piece cid"),
+		PieceSize: abi.PaddedPieceSize(100),
+		Client:    client,
+		Provider:  prov,
+
+		StartEpoch:           100,
+		EndEpoch:             200,
+		StoragePricePerEpoch: abi.NewTokenAmount(1),
+
+		ProviderCollateral: abi.NewTokenAmount(1),
+		ClientCollateral:   abi.NewTokenAmount(1),
+	}
+}
+
+func TestMarketActorDeals(t *testing.T) {
+	marketActor := tutil.NewIDAddr(t, 100)
+	owner := tutil.NewIDAddr(t, 101)
+	provider := tutil.NewIDAddr(t, 102)
+	worker := tutil.NewIDAddr(t, 103)
+	client := tutil.NewIDAddr(t, 104)
+
+	var st market.State
+
+	// Test adding provider funds from both worker and owner address
+	rt, actor := basicMarketSetup(t, marketActor, owner, provider, worker, client)
+
+	rt.SetCaller(owner, builtin.AccountActorCodeID)
+	rt.SetReceived(abi.NewTokenAmount(10000))
+	actor.expectProviderControlAddressesAndValidateCaller(rt, provider, owner, worker)
+
+	rt.Call(actor.AddBalance, &provider)
+
+	rt.Verify()
+
+	rt.GetState(&st)
+	assert.Equal(t, abi.NewTokenAmount(10000), st.GetEscrowBalance(rt, provider))
+
+	actor.addParticipantFunds(rt, client, abi.NewTokenAmount(10000))
+
+	rt.SetReceived(abi.NewTokenAmount(10))
+
+	params := &market.PublishStorageDealsParams{
+		Deals: []market.ClientDealProposal{
+			market.ClientDealProposal{
+				Proposal: mkDealProposal(client, provider),
+			},
+		},
+	}
+
+	// First attempt at publishing the deal should work
+	{
+		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
+		rt.ExpectSend(provider, builtin.MethodsMiner.ControlAddresses, nil, abi.NewTokenAmount(0), &miner.GetControlAddressesReturn{Worker: worker, Owner: owner}, 0)
+
+		rt.ExpectVerifySignature(crypto.Signature{}, client, mustCbor(&params.Deals[0].Proposal), nil)
+
+		rt.SetCaller(worker, builtin.AccountActorCodeID)
+		rt.Call(actor.PublishStorageDeals, params)
+		rt.Verify()
+	}
+
+	// Second attempt at publishing the same deal should fail
+	{
+		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
+		rt.ExpectSend(provider, builtin.MethodsMiner.ControlAddresses, nil, abi.NewTokenAmount(0), &miner.GetControlAddressesReturn{Worker: worker, Owner: owner}, 0)
+
+		rt.ExpectVerifySignature(crypto.Signature{}, client, mustCbor(&params.Deals[0].Proposal), nil)
+		rt.SetCaller(worker, builtin.AccountActorCodeID)
+		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
+			rt.Call(actor.PublishStorageDeals, params)
+		})
+
+		rt.Verify()
+	}
+
+	params.Deals[0].Proposal.Label = "foo"
+
+	// Same deal with a different label should work
+	{
+		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
+		rt.ExpectSend(provider, builtin.MethodsMiner.ControlAddresses, nil, abi.NewTokenAmount(0), &miner.GetControlAddressesReturn{Worker: worker, Owner: owner}, 0)
+
+		rt.ExpectVerifySignature(crypto.Signature{}, client, mustCbor(&params.Deals[0].Proposal), nil)
+		rt.SetCaller(worker, builtin.AccountActorCodeID)
+		rt.Call(actor.PublishStorageDeals, params)
+
+		rt.Verify()
+	}
 }
 
 type marketActorTestHarness struct {

--- a/actors/util/adt/store.go
+++ b/actors/util/adt/store.go
@@ -82,6 +82,12 @@ func (k AddrKey) Key() string {
 	return string(addr.Address(k).Bytes())
 }
 
+type CidKey cid.Cid
+
+func (k CidKey) Key() string {
+	return cid.Cid(k).KeyString()
+}
+
 // Adapts an int64 as a mapping key.
 type intKey struct {
 	int64


### PR DESCRIPTION
I think that this works, but it has one caveat that i think is okay.

If a miner publishes a deal, seals the sector, publishes the prove commit, and terminates the sector *all before the deal start date* the miner could then resubmit the deal. I think that this is fine because the miner isnt paid for the deal until the deal start date anyways, so theres no way to get any extra money out of this.

Closes #364