### PR TITLE
Add WinCount to reward actor

### DIFF
--- a/actors/builtin/reward/cbor_gen.go
+++ b/actors/builtin/reward/cbor_gen.go
@@ -195,7 +195,7 @@ func (t *AwardBlockRewardParams) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{131}); err != nil {
+	if _, err := w.Write([]byte{132}); err != nil {
 		return err
 	}
 
@@ -213,6 +213,17 @@ func (t *AwardBlockRewardParams) MarshalCBOR(w io.Writer) error {
 	if err := t.GasReward.MarshalCBOR(w); err != nil {
 		return err
 	}
+
+	// t.WinCount (int64) (int64)
+	if t.WinCount >= 0 {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.WinCount))); err != nil {
+			return err
+		}
+	} else {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.WinCount)-1)); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -227,7 +238,7 @@ func (t *AwardBlockRewardParams) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 3 {
+	if extra != 4 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -257,6 +268,31 @@ func (t *AwardBlockRewardParams) UnmarshalCBOR(r io.Reader) error {
 			return xerrors.Errorf("unmarshaling t.GasReward: %w", err)
 		}
 
+	}
+	// t.WinCount (int64) (int64)
+	{
+		maj, extra, err := cbg.CborReadHeader(br)
+		var extraI int64
+		if err != nil {
+			return err
+		}
+		switch maj {
+		case cbg.MajUnsignedInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 positive overflow")
+			}
+		case cbg.MajNegativeInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 negative oveflow")
+			}
+			extraI = -1 - extraI
+		default:
+			return fmt.Errorf("wrong type for int64 field: %d", maj)
+		}
+
+		t.WinCount = int64(extraI)
 	}
 	return nil
 }

--- a/actors/builtin/reward/reward_actor.go
+++ b/actors/builtin/reward/reward_actor.go
@@ -38,6 +38,7 @@ type AwardBlockRewardParams struct {
 	Miner     address.Address
 	Penalty   abi.TokenAmount // penalty for including bad messages in a block
 	GasReward abi.TokenAmount // gas reward from all gas fees in a block
+	WinCount  int64
 }
 
 // Awards a reward to a block producer.
@@ -66,6 +67,7 @@ func (a Actor) AwardBlockReward(rt vmr.Runtime, params *AwardBlockRewardParams) 
 	var st State
 	rt.State().Readonly(&st)
 	blockReward := big.Div(st.LastPerEpochReward, big.NewInt(builtin.ExpectedLeadersPerEpoch))
+	blockReward = big.Mul(blockReward, big.NewInt(params.WinCount))
 	totalReward := big.Add(blockReward, params.GasReward)
 
 	// Cap the penalty at the total reward value.


### PR DESCRIPTION
It is necessary as we transition toward Poisson Sortition for the leader
election.

Q: How well does the reward actor handle over issuing rewards? We've currently set max `WinCount` of `15` in lotus but there can be also multiple blocks in a tipset.