### PR TITLE
Feat/termination fees

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -1888,7 +1888,7 @@ func unlockTerminationPenalty(st *State, store adt.Store, curEpoch abi.ChainEpoc
 	sectorSize := st.Info.SectorSize
 	for _, s := range sectors {
 		sectorPower := QAPowerForSector(sectorSize, s)
-		fee := PledgePenaltyForTermination(s, curEpoch, epochTargetReward, networkQAPower, sectorPower)
+		fee := PledgePenaltyForTermination(s.InitialPledge, curEpoch-s.Activation, epochTargetReward, networkQAPower, sectorPower)
 		totalFee = big.Add(fee, totalFee)
 	}
 	return totalFee, nil

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -1888,7 +1888,7 @@ func unlockTerminationPenalty(st *State, store adt.Store, curEpoch abi.ChainEpoc
 	sectorSize := st.Info.SectorSize
 	for _, s := range sectors {
 		sectorPower := QAPowerForSector(sectorSize, s)
-		fee := pledgePenaltyForTermination(s, epochTargetReward, networkQAPower, sectorPower)
+		fee := PledgePenaltyForTermination(s, curEpoch, epochTargetReward, networkQAPower, sectorPower)
 		totalFee = big.Add(fee, totalFee)
 	}
 	return totalFee, nil

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -702,7 +702,8 @@ func TestTerminateSectors(t *testing.T) {
 		sectorSize, err := sector.SealProof.SectorSize()
 		require.NoError(t, err)
 		sectorPower := miner.QAPowerForSector(sectorSize, sector)
-		expectedFee := miner.PledgePenaltyForTermination(sector, rt.Epoch(), actor.epochReward, actor.networkQAPower, sectorPower)
+		sectorAge := rt.Epoch() - sector.Activation
+		expectedFee := miner.PledgePenaltyForTermination(sector.InitialPledge, sectorAge, actor.epochReward, actor.networkQAPower, sectorPower)
 
 		sectors := bitfield.New()
 		sectors.Set(uint64(sector.SectorNumber))

--- a/actors/builtin/miner/monies.go
+++ b/actors/builtin/miner/monies.go
@@ -46,13 +46,13 @@ func PledgePenaltyForUndeclaredFault(epochTargetReward abi.TokenAmount, networkQ
 // Penalty to locked pledge collateral for the termination of a sector before scheduled expiry.
 func PledgePenaltyForTermination(s *SectorOnChainInfo, currEpoch abi.ChainEpoch, epochTargetReward abi.TokenAmount, networkQAPower abi.StoragePower, qaSectorPower abi.StoragePower) abi.TokenAmount {
 	// max(SP(t), InitialPledge + BR(StartEpoch)*min(SectorAgeInDays, 180)) where BF(StartEpoch)=InitialPledge/InitialPledgeFactor
-	sectorAge := int64(min64(uint64(currEpoch-s.Activation), 180*builtin.EpochsInDay))
+	sectorAge := big.NewInt(int64(minEpoch(currEpoch-s.Activation, 180*builtin.EpochsInDay)))
 	return big.Max(
 		PledgePenaltyForUndeclaredFault(epochTargetReward, networkQAPower, qaSectorPower),
 		big.Add(
 			InitialPledgeFactor,
 			big.Div(
-				big.Mul(s.InitialPledge, big.NewInt(sectorAge)),
+				big.Mul(s.InitialPledge, sectorAge),
 				InitialPledgeFactor)))
 }
 

--- a/actors/builtin/miner/monies.go
+++ b/actors/builtin/miner/monies.go
@@ -44,9 +44,16 @@ func PledgePenaltyForUndeclaredFault(epochTargetReward abi.TokenAmount, networkQ
 }
 
 // Penalty to locked pledge collateral for the termination of a sector before scheduled expiry.
-func pledgePenaltyForTermination(s *SectorOnChainInfo, epochTargetReward abi.TokenAmount, networkQAPower abi.StoragePower, qaSectorPower abi.StoragePower) abi.TokenAmount {
-	//TODO #437 compute correct termination fee using initial pledge value from SectorOnChainInfo
-	return big.Zero() // PARAM_FINISH
+func PledgePenaltyForTermination(s *SectorOnChainInfo, currEpoch abi.ChainEpoch, epochTargetReward abi.TokenAmount, networkQAPower abi.StoragePower, qaSectorPower abi.StoragePower) abi.TokenAmount {
+	// max(SP(t), InitialPledge + BR(StartEpoch)*min(SectorAgeInDays, 180)) where BF(StartEpoch)=InitialPledge/InitialPledgeFactor
+	sectorAge := int64(min64(uint64(currEpoch-s.Activation), 180*builtin.EpochsInDay))
+	return big.Max(
+		PledgePenaltyForUndeclaredFault(epochTargetReward, networkQAPower, qaSectorPower),
+		big.Add(
+			InitialPledgeFactor,
+			big.Div(
+				big.Mul(s.InitialPledge, big.NewInt(sectorAge)),
+				InitialPledgeFactor)))
 }
 
 // Computes the pledge requirement for committing new quality-adjusted power to the network, given the current

--- a/actors/builtin/miner/monies_test.go
+++ b/actors/builtin/miner/monies_test.go
@@ -1,0 +1,61 @@
+package miner_test
+
+import (
+	"github.com/filecoin-project/specs-actors/actors/builtin"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
+)
+
+// Test termination fee
+func TestPledgePenaltyForTermination(t *testing.T) {
+	epochTargetReward := abi.NewTokenAmount(1 << 50)
+	qaSectorPower := abi.NewStoragePower(1 << 36)
+	networkQAPower := abi.NewStoragePower(1 << 50)
+	undeclaredPenalty := miner.PledgePenaltyForUndeclaredFault(epochTargetReward, networkQAPower, qaSectorPower)
+
+	t.Run("when undeclared fault fee exceeds expected reward, returns undeclaraed fault fee", func(t *testing.T) {
+		// small pledge and means undeclared penalty will be bigger
+		initialPledge := abi.NewTokenAmount(1 << 10)
+		sectorAge := abi.ChainEpoch(100)
+
+		fee := miner.PledgePenaltyForTermination(initialPledge, sectorAge, epochTargetReward, networkQAPower, qaSectorPower)
+
+		assert.Equal(t, undeclaredPenalty, fee)
+	})
+
+	t.Run("when expected reward exceeds undeclared fault fee, returns expected reward", func(t *testing.T) {
+		// initialPledge equal to undeclaredPenalty guarantees expected reward is greater
+		initialPledge := undeclaredPenalty
+		sectorAge := abi.ChainEpoch(100)
+
+		fee := miner.PledgePenaltyForTermination(initialPledge, sectorAge, epochTargetReward, networkQAPower, qaSectorPower)
+
+		// expect fee to be pledge * br * age where br = pledge/initialPledgeFactor
+		expectedFee := big.Add(
+			initialPledge,
+			big.Div(
+				big.Mul(initialPledge, big.NewInt(int64(sectorAge))),
+				miner.InitialPledgeFactor))
+		assert.Equal(t, expectedFee, fee)
+	})
+
+	t.Run("sector age is capped", func(t *testing.T) {
+		initialPledge := undeclaredPenalty
+		sectorAge := abi.ChainEpoch(200 * builtin.EpochsInDay)
+
+		fee := miner.PledgePenaltyForTermination(initialPledge, sectorAge, epochTargetReward, networkQAPower, qaSectorPower)
+
+		// expect fee to be pledge * br * age where br = pledge/initialPledgeFactor
+		expectedFee := big.Add(
+			initialPledge,
+			big.Div(
+				big.Mul(initialPledge, big.NewInt(180*builtin.EpochsInDay)),
+				miner.InitialPledgeFactor))
+		assert.Equal(t, expectedFee, fee)
+	})
+}

--- a/actors/builtin/miner/monies_test.go
+++ b/actors/builtin/miner/monies_test.go
@@ -21,7 +21,7 @@ func TestPledgePenaltyForTermination(t *testing.T) {
 	t.Run("when undeclared fault fee exceeds expected reward, returns undeclaraed fault fee", func(t *testing.T) {
 		// small pledge and means undeclared penalty will be bigger
 		initialPledge := abi.NewTokenAmount(1 << 10)
-		sectorAge := abi.ChainEpoch(100)
+		sectorAge := 20 * abi.ChainEpoch(builtin.EpochsInDay)
 
 		fee := miner.PledgePenaltyForTermination(initialPledge, sectorAge, epochTargetReward, networkQAPower, qaSectorPower)
 
@@ -31,7 +31,8 @@ func TestPledgePenaltyForTermination(t *testing.T) {
 	t.Run("when expected reward exceeds undeclared fault fee, returns expected reward", func(t *testing.T) {
 		// initialPledge equal to undeclaredPenalty guarantees expected reward is greater
 		initialPledge := undeclaredPenalty
-		sectorAge := abi.ChainEpoch(100)
+		sectorAgeInDays := int64(20)
+		sectorAge := abi.ChainEpoch(sectorAgeInDays * builtin.EpochsInDay)
 
 		fee := miner.PledgePenaltyForTermination(initialPledge, sectorAge, epochTargetReward, networkQAPower, qaSectorPower)
 
@@ -39,14 +40,15 @@ func TestPledgePenaltyForTermination(t *testing.T) {
 		expectedFee := big.Add(
 			initialPledge,
 			big.Div(
-				big.Mul(initialPledge, big.NewInt(int64(sectorAge))),
+				big.Mul(initialPledge, big.NewInt(sectorAgeInDays)),
 				miner.InitialPledgeFactor))
 		assert.Equal(t, expectedFee, fee)
 	})
 
 	t.Run("sector age is capped", func(t *testing.T) {
 		initialPledge := undeclaredPenalty
-		sectorAge := abi.ChainEpoch(200 * builtin.EpochsInDay)
+		sectorAgeInDays := 500
+		sectorAge := abi.ChainEpoch(sectorAgeInDays * builtin.EpochsInDay)
 
 		fee := miner.PledgePenaltyForTermination(initialPledge, sectorAge, epochTargetReward, networkQAPower, qaSectorPower)
 
@@ -54,7 +56,7 @@ func TestPledgePenaltyForTermination(t *testing.T) {
 		expectedFee := big.Add(
 			initialPledge,
 			big.Div(
-				big.Mul(initialPledge, big.NewInt(180*builtin.EpochsInDay)),
+				big.Mul(initialPledge, big.NewInt(180)),
 				miner.InitialPledgeFactor))
 		assert.Equal(t, expectedFee, fee)
 	})


### PR DESCRIPTION
closes #437

### Motivation

While the infrastructure for charging sector termination fees exists, the actual calculation has not been implemented. This PR implements that calculation and tests.

### Proposed Changes

1. Implement the termination fee formula based on the initial pledge of the sector.
2. Augment test to show correct fee has been sent to burnt funds and pledge has been updated in power actor
3. Clean up miner actor harness by adding `networkQAPower` and `networkRawPower` as instance variables with defaults.