### PR TITLE
Disable codecov 'patch' PR status, set more attainable range target.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,20 @@
-# "documentation": https://gist.github.com/stevepeak/53bee7b2c326b24a9b4a
-#
+# Documentation:
+# https://docs.codecov.io/docs/codecovyml-reference
 # https://docs.codecov.io/docs/pull-request-comments
+# https://gist.github.com/stevepeak/53bee7b2c326b24a9b4a
+
+coverage:
+  range: 50..90
+  round: down
+  precision: 1
+  status:
+    patch: off
+
+ignore:
+  - "**/*/cbor_gen.go"
+  - "support/**/*"
+  - "gen/**/*"
+
 comment:
   layout: "diff"           # "diff, flags, files"
   behavior: default
@@ -9,13 +23,9 @@ comment:
   require_head: true       # [yes :: must have a head report to post]
   branches: []             # branch names that can post comment
 
-ignore:
-  - "**/*/cbor_gen.go"
-  - "support/**/*"
-  - "gen/**/*"
-
 codecov:
   notify:
     # yes: will delay sending notifications until all ci is finished
     # no: will send notifications without checking ci status and wait till "after_n_builds" are uploaded
     require_ci_to_pass: false
+


### PR DESCRIPTION
Prevent a scary red cross when project coverage has in fact improved.

![Screen Shot 2020-06-18 at 2 41 23 pm](https://user-images.githubusercontent.com/445306/84979059-cdc6cc80-b171-11ea-994d-4a1acc4704d1.png)
