### PR TITLE
Denormalize sector precommit info into sector on-chain info

### DIFF
--- a/actors/builtin/miner/cbor_gen.go
+++ b/actors/builtin/miner/cbor_gen.go
@@ -1001,22 +1001,65 @@ func (t *SectorOnChainInfo) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{132}); err != nil {
+	if _, err := w.Write([]byte{136}); err != nil {
 		return err
 	}
 
-	// t.Info (miner.SectorPreCommitInfo) (struct)
-	if err := t.Info.MarshalCBOR(w); err != nil {
+	// t.SectorNumber (abi.SectorNumber) (uint64)
+
+	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.SectorNumber))); err != nil {
 		return err
 	}
 
-	// t.ActivationEpoch (abi.ChainEpoch) (int64)
-	if t.ActivationEpoch >= 0 {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.ActivationEpoch))); err != nil {
+	// t.SealProof (abi.RegisteredSealProof) (int64)
+	if t.SealProof >= 0 {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.SealProof))); err != nil {
 			return err
 		}
 	} else {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.ActivationEpoch)-1)); err != nil {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.SealProof)-1)); err != nil {
+			return err
+		}
+	}
+
+	// t.SealedCID (cid.Cid) (struct)
+
+	if err := cbg.WriteCid(w, t.SealedCID); err != nil {
+		return xerrors.Errorf("failed to write cid field t.SealedCID: %w", err)
+	}
+
+	// t.DealIDs ([]abi.DealID) (slice)
+	if len(t.DealIDs) > cbg.MaxLength {
+		return xerrors.Errorf("Slice value in field t.DealIDs was too long")
+	}
+
+	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajArray, uint64(len(t.DealIDs)))); err != nil {
+		return err
+	}
+	for _, v := range t.DealIDs {
+		if err := cbg.CborWriteHeader(w, cbg.MajUnsignedInt, uint64(v)); err != nil {
+			return err
+		}
+	}
+
+	// t.Activation (abi.ChainEpoch) (int64)
+	if t.Activation >= 0 {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.Activation))); err != nil {
+			return err
+		}
+	} else {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.Activation)-1)); err != nil {
+			return err
+		}
+	}
+
+	// t.Expiration (abi.ChainEpoch) (int64)
+	if t.Expiration >= 0 {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.Expiration))); err != nil {
+			return err
+		}
+	} else {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.Expiration)-1)); err != nil {
 			return err
 		}
 	}
@@ -1044,20 +1087,25 @@ func (t *SectorOnChainInfo) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 4 {
+	if extra != 8 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
-	// t.Info (miner.SectorPreCommitInfo) (struct)
+	// t.SectorNumber (abi.SectorNumber) (uint64)
 
 	{
 
-		if err := t.Info.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.Info: %w", err)
+		maj, extra, err = cbg.CborReadHeader(br)
+		if err != nil {
+			return err
 		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.SectorNumber = abi.SectorNumber(extra)
 
 	}
-	// t.ActivationEpoch (abi.ChainEpoch) (int64)
+	// t.SealProof (abi.RegisteredSealProof) (int64)
 	{
 		maj, extra, err := cbg.CborReadHeader(br)
 		var extraI int64
@@ -1080,7 +1128,102 @@ func (t *SectorOnChainInfo) UnmarshalCBOR(r io.Reader) error {
 			return fmt.Errorf("wrong type for int64 field: %d", maj)
 		}
 
-		t.ActivationEpoch = abi.ChainEpoch(extraI)
+		t.SealProof = abi.RegisteredSealProof(extraI)
+	}
+	// t.SealedCID (cid.Cid) (struct)
+
+	{
+
+		c, err := cbg.ReadCid(br)
+		if err != nil {
+			return xerrors.Errorf("failed to read cid field t.SealedCID: %w", err)
+		}
+
+		t.SealedCID = c
+
+	}
+	// t.DealIDs ([]abi.DealID) (slice)
+
+	maj, extra, err = cbg.CborReadHeader(br)
+	if err != nil {
+		return err
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("t.DealIDs: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.DealIDs = make([]abi.DealID, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+
+		maj, val, err := cbg.CborReadHeader(br)
+		if err != nil {
+			return xerrors.Errorf("failed to read uint64 for t.DealIDs slice: %w", err)
+		}
+
+		if maj != cbg.MajUnsignedInt {
+			return xerrors.Errorf("value read for array t.DealIDs was not a uint, instead got %d", maj)
+		}
+
+		t.DealIDs[i] = abi.DealID(val)
+	}
+
+	// t.Activation (abi.ChainEpoch) (int64)
+	{
+		maj, extra, err := cbg.CborReadHeader(br)
+		var extraI int64
+		if err != nil {
+			return err
+		}
+		switch maj {
+		case cbg.MajUnsignedInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 positive overflow")
+			}
+		case cbg.MajNegativeInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 negative oveflow")
+			}
+			extraI = -1 - extraI
+		default:
+			return fmt.Errorf("wrong type for int64 field: %d", maj)
+		}
+
+		t.Activation = abi.ChainEpoch(extraI)
+	}
+	// t.Expiration (abi.ChainEpoch) (int64)
+	{
+		maj, extra, err := cbg.CborReadHeader(br)
+		var extraI int64
+		if err != nil {
+			return err
+		}
+		switch maj {
+		case cbg.MajUnsignedInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 positive overflow")
+			}
+		case cbg.MajNegativeInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 negative oveflow")
+			}
+			extraI = -1 - extraI
+		default:
+			return fmt.Errorf("wrong type for int64 field: %d", maj)
+		}
+
+		t.Expiration = abi.ChainEpoch(extraI)
 	}
 	// t.DealWeight (big.Int) (struct)
 

--- a/actors/builtin/miner/miner_state_test.go
+++ b/actors/builtin/miner/miner_state_test.go
@@ -102,7 +102,7 @@ func TestSectorsStore(t *testing.T) {
 
 		sectorNoIdx := 0
 		err := harness.s.ForEachSector(harness.store, func(si *miner.SectorOnChainInfo) {
-			require.Equal(t, abi.SectorNumber(sectorNos[sectorNoIdx]), si.Info.SectorNumber)
+			require.Equal(t, abi.SectorNumber(sectorNos[sectorNoIdx]), si.SectorNumber)
 			sectorNoIdx++
 		})
 		assert.NoError(t, err)
@@ -982,21 +982,24 @@ func newSectorPreCommitOnChainInfo(sectorNo abi.SectorNumber, sealed cid.Cid, de
 	}
 }
 
-// returns a unique SectorOnChainInfo with each invocation with SectorNumber set to `sectorNo`.
-func newSectorOnChainInfo(sectorNo abi.SectorNumber, sealed cid.Cid, weight big.Int, activation abi.ChainEpoch) *miner.SectorOnChainInfo {
-	info := newSectorPreCommitInfo(sectorNo, sealed)
-	return &miner.SectorOnChainInfo{
-		Info:               *info,
-		ActivationEpoch:    activation,
-		DealWeight:         weight,
-		VerifiedDealWeight: weight,
-	}
-}
-
 const (
 	sectorSealRandEpochValue = abi.ChainEpoch(1)
 	sectorExpiration         = abi.ChainEpoch(1)
 )
+
+// returns a unique SectorOnChainInfo with each invocation with SectorNumber set to `sectorNo`.
+func newSectorOnChainInfo(sectorNo abi.SectorNumber, sealed cid.Cid, weight big.Int, activation abi.ChainEpoch) *miner.SectorOnChainInfo {
+	return &miner.SectorOnChainInfo{
+		SectorNumber:       sectorNo,
+		SealProof:          abi.RegisteredSealProof_StackedDrg32GiBV1,
+		SealedCID:          sealed,
+		DealIDs:            nil,
+		Activation:         activation,
+		Expiration:         sectorExpiration,
+		DealWeight:         weight,
+		VerifiedDealWeight: weight,
+	}
+}
 
 // returns a unique SectorPreCommitInfo with each invocation with SectorNumber set to `sectorNo`.
 func newSectorPreCommitInfo(sectorNo abi.SectorNumber, sealed cid.Cid) *miner.SectorPreCommitInfo {

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -127,7 +127,7 @@ func QAPowerForWeight(size abi.SectorSize, duration abi.ChainEpoch, dealWeight, 
 
 // Returns the quality-adjusted power for a sector.
 func QAPowerForSector(size abi.SectorSize, sector *SectorOnChainInfo) abi.StoragePower {
-	duration := sector.Info.Expiration - sector.ActivationEpoch
+	duration := sector.Expiration - sector.Activation
 	return QAPowerForWeight(size, duration, sector.DealWeight, sector.VerifiedDealWeight)
 }
 

--- a/actors/builtin/multisig/cbor_gen.go
+++ b/actors/builtin/multisig/cbor_gen.go
@@ -1107,7 +1107,7 @@ func (t *ApproveReturn) MarshalCBOR(w io.Writer) error {
 		}
 	}
 
-	// t.Ret (runtime.CBORBytes) (slice)
+	// t.Ret ([]uint8) (slice)
 	if len(t.Ret) > cbg.ByteArrayMaxLen {
 		return xerrors.Errorf("Byte array in field t.Ret was too long")
 	}
@@ -1178,7 +1178,7 @@ func (t *ApproveReturn) UnmarshalCBOR(r io.Reader) error {
 
 		t.Code = exitcode.ExitCode(extraI)
 	}
-	// t.Ret (runtime.CBORBytes) (slice)
+	// t.Ret ([]uint8) (slice)
 
 	maj, extra, err = cbg.CborReadHeader(br)
 	if err != nil {
@@ -1234,7 +1234,7 @@ func (t *ProposeReturn) MarshalCBOR(w io.Writer) error {
 		}
 	}
 
-	// t.Ret (runtime.CBORBytes) (slice)
+	// t.Ret ([]uint8) (slice)
 	if len(t.Ret) > cbg.ByteArrayMaxLen {
 		return xerrors.Errorf("Byte array in field t.Ret was too long")
 	}
@@ -1330,7 +1330,7 @@ func (t *ProposeReturn) UnmarshalCBOR(r io.Reader) error {
 
 		t.Code = exitcode.ExitCode(extraI)
 	}
-	// t.Ret (runtime.CBORBytes) (slice)
+	// t.Ret ([]uint8) (slice)
 
 	maj, extra, err = cbg.CborReadHeader(br)
 	if err != nil {


### PR DESCRIPTION
Previously, the `SectorOnChainInfo` (which lives in chain state for the life of the sector) had the `SectorPreCommitInfo` embedded in it, I think primarily for expediency in initial implementation. Bytes of `SectorOnChainInfo` are expensive, because we expect 10s-100s of million of them for exabyte-scale network. The pre-commit info contains the `SealRandEpoch`, which is not relevant after the sector is proven, wasting a few (hundred mega-)bytes. 

I am about to add another pre-commit-only field, so decided to clean this up first.

This changes inlines the relevant sector pre-commit information into SectorOnChainInfo, dropping the `SealRandEpoch` and saving another byte on the CBOR nested struct delimiter.

(Aside: it should be possible to remove the SectorNumber from this struct too, but require some awkward data flow in one place that we use it, and is useful for manual state inspection).