### PR TITLE
add logging through runtime for power actor

### DIFF
--- a/actors/builtin/power/power_actor.go
+++ b/actors/builtin/power/power_actor.go
@@ -441,6 +441,7 @@ func (a Actor) processDeferredCronEvents(rt Runtime) error {
 		// Failures are unexpected here but will result in removal of miner power
 		// A log message would really help here.
 		if code != exitcode.Ok {
+			rt.Log(vmr.WARN, "OnDeferredCronEvent failed for miner %s", event.MinerAddr)
 			failedMinerCrons = append(failedMinerCrons, event.MinerAddr)
 		}
 	}
@@ -450,18 +451,18 @@ func (a Actor) processDeferredCronEvents(rt Runtime) error {
 		for _, minerAddr := range failedMinerCrons {
 			claim, found, err := st.GetClaim(store, minerAddr)
 			if err != nil {
-				// TODO #564 log this, failing without deducting power: bad
+				rt.Log(vmr.ERROR, "failed to get claim for miner %s after failing OnDeferredCronEvent: %s", minerAddr.String(), err)
 				continue
 			}
 			if !found {
-				// TODO #564 log this, failing without deducting power, but power doesn't exist so maybe ok?
+				rt.Log(vmr.WARN, "miner OnDeferredCronEvent failed for miner %s with no power", minerAddr.String())
 				continue
 			}
 
 			// zero out miner power
 			err = st.AddToClaim(store, minerAddr, claim.RawBytePower.Neg(), claim.QualityAdjPower.Neg())
 			if err != nil {
-				// TODO #564 log this, failing without deducting power: bad
+				rt.Log(vmr.WARN, "failed to remove (%d, %d) power for miner %s after to failed cron", claim.RawBytePower, claim.QualityAdjPower, minerAddr.String())
 				continue
 			}
 		}

--- a/actors/builtin/power/power_actor.go
+++ b/actors/builtin/power/power_actor.go
@@ -441,7 +441,7 @@ func (a Actor) processDeferredCronEvents(rt Runtime) error {
 		// Failures are unexpected here but will result in removal of miner power
 		// A log message would really help here.
 		if code != exitcode.Ok {
-			rt.Log(vmr.WARN, "OnDeferredCronEvent failed for miner %s", event.MinerAddr)
+			rt.Log(vmr.WARN, "OnDeferredCronEvent failed for miner %s: exitcode %d", event.MinerAddr, code)
 			failedMinerCrons = append(failedMinerCrons, event.MinerAddr)
 		}
 	}
@@ -451,18 +451,18 @@ func (a Actor) processDeferredCronEvents(rt Runtime) error {
 		for _, minerAddr := range failedMinerCrons {
 			claim, found, err := st.GetClaim(store, minerAddr)
 			if err != nil {
-				rt.Log(vmr.ERROR, "failed to get claim for miner %s after failing OnDeferredCronEvent: %s", minerAddr.String(), err)
+				rt.Log(vmr.ERROR, "failed to get claim for miner %s after failing OnDeferredCronEvent: %s", minerAddr, err)
 				continue
 			}
 			if !found {
-				rt.Log(vmr.WARN, "miner OnDeferredCronEvent failed for miner %s with no power", minerAddr.String())
+				rt.Log(vmr.WARN, "miner OnDeferredCronEvent failed for miner %s with no power", minerAddr)
 				continue
 			}
 
 			// zero out miner power
 			err = st.AddToClaim(store, minerAddr, claim.RawBytePower.Neg(), claim.QualityAdjPower.Neg())
 			if err != nil {
-				rt.Log(vmr.WARN, "failed to remove (%d, %d) power for miner %s after to failed cron", claim.RawBytePower, claim.QualityAdjPower, minerAddr.String())
+				rt.Log(vmr.WARN, "failed to remove (%d, %d) power for miner %s after to failed cron", claim.RawBytePower, claim.QualityAdjPower, minerAddr)
 				continue
 			}
 		}

--- a/actors/builtin/power/power_test.go
+++ b/actors/builtin/power/power_test.go
@@ -224,6 +224,9 @@ func TestCron(t *testing.T) {
 		rt.Call(actor.Actor.OnEpochTickEnd, nil)
 		rt.Verify()
 
+		// expect cron failure was logged
+		rt.ExpectLogsContain("OnDeferredCronEvent failed for miner")
+
 		newPow := actor.currentPowerTotal(rt)
 		assert.Equal(t, abi.NewStoragePower(0), newPow.RawBytePower)
 		assert.Equal(t, abi.NewStoragePower(0), newPow.QualityAdjPower)

--- a/actors/runtime/runtime.go
+++ b/actors/runtime/runtime.go
@@ -14,6 +14,22 @@ import (
 	exitcode "github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 )
 
+type LogLevel int
+
+const (
+	// DebugLevel logs are typically voluminous, and are usually disabled in
+	// production.
+	DEBUG = iota
+	// InfoLevel is the default logging priority.
+	INFO
+	// WarnLevel logs are more important than Info, but don't need individual
+	// human review.
+	WARN
+	// ErrorLevel logs are high-priority. If an application is running smoothly,
+	// it shouldn't generate any error-level logs.
+	ERROR
+)
+
 // Runtime is the VM's internal runtime object.
 // this is everything that is accessible to actors, beyond parameters.
 type Runtime interface {
@@ -103,6 +119,9 @@ type Runtime interface {
 	// toward execution cost. This functionality is used for observing global changes
 	// in total gas charged if amount of gas charged was to be changed.
 	ChargeGas(name string, gas int64, virtual int64)
+
+	// Note events that may make debugging easier
+	Log(level LogLevel, msg string, args ...interface{})
 }
 
 // Store defines the storage module exposed to actors.

--- a/actors/runtime/runtime.go
+++ b/actors/runtime/runtime.go
@@ -14,12 +14,13 @@ import (
 	exitcode "github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 )
 
+// Specifies importance of message, LogLevel numbering is consistent with the uber-go/zap package.
 type LogLevel int
 
 const (
 	// DebugLevel logs are typically voluminous, and are usually disabled in
 	// production.
-	DEBUG = iota
+	DEBUG LogLevel = iota - 1
 	// InfoLevel is the default logging priority.
 	INFO
 	// WarnLevel logs are more important than Info, but don't need individual

--- a/support/mock/mockrt.go
+++ b/support/mock/mockrt.go
@@ -63,6 +63,8 @@ type Runtime struct {
 	expectVerifyPoSt           *expectVerifyPoSt
 	expectVerifyConsensusFault *expectVerifyConsensusFault
 	expectDeleteActor          *address.Address
+
+	logs []string
 }
 
 type expectRandomness struct {
@@ -551,6 +553,10 @@ func (rt *Runtime) VerifyConsensusFault(h1, h2, extra []byte) (*runtime.Consensu
 	return fault, err
 }
 
+func (rt *Runtime) Log(level runtime.LogLevel, msg string, args ...interface{}) {
+	rt.logs = append(rt.logs, fmt.Sprintf(msg, args...))
+}
+
 ///// Trace span implementation /////
 
 type TraceSpan struct {
@@ -839,6 +845,15 @@ func (rt *Runtime) ExpectAssertionFailure(expected string, f func()) {
 		rt.state = prevState
 	}()
 	f()
+}
+
+func (rt *Runtime) ExpectLogsContain(substr string) {
+	for _, msg := range rt.logs {
+		if strings.Contains(msg, substr) {
+			return
+		}
+	}
+	rt.failTest("logs contain %d message(s) and do not contain \"%s\"", len(rt.logs), substr)
 }
 
 func (rt *Runtime) Call(method interface{}, params interface{}) interface{} {


### PR DESCRIPTION
closes #564

### Motivation

The actors will sometimes encounter problems for which aborting and losing state is not an option. Silently accepting the situation is not a good option either. A logging hook that can be integrated into the implementations native logging system provides a good in-between.

### Proposed changes

1. Add a logging method to Runtime with four log levels (WARN, INFO, WARN, and ERROR).
2. Add logging for purposely unhandled errors in power actor.
3. Modify MockRt implement the additional message and support testing of logging.