### PR TITLE
validateExpiration() checks current extension and total sector lifetime are not too long

### DIFF
--- a/actors/abi/sector.go
+++ b/actors/abi/sector.go
@@ -68,33 +68,35 @@ type RegisteredProof = int64
 
 // This ordering, defines mappings to UInt in a way which MUST never change.
 type RegisteredSealProof RegisteredProof
+
 const (
-	RegisteredSealProof_StackedDrg2KiBV1 = RegisteredSealProof(0);
-	RegisteredSealProof_StackedDrg8MiBV1 = RegisteredSealProof(1);
-	RegisteredSealProof_StackedDrg512MiBV1 = RegisteredSealProof(2);
-	RegisteredSealProof_StackedDrg32GiBV1 = RegisteredSealProof(3);
-	RegisteredSealProof_StackedDrg64GiBV1 = RegisteredSealProof(4);
+	RegisteredSealProof_StackedDrg2KiBV1   = RegisteredSealProof(0)
+	RegisteredSealProof_StackedDrg8MiBV1   = RegisteredSealProof(1)
+	RegisteredSealProof_StackedDrg512MiBV1 = RegisteredSealProof(2)
+	RegisteredSealProof_StackedDrg32GiBV1  = RegisteredSealProof(3)
+	RegisteredSealProof_StackedDrg64GiBV1  = RegisteredSealProof(4)
 )
 
 type RegisteredPoStProof RegisteredProof
-const(
- 	RegisteredPoStProof_StackedDrgWinning2KiBV1 = RegisteredPoStProof(0);
-   	RegisteredPoStProof_StackedDrgWinning8MiBV1 = RegisteredPoStProof(1);
-	RegisteredPoStProof_StackedDrgWinning512MiBV1 = RegisteredPoStProof(2);
-	RegisteredPoStProof_StackedDrgWinning32GiBV1 = RegisteredPoStProof(3);
-	RegisteredPoStProof_StackedDrgWinning64GiBV1 = RegisteredPoStProof(4);
-	RegisteredPoStProof_StackedDrgWindow2KiBV1 = RegisteredPoStProof(5);
-	RegisteredPoStProof_StackedDrgWindow8MiBV1 = RegisteredPoStProof(6);
-	RegisteredPoStProof_StackedDrgWindow512MiBV1 = RegisteredPoStProof(7);
-	RegisteredPoStProof_StackedDrgWindow32GiBV1 = RegisteredPoStProof(8);
-	RegisteredPoStProof_StackedDrgWindow64GiBV1 = RegisteredPoStProof(9);
+
+const (
+	RegisteredPoStProof_StackedDrgWinning2KiBV1   = RegisteredPoStProof(0)
+	RegisteredPoStProof_StackedDrgWinning8MiBV1   = RegisteredPoStProof(1)
+	RegisteredPoStProof_StackedDrgWinning512MiBV1 = RegisteredPoStProof(2)
+	RegisteredPoStProof_StackedDrgWinning32GiBV1  = RegisteredPoStProof(3)
+	RegisteredPoStProof_StackedDrgWinning64GiBV1  = RegisteredPoStProof(4)
+	RegisteredPoStProof_StackedDrgWindow2KiBV1    = RegisteredPoStProof(5)
+	RegisteredPoStProof_StackedDrgWindow8MiBV1    = RegisteredPoStProof(6)
+	RegisteredPoStProof_StackedDrgWindow512MiBV1  = RegisteredPoStProof(7)
+	RegisteredPoStProof_StackedDrgWindow32GiBV1   = RegisteredPoStProof(8)
+	RegisteredPoStProof_StackedDrgWindow64GiBV1   = RegisteredPoStProof(9)
 )
 
 func (p RegisteredPoStProof) RegisteredSealProof() (RegisteredSealProof, error) {
 	switch p {
- 	case RegisteredPoStProof_StackedDrgWinning2KiBV1, RegisteredPoStProof_StackedDrgWindow2KiBV1:
+	case RegisteredPoStProof_StackedDrgWinning2KiBV1, RegisteredPoStProof_StackedDrgWindow2KiBV1:
 		return RegisteredSealProof_StackedDrg2KiBV1, nil
-   	case RegisteredPoStProof_StackedDrgWinning8MiBV1, RegisteredPoStProof_StackedDrgWindow8MiBV1:
+	case RegisteredPoStProof_StackedDrgWinning8MiBV1, RegisteredPoStProof_StackedDrgWindow8MiBV1:
 		return RegisteredSealProof_StackedDrg8MiBV1, nil
 	case RegisteredPoStProof_StackedDrgWinning512MiBV1, RegisteredPoStProof_StackedDrgWindow512MiBV1:
 		return RegisteredSealProof_StackedDrg512MiBV1, nil
@@ -203,6 +205,14 @@ func (p RegisteredSealProof) RegisteredWindowPoStProof() (RegisteredPoStProof, e
 	}
 }
 
+// SectorMaximumLifetime is the maximum duration a sector sealed with this proof may exist between activation and expiration
+func (p RegisteredSealProof) SectorMaximumLifetime() ChainEpoch {
+	// currently all proofs set to around 5 years
+	epochsPerYear := 1_262_277
+	fiveYears := 5 * epochsPerYear
+	return ChainEpoch(fiveYears)
+}
+
 ///
 /// Sealing
 ///
@@ -212,7 +222,7 @@ type InteractiveSealRandomness Randomness
 
 // Information needed to verify a seal proof.
 type SealVerifyInfo struct {
-	SealProof             RegisteredSealProof
+	SealProof RegisteredSealProof
 	SectorID
 	DealIDs               []DealID
 	Randomness            SealRandomness
@@ -230,9 +240,9 @@ type PoStRandomness Randomness
 
 // Information about a sector necessary for PoSt verification.
 type SectorInfo struct {
-	SealProof       RegisteredSealProof // RegisteredProof used when sealing - needs to be mapped to PoSt registered proof when used to verify a PoSt
-	SectorNumber    SectorNumber
-	SealedCID       cid.Cid // CommR
+	SealProof    RegisteredSealProof // RegisteredProof used when sealing - needs to be mapped to PoSt registered proof when used to verify a PoSt
+	SectorNumber SectorNumber
+	SealedCID    cid.Cid // CommR
 }
 
 type PoStProof struct {

--- a/actors/abi/sector.go
+++ b/actors/abi/sector.go
@@ -207,7 +207,7 @@ func (p RegisteredSealProof) RegisteredWindowPoStProof() (RegisteredPoStProof, e
 
 // SectorMaximumLifetime is the maximum duration a sector sealed with this proof may exist between activation and expiration
 func (p RegisteredSealProof) SectorMaximumLifetime() ChainEpoch {
-	// currently all proofs set to around 5 years
+	// For all Stacked DRG sectors, the max is 5 years
 	epochsPerYear := 1_262_277
 	fiveYears := 5 * epochsPerYear
 	return ChainEpoch(fiveYears)

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -1249,8 +1249,8 @@ func validateExpiration(rt Runtime, st *State, activation, expiration abi.ChainE
 
 	// total sector lifetime cannot exceed SectorMaximumLifetime for the sector's seal proof
 	if expiration-activation > sealProof.SectorMaximumLifetime() {
-		rt.Abortf(exitcode.ErrIllegalArgument, "invalid expiration %d, total sector lifetime (%d) cannot exceed %d",
-			expiration, expiration-activation, sealProof.SectorMaximumLifetime())
+		rt.Abortf(exitcode.ErrIllegalArgument, "invalid expiration %d, total sector lifetime (%d) cannot exceed %d after activation %d",
+			expiration, expiration-activation, sealProof.SectorMaximumLifetime(), activation)
 	}
 
 	// ensure expiration is one epoch before a proving period boundary

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -250,7 +250,7 @@ func TestCommitments(t *testing.T) {
 
 		// Expires before current epoch
 		expiration := deadline.PeriodEnd()
-		rt.SetEpoch(deadline.PeriodEnd() + 1)
+		rt.SetEpoch(expiration + 1)
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			actor.preCommitSector(rt, makePreCommit(112, challengeEpoch, deadline.PeriodEnd(), nil), networkPower)
 		})

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -249,6 +249,7 @@ func TestCommitments(t *testing.T) {
 		rt.Reset()
 
 		// Expires before current epoch
+		expiration := deadline.PeriodEnd()
 		rt.SetEpoch(deadline.PeriodEnd() + 1)
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			actor.preCommitSector(rt, makePreCommit(112, challengeEpoch, deadline.PeriodEnd(), nil), networkPower)
@@ -256,7 +257,16 @@ func TestCommitments(t *testing.T) {
 		rt.Reset()
 
 		// Expires not on period end
+		expiration = deadline.PeriodEnd() - 1
 		rt.SetEpoch(precommitEpoch)
+		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
+			actor.preCommitSector(rt, makePreCommit(113, challengeEpoch, expiration, nil), networkPower)
+		})
+		rt.Reset()
+
+		// Errors when expiry too far in the future
+		rt.SetEpoch(precommitEpoch)
+		expiration = deadline.PeriodEnd() + miner.WPoStProvingPeriod*(miner.MaxSectorExpirationExtension/miner.WPoStProvingPeriod+1)
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			actor.preCommitSector(rt, makePreCommit(113, challengeEpoch, deadline.PeriodEnd()-1, nil), networkPower)
 		})
@@ -589,6 +599,55 @@ func TestExtendSectorExpiration(t *testing.T) {
 		params := &miner.ExtendSectorExpirationParams{
 			SectorNumber:  sector.SectorNumber,
 			NewExpiration: newExpiration,
+		}
+
+		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
+			actor.extendSector(rt, sector, extension, params)
+		})
+	})
+
+	t.Run("rejects extension too far in future", func(t *testing.T) {
+		rt := builder.Build(t)
+		sector := commitSector(t, rt)
+
+		// extend by even proving period after max
+		rt.SetEpoch(sector.Expiration)
+		extension := miner.WPoStProvingPeriod * (miner.MaxSectorExpirationExtension/miner.WPoStProvingPeriod + 1)
+		newExpiration := rt.Epoch() + extension
+		params := &miner.ExtendSectorExpirationParams{
+			SectorNumber:  sector.SectorNumber,
+			NewExpiration: newExpiration,
+		}
+
+		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
+			actor.extendSector(rt, sector, extension, params)
+		})
+	})
+
+	t.Run("rejects extension past max for seal proof", func(t *testing.T) {
+		rt := builder.Build(t)
+		sector := commitSector(t, rt)
+		rt.SetEpoch(sector.Expiration)
+
+		maxLifetime := sector.SealProof.SectorMaximumLifetime()
+
+		// extend sector until just below threshold
+		extension := miner.WPoStProvingPeriod * (miner.MaxSectorExpirationExtension/miner.WPoStProvingPeriod - 1)
+		expiration := rt.Epoch() + extension
+		for ; expiration-sector.Activation < maxLifetime; expiration += extension {
+			params := &miner.ExtendSectorExpirationParams{
+				SectorNumber:  sector.SectorNumber,
+				NewExpiration: expiration,
+			}
+
+			actor.extendSector(rt, sector, extension, params)
+			rt.SetEpoch(expiration)
+		}
+
+		// next extension fails because it extends sector past max lifetime
+		params := &miner.ExtendSectorExpirationParams{
+			SectorNumber:  sector.SectorNumber,
+			NewExpiration: expiration,
 		}
 
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -89,10 +89,15 @@ const FaultDeclarationCutoff = WPoStChallengeLookback + 10
 const FaultMaxAge = WPoStProvingPeriod*14 - 1
 
 // Staging period for a miner worker key change.
-// Finality is a harsh delay for a miner who has lost their worker key, as the miner will miss Winow PoSts until
+// Finality is a harsh delay for a miner who has lost their worker key, as the miner will miss Window PoSts until
 // it can be changed. It's the only safe value, though. We may implement a mitigation mechanism such as a second
 // key or allowing the owner account to submit PoSts while a key change is pending.
 const WorkerKeyChangeDelay = ChainFinality
+
+// Maximum number of epochs past the current epoch a sector may be set to expire.
+// The actual maximum extension will be the minimum of CurrEpoch + MaximumSectorExpirationExtension
+// and sector.ActivationEpoch+sealProof.SectorMaximumLifetime()
+const MaxSectorExpirationExtension = builtin.EpochsInYear
 
 var QualityBaseMultiplier = big.NewInt(10)         // PARAM_FINISH
 var DealWeightMultiplier = big.NewInt(11)          // PARAM_FINISH


### PR DESCRIPTION
closes  #454

### Motivation

Extending a sector's expiration more than a year or extending a sector past the maximum lifetime for its seal proof type decreases security (in ways unknown to the implementer).

### Proposed Changes

1. Introduce `sealProof.SectorMaximumLifetime` method to limit the total lifetime of a sector after multiple extensions (currently always returns 5 years).
2. Introduce `MaxSectorExpirationExtension` as the maximum single shot expiration.
3. Augment `validateExpiration()` to check that `MaxSectorExpirationExtension` and `sealProof.SectorMaximumLifetime` are not exceeded.
4. Test.
