### PR TITLE
Move spacetime type from abi to reward actor

### DIFF
--- a/actors/abi/sector.go
+++ b/actors/abi/sector.go
@@ -57,9 +57,6 @@ type StoragePower = big.Int
 
 type SectorQuality = big.Int
 
-// The unit of spacetime committed to the network
-type Spacetime = big.Int
-
 func NewStoragePower(n int64) StoragePower {
 	return big.NewInt(n)
 }

--- a/actors/builtin/reward/reward_actor.go
+++ b/actors/builtin/reward/reward_actor.go
@@ -124,7 +124,7 @@ func (a Actor) newBaselinePower(st *State, rewardEpochsPaid abi.ChainEpoch) abi.
 	return big.NewInt(baselinePower)
 }
 
-func (a Actor) getEffectiveNetworkTime(st *State, cumsumBaseline abi.Spacetime, cumsumRealized abi.Spacetime) NetworkTime {
+func (a Actor) getEffectiveNetworkTime(st *State, cumsumBaseline Spacetime, cumsumRealized Spacetime) NetworkTime {
 	// TODO: this function depends on the final baseline
 	// EffectiveNetworkTime is a fractional input with an implicit denominator of (2^MintingInputFixedPoint).
 	// realizedCumsum is thus left shifted by MintingInputFixedPoint before converted into a FixedPoint fraction

--- a/actors/builtin/reward/reward_state.go
+++ b/actors/builtin/reward/reward_state.go
@@ -10,11 +10,14 @@ import (
 // Fractional representation of NetworkTime with an implicit denominator of (2^MintingInputFixedPoint).
 type NetworkTime = big.Int
 
+// A quantity of space * time (in byte-epochs) representing power committed to the network for some duration.
+type Spacetime = big.Int
+
 type State struct {
 	BaselinePower        abi.StoragePower
 	RealizedPower        abi.StoragePower
-	CumsumBaseline       abi.Spacetime
-	CumsumRealized       abi.Spacetime
+	CumsumBaseline       Spacetime
+	CumsumRealized       Spacetime
 	EffectiveNetworkTime NetworkTime
 
 	SimpleSupply   abi.TokenAmount // current supply


### PR DESCRIPTION
This unit is only used in reward actor state and calculations (though a similar concept exists for deal weights).

FYI @zixuanzh 
