### PR TITLE
Remove DeleteMiner method

### DIFF
--- a/actors/builtin/methods.go
+++ b/actors/builtin/methods.go
@@ -68,7 +68,6 @@ var MethodsMarket = struct {
 var MethodsPower = struct {
 	Constructor              abi.MethodNum
 	CreateMiner              abi.MethodNum
-	DeleteMiner              abi.MethodNum
 	UpdateClaimedPower       abi.MethodNum
 	EnrollCronEvent          abi.MethodNum
 	OnEpochTickEnd           abi.MethodNum
@@ -76,7 +75,7 @@ var MethodsPower = struct {
 	OnConsensusFault         abi.MethodNum
 	SubmitPoRepForBulkVerify abi.MethodNum
 	CurrentTotalPower        abi.MethodNum
-}{MethodConstructor, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+}{MethodConstructor, 2, 3, 4, 5, 6, 7, 8, 9}
 
 var MethodsMiner = struct {
 	Constructor              abi.MethodNum

--- a/actors/builtin/power/cbor_gen.go
+++ b/actors/builtin/power/cbor_gen.go
@@ -580,49 +580,6 @@ func (t *CreateMinerParams) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
-func (t *DeleteMinerParams) MarshalCBOR(w io.Writer) error {
-	if t == nil {
-		_, err := w.Write(cbg.CborNull)
-		return err
-	}
-	if _, err := w.Write([]byte{129}); err != nil {
-		return err
-	}
-
-	// t.Miner (address.Address) (struct)
-	if err := t.Miner.MarshalCBOR(w); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (t *DeleteMinerParams) UnmarshalCBOR(r io.Reader) error {
-	br := cbg.GetPeeker(r)
-
-	maj, extra, err := cbg.CborReadHeader(br)
-	if err != nil {
-		return err
-	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
-	}
-
-	if extra != 1 {
-		return fmt.Errorf("cbor input had wrong number of fields")
-	}
-
-	// t.Miner (address.Address) (struct)
-
-	{
-
-		if err := t.Miner.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.Miner: %w", err)
-		}
-
-	}
-	return nil
-}
-
 func (t *EnrollCronEventParams) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -127,7 +127,6 @@ func main() {
 		power.CronEvent{},
 		// method params
 		power.CreateMinerParams{},
-		power.DeleteMinerParams{},
 		power.EnrollCronEventParams{},
 		power.UpdateClaimedPowerParams{},
 		// method returns


### PR DESCRIPTION
This method isn't used anywhere, and doesn't really do what the user would expect.

Later, we should add a method on the miner itself that:

1. Sets it's power to 0.
2. Deletes the miner actor.