### PR TITLE
Multisig: Use correct error codes

### DIFF
--- a/actors/builtin/multisig/multisig_actor.go
+++ b/actors/builtin/multisig/multisig_actor.go
@@ -377,7 +377,7 @@ func (a Actor) approveTransaction(rt vmr.Runtime, txnID TxnID, txn *Transaction)
 	// abort duplicate approval
 	for _, previousApprover := range txn.Approved {
 		if previousApprover == rt.Message().Caller() {
-			rt.Abortf(exitcode.ErrIllegalState, "already approved this message")
+			rt.Abortf(exitcode.ErrForbidden, "%s already approved this message", previousApprover)
 		}
 	}
 
@@ -411,7 +411,7 @@ func (a Actor) getTransaction(rt vmr.Runtime, st State, txnID TxnID, proposalHas
 			rt.Abortf(exitcode.ErrIllegalState, "failed to compute proposal hash: %v", err)
 		}
 		if proposalHash != nil && !bytes.Equal(proposalHash, calculatedHash[:]) {
-			rt.Abortf(exitcode.ErrIllegalState, "hash does not match proposal params")
+			rt.Abortf(exitcode.ErrIllegalArgument, "hash does not match proposal params")
 		}
 	}
 

--- a/actors/builtin/multisig/multisig_test.go
+++ b/actors/builtin/multisig/multisig_test.go
@@ -518,7 +518,7 @@ func TestApprove(t *testing.T) {
 		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
 		rt.ExpectSend(chuck, fakeMethod, fakeParams, sendValue, nil, 0)
 
-		rt.ExpectAbort(exitcode.ErrIllegalState, func() {
+		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			proposalHashData := makeProposalHash(t, &multisig.Transaction{
 				To:       chuck,
 				Value:    sendValue,
@@ -543,8 +543,7 @@ func TestApprove(t *testing.T) {
 
 		// anne is going to approve it twice and fail, poor anne.
 		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
-		// TODO replace with correct exit code when multisig actor breaks the AbortStateMsg pattern.
-		rt.ExpectAbort(exitcode.ErrIllegalState, func() {
+		rt.ExpectAbort(exitcode.ErrForbidden, func() {
 			proposalHashData := makeProposalHash(t, &multisig.Transaction{
 				To:       chuck,
 				Value:    sendValue,


### PR DESCRIPTION
Closes #473 

@anorth On second thoughts, replacing the `AbortMsg` pattern in the plumbing methods looks like a larger refactor that we can defer to later. Do we have an issue for it or should I create one ?