### PR TITLE
Skipped Faults

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -274,7 +274,7 @@ func (a Actor) SubmitWindowedPoSt(rt Runtime, params *SubmitWindowedPoStParams) 
 		newFaultSectors = append(newFaultSectors, detectedFaultSectors...)
 
 		// Add skipped as faults
-		skippedFaultSectors, skippedPenalty := processSkippedFaults(rt, &st, store, currDeadline, deadlines, epochReward, pwrTotal.QualityAdjPower, &params.Skipped)
+		skippedFaultSectors, skippedPenalty := processSkippedFaults(rt, &st, store, currDeadline, info, deadlines, epochReward, pwrTotal.QualityAdjPower, &params.Skipped)
 		penalty = big.Add(penalty, skippedPenalty)
 		newFaultSectors = append(newFaultSectors, skippedFaultSectors...)
 
@@ -1222,7 +1222,7 @@ func detectFaultsThisPeriod(rt Runtime, st *State, store adt.Store, currDeadline
 	return processMissingPoStFaults(rt, st, store, deadlines, currDeadline.PeriodStart, currDeadline.Index, currDeadline.CurrentEpoch, epochReward, currentTotalPower)
 }
 
-func processSkippedFaults(rt Runtime, st *State, store adt.Store, currDeadline *DeadlineInfo, deadlines *Deadlines, epochReward abi.TokenAmount, currentTotalPower abi.StoragePower, skipped *bitfield.BitField) ([]*SectorOnChainInfo, abi.TokenAmount) {
+func processSkippedFaults(rt Runtime, st *State, store adt.Store, currDeadline *DeadlineInfo, minerInfo *MinerInfo, deadlines *Deadlines, epochReward abi.TokenAmount, currentTotalPower abi.StoragePower, skipped *bitfield.BitField) ([]*SectorOnChainInfo, abi.TokenAmount) {
 	empty, err := skipped.IsEmpty()
 	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalArgument, "failed to check if skipped sectors is empty")
 	if empty {
@@ -1231,7 +1231,6 @@ func processSkippedFaults(rt Runtime, st *State, store adt.Store, currDeadline *
 
 	currEpoch := rt.CurrEpoch()
 	var skippedFaultSectors []*SectorOnChainInfo
-	minerInfo := getMinerInfo(rt, st)
 
 	// Check that the declared sectors are actually due at the deadline.
 	deadlineSectors := deadlines.Due[currDeadline.Index]

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -1231,6 +1231,7 @@ func processSkippedFaults(rt Runtime, st *State, store adt.Store, currDeadline *
 
 	currEpoch := rt.CurrEpoch()
 	var skippedFaultSectors []*SectorOnChainInfo
+	minerInfo := getMinerInfo(rt, st)
 
 	// Check that the declared sectors are actually due at the deadline.
 	deadlineSectors := deadlines.Due[currDeadline.Index]
@@ -1259,7 +1260,7 @@ func processSkippedFaults(rt Runtime, st *State, store adt.Store, currDeadline *
 	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load fault sectors")
 
 	// Unlock undeclared penalty for faults.
-	penalty, err := unlockUndeclaredFaultPenalty(st, store, currEpoch, epochReward, currentTotalPower, skippedFaultSectors)
+	penalty, err := unlockUndeclaredFaultPenalty(st, store, minerInfo.SectorSize, currEpoch, epochReward, currentTotalPower, skippedFaultSectors)
 	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to charge fault fee")
 
 	// Remove faulty recoveries

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -269,7 +269,7 @@ func (a Actor) SubmitWindowedPoSt(rt Runtime, params *SubmitWindowedPoStParams) 
 		// Traverse earlier submissions and enact detected faults.
 		// This isn't strictly necessary, but keeps the power table up to date eagerly and can force payment
 		// of penalties if locked pledge drops too low.
-		detectedFaultSectors, faultPenalty := detectFaultsThisPeriod(rt, &st, store, currDeadline, deadlines, epochReward, pwrTotal.QualityAdjPower)
+		detectedFaultSectors, detectedFaultPenalty := detectFaultsThisPeriod(rt, &st, store, currDeadline, deadlines, epochReward, pwrTotal.QualityAdjPower)
 		penalty = big.Add(penalty, faultPenalty)
 		newFaultSectors = append(newFaultSectors, detectedFaultSectors...)
 

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -609,7 +609,7 @@ func TestWindowPost(t *testing.T) {
 
 		deadlines, err := st.LoadDeadlines(rt.AdtStore())
 		require.NoError(t, err)
-		deadline := st.DeadlineInfo(rt.Epoch())
+		deadline := actor.deadline(rt)
 
 		// advance to next dealine where we expect the first sectors to appear
 		rt.SetEpoch(deadline.Close + 1)

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -567,12 +567,11 @@ func TestWindowPost(t *testing.T) {
 		rt := builder.Build(t)
 		actor.constructAndVerify(rt)
 		store := rt.AdtStore()
-		st := getState(rt)
 		_ = actor.commitAndProveSectors(rt, 1, 100, nil)
 
 		// Skip to end of proving period, cron adds sectors to proving set.
 		actor.advancePastProvingPeriodWithCron(rt)
-		st = getState(rt)
+		st := getState(rt)
 
 		// Iterate deadlines in the proving period, setting epoch to the first in each deadline.
 		// Submit a window post for all partitions due at each deadline when necessary.
@@ -1421,7 +1420,6 @@ func (h *actorHarness) advancePastProvingPeriodWithCron(rt *mock.Runtime) {
 	rt.SetEpoch(deadline.PeriodEnd())
 	nextCron := deadline.NextPeriodStart() + miner.WPoStProvingPeriod - 1
 	h.onProvingPeriodCron(rt, nextCron, true, nil, nil)
-	st = getState(rt)
 	rt.SetEpoch(deadline.NextPeriodStart())
 }
 

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -572,6 +572,7 @@ func TestWindowPost(t *testing.T) {
 
 		// Skip to end of proving period, cron adds sectors to proving set.
 		actor.advancePastProvingPeriodWithCron(rt)
+		st = getState(rt)
 
 		// Iterate deadlines in the proving period, setting epoch to the first in each deadline.
 		// Submit a window post for all partitions due at each deadline when necessary.

--- a/support/mock/mockrt.go
+++ b/support/mock/mockrt.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"reflect"
 	"runtime/debug"
+	"strings"
 	"testing"
 
 	"github.com/filecoin-project/go-address"
@@ -775,6 +776,11 @@ func (rt *Runtime) Reset() {
 
 // Calls f() expecting it to invoke Runtime.Abortf() with a specified exit code.
 func (rt *Runtime) ExpectAbort(expected exitcode.ExitCode, f func()) {
+	rt.ExpectAbortConstainsMessage(expected, "", f)
+}
+
+// Calls f() expecting it to invoke Runtime.Abortf() with a specified exit code and message.
+func (rt *Runtime) ExpectAbortConstainsMessage(expected exitcode.ExitCode, substr string, f func()) {
 	rt.t.Helper()
 	prevState := rt.state
 
@@ -791,6 +797,11 @@ func (rt *Runtime) ExpectAbort(expected exitcode.ExitCode, f func()) {
 		}
 		if a.code != expected {
 			rt.failTest("abort expected code %v, got %v %s", expected, a.code, a.msg)
+		}
+		if substr != "" {
+			if !strings.Contains(a.msg, substr) {
+				rt.failTest("abort expected message\n'%s'\nto contain\n'%s'\n", a.msg, substr)
+			}
 		}
 		// Roll back state change.
 		rt.state = prevState


### PR DESCRIPTION
closes #410

### Motivation

The `Skipped` field in `SubmitWindowedPoSt` is currently ignored. This field is important because it allows miners to signal which sectors have faulted late without losing the entire PoSt. This PR adds the functionality to penalize skipped faults and add them to declared faults so that the proof verification will not fail.

### Proposed Changes

1. Introduce `processSkippedFaults` call into `SubmitWindowedPoSt` to handle the `Skipped` parameter.
2. Add logic to handle intersection with recoveries.
3. Add logic to add skipped faults to `Faults` and the current `FaultEpoch`.
4. Add logic to compute an undeclared fault penalty for the skipped faults, unlock that amount and burn it.
5. Add logic to compute power delta for unlocked faults and notify power actor of the change.
6. Test.