### PR TITLE
trying to reduce window periods

### DIFF
--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -3,6 +3,7 @@ package miner
 import (
 	"fmt"
 	"reflect"
+	"sort"
 
 	addr "github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-bitfield"
@@ -577,7 +578,17 @@ func (st *State) RemoveFaults(store adt.Store, sectorNos *abi.BitField) error {
 		return err
 	}
 
-	for i, newFaults := range epochsChanged {
+	epochsChangedKeys := make([]uint64, 0, len(epochsChanged))
+	for k := range epochsChanged {
+		epochsChangedKeys = append(epochsChangedKeys, k)
+	}
+	sort.Slice(epochsChangedKeys, func(i, j int) bool {
+		return epochsChangedKeys[i] < epochsChangedKeys[j]
+	})
+
+	for _, i := range epochsChangedKeys {
+		newFaults := epochsChanged[i]
+
 		if empty, err := newFaults.IsEmpty(); err != nil {
 			return err
 		} else if empty {

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -8,15 +8,6 @@ import (
 	builtin "github.com/filecoin-project/specs-actors/actors/builtin"
 )
 
-// The period over which all a miner's active sectors will be challenged.
-const WPoStProvingPeriod = abi.ChainEpoch(builtin.EpochsInDay) // 24 hours
-
-// The duration of a deadline's challenge window, the period before a deadline when the challenge is available.
-const WPoStChallengeWindow = abi.ChainEpoch(40 * 60 / builtin.EpochDurationSeconds) // 40 minutes (36 per day)
-
-// The number of non-overlapping PoSt deadlines in each proving period.
-const WPoStPeriodDeadlines = uint64(WPoStProvingPeriod / WPoStChallengeWindow)
-
 func init() {
 	// Check that the challenge windows divide the proving period evenly.
 	if WPoStProvingPeriod%WPoStChallengeWindow != 0 {
@@ -80,9 +71,6 @@ const WPoStChallengeLookback = abi.ChainEpoch(20) // PARAM_FINISH
 // A fault declaration may appear in the challenge epoch, since it must have been posted before the
 // epoch completed, and hence before the challenge was knowable.
 const FaultDeclarationCutoff = WPoStChallengeLookback // PARAM_FINISH
-
-// The maximum age of a fault before the sector is terminated.
-const FaultMaxAge = WPoStProvingPeriod*14 - 1
 
 // Staging period for a miner worker key change.
 const WorkerKeyChangeDelay = 2 * ElectionLookback // PARAM_FINISH

--- a/actors/builtin/miner/policy_params.go
+++ b/actors/builtin/miner/policy_params.go
@@ -1,0 +1,20 @@
+// +build !testground
+
+package miner
+
+import (
+	abi "github.com/filecoin-project/specs-actors/actors/abi"
+	builtin "github.com/filecoin-project/specs-actors/actors/builtin"
+)
+
+// The period over which all a miner's active sectors will be challenged.
+const WPoStProvingPeriod = abi.ChainEpoch(builtin.EpochsInDay) // 24 hours
+
+// The duration of a deadline's challenge window, the period before a deadline when the challenge is available.
+const WPoStChallengeWindow = abi.ChainEpoch(40 * 60 / builtin.EpochDurationSeconds) // 40 minutes (36 per day)
+
+// The number of non-overlapping PoSt deadlines in each proving period.
+const WPoStPeriodDeadlines = uint64(WPoStProvingPeriod / WPoStChallengeWindow)
+
+// The maximum age of a fault before the sector is terminated.
+const FaultMaxAge = WPoStProvingPeriod*14 - 1

--- a/actors/builtin/miner/policy_params_testground.go
+++ b/actors/builtin/miner/policy_params_testground.go
@@ -1,0 +1,19 @@
+// +build testground
+
+package miner
+
+import (
+	abi "github.com/filecoin-project/specs-actors/actors/abi"
+)
+
+// The period over which all a miner's active sectors will be challenged.
+const WPoStProvingPeriod = abi.ChainEpoch(360) // proving period set to 360 epochs ~ 6min. instead of 24 hours (assuming block time delay of 1sec.)
+
+// The duration of a deadline's challenge window, the period before a deadline when the challenge is available.
+const WPoStChallengeWindow = abi.ChainEpoch(10) // challenge window set to 10 epochs ~ 10sec. instead of 40 minutes (assuming block time delay of 1sec.)
+
+// The number of non-overlapping PoSt deadlines in each proving period.
+const WPoStPeriodDeadlines = uint64(WPoStProvingPeriod / WPoStChallengeWindow) // Again 36 non-overlapping windows, same as production.
+
+// The maximum age of a fault before the sector is terminated.
+const FaultMaxAge = WPoStProvingPeriod*14 - 1

--- a/actors/runtime/runtime.go
+++ b/actors/runtime/runtime.go
@@ -87,6 +87,13 @@ type Runtime interface {
 
 	// Starts a new tracing span. The span must be End()ed explicitly, typically with a deferred invocation.
 	StartSpan(name string) TraceSpan
+
+	// ChargeGas charges specified amount of `gas` for execution.
+	// `name` provides information about gas charging point
+	// `virtual` sets virtual amount of gas to charge, this amount is not counted
+	// toward execution cost. This functionality is used for observing global changes
+	// in total gas charged if amount of gas charged was to be changed.
+	ChargeGas(name string, gas int64, virtual int64)
 }
 
 // Store defines the storage module exposed to actors.

--- a/support/mock/mockrt.go
+++ b/support/mock/mockrt.go
@@ -803,6 +803,8 @@ func (rt *Runtime) TotalFilCircSupply() abi.TokenAmount {
 	panic("todo crypto econ")
 }
 
+func (rt *Runtime) ChargeGas(_ string, _, _ int64) {}
+
 type ReturnWrapper struct {
 	V runtime.CBORMarshaler
 }


### PR DESCRIPTION
An attempt to reduce the various periods in `specs-actors`, so that we can test various behaviours in Project Oni, without having to wait for thousands of epochs.

There has been some success when reducing the `WPoStProvingPeriod` to 360 and `WPoStChallengeWindow` to 10, but it is not yet clear if this introduces other issues.

In the future we will probably also want to reduce `FaultMaxAge`

---

I also considered changing `const`s to `var`s, but this is not possible, since we allocate arrays with const sizes. I am not aware of any other way to change these, but to introduce build flags, similar to what we already did on Lotus side (for example https://github.com/filecoin-project/lotus/blob/master/build/params_testground.go)

---

Related: https://github.com/filecoin-project/oni/issues/12

cc @raulk 