### PR TITLE
older undetected faults penalized 2x SP

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -293,9 +293,12 @@ func (a Actor) SubmitWindowedPoSt(rt Runtime, params *SubmitWindowedPoStParams) 
 		sectorInfos, declaredRecoveries, err := st.LoadSectorInfosForProof(store, provenSectors)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load proven sector info")
 
-		// Verify the proof.
-		// A failed verification doesn't immediately cause a penalty; the miner can try again.
-		verifyWindowedPost(rt, currDeadline.Challenge, sectorInfos, params.Proofs)
+		// Skip verification if all sectors are faults
+		if len(sectorInfos) > 0 {
+			// Verify the proof.
+			// A failed verification doesn't immediately cause a penalty; the miner can try again.
+			verifyWindowedPost(rt, currDeadline.Challenge, sectorInfos, params.Proofs)
+		}
 
 		// Record the successful submission
 		postedPartitions := bitfield.NewFromSet(params.Partitions)

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -1319,7 +1319,7 @@ func processMissingPoStFaults(rt Runtime, st *State, store adt.Store, deadlines 
 	// TODO: this is potentially super expensive for a large miner failing to submit proofs.
 	// https://github.com/filecoin-project/specs-actors/issues/411
 	detectedFaultSectors, err := st.LoadSectorInfos(store, detectedFaults)
-	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load old fault sectors")
+	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load fault sectors")
 	failedRecoverySectors, err := st.LoadSectorInfos(store, failedRecoveries)
 	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load failed recovery sectors")
 

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -1285,8 +1285,8 @@ func processSkippedFaults(rt Runtime, st *State, store adt.Store, currDeadline *
 
 	// Penalize new skipped faults and retracted recoveries
 	// This differs from declaring faults "on time", where retracting recoveries doesn't attract an extra penalty
-	penalizedSectors := append(newFaultSectors, retractedRecoveryInfos...)
-	penalty, err := unlockUndeclaredFaultPenalty(st, store, minerInfo.SectorSize, currEpoch, epochReward, currentTotalPower, penalizedSectors)
+	penalizeFaultSectors := append(newFaultSectors, retractedRecoveryInfos...)
+	penalty, err := unlockUndeclaredFaultPenalty(st, store, minerInfo.SectorSize, currEpoch, epochReward, currentTotalPower, penalizeFaultSectors)
 	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to charge fault fee")
 
 	// Return only new faulty sectors (excluding retracted recoveries) for power updates

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -1285,12 +1285,15 @@ func processSkippedFaults(rt Runtime, st *State, store adt.Store, currDeadline *
 
 	// Penalize new skipped faults and retracted recoveries
 	// This differs from declaring faults "on time", where retracting recoveries doesn't attract an extra penalty
-	penalizeFaultSectors := append(newFaultSectors, retractedRecoveryInfos...)
-	penalty, err := unlockUndeclaredFaultPenalty(st, store, minerInfo.SectorSize, currEpoch, epochReward, currentTotalPower, penalizeFaultSectors)
+	faultPenalty, err := unlockUndeclaredFaultPenalty(st, store, minerInfo.SectorSize, currEpoch, epochReward, currentTotalPower, newFaultSectors)
+	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to charge fault fee")
+
+	// retracted recoveries are penalized at a higher rate
+	retractedPenalty, err := unlockUndeclaredLateFaultPenalty(st, store, minerInfo.SectorSize, currEpoch, epochReward, currentTotalPower, retractedRecoveryInfos)
 	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to charge fault fee")
 
 	// Return only new faulty sectors (excluding retracted recoveries) for power updates
-	return newFaultSectors, penalty
+	return newFaultSectors, big.Add(faultPenalty, retractedPenalty)
 }
 
 // Detects faults from missing PoSt submissions that did not arrive by some deadline, and moves

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -1315,36 +1315,20 @@ func processMissingPoStFaults(rt Runtime, st *State, store adt.Store, deadlines 
 	err = st.RemoveRecoveries(failedRecoveries)
 	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to record failed recoveries")
 
-	// Determine which faults are from the previous deadline. Faults from previous deadline are penalized
-	// the undetected fault fee. Older faults are charged the late undetected fault fee.
-	oldDetectedFaults := detectedFaults
-	newDetectedFaults := bitfield.NewFromSet(nil)
-	// New faults in previous proving period will have been handled in handleProvingPeriod
-	if beforeDeadline > 0 {
-		newDetectedFaults = deadlines.Due[beforeDeadline-1]
-		oldDetectedFaults, err = bitfield.SubtractBitField(oldDetectedFaults, newDetectedFaults)
-		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to subtract last deadline from detected faults")
-	}
-
 	// Load info for sectors.
 	// TODO: this is potentially super expensive for a large miner failing to submit proofs.
 	// https://github.com/filecoin-project/specs-actors/issues/411
-	oldDetectedFaultSectors, err := st.LoadSectorInfos(store, oldDetectedFaults)
+	detectedFaultSectors, err := st.LoadSectorInfos(store, detectedFaults)
 	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load old fault sectors")
-	newDetectedFaultSectors, err := st.LoadSectorInfos(store, newDetectedFaults)
-	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load new fault sectors")
 	failedRecoverySectors, err := st.LoadSectorInfos(store, failedRecoveries)
 	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load failed recovery sectors")
 
 	// Unlock sector penalty for all undeclared faults.
-	latePenalizedSectors := append(oldDetectedFaultSectors, failedRecoverySectors...)
-	oldPenalty, err := unlockUndeclaredLateFaultPenalty(st, store, info.SectorSize, currEpoch, epochReward, currentTotalPower, latePenalizedSectors)
+	latePenalizedSectors := append(detectedFaultSectors, failedRecoverySectors...)
+	penalty, err := unlockUndeclaredLateFaultPenalty(st, store, info.SectorSize, currEpoch, epochReward, currentTotalPower, latePenalizedSectors)
 	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to charge sector penalty")
 
-	newPenalty, err := unlockUndeclaredFaultPenalty(st, store, info.SectorSize, currEpoch, epochReward, currentTotalPower, newDetectedFaultSectors)
-	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to charge sector penalty")
-
-	return append(oldDetectedFaultSectors, newDetectedFaultSectors...), big.Add(oldPenalty, newPenalty)
+	return detectedFaultSectors, penalty
 }
 
 // Computes the sectors that were expected to be present in partitions of a PoSt submission but were not, in the

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -764,12 +764,13 @@ func (st *State) LoadSectorInfosForProof(store adt.Store, provenSectors *abi.Bit
 		return nil, nil, xerrors.Errorf("failed to diff bitfields: %w", err)
 	}
 
+	// return empty if no non-faults
 	empty, err := nonFaults.IsEmpty()
 	if err != nil {
 		return nil, nil, xerrors.Errorf("failed to check if bitfield was empty: %w", err)
 	}
 	if empty {
-		return nil, nil, xerrors.Errorf("no non-faulty sectors in partitions: %w", err)
+		return nil, recoveries, nil
 	}
 
 	// Select a non-faulty sector as a substitute for faulty ones.

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -692,6 +692,9 @@ func TestWindowPost(t *testing.T) {
 		deadlines, err := st.LoadDeadlines(rt.AdtStore())
 		require.NoError(t, err)
 		skipped := deadlines.Due[deadline.Index]
+		count, err := skipped.Count()
+		require.NoError(t, err)
+		assert.Greater(t, count, uint64(0))
 
 		rawPower, qaPower := miner.PowerForSectors(actor.sectorSize, infos)
 
@@ -784,8 +787,7 @@ func TestWindowPost(t *testing.T) {
 		// expect power to be deducted for all sectors in first two deadlines
 		rawPower, qaPower := miner.PowerForSectors(actor.sectorSize, append(infos1, infos2...))
 
-		// expected penalty is the undeclared fault penalty for all sectors in previous deadline
-		// and the undeclared late penalty for new faults preceding that.
+		// expected penalty is the late undeclared fault penalty for all faulted sectors including retracted recoveries..
 		expectedPenalty := miner.PledgePenaltyForLateUndeclaredFault(actor.epochReward, actor.networkQAPower, qaPower)
 
 		cfg := &poStConfig{

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -693,7 +693,7 @@ func TestWindowPost(t *testing.T) {
 		// skip the first sector in the partition
 		skipped := bitfield.NewFromSet([]uint64{uint64(infos[0].SectorNumber)})
 		// expected penalty is the fee for an undeclared fault
-		expectedPenalty := miner.PledgePenaltyForLateUndeclaredFault(actor.epochReward, actor.networkQAPower, qaPower)
+		expectedPenalty := miner.PledgePenaltyForUndeclaredFault(actor.epochReward, actor.networkQAPower, qaPower)
 
 		cfg := &poStConfig{
 			expectedRawPowerDelta: big.Zero(),
@@ -796,7 +796,7 @@ func TestWindowPost(t *testing.T) {
 		skipped := bitfield.NewFromSet([]uint64{uint64(nextInfos1[0].SectorNumber)})
 
 		// expected penalty is the late fee for first sector as retracted recovery
-		expectedPenalty := miner.PledgePenaltyForLateUndeclaredFault(actor.epochReward, actor.networkQAPower, qaPower)
+		expectedPenalty := miner.PledgePenaltyForUndeclaredFault(actor.epochReward, actor.networkQAPower, qaPower)
 
 		cfg := &poStConfig{
 			expectedRawPowerDelta: rawPower,

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -693,7 +693,7 @@ func TestWindowPost(t *testing.T) {
 		// skip the first sector in the partition
 		skipped := bitfield.NewFromSet([]uint64{uint64(infos[0].SectorNumber)})
 		// expected penalty is the fee for an undeclared fault
-		expectedPenalty := miner.PledgePenaltyForUndeclaredFault(actor.epochReward, actor.networkQAPower, qaPower)
+		expectedPenalty := miner.PledgePenaltyForLateUndeclaredFault(actor.epochReward, actor.networkQAPower, qaPower)
 
 		cfg := &poStConfig{
 			expectedRawPowerDelta: big.Zero(),

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -748,16 +748,13 @@ func TestWindowPost(t *testing.T) {
 
 		// expected penalty is the undeclared fault penalty for all sectors in previous deadline
 		// and the undeclared late penalty for new faults preceding that.
-		_, qaPower1 := miner.PowerForSectors(actor.sectorSize, infos1)
-		expectedPenalty1 := miner.PledgePenaltyForLateUndeclaredFault(actor.epochReward, actor.networkQAPower, qaPower1)
-		_, qaPower2 := miner.PowerForSectors(actor.sectorSize, infos2)
-		expectedPenalty2 := miner.PledgePenaltyForUndeclaredFault(actor.epochReward, actor.networkQAPower, qaPower2)
+		expectedPenalty := miner.PledgePenaltyForLateUndeclaredFault(actor.epochReward, actor.networkQAPower, qaPower)
 
 		cfg := &poStConfig{
 			skipped:               bitfield.NewFromSet(nil),
 			expectedRawPowerDelta: rawPower.Neg(),
 			expectedQAPowerDelta:  qaPower.Neg(),
-			expectedPenalty:       big.Add(expectedPenalty1, expectedPenalty2),
+			expectedPenalty:       expectedPenalty,
 		}
 
 		actor.submitWindowPoSt(rt, deadline, partitions, infos3, cfg)

--- a/actors/builtin/miner/monies.go
+++ b/actors/builtin/miner/monies.go
@@ -57,7 +57,7 @@ func PledgePenaltyForTermination(initialPledge abi.TokenAmount, sectorAge abi.Ch
 	// and sectorAgeInDays = sectorAge / EpochsInDay
 	cappedSectorAge := big.NewInt(int64(minEpoch(sectorAge, 180*builtin.EpochsInDay)))
 	return big.Max(
-		PledgePenaltyForUndeclaredFault(epochTargetReward, networkQAPower, qaSectorPower),
+		PledgePenaltyForLateUndeclaredFault(epochTargetReward, networkQAPower, qaSectorPower),
 		big.Add(
 			initialPledge,
 			big.Div(

--- a/actors/builtin/miner/monies.go
+++ b/actors/builtin/miner/monies.go
@@ -42,6 +42,13 @@ func PledgePenaltyForUndeclaredFault(epochTargetReward abi.TokenAmount, networkQ
 		UndeclaredFaultFactorDenom)
 }
 
+// This is the SP(t) penalty for a newly faulty sector that has not been declared later than one deadline.
+// SP_late(t) = 2*SP(t)
+func PledgePenaltyForLateUndeclaredFault(epochTargetReward abi.TokenAmount, networkQAPower abi.StoragePower, qaSectorPower abi.StoragePower) abi.TokenAmount {
+	return big.Mul(big.NewInt(2),
+		PledgePenaltyForUndeclaredFault(epochTargetReward, networkQAPower, qaSectorPower))
+}
+
 // Penalty to locked pledge collateral for the termination of a sector before scheduled expiry.
 // SectorAge is the time between now and the sector's activation.
 func PledgePenaltyForTermination(initialPledge abi.TokenAmount, sectorAge abi.ChainEpoch, epochTargetReward abi.TokenAmount, networkQAPower, qaSectorPower abi.StoragePower) abi.TokenAmount {

--- a/actors/builtin/miner/monies_test.go
+++ b/actors/builtin/miner/monies_test.go
@@ -16,7 +16,7 @@ func TestPledgePenaltyForTermination(t *testing.T) {
 	epochTargetReward := abi.NewTokenAmount(1 << 50)
 	qaSectorPower := abi.NewStoragePower(1 << 36)
 	networkQAPower := abi.NewStoragePower(1 << 50)
-	undeclaredPenalty := miner.PledgePenaltyForUndeclaredFault(epochTargetReward, networkQAPower, qaSectorPower)
+	undeclaredPenalty := miner.PledgePenaltyForLateUndeclaredFault(epochTargetReward, networkQAPower, qaSectorPower)
 
 	t.Run("when undeclared fault fee exceeds expected reward, returns undeclaraed fault fee", func(t *testing.T) {
 		// small pledge and means undeclared penalty will be bigger


### PR DESCRIPTION
closes #561

### Motivation

Undetected faults have likely lived in an undetected state much longer than declared faults. To compensate, these late undetected faults should be charged 2x the undeclared fault penalty. This includes skipped recoveries as well.

### Proposed changes

1. Add logic in `processMissingPoStFaults` to separate faults older than one dead line from newer undetected faults.
2. Charge the new late undeclared penalty (2xSP) for these.
3. Alter `processSkippedFaults` to charge late undeclared penalty for skipped recoveries.
4. Add test logic to test declared recoveries and undeclared faults in `handleProvingPeriod`.
5. Add tests for the new behavior.