### PR TITLE
Small Network Power Accounting

### DIFF
--- a/actors/builtin/cron/cbor_gen.go
+++ b/actors/builtin/cron/cbor_gen.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 
-	abi "github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/specs-actors/actors/abi"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	xerrors "golang.org/x/xerrors"
 )

--- a/actors/builtin/market/cbor_gen.go
+++ b/actors/builtin/market/cbor_gen.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 
-	abi "github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/specs-actors/actors/abi"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	xerrors "golang.org/x/xerrors"
 )

--- a/actors/builtin/power/cbor_gen.go
+++ b/actors/builtin/power/cbor_gen.go
@@ -18,7 +18,7 @@ func (t *State) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{137}); err != nil {
+	if _, err := w.Write([]byte{139}); err != nil {
 		return err
 	}
 
@@ -27,8 +27,18 @@ func (t *State) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
+	// t.TotalRawBytePowerNoMin (big.Int) (struct)
+	if err := t.TotalRawBytePowerNoMin.MarshalCBOR(w); err != nil {
+		return err
+	}
+
 	// t.TotalQualityAdjPower (big.Int) (struct)
 	if err := t.TotalQualityAdjPower.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.TotalQualityAdjPowerNoMin (big.Int) (struct)
+	if err := t.TotalQualityAdjPowerNoMin.MarshalCBOR(w); err != nil {
 		return err
 	}
 
@@ -108,7 +118,7 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 9 {
+	if extra != 11 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -121,12 +131,30 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 		}
 
 	}
+	// t.TotalRawBytePowerNoMin (big.Int) (struct)
+
+	{
+
+		if err := t.TotalRawBytePowerNoMin.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.TotalRawBytePowerNoMin: %w", err)
+		}
+
+	}
 	// t.TotalQualityAdjPower (big.Int) (struct)
 
 	{
 
 		if err := t.TotalQualityAdjPower.UnmarshalCBOR(br); err != nil {
 			return xerrors.Errorf("unmarshaling t.TotalQualityAdjPower: %w", err)
+		}
+
+	}
+	// t.TotalQualityAdjPowerNoMin (big.Int) (struct)
+
+	{
+
+		if err := t.TotalQualityAdjPowerNoMin.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.TotalQualityAdjPowerNoMin: %w", err)
 		}
 
 	}

--- a/actors/builtin/power/cbor_gen.go
+++ b/actors/builtin/power/cbor_gen.go
@@ -27,8 +27,8 @@ func (t *State) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.TotalRawBytePowerNoMin (big.Int) (struct)
-	if err := t.TotalRawBytePowerNoMin.MarshalCBOR(w); err != nil {
+	// t.TotalBytesCommitted (big.Int) (struct)
+	if err := t.TotalBytesCommitted.MarshalCBOR(w); err != nil {
 		return err
 	}
 
@@ -37,8 +37,8 @@ func (t *State) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.TotalQualityAdjPowerNoMin (big.Int) (struct)
-	if err := t.TotalQualityAdjPowerNoMin.MarshalCBOR(w); err != nil {
+	// t.TotalQABytesCommitted (big.Int) (struct)
+	if err := t.TotalQABytesCommitted.MarshalCBOR(w); err != nil {
 		return err
 	}
 
@@ -81,13 +81,13 @@ func (t *State) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("failed to write cid field t.Claims: %w", err)
 	}
 
-	// t.NumMinersMeetingMinPower (int64) (int64)
-	if t.NumMinersMeetingMinPower >= 0 {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.NumMinersMeetingMinPower))); err != nil {
+	// t.MinerAboveMinPowerCount (int64) (int64)
+	if t.MinerAboveMinPowerCount >= 0 {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.MinerAboveMinPowerCount))); err != nil {
 			return err
 		}
 	} else {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.NumMinersMeetingMinPower)-1)); err != nil {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.MinerAboveMinPowerCount)-1)); err != nil {
 			return err
 		}
 	}
@@ -131,12 +131,12 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 		}
 
 	}
-	// t.TotalRawBytePowerNoMin (big.Int) (struct)
+	// t.TotalBytesCommitted (big.Int) (struct)
 
 	{
 
-		if err := t.TotalRawBytePowerNoMin.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.TotalRawBytePowerNoMin: %w", err)
+		if err := t.TotalBytesCommitted.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.TotalBytesCommitted: %w", err)
 		}
 
 	}
@@ -149,12 +149,12 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 		}
 
 	}
-	// t.TotalQualityAdjPowerNoMin (big.Int) (struct)
+	// t.TotalQABytesCommitted (big.Int) (struct)
 
 	{
 
-		if err := t.TotalQualityAdjPowerNoMin.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.TotalQualityAdjPowerNoMin: %w", err)
+		if err := t.TotalQABytesCommitted.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.TotalQABytesCommitted: %w", err)
 		}
 
 	}
@@ -241,7 +241,7 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 		t.Claims = c
 
 	}
-	// t.NumMinersMeetingMinPower (int64) (int64)
+	// t.MinerAboveMinPowerCount (int64) (int64)
 	{
 		maj, extra, err := cbg.CborReadHeader(br)
 		var extraI int64
@@ -264,7 +264,7 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 			return fmt.Errorf("wrong type for int64 field: %d", maj)
 		}
 
-		t.NumMinersMeetingMinPower = int64(extraI)
+		t.MinerAboveMinPowerCount = int64(extraI)
 	}
 	// t.ProofValidationBatch (cid.Cid) (struct)
 

--- a/actors/builtin/power/power_actor.go
+++ b/actors/builtin/power/power_actor.go
@@ -479,13 +479,16 @@ func (a Actor) processDeferredCronEvents(rt Runtime) error {
 
 func (a Actor) deleteMinerActor(rt Runtime, miner addr.Address) error {
 	var st State
-	err := rt.State().Transaction(&st, func() interface{} {
-		if err := st.deleteClaim(adt.AsStore(rt), miner); err != nil {
-			return errors.Wrapf(err, "failed to delete %v from claimed power table", miner)
+	var err error
+	rt.State().Transaction(&st, func() interface{} {
+		err = st.deleteClaim(adt.AsStore(rt), miner)
+		if err != nil {
+			err = errors.Wrapf(err, "failed to delete %v from claimed power table", miner)
+			return nil
 		}
 
 		st.MinerCount -= 1
 		return nil
-	}).(error)
+	})
 	return err
 }

--- a/actors/builtin/power/power_actor.go
+++ b/actors/builtin/power/power_actor.go
@@ -303,16 +303,11 @@ func (a Actor) CurrentTotalPower(rt Runtime, _ *adt.EmptyValue) *CurrentTotalPow
 	rt.ValidateImmediateCallerAcceptAny()
 	var st State
 	rt.State().Readonly(&st)
-	if st.NumMinersMeetingMinPower < ConsensusMinerMinMiners {
-		return &CurrentTotalPowerReturn{
-			RawBytePower:     st.TotalRawBytePowerNoMin,
-			QualityAdjPower:  st.TotalQualityAdjPowerNoMin,
-			PledgeCollateral: st.TotalPledgeCollateral,
-		}
-	}
+
+	rawBytePower, qaPower := CurrentTotalPower(&st)
 	return &CurrentTotalPowerReturn{
-		RawBytePower:     st.TotalRawBytePower,
-		QualityAdjPower:  st.TotalQualityAdjPower,
+		RawBytePower:     rawBytePower,
+		QualityAdjPower:  qaPower,
 		PledgeCollateral: st.TotalPledgeCollateral,
 	}
 }

--- a/actors/builtin/power/power_state.go
+++ b/actors/builtin/power/power_state.go
@@ -15,10 +15,12 @@ import (
 )
 
 type State struct {
-	TotalRawBytePower     abi.StoragePower
-	TotalQualityAdjPower  abi.StoragePower
-	TotalPledgeCollateral abi.TokenAmount
-	MinerCount            int64
+	TotalRawBytePower         abi.StoragePower
+	TotalRawBytePowerNoMin    abi.StoragePower
+	TotalQualityAdjPower      abi.StoragePower
+	TotalQualityAdjPowerNoMin abi.StoragePower
+	TotalPledgeCollateral     abi.TokenAmount
+	MinerCount                int64
 
 	// A queue of events to be triggered by cron, indexed by epoch.
 	CronEventQueue cid.Cid // Multimap, (HAMT[ChainEpoch]AMT[CronEvent]
@@ -52,13 +54,15 @@ type AddrKey = adt.AddrKey
 
 func ConstructState(emptyMapCid, emptyMMapCid cid.Cid) *State {
 	return &State{
-		TotalRawBytePower:        abi.NewStoragePower(0),
-		TotalQualityAdjPower:     abi.NewStoragePower(0),
-		TotalPledgeCollateral:    abi.NewTokenAmount(0),
-		LastEpochTick:            -1,
-		CronEventQueue:           emptyMapCid,
-		Claims:                   emptyMapCid,
-		NumMinersMeetingMinPower: 0,
+		TotalRawBytePower:         abi.NewStoragePower(0),
+		TotalRawBytePowerNoMin:    abi.NewStoragePower(0),
+		TotalQualityAdjPower:      abi.NewStoragePower(0),
+		TotalQualityAdjPowerNoMin: abi.NewStoragePower(0),
+		TotalPledgeCollateral:     abi.NewTokenAmount(0),
+		LastEpochTick:             -1,
+		CronEventQueue:            emptyMapCid,
+		Claims:                    emptyMapCid,
+		NumMinersMeetingMinPower:  0,
 	}
 }
 
@@ -145,6 +149,10 @@ func (st *State) AddToClaim(s adt.Store, miner addr.Address, power abi.StoragePo
 		st.TotalQualityAdjPower = big.Add(st.TotalQualityAdjPower, qapower)
 		st.TotalRawBytePower = big.Add(st.TotalRawBytePower, power)
 	}
+
+	// NoMin powers always update directly
+	st.TotalQualityAdjPowerNoMin = big.Add(st.TotalQualityAdjPowerNoMin, qapower)
+	st.TotalRawBytePowerNoMin = big.Add(st.TotalRawBytePowerNoMin, power)
 
 	AssertMsg(newClaim.RawBytePower.GreaterThanEqual(big.Zero()), "negative claimed raw byte power: %v", newClaim.RawBytePower)
 	AssertMsg(newClaim.QualityAdjPower.GreaterThanEqual(big.Zero()), "negative claimed quality adjusted power: %v", newClaim.QualityAdjPower)

--- a/actors/builtin/power/power_test.go
+++ b/actors/builtin/power/power_test.go
@@ -171,20 +171,21 @@ func TestPowerAndPledgeAccounting(t *testing.T) {
 		actor.expectTotalPower(rt, expectedTotalBelow, mul(expectedTotalBelow, 2))
 
 		// Above threshold (power.ConsensusMinerMinMiners = 3) small miner power is ignored
-		actor.updateClaimedPower(rt, miner3, powerUnit, mul(powerUnit, 2))
-		expectedTotalAbove := big.Sum(smallPowerUnit, mul(powerUnit, 3))
+		delta := big.Sub(powerUnit, smallPowerUnit)
+		actor.updateClaimedPower(rt, miner3, delta, mul(delta, 2))
+		expectedTotalAbove := mul(powerUnit, 3)
 		actor.expectTotalPower(rt, expectedTotalAbove, mul(expectedTotalAbove, 2))
 
 		st := getState(rt)
 		assert.Equal(t, int64(3), st.NumMinersMeetingMinPower)
 
-		// Less than 3 miners below threshold again small miner power is counted again
-		negPowerUnit := powerUnit.Neg()
-		actor.updateClaimedPower(rt, miner3, negPowerUnit, mul(negPowerUnit, 2))
+		// Less than 3 miners above threshold again small miner power is counted again
+	
+		actor.updateClaimedPower(rt, miner3, delta.Neg(), mul(delta.Neg(), 2))
 		actor.expectTotalPower(rt, expectedTotalBelow, mul(expectedTotalBelow, 2))
 	})
 
-	t.Run("all miner power dissapears when miner dips below min power threshold", func(t *testing.T) {
+	t.Run("all of one miner's power dissapears when that miner dips below min power threshold", func(t *testing.T) {
 		// Setup four miners above threshold
 		rt := builder.Build(t)
 		actor.constructAndVerify(rt)
@@ -230,7 +231,7 @@ func TestPowerAndPledgeAccounting(t *testing.T) {
 		assert.Equal(t, int64(3), st.NumMinersMeetingMinPower)
 	})
 
-	t.Run("slashing miner below minimum does not impact power", func(t *testing.T) {
+	t.Run("slashing miner that is already below minimum does not impact power", func(t *testing.T) {
 		rt := builder.Build(t)
 		actor.constructAndVerify(rt)
 

--- a/actors/builtin/power/power_test.go
+++ b/actors/builtin/power/power_test.go
@@ -74,26 +74,27 @@ func TestPowerAndPledgeAccounting(t *testing.T) {
 	miner1 := tutil.NewIDAddr(t, 111)
 	miner2 := tutil.NewIDAddr(t, 112)
 	miner3 := tutil.NewIDAddr(t, 113)
+	miner4 := tutil.NewIDAddr(t, 114)
+	miner5 := tutil.NewIDAddr(t, 115)
 
 	// These tests use the min power for consensus to check the accounting above and below that value.
 	powerUnit := power.ConsensusMinerMinPower
 	mul := func(a big.Int, b int64) big.Int {
 		return big.Mul(a, big.NewInt(b))
 	}
+	smallPowerUnit := big.NewInt(1_000_000)
+	require.True(t, smallPowerUnit.LessThan(powerUnit), "power.CosensusMinerMinPower has changed requiring update to this test")
 
 	builder := mock.NewBuilder(context.Background(), builtin.StoragePowerActorAddr).
 		WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
 
 	t.Run("power & pledge accounted below threshold", func(t *testing.T) {
-		smallPowerUnit := big.NewInt(1_000_000)
-		require.True(t, smallPowerUnit.LessThan(powerUnit), "power.CosensusMinerMinPower has changed requiring update to this test")
 
 		rt := builder.Build(t)
 		actor.constructAndVerify(rt)
 
 		actor.createMinerBasic(rt, owner, owner, miner1)
 		actor.createMinerBasic(rt, owner, owner, miner2)
-		actor.createMinerBasic(rt, owner, owner, miner3)
 
 		ret := actor.currentPowerTotal(rt)
 		assert.Equal(t, big.Zero(), ret.RawBytePower)
@@ -148,7 +149,112 @@ func TestPowerAndPledgeAccounting(t *testing.T) {
 		require.Equal(t, big.Zero(), claim2.QualityAdjPower)
 	})
 
-	t.Run("power accounting below miner minimums", func(t *testing.T) {
+	t.Run("power accounting crossing threshold", func(t *testing.T) {
+		rt := builder.Build(t)
+		actor.constructAndVerify(rt)
+
+		actor.createMinerBasic(rt, owner, owner, miner1)
+		actor.createMinerBasic(rt, owner, owner, miner2)
+		actor.createMinerBasic(rt, owner, owner, miner3)		
+		actor.createMinerBasic(rt, owner, owner, miner4)				
+		actor.createMinerBasic(rt, owner, owner, miner5)
+
+		actor.updateClaimedPower(rt, miner1, smallPowerUnit, mul(smallPowerUnit, 2))
+		actor.updateClaimedPower(rt, miner2, smallPowerUnit, mul(smallPowerUnit, 2))		
+		actor.updateClaimedPower(rt, miner3, smallPowerUnit, mul(smallPowerUnit, 2))				
+
+		actor.updateClaimedPower(rt, miner4, powerUnit, mul(powerUnit, 2))
+		actor.updateClaimedPower(rt, miner5, powerUnit, mul(powerUnit, 2))		
+
+		// Below threshold small miner power is counted
+		expectedTotalBelow := big.Sum(mul(smallPowerUnit, 3), mul(powerUnit, 2))
+		actor.expectTotalPower(rt, expectedTotalBelow, mul(expectedTotalBelow, 2))
+
+		// Above threshold (power.ConsensusMinerMinMiners = 3) small miner power is ignored
+		actor.updateClaimedPower(rt, miner3, powerUnit, mul(powerUnit, 2))
+		expectedTotalAbove := big.Sum(smallPowerUnit, mul(powerUnit, 3))
+		actor.expectTotalPower(rt, expectedTotalAbove, mul(expectedTotalAbove, 2))
+
+		st := getState(rt)
+		assert.Equal(t, int64(3), st.NumMinersMeetingMinPower)
+
+		// Less than 3 miners below threshold again small miner power is counted again
+		negPowerUnit := powerUnit.Neg()
+		actor.updateClaimedPower(rt, miner3, negPowerUnit, mul(negPowerUnit, 2))
+		actor.expectTotalPower(rt, expectedTotalBelow, mul(expectedTotalBelow, 2))
+	})
+
+	t.Run("all miner power dissapears when miner dips below min power threshold", func(t *testing.T) {
+		// Setup four miners above threshold
+		rt := builder.Build(t)
+		actor.constructAndVerify(rt)
+
+		actor.createMinerBasic(rt, owner, owner, miner1)
+		actor.createMinerBasic(rt, owner, owner, miner2)
+		actor.createMinerBasic(rt, owner, owner, miner3)		
+		actor.createMinerBasic(rt, owner, owner, miner4)				
+
+		actor.updateClaimedPower(rt, miner1, powerUnit, powerUnit)
+		actor.updateClaimedPower(rt, miner2, powerUnit, powerUnit)
+		actor.updateClaimedPower(rt, miner3, powerUnit, powerUnit)
+		actor.updateClaimedPower(rt, miner4, powerUnit, powerUnit)
+
+		expectedTotal := mul(powerUnit, 4)
+		actor.expectTotalPower(rt, expectedTotal, expectedTotal)
+
+		// miner4 dips just below threshold
+		actor.updateClaimedPower(rt, miner4, smallPowerUnit.Neg(), smallPowerUnit.Neg())
+
+		expectedTotal = mul(powerUnit, 3)
+		actor.expectTotalPower(rt, expectedTotal, expectedTotal)
+	})
+
+	t.Run("threshold only depends on qa power, not raw byte", func(t *testing.T) {
+		rt := builder.Build(t)
+		actor.constructAndVerify(rt)
+
+		actor.createMinerBasic(rt, owner, owner, miner1)
+		actor.createMinerBasic(rt, owner, owner, miner2)
+		actor.createMinerBasic(rt, owner, owner, miner3)		
+
+		actor.updateClaimedPower(rt, miner1, powerUnit, big.Zero())
+		actor.updateClaimedPower(rt, miner2, powerUnit, big.Zero())
+		actor.updateClaimedPower(rt, miner3, powerUnit, big.Zero())
+		st := getState(rt)
+		assert.Equal(t, int64(0), st.NumMinersMeetingMinPower)
+
+		actor.updateClaimedPower(rt, miner1, big.Zero(), powerUnit)
+		actor.updateClaimedPower(rt, miner2, big.Zero(), powerUnit)
+		actor.updateClaimedPower(rt, miner3, big.Zero(), powerUnit)
+		st = getState(rt)
+		assert.Equal(t, int64(3), st.NumMinersMeetingMinPower)
+	})
+
+	t.Run("slashing miner below minimum does not impact power", func(t *testing.T) {
+		rt := builder.Build(t)
+		actor.constructAndVerify(rt)
+
+		actor.createMinerBasic(rt, owner, owner, miner1)
+		actor.createMinerBasic(rt, owner, owner, miner2)
+		actor.createMinerBasic(rt, owner, owner, miner3)	
+
+		actor.updateClaimedPower(rt, miner1, powerUnit, powerUnit)
+		actor.updateClaimedPower(rt, miner2, powerUnit, powerUnit)
+		actor.updateClaimedPower(rt, miner3, powerUnit, powerUnit)
+
+		// create small miner
+		actor.createMinerBasic(rt, owner, owner, miner4)
+
+		actor.updateClaimedPower(rt, miner4, smallPowerUnit, smallPowerUnit)
+
+		actor.expectTotalPower(rt, mul(powerUnit, 3), mul(powerUnit, 3))
+
+		// fault small miner
+		zeroPledge := abi.NewTokenAmount(0)
+		actor.onConsensusFault(rt, miner4, &zeroPledge)
+
+		// power unchanged
+		actor.expectTotalPower(rt, mul(powerUnit, 3), mul(powerUnit, 3))
 
 	})
 }
@@ -371,6 +477,26 @@ func (h *spActorHarness) enrollCronEvent(rt *mock.Runtime, miner addr.Address, e
 	rt.Verify()
 }
 
+func (h *spActorHarness) onConsensusFault(rt *mock.Runtime, minerAddr addr.Address, pledgeAmount *abi.TokenAmount) {
+	rt.ExpectValidateCallerType(builtin.StorageMinerActorCodeID)
+	rt.SetCaller(minerAddr, builtin.StorageMinerActorCodeID)
+	rt.Call(h.Actor.OnConsensusFault, pledgeAmount)
+	rt.Verify()
+
+	// verify that miner claim is erased from state
+	st := getState(rt)
+	_, found, err := st.GetClaim(rt.AdtStore(), minerAddr)
+	require.NoError(h.t, err)
+	require.False(h.t, found)
+}
+
+
+func (h *spActorHarness) expectTotalPower(rt *mock.Runtime, expectedRaw, expectedQA abi.StoragePower) {
+	ret := h.currentPowerTotal(rt)
+	assert.Equal(h.t, expectedRaw, ret.RawBytePower)
+	assert.Equal(h.t, expectedQA, ret.QualityAdjPower)
+}
+
 func initCreateMinerBytes(t testing.TB, owner, worker addr.Address, peer abi.PeerID, multiaddrs []abi.Multiaddrs, sealProofType abi.RegisteredSealProof) []byte {
 	params := &power.MinerConstructorParams{
 		OwnerAddr:     owner,
@@ -387,4 +513,10 @@ func initCreateMinerBytes(t testing.TB, owner, worker addr.Address, peer abi.Pee
 
 func (s key) Key() string {
 	return string(s)
+}
+
+func getState(rt *mock.Runtime) *power.State {
+	var st power.State
+	rt.GetState(&st)
+	return &st
 }


### PR DESCRIPTION
Closes #266 
Closes #565 

This makes total power accounting work for small networks where no miner has the minimum needed consensus power.  It also makes `OnConsensusFault` do its power changes through `AddClaim` removing the accounting error from #565.  

The approach is very simple.  It wasn't 100% clear if this simple approach meets the issue requirements, so I want feedback on this high level plan.  We keep two more top level state counters in the power actor for the sum of all qa and raw claim power.  We then modify the `CurrentTotalPower` call to check whether the total number of miners above the minimum power is above some threshold (set to 3 before this pr).  If it's above we do things as before ignoring all claims from miners below the minimum threshold.  If its below we use the total sum of claims.  

Some more things to note:
1. I have done nothing to change how we determine if a miner "meets the consensus minimum".  We still just compare QA power to some constant.  This means `minerNominalPowerMeetsConsensusMinimum` is still deadcode.  I need help understanding what we are trying to do if this work should somehow use that notion of minimum; it doesn't seem easily compatible with the issue description or what I've done here.
2. The existing solution has some weird quirks.  For example the total network power can go down if storage goes up.  Maybe we should brief cryptoecon / redteam on these changes?
3. Unrelatedly testing power updates during `OnConsensusFault` found a bug where the method panics by default which this PR should fix.