### PR TITLE
Fix up CircleCI lint configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
         default: golang
       golangci-lint-version:
         type: string
-        default: 1.21.0
+        default: 1.23.1
       concurrency:
         type: string
         default: '2'
@@ -110,8 +110,6 @@ jobs:
           command: |
             $HOME/.local/bin/golangci-lint run -v --skip-dirs-use-default=false\
               --concurrency << parameters.concurrency >> << parameters.args >>
-  lint-changes:
-    <<: *lint
 
   lint-all:
     <<: *lint
@@ -120,8 +118,7 @@ workflows:
   version: 2.1
   ci:
     jobs:
-      - lint-changes:
-          args: "--new-from-rev origin/master"
+      - lint-all
       - mod-tidy-check
       - build-all
       - test-all

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ tidy:
 .PHONY: tidy
 
 lint:
-	$(GOLINT) run -v --skip-dirs-use-default=false ./...
+	$(GOLINT) run --skip-dirs-use-default=false ./...
 .PHONY: lint
 
 gen:

--- a/actors/builtin/multisig/multisig_actor.go
+++ b/actors/builtin/multisig/multisig_actor.go
@@ -326,7 +326,7 @@ func (a Actor) ChangeNumApprovalsThreshold(rt vmr.Runtime, params *ChangeNumAppr
 
 	var st State
 	rt.State().Transaction(&st, func() interface{} {
-		if params.NewThreshold <= 0 || params.NewThreshold > uint64(len(st.Signers)) {
+		if params.NewThreshold == 0 || params.NewThreshold > uint64(len(st.Signers)) {
 			rt.Abortf(exitcode.ErrIllegalArgument, "New threshold value not supported")
 		}
 


### PR DESCRIPTION
I observed lint failures locally with `make` that were not happening on CircleCI.

The command invoked in [this build](https://circleci.com/gh/filecoin-project/specs-actors/5938) was
```
$HOME/.local/bin/golangci-lint run -v \
  --concurrency 2 --new-from-rev origin/master
```
Note the lack of `--skip-dirs-use-default=false` and also a now-unwanted `--new-from-rev` (that was previously in place when linting first installed but many error remained)

Maybe the `args` from `lint-changes` was overriding the `--skip-dirs-use-default` somehow?

Note that to merge this I will override the branch protection rules, and then immediately change the rules to require `lint-all` instead of `lint-changes`.