### PR TITLE
Update and optimize bitfield operations

### DIFF
--- a/actors/abi/bitfield_test.go
+++ b/actors/abi/bitfield_test.go
@@ -65,51 +65,31 @@ func TestBitFieldContains(t *testing.T) {
 	c.Set(2)
 	c.Set(5)
 
-	contains, err := abi.BitFieldContainsAny(a, b)
-	assert.NoError(t, err)
-	assert.True(t, contains)
+	assertContainsAny := func(a, b *abi.BitField, expected bool) {
+		t.Helper()
+		actual, err := abi.BitFieldContainsAny(a, b)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, actual)
+	}
 
-	contains, err = abi.BitFieldContainsAny(b, a)
-	assert.NoError(t, err)
-	assert.True(t, contains)
+	assertContainsAll := func(a, b *abi.BitField, expected bool) {
+		t.Helper()
+		actual, err := abi.BitFieldContainsAll(a, b)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, actual)
+	}
 
-	contains, err = abi.BitFieldContainsAny(a, c)
-	assert.NoError(t, err)
-	assert.True(t, contains)
+	assertContainsAny(a, b, true)
+	assertContainsAny(b, a, true)
+	assertContainsAny(a, c, true)
+	assertContainsAny(c, a, true)
+	assertContainsAny(b, c, false)
+	assertContainsAny(c, b, false)
 
-	contains, err = abi.BitFieldContainsAny(c, a)
-	assert.NoError(t, err)
-	assert.True(t, contains)
-
-	contains, err = abi.BitFieldContainsAny(b, c)
-	assert.NoError(t, err)
-	assert.False(t, contains)
-
-	contains, err = abi.BitFieldContainsAny(c, b)
-	assert.NoError(t, err)
-	assert.False(t, contains)
-
-	contains, err = abi.BitFieldContainsAll(a, b)
-	assert.NoError(t, err)
-	assert.False(t, contains)
-
-	contains, err = abi.BitFieldContainsAll(b, a)
-	assert.NoError(t, err)
-	assert.False(t, contains)
-
-	contains, err = abi.BitFieldContainsAll(a, c)
-	assert.NoError(t, err)
-	assert.True(t, contains)
-
-	contains, err = abi.BitFieldContainsAll(c, a)
-	assert.NoError(t, err)
-	assert.False(t, contains)
-
-	contains, err = abi.BitFieldContainsAll(b, c)
-	assert.NoError(t, err)
-	assert.False(t, contains)
-
-	contains, err = abi.BitFieldContainsAll(c, b)
-	assert.NoError(t, err)
-	assert.False(t, contains)
+	assertContainsAll(a, b, false)
+	assertContainsAll(b, a, false)
+	assertContainsAll(a, c, true)
+	assertContainsAll(c, a, false)
+	assertContainsAll(b, c, false)
+	assertContainsAll(c, b, false)
 }

--- a/actors/abi/bitfield_test.go
+++ b/actors/abi/bitfield_test.go
@@ -50,3 +50,66 @@ func roundtripMarshal(t *testing.T, in *abi.BitField) *abi.BitField {
 	assert.NoError(t, err)
 	return bf2
 }
+
+func TestBitFieldContains(t *testing.T) {
+	a := abi.NewBitField()
+	a.Set(2)
+	a.Set(4)
+	a.Set(5)
+
+	b := abi.NewBitField()
+	b.Set(3)
+	b.Set(4)
+
+	c := abi.NewBitField()
+	c.Set(2)
+	c.Set(5)
+
+	contains, err := abi.BitFieldContainsAny(a, b)
+	assert.NoError(t, err)
+	assert.True(t, contains)
+
+	contains, err = abi.BitFieldContainsAny(b, a)
+	assert.NoError(t, err)
+	assert.True(t, contains)
+
+	contains, err = abi.BitFieldContainsAny(a, c)
+	assert.NoError(t, err)
+	assert.True(t, contains)
+
+	contains, err = abi.BitFieldContainsAny(c, a)
+	assert.NoError(t, err)
+	assert.True(t, contains)
+
+	contains, err = abi.BitFieldContainsAny(b, c)
+	assert.NoError(t, err)
+	assert.False(t, contains)
+
+	contains, err = abi.BitFieldContainsAny(c, b)
+	assert.NoError(t, err)
+	assert.False(t, contains)
+
+	contains, err = abi.BitFieldContainsAll(a, b)
+	assert.NoError(t, err)
+	assert.False(t, contains)
+
+	contains, err = abi.BitFieldContainsAll(b, a)
+	assert.NoError(t, err)
+	assert.False(t, contains)
+
+	contains, err = abi.BitFieldContainsAll(a, c)
+	assert.NoError(t, err)
+	assert.True(t, contains)
+
+	contains, err = abi.BitFieldContainsAll(c, a)
+	assert.NoError(t, err)
+	assert.False(t, contains)
+
+	contains, err = abi.BitFieldContainsAll(b, c)
+	assert.NoError(t, err)
+	assert.False(t, contains)
+
+	contains, err = abi.BitFieldContainsAll(c, b)
+	assert.NoError(t, err)
+	assert.False(t, contains)
+}

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -279,7 +279,7 @@ func (a Actor) SubmitWindowedPoSt(rt Runtime, params *SubmitWindowedPoStParams) 
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to compute partitions sectors at deadline %d, partitions %s",
 			currDeadline.Index, params.Partitions)
 
-		provenSectors, err := abi.BitFieldUnion(partitionsSectors...)
+		provenSectors, err := bitfield.MultiMerge(partitionsSectors...)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to union %d partitions of sectors", len(partitionsSectors))
 
 		// Load sector infos, substituting a known-good sector for known-faulty sectors.
@@ -787,7 +787,7 @@ func (a Actor) DeclareFaults(rt Runtime, params *DeclareFaultsParams) *adt.Empty
 			decaredSectors = append(decaredSectors, decl.Sectors)
 		}
 
-		allDeclared, err := abi.BitFieldUnion(decaredSectors...)
+		allDeclared, err := bitfield.MultiMerge(decaredSectors...)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to union faults")
 
 		// Split declarations into declarations of new faults, and retraction of declared recoveries.
@@ -907,7 +907,7 @@ func (a Actor) DeclareFaultsRecovered(rt Runtime, params *DeclareFaultsRecovered
 			declaredSectors = append(declaredSectors, decl.Sectors)
 		}
 
-		allRecoveries, err := abi.BitFieldUnion(declaredSectors...)
+		allRecoveries, err := bitfield.MultiMerge(declaredSectors...)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to union recoveries")
 
 		contains, err := abi.BitFieldContainsAll(st.Faults, allRecoveries)
@@ -1309,11 +1309,11 @@ func computeFaultsFromMissingPoSts(partitionSize uint64, faults, recoveries, pos
 
 		deadlineFirstPartition += dlPartCount
 	}
-	detectedFaults, err = abi.BitFieldUnion(fGroups...)
+	detectedFaults, err = bitfield.MultiMerge(fGroups...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to union detected fault groups: %w", err)
 	}
-	failedRecoveries, err = abi.BitFieldUnion(rGroups...)
+	failedRecoveries, err = bitfield.MultiMerge(rGroups...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to union failed recovery groups: %w", err)
 	}
@@ -1427,7 +1427,7 @@ func popSectorExpirations(st *State, store adt.Store, epoch abi.ChainEpoch) (*ab
 		return nil, fmt.Errorf("failed to clear sector expirations %s: %w", expiredEpochs, err)
 	}
 
-	allExpiries, err := abi.BitFieldUnion(expiredSectors...)
+	allExpiries, err := bitfield.MultiMerge(expiredSectors...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to union expired sectors: %w", err)
 	}
@@ -1458,11 +1458,11 @@ func popExpiredFaults(st *State, store adt.Store, latestTermination abi.ChainEpo
 		return nil, nil, fmt.Errorf("failed to clear fault epochs %s: %w", expiredEpochs, err)
 	}
 
-	allExpiries, err := abi.BitFieldUnion(expiredFaults...)
+	allExpiries, err := bitfield.MultiMerge(expiredFaults...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to union expired faults: %w", err)
 	}
-	allOngoing, err := abi.BitFieldUnion(ongoingFaults...)
+	allOngoing, err := bitfield.MultiMerge(ongoingFaults...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to union ongoing faults: %w", err)
 	}

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -404,9 +404,8 @@ func (st *State) ForEachSectorExpiration(store adt.Store, f func(expiry abi.Chai
 	}
 
 	var bf bitfield.BitField
-	empty := abi.NewBitField()
 	return arr.ForEach(&bf, func(i int64) error {
-		bfCopy, err := bitfield.MergeBitFields(&bf, empty)
+		bfCopy, err := bf.Copy()
 		if err != nil {
 			return err
 		}
@@ -629,9 +628,8 @@ func (st *State) ForEachFaultEpoch(store adt.Store, cb func(epoch abi.ChainEpoch
 	}
 
 	var bf bitfield.BitField
-	empty := abi.NewBitField()
 	return arr.ForEach(&bf, func(i int64) error {
-		bfCopy, err := bitfield.MergeBitFields(&bf, empty)
+		bfCopy, err := bf.Copy()
 		if err != nil {
 			return err
 		}

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -598,7 +598,7 @@ func TestWindowPost(t *testing.T) {
 
 				partitionsSectors, err := miner.ComputePartitionsSectors(deadlines, actor.partitionSize, deadline.Index, partitions)
 				require.NoError(t, err)
-				provenSectors, err := abi.BitFieldUnion(partitionsSectors...)
+				provenSectors, err := bitfield.MultiMerge(partitionsSectors...)
 				require.NoError(t, err)
 				infos, _, err := st.LoadSectorInfosForProof(store, provenSectors)
 				require.NoError(t, err)
@@ -1498,7 +1498,7 @@ func (h *actorHarness) advanceProvingPeriodWithoutFaults(rt *mock.Runtime) {
 
 			partitionsSectors, err := miner.ComputePartitionsSectors(deadlines, h.partitionSize, deadline.Index, partitions)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "could not compute partitions")
-			provenSectors, err := abi.BitFieldUnion(partitionsSectors...)
+			provenSectors, err := bitfield.MultiMerge(partitionsSectors...)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "could not get proven sectors")
 			infos, _, err := st.LoadSectorInfosForProof(store, provenSectors)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "could not load sector info for proof")

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/filecoin-project/go-address v0.0.2-0.20200218010043-eb9bb40ed5be
 	github.com/filecoin-project/go-amt-ipld/v2 v2.0.1-0.20200424220931-6263827e49f2
-	github.com/filecoin-project/go-bitfield v0.0.1
+	github.com/filecoin-project/go-bitfield v0.0.3
 	github.com/gogo/protobuf v1.3.1 // indirect
 	github.com/gopherjs/gopherjs v0.0.0-20190812055157-5d271430af9f // indirect
 	github.com/ipfs/go-block-format v0.0.2

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/filecoin-project/go-address v0.0.2-0.20200218010043-eb9bb40ed5be h1:T
 github.com/filecoin-project/go-address v0.0.2-0.20200218010043-eb9bb40ed5be/go.mod h1:SAOwJoakQ8EPjwNIsiakIQKsoKdkcbx8U3IapgCg9R0=
 github.com/filecoin-project/go-amt-ipld/v2 v2.0.1-0.20200424220931-6263827e49f2 h1:jamfsxfK0Q9yCMHt8MPWx7Aa/O9k2Lve8eSc6FILYGQ=
 github.com/filecoin-project/go-amt-ipld/v2 v2.0.1-0.20200424220931-6263827e49f2/go.mod h1:boRtQhzmxNocrMxOXo1NYn4oUc1NGvR8tEa79wApNXg=
-github.com/filecoin-project/go-bitfield v0.0.1 h1:Xg/JnrqqE77aJVKdbEyR04n9FZQWhwrN+buDgQCVpZU=
-github.com/filecoin-project/go-bitfield v0.0.1/go.mod h1:Ry9/iUlWSyjPUzlAvdnfy4Gtvrq4kWmWDztCU1yEgJY=
+github.com/filecoin-project/go-bitfield v0.0.3 h1:W04NDq2HBJ+qSoAJZbfChvpKHSI61rUWKaDMtClKCkI=
+github.com/filecoin-project/go-bitfield v0.0.3/go.mod h1:Ry9/iUlWSyjPUzlAvdnfy4Gtvrq4kWmWDztCU1yEgJY=
 github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03 h1:2pMXdBnCiXjfCYx/hLqFxccPoqsSveQFxVLvNxy9bus=
 github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03/go.mod h1:+viYnvGtUTgJRdy6oaeF4MTFKAfatX071MPDPBL11EQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=


### PR DESCRIPTION
Replaces #568
Fixes #460

* Removes BitFieldUnion (we can now use bitfield.MultiMerge).
* Optimizes contains functions to avoid creating new bitfields, or iterating over the bitfields any more than necessary.
* Adds tests for the contains functions.

Note: This removes an abi method: BitFieldUnion. This will require updating lotus.