### PR TITLE
compute initial pledge for precommit deposit

### DIFF
--- a/actors/builtin/market/cbor_gen.go
+++ b/actors/builtin/market/cbor_gen.go
@@ -317,7 +317,7 @@ func (t *PublishStorageDealsParams) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
-func (t *ActivateDeals) MarshalCBOR(w io.Writer) error {
+func (t *ActivateDealsParams) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
@@ -353,7 +353,7 @@ func (t *ActivateDeals) MarshalCBOR(w io.Writer) error {
 	return nil
 }
 
-func (t *ActivateDeals) UnmarshalCBOR(r io.Reader) error {
+func (t *ActivateDealsParams) UnmarshalCBOR(r io.Reader) error {
 	br := cbg.GetPeeker(r)
 
 	maj, extra, err := cbg.CborReadHeader(br)

--- a/actors/builtin/market/cbor_gen.go
+++ b/actors/builtin/market/cbor_gen.go
@@ -429,7 +429,7 @@ func (t *ActivateDealsOnSectorProveCommitParams) UnmarshalCBOR(r io.Reader) erro
 	return nil
 }
 
-func (t *VerifyDealsParams) MarshalCBOR(w io.Writer) error {
+func (t *VerifyDealsForActivationParams) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
@@ -476,7 +476,7 @@ func (t *VerifyDealsParams) MarshalCBOR(w io.Writer) error {
 	return nil
 }
 
-func (t *VerifyDealsParams) UnmarshalCBOR(r io.Reader) error {
+func (t *VerifyDealsForActivationParams) UnmarshalCBOR(r io.Reader) error {
 	br := cbg.GetPeeker(r)
 
 	maj, extra, err := cbg.CborReadHeader(br)
@@ -577,7 +577,7 @@ func (t *VerifyDealsParams) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
-func (t *VerifyDealsReturn) MarshalCBOR(w io.Writer) error {
+func (t *VerifyDealsForActivationReturn) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
@@ -598,7 +598,7 @@ func (t *VerifyDealsReturn) MarshalCBOR(w io.Writer) error {
 	return nil
 }
 
-func (t *VerifyDealsReturn) UnmarshalCBOR(r io.Reader) error {
+func (t *VerifyDealsForActivationReturn) UnmarshalCBOR(r io.Reader) error {
 	br := cbg.GetPeeker(r)
 
 	maj, extra, err := cbg.CborReadHeader(br)

--- a/actors/builtin/market/cbor_gen.go
+++ b/actors/builtin/market/cbor_gen.go
@@ -317,7 +317,7 @@ func (t *PublishStorageDealsParams) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
-func (t *ActivateDealsOnSectorProveCommitParams) MarshalCBOR(w io.Writer) error {
+func (t *ActivateDeals) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
@@ -353,7 +353,7 @@ func (t *ActivateDealsOnSectorProveCommitParams) MarshalCBOR(w io.Writer) error 
 	return nil
 }
 
-func (t *ActivateDealsOnSectorProveCommitParams) UnmarshalCBOR(r io.Reader) error {
+func (t *ActivateDeals) UnmarshalCBOR(r io.Reader) error {
 	br := cbg.GetPeeker(r)
 
 	maj, extra, err := cbg.CborReadHeader(br)

--- a/actors/builtin/market/market_actor.go
+++ b/actors/builtin/market/market_actor.go
@@ -280,14 +280,14 @@ func (A Actor) VerifyDealsForActivation(rt Runtime, params *VerifyDealsForActiva
 	}
 }
 
-type ActivateDeals struct {
+type ActivateDealsParams struct {
 	DealIDs      []abi.DealID
 	SectorExpiry abi.ChainEpoch
 }
 
 // Verify that a given set of storage deals is valid for a sector currently being ProveCommitted,
 // update the market's internal state accordingly.
-func (a Actor) ActivateDeals(rt Runtime, params *ActivateDeals) *adt.EmptyValue {
+func (a Actor) ActivateDeals(rt Runtime, params *ActivateDealsParams) *adt.EmptyValue {
 	rt.ValidateImmediateCallerType(builtin.StorageMinerActorCodeID)
 	minerAddr := rt.Message().Caller()
 	currEpoch := rt.CurrEpoch()

--- a/actors/builtin/market/market_actor.go
+++ b/actors/builtin/market/market_actor.go
@@ -26,7 +26,7 @@ func (a Actor) Exports() []interface{} {
 		2:                         a.AddBalance,
 		3:                         a.WithdrawBalance,
 		4:                         a.PublishStorageDeals,
-		5:                         a.VerifyDeals,
+		5:                         a.VerifyDealsForActivation,
 		6:                         a.ActivateDealsOnSectorProveCommit,
 		7:                         a.OnMinerSectorsTerminate,
 		8:                         a.ComputeDataCommitment,
@@ -249,13 +249,13 @@ func (a Actor) PublishStorageDeals(rt Runtime, params *PublishStorageDealsParams
 	return &PublishStorageDealsReturn{newDealIds}
 }
 
-type VerifyDealsParams struct {
+type VerifyDealsForActivationParams struct {
 	DealIDs      []abi.DealID
 	SectorExpiry abi.ChainEpoch
 	SectorStart  abi.ChainEpoch
 }
 
-type VerifyDealsReturn struct {
+type VerifyDealsForActivationReturn struct {
 	DealWeight         abi.DealWeight
 	VerifiedDealWeight abi.DealWeight
 }
@@ -263,7 +263,7 @@ type VerifyDealsReturn struct {
 // Verify that a given set of storage deals is valid for a sector currently being PreCommitted
 // and return DealWeight of the set of storage deals given.
 // The weight is defined as the sum, over all deals in the set, of the product of deal size and duration.
-func (A Actor) VerifyDeals(rt Runtime, params *VerifyDealsParams) *VerifyDealsReturn {
+func (A Actor) VerifyDealsForActivation(rt Runtime, params *VerifyDealsForActivationParams) *VerifyDealsForActivationReturn {
 	rt.ValidateImmediateCallerType(builtin.StorageMinerActorCodeID)
 	minerAddr := rt.Message().Caller()
 
@@ -274,7 +274,7 @@ func (A Actor) VerifyDeals(rt Runtime, params *VerifyDealsParams) *VerifyDealsRe
 	dealWeight, verifiedWeight, err := ValidateDealsForActivation(&st, store, params.DealIDs, minerAddr, params.SectorExpiry, params.SectorStart)
 	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to validate proposals for activation")
 
-	return &VerifyDealsReturn{
+	return &VerifyDealsForActivationReturn{
 		DealWeight:         dealWeight,
 		VerifiedDealWeight: verifiedWeight,
 	}

--- a/actors/builtin/market/market_actor.go
+++ b/actors/builtin/market/market_actor.go
@@ -27,7 +27,7 @@ func (a Actor) Exports() []interface{} {
 		3:                         a.WithdrawBalance,
 		4:                         a.PublishStorageDeals,
 		5:                         a.VerifyDealsForActivation,
-		6:                         a.ActivateDealsOnSectorProveCommit,
+		6:                         a.ActivateDeals,
 		7:                         a.OnMinerSectorsTerminate,
 		8:                         a.ComputeDataCommitment,
 		9:                         a.CronTick,
@@ -280,14 +280,14 @@ func (A Actor) VerifyDealsForActivation(rt Runtime, params *VerifyDealsForActiva
 	}
 }
 
-type ActivateDealsOnSectorProveCommitParams struct {
+type ActivateDeals struct {
 	DealIDs      []abi.DealID
 	SectorExpiry abi.ChainEpoch
 }
 
 // Verify that a given set of storage deals is valid for a sector currently being ProveCommitted,
 // update the market's internal state accordingly.
-func (a Actor) ActivateDealsOnSectorProveCommit(rt Runtime, params *ActivateDealsOnSectorProveCommitParams) *adt.EmptyValue {
+func (a Actor) ActivateDeals(rt Runtime, params *ActivateDeals) *adt.EmptyValue {
 	rt.ValidateImmediateCallerType(builtin.StorageMinerActorCodeID)
 	minerAddr := rt.Message().Caller()
 	currEpoch := rt.CurrEpoch()

--- a/actors/builtin/methods.go
+++ b/actors/builtin/methods.go
@@ -54,15 +54,16 @@ var MethodsPaych = struct {
 }{MethodConstructor, 2, 3, 4}
 
 var MethodsMarket = struct {
-	Constructor                    abi.MethodNum
-	AddBalance                     abi.MethodNum
-	WithdrawBalance                abi.MethodNum
-	PublishStorageDeals            abi.MethodNum
-	VerifyDealsOnSectorProveCommit abi.MethodNum
-	OnMinerSectorsTerminate        abi.MethodNum
-	ComputeDataCommitment          abi.MethodNum
-	CronTick                       abi.MethodNum
-}{MethodConstructor, 2, 3, 4, 5, 6, 7, 8}
+	Constructor                      abi.MethodNum
+	AddBalance                       abi.MethodNum
+	WithdrawBalance                  abi.MethodNum
+	PublishStorageDeals              abi.MethodNum
+	VerifyDeals                      abi.MethodNum
+	ActivateDealsOnSectorProveCommit abi.MethodNum
+	OnMinerSectorsTerminate          abi.MethodNum
+	ComputeDataCommitment            abi.MethodNum
+	CronTick                         abi.MethodNum
+}{MethodConstructor, 2, 3, 4, 5, 6, 7, 8, 9}
 
 var MethodsPower = struct {
 	Constructor              abi.MethodNum

--- a/actors/builtin/methods.go
+++ b/actors/builtin/methods.go
@@ -54,15 +54,15 @@ var MethodsPaych = struct {
 }{MethodConstructor, 2, 3, 4}
 
 var MethodsMarket = struct {
-	Constructor                      abi.MethodNum
-	AddBalance                       abi.MethodNum
-	WithdrawBalance                  abi.MethodNum
-	PublishStorageDeals              abi.MethodNum
-	VerifyDealsForActivation         abi.MethodNum
-	ActivateDealsOnSectorProveCommit abi.MethodNum
-	OnMinerSectorsTerminate          abi.MethodNum
-	ComputeDataCommitment            abi.MethodNum
-	CronTick                         abi.MethodNum
+	Constructor              abi.MethodNum
+	AddBalance               abi.MethodNum
+	WithdrawBalance          abi.MethodNum
+	PublishStorageDeals      abi.MethodNum
+	VerifyDealsForActivation abi.MethodNum
+	ActivateDeals            abi.MethodNum
+	OnMinerSectorsTerminate  abi.MethodNum
+	ComputeDataCommitment    abi.MethodNum
+	CronTick                 abi.MethodNum
 }{MethodConstructor, 2, 3, 4, 5, 6, 7, 8, 9}
 
 var MethodsPower = struct {

--- a/actors/builtin/methods.go
+++ b/actors/builtin/methods.go
@@ -58,7 +58,7 @@ var MethodsMarket = struct {
 	AddBalance                       abi.MethodNum
 	WithdrawBalance                  abi.MethodNum
 	PublishStorageDeals              abi.MethodNum
-	VerifyDeals                      abi.MethodNum
+	VerifyDealsForActivation         abi.MethodNum
 	ActivateDealsOnSectorProveCommit abi.MethodNum
 	OnMinerSectorsTerminate          abi.MethodNum
 	ComputeDataCommitment            abi.MethodNum

--- a/actors/builtin/miner/cbor_gen.go
+++ b/actors/builtin/miner/cbor_gen.go
@@ -686,7 +686,7 @@ func (t *SectorPreCommitOnChainInfo) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{131}); err != nil {
+	if _, err := w.Write([]byte{133}); err != nil {
 		return err
 	}
 
@@ -710,6 +710,16 @@ func (t *SectorPreCommitOnChainInfo) MarshalCBOR(w io.Writer) error {
 			return err
 		}
 	}
+
+	// t.DealWeight (big.Int) (struct)
+	if err := t.DealWeight.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.VerifiedDealWeight (big.Int) (struct)
+	if err := t.VerifiedDealWeight.MarshalCBOR(w); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -724,7 +734,7 @@ func (t *SectorPreCommitOnChainInfo) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 3 {
+	if extra != 5 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -770,6 +780,24 @@ func (t *SectorPreCommitOnChainInfo) UnmarshalCBOR(r io.Reader) error {
 		}
 
 		t.PreCommitEpoch = abi.ChainEpoch(extraI)
+	}
+	// t.DealWeight (big.Int) (struct)
+
+	{
+
+		if err := t.DealWeight.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.DealWeight: %w", err)
+		}
+
+	}
+	// t.VerifiedDealWeight (big.Int) (struct)
+
+	{
+
+		if err := t.VerifiedDealWeight.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.VerifiedDealWeight: %w", err)
+		}
+
 	}
 	return nil
 }

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -1625,12 +1625,12 @@ func requestUnsealedSectorCID(rt Runtime, proofType abi.RegisteredSealProof, dea
 	return cid.Cid(unsealedCID)
 }
 
-func requestDealWeight(rt Runtime, dealIDs []abi.DealID, sectorStart, sectorExpiry abi.ChainEpoch) market.VerifyDealsReturn {
-	var dealWeights market.VerifyDealsReturn
+func requestDealWeight(rt Runtime, dealIDs []abi.DealID, sectorStart, sectorExpiry abi.ChainEpoch) market.VerifyDealsForActivationReturn {
+	var dealWeights market.VerifyDealsForActivationReturn
 	ret, code := rt.Send(
 		builtin.StorageMarketActorAddr,
-		builtin.MethodsMarket.VerifyDeals,
-		&market.VerifyDealsParams{
+		builtin.MethodsMarket.VerifyDealsForActivation,
+		&market.VerifyDealsForActivationParams{
 			DealIDs:      dealIDs,
 			SectorStart:  sectorStart,
 			SectorExpiry: sectorExpiry,

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -506,7 +506,7 @@ func (a Actor) ConfirmSectorProofsValid(rt Runtime, params *builtin.ConfirmSecto
 			SealedCID:          precommit.Info.SealedCID,
 			DealIDs:            precommit.Info.DealIDs,
 			Expiration:         precommit.Info.Expiration,
-			Activation:         rt.CurrEpoch(),
+			Activation:         precommit.PreCommitEpoch,
 			DealWeight:         precommit.DealWeight,
 			VerifiedDealWeight: precommit.VerifiedDealWeight,
 		}

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -368,11 +368,11 @@ func (a Actor) PreCommitSector(rt Runtime, params *SectorPreCommitInfo) *adt.Emp
 		newlyVestedFund, err := st.UnlockVestedFunds(store, rt.CurrEpoch())
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to vest funds")
 		availableBalance := st.GetAvailableBalance(rt.CurrentBalance())
-		duration := params.Expiration - maxSectorStart
+		duration := params.Expiration - rt.CurrEpoch()
 
 		// maximum sector weigh is maximum deal weight assuming it's verified
-		qaSectorWeight := QAPowerForWeight(st.GetSectorSize(), duration, big.Zero(), dealWeight.VerifiedDealWeight)
-		depositReq := precommitDeposit(qaSectorWeight, pwrTotal.QualityAdjPower, pwrTotal.PledgeCollateral, epochReward, circulatingSupply)
+		sectorWeight := QAPowerForWeight(st.GetSectorSize(), duration, dealWeight.DealWeight, dealWeight.VerifiedDealWeight)
+		depositReq := precommitDeposit(sectorWeight, pwrTotal.QualityAdjPower, pwrTotal.PledgeCollateral, epochReward, circulatingSupply)
 		if availableBalance.LessThan(depositReq) {
 			rt.Abortf(exitcode.ErrInsufficientFunds, "insufficient funds for pre-commit deposit: %v", depositReq)
 		}

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -367,7 +367,6 @@ func (a Actor) PreCommitSector(rt Runtime, params *SectorPreCommitInfo) *adt.Emp
 		availableBalance := st.GetAvailableBalance(rt.CurrentBalance())
 		duration := params.Expiration - rt.CurrEpoch()
 
-		// maximum sector weight is maximum deal weight assuming it's verified
 		sectorWeight := QAPowerForWeight(st.GetSectorSize(), duration, dealWeight.DealWeight, dealWeight.VerifiedDealWeight)
 		depositReq := precommitDeposit(sectorWeight, pwrTotal.QualityAdjPower, pwrTotal.PledgeCollateral, epochReward, circulatingSupply)
 		if availableBalance.LessThan(depositReq) {

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -492,7 +492,7 @@ func (a Actor) ConfirmSectorProofsValid(rt Runtime, params *builtin.ConfirmSecto
 		_, code := rt.Send(
 			builtin.StorageMarketActorAddr,
 			builtin.MethodsMarket.ActivateDeals,
-			&market.ActivateDeals{
+			&market.ActivateDealsParams{
 				DealIDs:      precommit.Info.DealIDs,
 				SectorExpiry: precommit.Info.Expiration,
 			},

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -367,7 +367,7 @@ func (a Actor) PreCommitSector(rt Runtime, params *SectorPreCommitInfo) *adt.Emp
 		availableBalance := st.GetAvailableBalance(rt.CurrentBalance())
 		duration := params.Expiration - rt.CurrEpoch()
 
-		// maximum sector weigh is maximum deal weight assuming it's verified
+		// maximum sector weight is maximum deal weight assuming it's verified
 		sectorWeight := QAPowerForWeight(st.GetSectorSize(), duration, dealWeight.DealWeight, dealWeight.VerifiedDealWeight)
 		depositReq := precommitDeposit(sectorWeight, pwrTotal.QualityAdjPower, pwrTotal.PledgeCollateral, epochReward, circulatingSupply)
 		if availableBalance.LessThan(depositReq) {

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -490,8 +490,8 @@ func (a Actor) ConfirmSectorProofsValid(rt Runtime, params *builtin.ConfirmSecto
 		// https://github.com/filecoin-project/specs-actors/issues/474
 		_, code := rt.Send(
 			builtin.StorageMarketActorAddr,
-			builtin.MethodsMarket.ActivateDealsOnSectorProveCommit,
-			&market.ActivateDealsOnSectorProveCommitParams{
+			builtin.MethodsMarket.ActivateDeals,
+			&market.ActivateDeals{
 				DealIDs:      precommit.Info.DealIDs,
 				SectorExpiry: precommit.Info.Expiration,
 			},

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -130,9 +130,11 @@ type SectorPreCommitInfo struct {
 
 // Information stored on-chain for a pre-committed sector.
 type SectorPreCommitOnChainInfo struct {
-	Info             SectorPreCommitInfo
-	PreCommitDeposit abi.TokenAmount
-	PreCommitEpoch   abi.ChainEpoch
+	Info               SectorPreCommitInfo
+	PreCommitDeposit   abi.TokenAmount
+	PreCommitEpoch     abi.ChainEpoch
+	DealWeight         abi.DealWeight // Integral of active deals over sector lifetime
+	VerifiedDealWeight abi.DealWeight // Integral of active verified deals over sector lifetime
 }
 
 // Information stored on-chain for a proven sector.

--- a/actors/builtin/miner/miner_state_test.go
+++ b/actors/builtin/miner/miner_state_test.go
@@ -976,9 +976,11 @@ func constructStateHarness(t *testing.T, periodBoundary abi.ChainEpoch) *stateHa
 func newSectorPreCommitOnChainInfo(sectorNo abi.SectorNumber, sealed cid.Cid, deposit abi.TokenAmount, epoch abi.ChainEpoch) *miner.SectorPreCommitOnChainInfo {
 	info := newSectorPreCommitInfo(sectorNo, sealed)
 	return &miner.SectorPreCommitOnChainInfo{
-		Info:             *info,
-		PreCommitDeposit: deposit,
-		PreCommitEpoch:   epoch,
+		Info:               *info,
+		PreCommitDeposit:   deposit,
+		PreCommitEpoch:     epoch,
+		DealWeight:         big.Zero(),
+		VerifiedDealWeight: big.Zero(),
 	}
 }
 

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -203,9 +203,16 @@ func TestCommitments(t *testing.T) {
 		require.False(t, found)
 
 		// expect new onchain sector
-		_, found, err = st.GetSector(rt.AdtStore(), sectorNo)
+		onChainSector, found, err := st.GetSector(rt.AdtStore(), sectorNo)
 		require.NoError(t, err)
 		require.True(t, found)
+
+		// expect deal weights to be transfered to on chain info
+		assert.Equal(t, onChainPrecommit.DealWeight, onChainSector.DealWeight)
+		assert.Equal(t, onChainPrecommit.VerifiedDealWeight, onChainSector.VerifiedDealWeight)
+
+		// expect activation epoch to be precommit
+		assert.Equal(t, precommitEpoch, onChainSector.ActivationEpoch)
 
 		// expect deposit to have been released
 		assert.Equal(t, big.Zero(), st.PreCommitDeposits)

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -145,6 +145,7 @@ func TestCommitments(t *testing.T) {
 	worker := tutil.NewIDAddr(t, 101)
 	workerKey := tutil.NewBLSAddr(t, 0)
 	actor := newHarness(t, tutil.NewIDAddr(t, 1000), owner, worker, workerKey)
+	networkPower := abi.NewStoragePower(1 << 50)
 	periodBoundary := abi.ChainEpoch(100)
 	builder := mock.NewBuilder(context.Background(), actor.receiver).
 		WithActorType(owner, builtin.AccountActorCodeID).
@@ -162,36 +163,36 @@ func TestCommitments(t *testing.T) {
 		challengeEpoch := precommitEpoch - 1
 
 		// Good commitment.
-		actor.preCommitSector(rt, makePreCommit(100, challengeEpoch, deadline.PeriodEnd()), big.Zero())
+		actor.preCommitSector(rt, makePreCommit(100, challengeEpoch, deadline.PeriodEnd()), networkPower, big.Zero())
 
 		// Duplicate sector ID
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
-			actor.preCommitSector(rt, makePreCommit(100, challengeEpoch, deadline.PeriodEnd()), big.Zero())
+			actor.preCommitSector(rt, makePreCommit(100, challengeEpoch, deadline.PeriodEnd()), networkPower, big.Zero())
 		})
 
 		// Bad seal proof type
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			pc := makePreCommit(114, challengeEpoch, deadline.PeriodEnd())
 			pc.SealProof = abi.RegisteredSealProof_StackedDrg8MiBV1
-			actor.preCommitSector(rt, pc, big.Zero())
+			actor.preCommitSector(rt, pc, networkPower, big.Zero())
 		})
 
 		// Expires at current epoch
 		rt.SetEpoch(deadline.PeriodEnd())
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
-			actor.preCommitSector(rt, makePreCommit(111, challengeEpoch, deadline.PeriodEnd()), big.Zero())
+			actor.preCommitSector(rt, makePreCommit(111, challengeEpoch, deadline.PeriodEnd()), networkPower, big.Zero())
 		})
 
 		// Expires before current epoch
 		rt.SetEpoch(deadline.PeriodEnd() + 1)
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
-			actor.preCommitSector(rt, makePreCommit(112, challengeEpoch, deadline.PeriodEnd()), big.Zero())
+			actor.preCommitSector(rt, makePreCommit(112, challengeEpoch, deadline.PeriodEnd()), networkPower, big.Zero())
 		})
 
 		// Expires not on period end
 		rt.SetEpoch(precommitEpoch)
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
-			actor.preCommitSector(rt, makePreCommit(113, challengeEpoch, deadline.PeriodEnd()-1), big.Zero())
+			actor.preCommitSector(rt, makePreCommit(113, challengeEpoch, deadline.PeriodEnd()-1), networkPower, big.Zero())
 		})
 
 		// TODO: test insufficient funds when the precommit deposit is set above zero
@@ -208,7 +209,7 @@ func TestCommitments(t *testing.T) {
 		// Make a good commitment for the proof to target.
 		sectorNo := abi.SectorNumber(100)
 		precommit := makePreCommit(sectorNo, precommitEpoch-1, deadline.PeriodEnd())
-		actor.preCommitSector(rt, precommit, big.Zero())
+		actor.preCommitSector(rt, precommit, networkPower, big.Zero())
 
 		// Sector pre-commitment missing.
 		rt.SetEpoch(precommitEpoch + miner.PreCommitChallengeDelay + 1)
@@ -232,7 +233,7 @@ func TestCommitments(t *testing.T) {
 		// Set the right epoch for all following tests
 		rt.SetEpoch(precommitEpoch + miner.PreCommitChallengeDelay + 1)
 
-		// Invalid deals (market VerifyDealsOnSectorProveCommit aborts)
+		// Invalid deals (market ActivateDealsOnSectorProveCommit aborts)
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			actor.proveCommitSector(rt, precommit, precommitEpoch, makeProveCommit(sectorNo), proveCommitConf{
 				verifyDealsExit: exitcode.ErrIllegalArgument,
@@ -303,7 +304,7 @@ func TestWindowPost(t *testing.T) {
 		store := rt.AdtStore()
 		partitionSize := st.Info.WindowPoStPartitionSectors
 		deadline := st.DeadlineInfo(rt.Epoch())
-		expiration := deadline.PeriodEnd() + 10*miner.WPoStProvingPeriod
+		expiration := deadline.PeriodEnd() + 100*miner.WPoStProvingPeriod
 		_ = actor.commitAndProveSectors(rt, 1, expiration, 1<<50)
 
 		// Skip to end of proving period, cron adds sectors to proving set.
@@ -442,7 +443,7 @@ func TestDeclareFaults(t *testing.T) {
 		// Get sector into proving state
 		rt := builder.Build(t)
 		actor.constructAndVerify(rt, periodOffset)
-		expiration := 10*miner.WPoStProvingPeriod + periodOffset - 1
+		expiration := 100*miner.WPoStProvingPeriod + periodOffset - 1
 		sectorNumber := actor.nextSectorNo
 		actor.commitAndProveSectors(rt, 1, expiration, 1<<50)
 
@@ -489,7 +490,7 @@ func TestExtendSectorExpiration(t *testing.T) {
 		rt.SetEpoch(precommitEpoch)
 		st := getState(rt)
 		deadline := st.DeadlineInfo(rt.Epoch())
-		expiration := deadline.PeriodEnd() + 10*miner.WPoStProvingPeriod
+		expiration := deadline.PeriodEnd() + 100*miner.WPoStProvingPeriod
 		sectorInfo := actor.commitAndProveSectors(rt, 1, expiration, 0)
 
 		sector, found, err := getState(rt).GetSector(rt.AdtStore(), sectorInfo[0].SectorNumber)
@@ -609,13 +610,42 @@ func (h *actorHarness) controlAddresses(rt *mock.Runtime) (owner, worker addr.Ad
 	return ret.Owner, ret.Worker
 }
 
-func (h *actorHarness) preCommitSector(rt *mock.Runtime, params *miner.SectorPreCommitInfo, pledgeDelta abi.TokenAmount) {
+func (h *actorHarness) preCommitSector(rt *mock.Runtime, params *miner.SectorPreCommitInfo, networkPower abi.StoragePower, pledgeDelta abi.TokenAmount) {
+	epochReward := big.Mul(big.NewIntUnsigned(100), big.NewIntUnsigned(1e18))
+	networkPledge := big.Mul(epochReward, big.NewIntUnsigned(1000))
+
 	rt.SetCaller(h.worker, builtin.AccountActorCodeID)
 	rt.ExpectValidateCallerAddr(h.worker)
-	if !pledgeDelta.IsZero() {
-		rt.ExpectSend(builtin.StoragePowerActorAddr, builtin.MethodsPower.UpdatePledgeTotal, &pledgeDelta, big.Zero(), nil, exitcode.Ok)
-	}
 
+	// Prepare for and receive call to ConfirmSectorProofsValid at the end of the same epoch.
+	{
+		rt.ExpectSend(builtin.RewardActorAddr, builtin.MethodsReward.LastPerEpochReward, nil, big.Zero(), &epochReward, exitcode.Ok)
+
+		pwrTotal := power.CurrentTotalPowerReturn{
+			RawBytePower:     networkPower,
+			QualityAdjPower:  networkPower,
+			PledgeCollateral: networkPledge,
+		}
+		rt.ExpectSend(builtin.StoragePowerActorAddr, builtin.MethodsPower.CurrentTotalPower, nil, big.Zero(), &pwrTotal, exitcode.Ok)
+	}
+	{
+		sectorSize, err := params.SealProof.SectorSize()
+		require.NoError(h.t, err)
+		maxProveCommit, ok := miner.MaxSealDuration[params.SealProof]
+		require.True(h.t, ok)
+
+		vdParams := market.VerifyDealsParams{
+			DealIDs:      params.DealIDs,
+			SectorStart:  rt.Epoch() + maxProveCommit,
+			SectorExpiry: params.Expiration,
+		}
+
+		vdReturn := market.VerifyDealsReturn{
+			DealWeight:         big.NewInt(int64(sectorSize / 2)),
+			VerifiedDealWeight: big.NewInt(int64(sectorSize / 2)),
+		}
+		rt.ExpectSend(builtin.StorageMarketActorAddr, builtin.MethodsMarket.VerifyDeals, &vdParams, big.Zero(), &vdReturn, exitcode.Ok)
+	}
 	{
 		eventPayload := miner.CronEventPayload{
 			EventType: miner.CronEventPreCommitExpiry,
@@ -651,8 +681,6 @@ func (h *actorHarness) proveCommitSector(rt *mock.Runtime, precommit *miner.Sect
 	interactiveEpoch := precommitEpoch + miner.PreCommitChallengeDelay
 	dealWeight := big.NewInt(10)
 	verifiedDealWeight := big.NewInt(100)
-	epochReward := big.Mul(big.NewIntUnsigned(100), big.NewIntUnsigned(1e18))
-	networkPledge := big.Mul(epochReward, big.NewIntUnsigned(1000))
 
 	// Prepare for and receive call to ProveCommitSector
 	{
@@ -693,25 +721,11 @@ func (h *actorHarness) proveCommitSector(rt *mock.Runtime, precommit *miner.Sect
 
 	// Prepare for and receive call to ConfirmSectorProofsValid at the end of the same epoch.
 	{
-		rt.ExpectSend(builtin.RewardActorAddr, builtin.MethodsReward.LastPerEpochReward, nil, big.Zero(), &epochReward, exitcode.Ok)
-
-		pwrTotal := power.CurrentTotalPowerReturn{
-			RawBytePower:     big.NewIntUnsigned(conf.networkPower),
-			QualityAdjPower:  big.NewIntUnsigned(conf.networkPower),
-			PledgeCollateral: networkPledge,
-		}
-		rt.ExpectSend(builtin.StoragePowerActorAddr, builtin.MethodsPower.CurrentTotalPower, nil, big.Zero(), &pwrTotal, exitcode.Ok)
-	}
-	{
-		vdParams := market.VerifyDealsOnSectorProveCommitParams{
+		vdParams := market.ActivateDealsOnSectorProveCommitParams{
 			DealIDs:      precommit.DealIDs,
 			SectorExpiry: precommit.Expiration,
 		}
-		vdRet := market.VerifyDealsOnSectorProveCommitReturn{
-			DealWeight:         dealWeight,
-			VerifiedDealWeight: verifiedDealWeight,
-		}
-		rt.ExpectSend(builtin.StorageMarketActorAddr, builtin.MethodsMarket.VerifyDealsOnSectorProveCommit, &vdParams, big.Zero(), &vdRet, conf.verifyDealsExit)
+		rt.ExpectSend(builtin.StorageMarketActorAddr, builtin.MethodsMarket.ActivateDealsOnSectorProveCommit, &vdParams, big.Zero(), nil, conf.verifyDealsExit)
 	}
 	{
 		sectorSize, err := precommit.SealProof.SectorSize()
@@ -733,8 +747,12 @@ func (h *actorHarness) proveCommitSector(rt *mock.Runtime, precommit *miner.Sect
 		}
 		rt.ExpectSend(builtin.StoragePowerActorAddr, builtin.MethodsPower.UpdateClaimedPower, &pcParams, big.Zero(), nil, exitcode.Ok)
 
-		expectedPledge := miner.InitialPledgeForPower(qaPower, big.NewIntUnsigned(conf.networkPower), networkPledge,
-			epochReward, rt.TotalFilCircSupply())
+		// expected pledge is the precommit deposit
+		st := getState(rt)
+		precommitOnChain, found, err := st.GetPrecommittedSector(rt.AdtStore(), precommit.SectorNumber)
+		require.NoError(h.t, err)
+		require.True(h.t, found)
+		expectedPledge := precommitOnChain.PreCommitDeposit
 		rt.ExpectSend(builtin.StoragePowerActorAddr, builtin.MethodsPower.UpdatePledgeTotal, &expectedPledge, big.Zero(), nil, exitcode.Ok)
 	}
 
@@ -756,7 +774,7 @@ func (h *actorHarness) commitAndProveSectors(rt *mock.Runtime, n int, expiration
 	for i := 0; i < n; i++ {
 		sectorNo := h.nextSectorNo
 		precommit := makePreCommit(sectorNo, precommitEpoch-1, expiration)
-		h.preCommitSector(rt, precommit, big.Zero())
+		h.preCommitSector(rt, precommit, big.Zero(), abi.NewStoragePower(int64(networkPower)))
 		precommits[i] = precommit
 		h.nextSectorNo++
 	}

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -189,7 +189,7 @@ func TestCommitments(t *testing.T) {
 		// expect total precommit deposit to equal our new deposit
 		assert.Equal(t, expectedDeposit, st.PreCommitDeposits)
 
-		// Sector pre-commitment missing.
+		// run prove commit logic
 		rt.SetEpoch(precommitEpoch + miner.PreCommitChallengeDelay + 1)
 		rt.SetBalance(big.Mul(big.NewInt(1000), big.NewInt(1e18)))
 		actor.proveCommitSector(rt, precommit, precommitEpoch, makeProveCommit(sectorNo), proveCommitConf{

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -212,7 +212,7 @@ func TestCommitments(t *testing.T) {
 		assert.Equal(t, onChainPrecommit.VerifiedDealWeight, onChainSector.VerifiedDealWeight)
 
 		// expect activation epoch to be precommit
-		assert.Equal(t, precommitEpoch, onChainSector.ActivationEpoch)
+		assert.Equal(t, precommitEpoch, onChainSector.Activation)
 
 		// expect deposit to have been released
 		assert.Equal(t, big.Zero(), st.PreCommitDeposits)

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -634,17 +634,17 @@ func (h *actorHarness) preCommitSector(rt *mock.Runtime, params *miner.SectorPre
 		maxProveCommit, ok := miner.MaxSealDuration[params.SealProof]
 		require.True(h.t, ok)
 
-		vdParams := market.VerifyDealsParams{
+		vdParams := market.VerifyDealsForActivationParams{
 			DealIDs:      params.DealIDs,
 			SectorStart:  rt.Epoch() + maxProveCommit,
 			SectorExpiry: params.Expiration,
 		}
 
-		vdReturn := market.VerifyDealsReturn{
+		vdReturn := market.VerifyDealsForActivationReturn{
 			DealWeight:         big.NewInt(int64(sectorSize / 2)),
 			VerifiedDealWeight: big.NewInt(int64(sectorSize / 2)),
 		}
-		rt.ExpectSend(builtin.StorageMarketActorAddr, builtin.MethodsMarket.VerifyDeals, &vdParams, big.Zero(), &vdReturn, exitcode.Ok)
+		rt.ExpectSend(builtin.StorageMarketActorAddr, builtin.MethodsMarket.VerifyDealsForActivation, &vdParams, big.Zero(), &vdReturn, exitcode.Ok)
 	}
 	{
 		eventPayload := miner.CronEventPayload{

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -661,9 +661,6 @@ func (h *actorHarness) constructAndVerify(rt *mock.Runtime, provingPeriodStart a
 		PeerId:        testPid,
 	}
 
-	h.epochReward = big.Mul(big.NewIntUnsigned(100), big.NewIntUnsigned(1e18))
-	h.networkPledge = big.Mul(h.epochReward, big.NewIntUnsigned(1000))
-
 	rt.ExpectValidateCallerAddr(builtin.InitActorAddr)
 	// Fetch worker pubkey.
 	rt.ExpectSend(h.worker, builtin.MethodsAccount.PubkeyAddress, nil, big.Zero(), &h.key, exitcode.Ok)

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -787,7 +787,7 @@ func (h *actorHarness) proveCommitSector(rt *mock.Runtime, precommit *miner.Sect
 
 	// Prepare for and receive call to ConfirmSectorProofsValid at the end of the same epoch.
 	{
-		vdParams := market.ActivateDeals{
+		vdParams := market.ActivateDealsParams{
 			DealIDs:      precommit.DealIDs,
 			SectorExpiry: precommit.Expiration,
 		}

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -233,7 +233,7 @@ func TestCommitments(t *testing.T) {
 		// Set the right epoch for all following tests
 		rt.SetEpoch(precommitEpoch + miner.PreCommitChallengeDelay + 1)
 
-		// Invalid deals (market ActivateDealsOnSectorProveCommit aborts)
+		// Invalid deals (market ActivateDeals aborts)
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			actor.proveCommitSector(rt, precommit, precommitEpoch, makeProveCommit(sectorNo), proveCommitConf{
 				verifyDealsExit: exitcode.ErrIllegalArgument,
@@ -721,11 +721,11 @@ func (h *actorHarness) proveCommitSector(rt *mock.Runtime, precommit *miner.Sect
 
 	// Prepare for and receive call to ConfirmSectorProofsValid at the end of the same epoch.
 	{
-		vdParams := market.ActivateDealsOnSectorProveCommitParams{
+		vdParams := market.ActivateDeals{
 			DealIDs:      precommit.DealIDs,
 			SectorExpiry: precommit.Expiration,
 		}
-		rt.ExpectSend(builtin.StorageMarketActorAddr, builtin.MethodsMarket.ActivateDealsOnSectorProveCommit, &vdParams, big.Zero(), nil, conf.verifyDealsExit)
+		rt.ExpectSend(builtin.StorageMarketActorAddr, builtin.MethodsMarket.ActivateDeals, &vdParams, big.Zero(), nil, conf.verifyDealsExit)
 	}
 	{
 		sectorSize, err := precommit.SealProof.SectorSize()

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -240,6 +240,7 @@ func TestCommitments(t *testing.T) {
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			actor.preCommitSector(rt, makePreCommit(100, challengeEpoch, deadline.PeriodEnd()), networkPower, big.Zero())
 		})
+		rt.Reset()
 
 		// Bad seal proof type
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
@@ -247,18 +248,21 @@ func TestCommitments(t *testing.T) {
 			pc.SealProof = abi.RegisteredSealProof_StackedDrg8MiBV1
 			actor.preCommitSector(rt, pc, networkPower, big.Zero())
 		})
+		rt.Reset()
 
 		// Expires at current epoch
 		rt.SetEpoch(deadline.PeriodEnd())
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			actor.preCommitSector(rt, makePreCommit(111, challengeEpoch, deadline.PeriodEnd()), networkPower, big.Zero())
 		})
+		rt.Reset()
 
 		// Expires before current epoch
 		rt.SetEpoch(deadline.PeriodEnd() + 1)
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			actor.preCommitSector(rt, makePreCommit(112, challengeEpoch, deadline.PeriodEnd()), networkPower, big.Zero())
 		})
+		rt.Reset()
 
 		// Expires not on period end
 		rt.SetEpoch(precommitEpoch)

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -132,9 +132,8 @@ func QAPowerForSector(size abi.SectorSize, sector *SectorOnChainInfo) abi.Storag
 }
 
 // Deposit per sector required at pre-commitment, refunded after the commitment is proven (else burned).
-func precommitDeposit(sectorSize abi.SectorSize, duration abi.ChainEpoch) abi.TokenAmount {
-	depositPerByte := abi.NewTokenAmount(0) // PARAM_FINISH
-	return big.Mul(depositPerByte, big.NewIntUnsigned(uint64(sectorSize)))
+func precommitDeposit(qaSectorPower abi.StoragePower, networkQAPower abi.StoragePower, networkTotalPledge, epochTargetReward, circulatingSupply abi.TokenAmount) abi.TokenAmount {
+	return InitialPledgeForPower(qaSectorPower, networkQAPower, networkTotalPledge, epochTargetReward, circulatingSupply)
 }
 
 type BigFrac struct {

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -147,8 +147,9 @@ func main() {
 		// method params
 		market.WithdrawBalanceParams{},
 		market.PublishStorageDealsParams{},
-		market.VerifyDealsOnSectorProveCommitParams{},
-		market.VerifyDealsOnSectorProveCommitReturn{},
+		market.ActivateDealsOnSectorProveCommitParams{},
+		market.VerifyDealsParams{},
+		market.VerifyDealsReturn{},
 		market.ComputeDataCommitmentParams{},
 		market.OnMinerSectorsTerminateParams{},
 		// method returns

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -148,8 +148,8 @@ func main() {
 		market.WithdrawBalanceParams{},
 		market.PublishStorageDealsParams{},
 		market.ActivateDealsOnSectorProveCommitParams{},
-		market.VerifyDealsParams{},
-		market.VerifyDealsReturn{},
+		market.VerifyDealsForActivationParams{},
+		market.VerifyDealsForActivationReturn{},
 		market.ComputeDataCommitmentParams{},
 		market.OnMinerSectorsTerminateParams{},
 		// method returns

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -147,7 +147,7 @@ func main() {
 		// method params
 		market.WithdrawBalanceParams{},
 		market.PublishStorageDealsParams{},
-		market.ActivateDeals{},
+		market.ActivateDealsParams{},
 		market.VerifyDealsForActivationParams{},
 		market.VerifyDealsForActivationReturn{},
 		market.ComputeDataCommitmentParams{},

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -147,7 +147,7 @@ func main() {
 		// method params
 		market.WithdrawBalanceParams{},
 		market.PublishStorageDealsParams{},
-		market.ActivateDealsOnSectorProveCommitParams{},
+		market.ActivateDeals{},
 		market.VerifyDealsForActivationParams{},
 		market.VerifyDealsForActivationReturn{},
 		market.ComputeDataCommitmentParams{},

--- a/support/mock/mockrt.go
+++ b/support/mock/mockrt.go
@@ -722,6 +722,9 @@ func (rt *Runtime) ExpectAbort(expected exitcode.ExitCode, f func()) {
 		}
 		// Roll back state change.
 		rt.state = prevState
+
+		// clear expectations unfulfilled due to abort
+		rt.Reset()
 	}()
 	f()
 }

--- a/support/mock/mockrt.go
+++ b/support/mock/mockrt.go
@@ -722,9 +722,6 @@ func (rt *Runtime) ExpectAbort(expected exitcode.ExitCode, f func()) {
 		}
 		// Roll back state change.
 		rt.state = prevState
-
-		// clear expectations unfulfilled due to abort
-		rt.Reset()
 	}()
 	f()
 }


### PR DESCRIPTION
closes #424

### Motivation

We need to collect a deposit from miners precommitting sectors to be return when the sectors are committed. It has been decided that this deposit should be equivalent to the initial pledge that is locked when the sector is proven.

Tying precommit deposit to initial pledge has a few consequences. Initial pledge is a function of time, so we've decided to move the activation time of the sector to precommit time. This means we can compute the precommit deposit as `IP(currEpoch)` and then simply transfer this amount to lock funds to cover the initial pledge. This will have a small (but predictable) effect on the values of initial pledge and quality adjusted power, but shouldn't affect the behavior of the system beyond that. Power will still be granted and deals will still be activated when the sector is proven.

### Proposed Changes

1. Previously we had been both computing the initial pledge and activating deals in `ConfirmSectorProofsValid` so we had a `VerifyDealsOnProveCommit` method on the market actor that activated deals and returned the sum of their weight. Since we now actually compute initial pledge in precommit, this method has been split into a `VerifyDealsForActivation` that verifies the deals and computes their weights, and an `ActivateDeals` method that simply updates the activation state for a set of deals.
2. Compute precommit deposit in `miner.PreCommitSector` by computing `initialPledge` with parameters derived from the current epoch. Set this value to `SectorPreCommitOnChainInfo` and add it to `state.PreCommitDeposits`. 
3. Set intermediate values of deposit calculation, `DealWeight` and `VerifiedDealWeight`, into new fields in the `SectorPreCommitOnChainInfo` so they can be transferred to `SectorOnChainInfo` rather than being recomputed at a different type (resulting in slightly different values).
4. Add new "valid precommit then provecommit" test to assert precommit and prove commit make expected modifications to state on the happy path.