### PR TITLE
Enforce locked funds do not fall below initial pledges

### DIFF
--- a/actors/builtin/miner/cbor_gen.go
+++ b/actors/builtin/miner/cbor_gen.go
@@ -33,11 +33,6 @@ func (t *State) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.InitialPledges (big.Int) (struct)
-	if err := t.InitialPledges.MarshalCBOR(w); err != nil {
-		return err
-	}
-
 	// t.LockedFunds (big.Int) (struct)
 	if err := t.LockedFunds.MarshalCBOR(w); err != nil {
 		return err
@@ -47,6 +42,11 @@ func (t *State) MarshalCBOR(w io.Writer) error {
 
 	if err := cbg.WriteCid(w, t.VestingFunds); err != nil {
 		return xerrors.Errorf("failed to write cid field t.VestingFunds: %w", err)
+	}
+
+	// t.InitialPledgeRequirement (big.Int) (struct)
+	if err := t.InitialPledgeRequirement.MarshalCBOR(w); err != nil {
+		return err
 	}
 
 	// t.PreCommittedSectors (cid.Cid) (struct)
@@ -152,15 +152,6 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 		}
 
 	}
-	// t.InitialPledges (big.Int) (struct)
-
-	{
-
-		if err := t.InitialPledges.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.InitialPledges: %w", err)
-		}
-
-	}
 	// t.LockedFunds (big.Int) (struct)
 
 	{
@@ -180,6 +171,15 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 		}
 
 		t.VestingFunds = c
+
+	}
+	// t.InitialPledgeRequirement (big.Int) (struct)
+
+	{
+
+		if err := t.InitialPledgeRequirement.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.InitialPledgeRequirement: %w", err)
+		}
 
 	}
 	// t.PreCommittedSectors (cid.Cid) (struct)

--- a/actors/builtin/miner/cbor_gen.go
+++ b/actors/builtin/miner/cbor_gen.go
@@ -19,7 +19,7 @@ func (t *State) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{143}); err != nil {
+	if _, err := w.Write([]byte{144}); err != nil {
 		return err
 	}
 
@@ -30,6 +30,11 @@ func (t *State) MarshalCBOR(w io.Writer) error {
 
 	// t.PreCommitDeposits (big.Int) (struct)
 	if err := t.PreCommitDeposits.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.InitialPledges (big.Int) (struct)
+	if err := t.InitialPledges.MarshalCBOR(w); err != nil {
 		return err
 	}
 
@@ -125,7 +130,7 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 15 {
+	if extra != 16 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -144,6 +149,15 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 
 		if err := t.PreCommitDeposits.UnmarshalCBOR(br); err != nil {
 			return xerrors.Errorf("unmarshaling t.PreCommitDeposits: %w", err)
+		}
+
+	}
+	// t.InitialPledges (big.Int) (struct)
+
+	{
+
+		if err := t.InitialPledges.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.InitialPledges: %w", err)
 		}
 
 	}

--- a/actors/builtin/miner/cbor_gen.go
+++ b/actors/builtin/miner/cbor_gen.go
@@ -1043,7 +1043,7 @@ func (t *SectorOnChainInfo) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{136}); err != nil {
+	if _, err := w.Write([]byte{137}); err != nil {
 		return err
 	}
 
@@ -1115,6 +1115,11 @@ func (t *SectorOnChainInfo) MarshalCBOR(w io.Writer) error {
 	if err := t.VerifiedDealWeight.MarshalCBOR(w); err != nil {
 		return err
 	}
+
+	// t.InitialPledge (big.Int) (struct)
+	if err := t.InitialPledge.MarshalCBOR(w); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -1129,7 +1134,7 @@ func (t *SectorOnChainInfo) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 8 {
+	if extra != 9 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -1282,6 +1287,15 @@ func (t *SectorOnChainInfo) UnmarshalCBOR(r io.Reader) error {
 
 		if err := t.VerifiedDealWeight.UnmarshalCBOR(br); err != nil {
 			return xerrors.Errorf("unmarshaling t.VerifiedDealWeight: %w", err)
+		}
+
+	}
+	// t.InitialPledge (big.Int) (struct)
+
+	{
+
+		if err := t.InitialPledge.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.InitialPledge: %w", err)
 		}
 
 	}

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -499,6 +499,10 @@ func (a Actor) ConfirmSectorProofsValid(rt Runtime, params *builtin.ConfirmSecto
 		)
 		builtin.RequireSuccess(rt, code, "failed to verify deals and get deal weight")
 
+		// initial pledge is precommit deposit
+		// TODO: compute new initial pledge here (https://github.com/filecoin-project/specs-actors/issues/522)
+		initialPledge := precommit.PreCommitDeposit
+
 		newSectorInfo := SectorOnChainInfo{
 			SectorNumber:       precommit.Info.SectorNumber,
 			SealProof:          precommit.Info.SealProof,
@@ -508,14 +512,13 @@ func (a Actor) ConfirmSectorProofsValid(rt Runtime, params *builtin.ConfirmSecto
 			Activation:         precommit.PreCommitEpoch,
 			DealWeight:         precommit.DealWeight,
 			VerifiedDealWeight: precommit.VerifiedDealWeight,
+			InitialPledge:      initialPledge,
 		}
 
 		// Request power for activated sector.
 		// TODO: aggregate new power calculation and move this outside the loop, requesting power and pledge just once at the end.
 		// https://github.com/filecoin-project/specs-actors/issues/475
 		requestUpdateSectorPower(rt, st.Info.SectorSize, []*SectorOnChainInfo{&newSectorInfo}, nil)
-
-		initialPledge := precommit.PreCommitDeposit
 
 		// Add sector and pledge lock-up to miner state
 		// TODO: do this all at once after the loop

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -1694,8 +1694,8 @@ func requestCurrentTotalPower(rt Runtime) *power.CurrentTotalPowerReturn {
 
 // Verifies that the total locked balance exceeds the sum of sector initial pledges.
 func verifyPledgeMeetsInitialRequirements(rt Runtime, st *State) {
-	if st.LockedFunds.LessThan(st.InitialPledges) {
-		rt.Abortf(exitcode.ErrIllegalState, "locked funds insufficient to cover initial pledges (%v < %v)", st.LockedFunds, st.InitialPledges)
+	if st.LockedFunds.LessThan(st.InitialPledgeRequirement) {
+		rt.Abortf(exitcode.ErrIllegalState, "locked funds insufficient to cover initial pledges (%v < %v)", st.LockedFunds, st.InitialPledgeRequirement)
 	}
 }
 

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -530,7 +530,7 @@ func (a Actor) ConfirmSectorProofsValid(rt Runtime, params *builtin.ConfirmSecto
 
 			// Unlock deposit for successful proof, make it available for lock-up as initial pledge.
 			st.AddPreCommitDeposit(precommit.PreCommitDeposit.Neg())
-			st.AddInitialPledge(initialPledge)
+			st.AddInitialPledgeRequirement(initialPledge)
 
 			// Lock up initial pledge for new sector.
 			availableBalance := st.GetAvailableBalance(rt.CurrentBalance())
@@ -1382,7 +1382,7 @@ func terminateSectors(rt Runtime, sectorNos *abi.BitField, terminationType power
 			rt.Abortf(exitcode.ErrIllegalState, "failed to expand faults")
 		}
 
-		pledgeToRemove := abi.NewTokenAmount(0)
+		pledgeRequirementToRemove := abi.NewTokenAmount(0)
 		err = sectorNos.ForEach(func(sectorNo uint64) error {
 			sector, found, err := st.GetSector(store, abi.SectorNumber(sectorNo))
 			if err != nil {
@@ -1400,13 +1400,13 @@ func terminateSectors(rt Runtime, sectorNos *abi.BitField, terminationType power
 				faultySectors = append(faultySectors, sector)
 			}
 
-			pledgeToRemove = big.Add(pledgeToRemove, sector.InitialPledge)
+			pledgeRequirementToRemove = big.Add(pledgeRequirementToRemove, sector.InitialPledge)
 			return nil
 		})
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load sector metadata")
 
 		// lower initial pledge requirement
-		st.AddInitialPledge(pledgeToRemove.Neg())
+		st.AddInitialPledgeRequirement(pledgeRequirementToRemove.Neg())
 
 		deadlines, err := st.LoadDeadlines(store)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deadlines")

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -940,6 +940,9 @@ func (a Actor) WithdrawBalance(rt Runtime, params *WithdrawBalanceParams) *adt.E
 	}
 
 	newlyVestedAmount := rt.State().Transaction(&st, func() interface{} {
+		// Verify locked funds are are at least the sum of sector initial pledges.
+		verifyPledgeMeetsInitialRequirements(rt, &st)
+
 		rt.ValidateImmediateCallerIs(st.Info.Owner)
 		newlyVestedFund, err := st.UnlockVestedFunds(adt.AsStore(rt), rt.CurrEpoch())
 		if err != nil {

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -1433,7 +1433,11 @@ func terminateSectors(rt Runtime, sectorNos *abi.BitField, terminationType power
 
 // Removes a group sectors from the sector set and its number from all sector collections in state.
 func removeTerminatedSectors(st *State, store adt.Store, deadlines *Deadlines, sectors *abi.BitField) error {
-	err := st.DeleteSectors(store, sectors)
+	err := st.DeductPledges(store, sectors)
+	if err != nil {
+		return err
+	}
+	err = st.DeleteSectors(store, sectors)
 	if err != nil {
 		return err
 	}

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -528,6 +528,7 @@ func (a Actor) ConfirmSectorProofsValid(rt Runtime, params *builtin.ConfirmSecto
 
 			// Unlock deposit for successful proof, make it available for lock-up as initial pledge.
 			st.AddPreCommitDeposit(precommit.PreCommitDeposit.Neg())
+			st.AddInitialPledge(precommit.PreCommitDeposit)
 
 			// Verify locked funds are are at least the sum of sector initial pledges.
 			verifyPledgeMeetsInitialRequirements(rt, &st)

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -323,20 +323,6 @@ func (st *State) DeleteSectors(store adt.Store, sectorNos *abi.BitField) error {
 	return err
 }
 
-func (st *State) DeductPledges(store adt.Store, sectorNos *abi.BitField) error {
-	return sectorNos.ForEach(func(sectorNo uint64) error {
-		sector, found, err := st.GetSector(store, abi.SectorNumber(sectorNo))
-		if err != nil {
-			return errors.Wrapf(err, "failed to get sector to deduct pledge %v", sectorNo)
-		}
-		if !found {
-			return errors.Errorf("failed to find sector to deduct pledge %v", sectorNo)
-		}
-		st.InitialPledgeRequirement = big.Sub(st.InitialPledgeRequirement, sector.InitialPledge)
-		return nil
-	})
-}
-
 func (st *State) ForEachSector(store adt.Store, f func(*SectorOnChainInfo)) error {
 	sectors, err := adt.AsArray(store, st.Sectors)
 	if err != nil {

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -174,9 +174,9 @@ func ConstructState(emptyArrayCid, emptyMapCid, emptyDeadlinesCid cid.Cid, owner
 		},
 
 		PreCommitDeposits:        abi.NewTokenAmount(0),
-		InitialPledgeRequirement: abi.NewTokenAmount(0),
 		LockedFunds:              abi.NewTokenAmount(0),
 		VestingFunds:             emptyArrayCid,
+		InitialPledgeRequirement: abi.NewTokenAmount(0),
 
 		PreCommittedSectors: emptyMapCid,
 		Sectors:             emptyArrayCid,
@@ -858,7 +858,7 @@ func (st *State) AddPreCommitDeposit(amount abi.TokenAmount) {
 	st.PreCommitDeposits = newTotal
 }
 
-func (st *State) AddInitialPledge(amount abi.TokenAmount) {
+func (st *State) AddInitialPledgeRequirement(amount abi.TokenAmount) {
 	newTotal := big.Add(st.InitialPledgeRequirement, amount)
 	AssertMsg(newTotal.GreaterThanEqual(big.Zero()), "negative initial pledge %s after adding %s to prior %s",
 		newTotal, amount, st.InitialPledgeRequirement)

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -323,6 +323,20 @@ func (st *State) DeleteSectors(store adt.Store, sectorNos *abi.BitField) error {
 	return err
 }
 
+func (st *State) DeductPledges(store adt.Store, sectorNos *abi.BitField) error {
+	return sectorNos.ForEach(func(sectorNo uint64) error {
+		sector, found, err := st.GetSector(store, abi.SectorNumber(sectorNo))
+		if err != nil {
+			return errors.Wrapf(err, "failed to get sector to deduct pledge %v", sectorNo)
+		}
+		if !found {
+			return errors.Errorf("failed to find sector to deduct pledge %v", sectorNo)
+		}
+		st.InitialPledges = big.Sub(st.InitialPledges, sector.InitialPledge)
+		return nil
+	})
+}
+
 func (st *State) ForEachSector(store adt.Store, f func(*SectorOnChainInfo)) error {
 	sectors, err := adt.AsArray(store, st.Sectors)
 	if err != nil {

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -27,6 +27,7 @@ type State struct {
 	Info MinerInfo
 
 	PreCommitDeposits abi.TokenAmount // Total funds locked as PreCommitDeposits
+	InitialPledges    abi.TokenAmount // Total funds added as initial pledge
 	LockedFunds       abi.TokenAmount // Total unvested funds locked as pledge collateral
 	VestingFunds      cid.Cid         // Array, AMT[ChainEpoch]TokenAmount
 
@@ -172,6 +173,7 @@ func ConstructState(emptyArrayCid, emptyMapCid, emptyDeadlinesCid cid.Cid, owner
 		},
 
 		PreCommitDeposits: abi.NewTokenAmount(0),
+		InitialPledges:    abi.NewTokenAmount(0),
 		LockedFunds:       abi.NewTokenAmount(0),
 		VestingFunds:      emptyArrayCid,
 
@@ -853,6 +855,13 @@ func (st *State) AddPreCommitDeposit(amount abi.TokenAmount) {
 	AssertMsg(newTotal.GreaterThanEqual(big.Zero()), "negative pre-commit deposit %s after adding %s to prior %s",
 		newTotal, amount, st.PreCommitDeposits)
 	st.PreCommitDeposits = newTotal
+}
+
+func (st *State) AddInitialPledge(amount abi.TokenAmount) {
+	newTotal := big.Add(st.InitialPledges, amount)
+	AssertMsg(newTotal.GreaterThanEqual(big.Zero()), "negative initial pledge %s after adding %s to prior %s",
+		newTotal, amount, st.InitialPledges)
+	st.InitialPledges = newTotal
 }
 
 func (st *State) AddLockedFunds(store adt.Store, currEpoch abi.ChainEpoch, vestingSum abi.TokenAmount, spec *VestSpec) error {

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -144,10 +144,11 @@ type SectorOnChainInfo struct {
 	SealProof          abi.RegisteredSealProof // The seal proof type implies the PoSt proof/s
 	SealedCID          cid.Cid                 // CommR
 	DealIDs            []abi.DealID
-	Activation         abi.ChainEpoch // Epoch during which the sector proof was accepted
-	Expiration         abi.ChainEpoch // Epoch during which the sector expires
-	DealWeight         abi.DealWeight // Integral of active deals over sector lifetime
-	VerifiedDealWeight abi.DealWeight // Integral of active verified deals over sector lifetime
+	Activation         abi.ChainEpoch  // Epoch during which the sector proof was accepted
+	Expiration         abi.ChainEpoch  // Epoch during which the sector expires
+	DealWeight         abi.DealWeight  // Integral of active deals over sector lifetime
+	VerifiedDealWeight abi.DealWeight  // Integral of active verified deals over sector lifetime
+	InitialPledge      abi.TokenAmount // Pledge collected to commit this sector
 }
 
 func ConstructState(emptyArrayCid, emptyMapCid, emptyDeadlinesCid cid.Cid, ownerAddr, workerAddr addr.Address,

--- a/actors/builtin/miner/miner_state_test.go
+++ b/actors/builtin/miner/miner_state_test.go
@@ -1000,6 +1000,7 @@ func newSectorOnChainInfo(sectorNo abi.SectorNumber, sealed cid.Cid, weight big.
 		Expiration:         sectorExpiration,
 		DealWeight:         weight,
 		VerifiedDealWeight: weight,
+		InitialPledge:      abi.NewTokenAmount(0),
 	}
 }
 

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -661,7 +661,7 @@ func TestTerminateSectors(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, found)
 
-		// expect pleged funds to have been decremented
+		// expect pledged funds to have been decremented
 		assert.Equal(t, big.Zero(), st.InitialPledges)
 	})
 }
@@ -1199,14 +1199,10 @@ func (h *actorHarness) terminateSectors(rt *mock.Runtime, sectors *abi.BitField)
 			QualityAdjustedDelta: qaPower.Neg(),
 		}, abi.NewTokenAmount(0), nil, exitcode.Ok)
 	}
-	{
-		rt.ExpectSend(builtin.StorageMarketActorAddr, builtin.MethodsMarket.OnMinerSectorsTerminate, &market.OnMinerSectorsTerminateParams{
-			DealIDs: dealIDs,
-		}, abi.NewTokenAmount(0), nil, exitcode.Ok)
-	}
 
 	params := &miner.TerminateSectorsParams{Sectors: sectors}
 	rt.Call(h.a.TerminateSectors, params)
+	rt.Verify()
 }
 
 func (h *actorHarness) reportConsensusFault(rt *mock.Runtime, from addr.Address, params *miner.ReportConsensusFaultParams, dealIDs []abi.DealID) {

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -192,7 +192,7 @@ func TestCommitments(t *testing.T) {
 		// expect deposit to have been transferred to initial pledges
 		expectedInitialPledge := expectedDeposit
 		assert.Equal(t, big.Zero(), st.PreCommitDeposits)
-		assert.Equal(t, expectedInitialPledge, st.InitialPledges)
+		assert.Equal(t, expectedInitialPledge, st.InitialPledgeRequirement)
 
 		// expect new onchain sector
 		onChainSector, found, err := st.GetSector(rt.AdtStore(), sectorNo)
@@ -662,7 +662,7 @@ func TestTerminateSectors(t *testing.T) {
 		assert.False(t, found)
 
 		// expect pledged funds to have been decremented
-		assert.Equal(t, big.Zero(), st.InitialPledges)
+		assert.Equal(t, big.Zero(), st.InitialPledgeRequirement)
 	})
 }
 

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -201,11 +201,12 @@ func TestCommitments(t *testing.T) {
 		// expect activation epoch to be precommit
 		assert.Equal(t, precommitEpoch, onChainSector.Activation)
 
-		// expect deposit to have been released
+		// expect deposit to have been transferred to initial pledges
+		expectedInitialPledge := expectedDeposit
 		assert.Equal(t, big.Zero(), st.PreCommitDeposits)
+		assert.Equal(t, expectedInitialPledge, st.InitialPledges)
 
 		// expect locked initial pledge of sector to be the same as precommit deposit
-		expectedInitialPledge := expectedDeposit
 		assert.Equal(t, expectedInitialPledge, st.LockedFunds)
 	})
 

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -413,7 +413,6 @@ func TestProveCommit(t *testing.T) {
 	periodOffset := abi.ChainEpoch(100)
 	actor := newHarness(t, periodOffset)
 	builder := builderForHarness(actor).
-		WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID).
 		WithBalance(big.Mul(big.NewInt(1000), big.NewInt(1e18)), big.Zero())
 
 	t.Run("aborts if sum of initial pledges exceeds locked funds", func(t *testing.T) {

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -433,7 +433,7 @@ func TestProveCommit(t *testing.T) {
 		// alter lock funds to simulate vesting since last prove
 		st := getState(rt)
 		st.LockedFunds = big.Div(st.LockedFunds, big.NewInt(2))
-		rt.SetStateForTesting(st)
+		rt.ReplaceState(st)
 
 		rt.SetEpoch(precommitEpoch + miner.MaxSealDuration[st.Info.SealProofType] - 1)
 		rt.ExpectAbort(exitcode.ErrIllegalState, func() {
@@ -445,7 +445,7 @@ func TestProveCommit(t *testing.T) {
 
 		// succeeds when locked fund satisfy initial pledge requirement
 		st.LockedFunds = st.InitialPledgeRequirement
-		rt.SetStateForTesting(st)
+		rt.ReplaceState(st)
 		actor.proveCommitSector(rt, precommit, precommitEpoch, makeProveCommit(actor.nextSectorNo), proveCommitConf{
 			networkPower: 1 << 50,
 		})
@@ -690,7 +690,7 @@ func TestWithdrawBalance(t *testing.T) {
 		// alter lock funds to simulate vesting since last prove
 		st := getState(rt)
 		st.LockedFunds = big.Div(st.LockedFunds, big.NewInt(2))
-		rt.SetStateForTesting(st)
+		rt.ReplaceState(st)
 
 		// withdraw 1% of balance
 		rt.ExpectAbort(exitcode.ErrIllegalState, func() {

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -189,6 +189,11 @@ func TestCommitments(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, found)
 
+		// expect deposit to have been transferred to initial pledges
+		expectedInitialPledge := expectedDeposit
+		assert.Equal(t, big.Zero(), st.PreCommitDeposits)
+		assert.Equal(t, expectedInitialPledge, st.InitialPledges)
+
 		// expect new onchain sector
 		onChainSector, found, err := st.GetSector(rt.AdtStore(), sectorNo)
 		require.NoError(t, err)
@@ -201,10 +206,8 @@ func TestCommitments(t *testing.T) {
 		// expect activation epoch to be precommit
 		assert.Equal(t, precommitEpoch, onChainSector.Activation)
 
-		// expect deposit to have been transferred to initial pledges
-		expectedInitialPledge := expectedDeposit
-		assert.Equal(t, big.Zero(), st.PreCommitDeposits)
-		assert.Equal(t, expectedInitialPledge, st.InitialPledges)
+		// expect initial plege of sector to be set
+		assert.Equal(t, expectedInitialPledge, onChainSector.InitialPledge)
 
 		// expect locked initial pledge of sector to be the same as precommit deposit
 		assert.Equal(t, expectedInitialPledge, st.LockedFunds)

--- a/support/mock/mockrt.go
+++ b/support/mock/mockrt.go
@@ -585,6 +585,10 @@ func (rt *Runtime) GetState(o runtime.CBORUnmarshaler) {
 	}
 }
 
+func (rt *Runtime) SetStateForTesting(o runtime.CBORMarshaler) {
+	rt.state = rt.Store().Put(o)
+}
+
 func (rt *Runtime) Balance() abi.TokenAmount {
 	return rt.balance
 }

--- a/support/mock/mockrt.go
+++ b/support/mock/mockrt.go
@@ -585,10 +585,6 @@ func (rt *Runtime) GetState(o runtime.CBORUnmarshaler) {
 	}
 }
 
-func (rt *Runtime) SetStateForTesting(o runtime.CBORMarshaler) {
-	rt.state = rt.Store().Put(o)
-}
-
 func (rt *Runtime) Balance() abi.TokenAmount {
 	return rt.balance
 }
@@ -615,6 +611,10 @@ func (rt *Runtime) SetReceived(amt abi.TokenAmount) {
 
 func (rt *Runtime) SetEpoch(epoch abi.ChainEpoch) {
 	rt.epoch = epoch
+}
+
+func (rt *Runtime) ReplaceState(o runtime.CBORMarshaler) {
+	rt.state = rt.Store().Put(o)
 }
 
 func (rt *Runtime) SetCirculatingSupply(amt abi.TokenAmount) {


### PR DESCRIPTION
closes #415

### Motivation

We need to enforce that a miner's locked funds exceeds the sum of their initial pledges to ensure the miner has enough funds to over potential fees. To do this we need to track the sum of initial pledges (and maintain that sum). We will check lock funds against initial pledges before a miner proves a sector and before the miner withdraws funds.

### Proposed Changes

The bulk of this PR breaks out into its 5 initial commits:

1. Add `InitialPledges` to `miner.State` and add to it every time a sector is proven.
2. Add `InitialPledge' to 'SectorOnChainInfo' and set it to the sector's initial pledge when proven.
3. Use the sector's `InitialPledge` to subtract from `miner.State.InitialPledges` when sectors are terminated.
4. Add a check in `ProveCommitSector` to ensure locked funds are sufficient relative to initial pledges.
5. Do the same in `WithdrawFunds`.

All of these changes are tested. This required some new infrastructure in miner test.