### PR TITLE
Quantize vesting with offset 

### DIFF
--- a/actors/builtin/miner/miner_internal_test.go
+++ b/actors/builtin/miner/miner_internal_test.go
@@ -139,3 +139,26 @@ func TestFaultFeeInvariants(t *testing.T) {
 
 	 })
 }
+
+func TestQuantizeUp(t *testing.T) {
+	t.Run("zero offset", func(t *testing.T) {
+		assert.Equal(t, abi.ChainEpoch(50), quantizeUp(42, 10, 0))
+		assert.Equal(t, abi.ChainEpoch(16000), quantizeUp(16000, 100, 0))
+		assert.Equal(t, abi.ChainEpoch(0), quantizeUp(-5, 10, 0))
+		assert.Equal(t, abi.ChainEpoch(-50), quantizeUp(-50, 10, 0))
+		assert.Equal(t, abi.ChainEpoch(-50), quantizeUp(-53, 10, 0))
+	})
+
+	t.Run("non zero offset", func(t *testing.T) {
+		assert.Equal(t, abi.ChainEpoch(6), quantizeUp(4, 5, 1))
+		assert.Equal(t, abi.ChainEpoch(1), quantizeUp(0, 5, 1))
+		assert.Equal(t, abi.ChainEpoch(-4), quantizeUp(-6, 5, 1))
+		assert.Equal(t, abi.ChainEpoch(4), quantizeUp(2, 10, 4))
+	})
+
+	t.Run("offset seed bigger than unit is normalized", func(t *testing.T) {
+		assert.Equal(t, abi.ChainEpoch(13), quantizeUp(9, 5, 28)) // offset should be 3
+		assert.Equal(t, abi.ChainEpoch(10000), quantizeUp(10000, 100, 2000000))
+	})
+
+}

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -1079,7 +1079,12 @@ func quantizeUp(e abi.ChainEpoch, unit abi.ChainEpoch, offsetSeed abi.ChainEpoch
 
 	remainder := (e - offset) % unit
 	quotient := (e - offset) / unit
+	// Don't round if epoch falls on a quantization epoch
 	if remainder == 0 {
+		return unit*quotient + offset
+	}
+	// Negative truncating division rounds up
+	if e-offset < 0 {
 		return unit*quotient + offset
 	}
 	return unit*(quotient+1) + offset

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -868,7 +868,7 @@ func (st *State) AddLockedFunds(store adt.Store, currEpoch abi.ChainEpoch, vesti
 
 	vestedSoFar := big.Zero()
 	for e := vestBegin + spec.StepDuration; vestedSoFar.LessThan(vestingSum); e += spec.StepDuration {
-		vestEpoch := quantizeUp(e, spec.Quantization)
+		vestEpoch := quantizeUpWithOffset(e, spec.Quantization, st.ProvingPeriodStart)
 		elapsed := vestEpoch - vestBegin
 
 		targetVest := big.Zero() //nolint:ineffassign
@@ -1068,6 +1068,11 @@ func deleteMany(arr *adt.Array, keys []uint64) error {
 		}
 	}
 	return nil
+}
+
+func quantizeUpWithOffset(e abi.ChainEpoch, unit, offsetSeed abi.ChainEpoch) abi.ChainEpoch {
+	offset := offsetSeed % unit
+	return quantizeUp(e, unit) + offset
 }
 
 // Rounds e to the nearest exact multiple of the quantization unit, rounding up.

--- a/actors/builtin/miner/miner_state_test.go
+++ b/actors/builtin/miner/miner_state_test.go
@@ -407,13 +407,14 @@ func TestPostSubmissionsBitfield(t *testing.T) {
 }
 
 func TestVesting_AddLockedFunds_Table(t *testing.T) {
-	vestStart := abi.ChainEpoch(10)
+	vestStartDelay := abi.ChainEpoch(10)
 	vestSum := int64(100)
 
 	testcase := []struct {
-		desc   string
-		vspec  *miner.VestSpec
-		vepocs []int64
+		desc        string
+		vspec       *miner.VestSpec
+		periodStart abi.ChainEpoch
+		vepocs      []int64
 	}{
 		{
 			desc: "vest funds in a single epoch",
@@ -543,10 +544,45 @@ func TestVesting_AddLockedFunds_Table(t *testing.T) {
 			},
 			vepocs: []int64{0, 0, 0, 0, 0, 0, 0, 20, 20, 20, 20, 20, 0},
 		},
+		{
+			desc: "vest funds with offset 0",
+			vspec: &miner.VestSpec{
+				InitialDelay: 0,
+				VestPeriod:   10,
+				StepDuration: 2,
+				Quantization: 2,
+			},
+			vepocs: []int64{0, 0, 0, 20, 0, 20, 0, 20, 0, 20, 0, 20},
+		},
+		{
+			desc: "vest funds with offset 1",
+			vspec: &miner.VestSpec{
+				InitialDelay: 0,
+				VestPeriod:   10,
+				StepDuration: 2,
+				Quantization: 2,
+			},
+			periodStart: abi.ChainEpoch(1),
+			// start epoch is at 11 instead of 10 so vepocs are shifted by one from above case
+			vepocs: []int64{0, 0, 0, 20, 0, 20, 0, 20, 0, 20, 0, 20},
+		},
+		{
+			desc: "vest funds with proving period start > quantization unit",
+			vspec: &miner.VestSpec{
+				InitialDelay: 0,
+				VestPeriod:   10,
+				StepDuration: 2,
+				Quantization: 2,
+			},
+			// 55 % 2 = 1 so expect same vepocs with offset 1 as in previous case
+			periodStart: abi.ChainEpoch(55),
+			vepocs:      []int64{0, 0, 0, 20, 0, 20, 0, 20, 0, 20, 0, 20},
+		},
 	}
 	for _, tc := range testcase {
 		t.Run(tc.desc, func(t *testing.T) {
-			harness := constructStateHarness(t, abi.ChainEpoch(0))
+			harness := constructStateHarness(t, tc.periodStart)
+			vestStart := tc.periodStart + vestStartDelay
 
 			harness.addLockedFunds(vestStart, abi.NewTokenAmount(vestSum), tc.vspec)
 			assert.Equal(t, abi.NewTokenAmount(vestSum), harness.s.LockedFunds)

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -618,20 +618,16 @@ func TestReportConsensusFault(t *testing.T) {
 	actor.reportConsensusFault(rt, addr.TestAddress, params, allDeals)
 }
 func TestAddLockedFund(t *testing.T) {
-	owner := tutil.NewIDAddr(t, 100)
-	worker := tutil.NewIDAddr(t, 101)
-	workerKey := tutil.NewBLSAddr(t, 0)
-	actor := newHarness(t, tutil.NewIDAddr(t, 1000), owner, worker, workerKey)
+
 	periodOffset := abi.ChainEpoch(1808)
-	builder := mock.NewBuilder(context.Background(), actor.receiver).
-		WithActorType(owner, builtin.AccountActorCodeID).
-		WithActorType(worker, builtin.AccountActorCodeID).
-		WithHasher(fixedHasher(uint64(periodOffset))).
-		WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID).
+	actor := newHarness(t, periodOffset)
+
+	builder := builderForHarness(actor).
 		WithBalance(big.Mul(big.NewInt(1000), big.NewInt(1e18)), big.Zero())
+
 	t.Run("funds vest", func(t *testing.T) {
 		rt := builder.Build(t)
-		actor.constructAndVerify(rt, periodOffset)
+		actor.constructAndVerify(rt)
 		st := getState(rt)
 		store := rt.AdtStore()
 
@@ -661,7 +657,6 @@ func TestAddLockedFund(t *testing.T) {
 
 	})
 
-	// Inspect vesting schedule to see if the offset is respected
 }
 
 type actorHarness struct {


### PR DESCRIPTION
Use proving period start as entropy for setting offset in quantization boundaries for vesting.

Closes #301 