### PR TITLE
Market: Bug fixes in deal timeouts, deal deletion, payment transfers and slashing

### DIFF
--- a/actors/builtin/market/market_actor.go
+++ b/actors/builtin/market/market_actor.go
@@ -534,20 +534,6 @@ func (a Actor) CronTick(rt Runtime, params *adt.EmptyValue) *adt.EmptyValue {
 					rt.Abortf(exitcode.ErrIllegalState, "failed to delete pending proposal: %v", err)
 				}
 
-				if state.SectorStartEpoch == epochUndefined {
-					// Not yet appeared in proven sector; check for timeout.
-					AssertMsg(rt.CurrEpoch() >= deal.StartEpoch, "if sector start is not set, we must be in a timed out state")
-
-					slashed := st.processDealInitTimedOut(rt, et, lt, dealID, deal, state)
-					if !slashed.IsZero() {
-						amountSlashed = big.Add(amountSlashed, slashed)
-					}
-					if deal.VerifiedDeal {
-						timedOutVerifiedDeals = append(timedOutVerifiedDeals, deal)
-					}
-					return nil
-				}
-
 				slashAmount, nextEpoch := st.updatePendingDealState(rt, state, deal, dealID, et, lt, rt.CurrEpoch())
 				if !slashAmount.IsZero() {
 					amountSlashed = big.Add(amountSlashed, slashAmount)

--- a/actors/builtin/market/market_state.go
+++ b/actors/builtin/market/market_state.go
@@ -117,7 +117,10 @@ func (st *State) updatePendingDealState(rt Runtime, state *DealState, deal *Deal
 		// Process deal payment for the elapsed epochs.
 		totalPayment := big.Mul(big.NewInt(int64(numEpochsElapsed)), deal.StoragePricePerEpoch)
 
-		st.transferBalance(rt, deal.Client, deal.Provider, totalPayment, et, lt)
+		// the transfer amount can be less than or equal to zero if a deal is slashed before or at the deal's start epoch.
+		if totalPayment.GreaterThan(big.Zero()) {
+			st.transferBalance(rt, deal.Client, deal.Provider, totalPayment, et, lt)
+		}
 	}
 
 	if everSlashed {

--- a/actors/builtin/market/market_state.go
+++ b/actors/builtin/market/market_state.go
@@ -83,9 +83,9 @@ func ConstructState(emptyArrayCid, emptyMapCid, emptyMSetCid cid.Cid) *State {
 // Deal state operations
 ////////////////////////////////////////////////////////////////////////////////
 
-func (st *State) updatePendingDealState(rt Runtime, state *DealState, deal *DealProposal, dealID abi.DealID, et, lt *adt.BalanceTable, epoch abi.ChainEpoch) (abi.TokenAmount,
-	abi.ChainEpoch, bool) {
-	amountSlashed := abi.NewTokenAmount(0)
+func (st *State) updatePendingDealState(rt Runtime, state *DealState, deal *DealProposal, dealID abi.DealID, et, lt *adt.BalanceTable, epoch abi.ChainEpoch) (amountSlashed abi.TokenAmount,
+	nextEpoch abi.ChainEpoch, removeDeal bool) {
+	amountSlashed = abi.NewTokenAmount(0)
 
 	everUpdated := state.LastUpdatedEpoch != epochUndefined
 	everSlashed := state.SlashEpoch != epochUndefined
@@ -151,12 +151,12 @@ func (st *State) updatePendingDealState(rt Runtime, state *DealState, deal *Deal
 		return amountSlashed, epochUndefined, true
 	}
 
-	next := epoch + DealUpdatesInterval
-	if next > deal.EndEpoch {
-		next = deal.EndEpoch
+	nextEpoch = epoch + DealUpdatesInterval
+	if nextEpoch > deal.EndEpoch {
+		nextEpoch = deal.EndEpoch
 	}
 
-	return amountSlashed, next, false
+	return amountSlashed, nextEpoch, false
 }
 
 // Deal start deadline elapsed without appearing in a proven sector.

--- a/actors/builtin/market/market_state.go
+++ b/actors/builtin/market/market_state.go
@@ -211,9 +211,7 @@ func (st *State) deleteDeal(rt Runtime, dealID abi.DealID) {
 // Deal start deadline elapsed without appearing in a proven sector.
 // Delete deal, slash a portion of provider's collateral, and unlock remaining collaterals
 // for both provider and client.
-func (st *State) processDealInitTimedOut(rt Runtime, et, lt *adt.BalanceTable, dealID abi.DealID, deal *DealProposal, state *DealState) abi.TokenAmount {
-	Assert(state.SectorStartEpoch == epochUndefined)
-
+func (st *State) processDealInitTimedOut(rt Runtime, et, lt *adt.BalanceTable, dealID abi.DealID, deal *DealProposal) abi.TokenAmount {
 	if err := st.unlockBalance(lt, deal.Client, deal.TotalStorageFee(), ClientStorageFee); err != nil {
 		rt.Abortf(exitcode.ErrIllegalState, "failure unlocking client storage fee: %s", err)
 	}

--- a/actors/builtin/market/market_state.go
+++ b/actors/builtin/market/market_state.go
@@ -393,10 +393,15 @@ func dealProposalIsInternallyValid(rt Runtime, proposal ClientDealProposal) erro
 	return nil
 }
 
-func dealGetPaymentRemaining(deal *DealProposal, epoch abi.ChainEpoch) abi.TokenAmount {
-	Assert(epoch <= deal.EndEpoch)
+func dealGetPaymentRemaining(deal *DealProposal, slashEpoch abi.ChainEpoch) abi.TokenAmount {
+	Assert(slashEpoch <= deal.EndEpoch)
 
-	durationRemaining := deal.EndEpoch - epoch
+	// Payments are always for start -> end epoch irrespective of when the deal is slashed.
+	if slashEpoch < deal.StartEpoch {
+		slashEpoch = deal.StartEpoch
+	}
+
+	durationRemaining := deal.EndEpoch - slashEpoch
 	Assert(durationRemaining > 0)
 
 	return big.Mul(big.NewInt(int64(durationRemaining)), deal.StoragePricePerEpoch)

--- a/actors/builtin/market/market_state.go
+++ b/actors/builtin/market/market_state.go
@@ -396,7 +396,7 @@ func dealProposalIsInternallyValid(rt Runtime, proposal ClientDealProposal) erro
 func dealGetPaymentRemaining(deal *DealProposal, epoch abi.ChainEpoch) abi.TokenAmount {
 	Assert(epoch <= deal.EndEpoch)
 
-	durationRemaining := deal.EndEpoch - (epoch - 1)
+	durationRemaining := deal.EndEpoch - epoch
 	Assert(durationRemaining > 0)
 
 	return big.Mul(big.NewInt(int64(durationRemaining)), deal.StoragePricePerEpoch)

--- a/actors/builtin/market/market_state.go
+++ b/actors/builtin/market/market_state.go
@@ -100,7 +100,8 @@ func (st *State) updatePendingDealState(rt Runtime, state *DealState, deal *Deal
 
 	paymentEndEpoch := deal.EndEpoch
 	if everSlashed {
-		Assert(state.SlashEpoch <= paymentEndEpoch)
+		Assert(epoch >= state.SlashEpoch)
+		Assert(state.SlashEpoch <= deal.EndEpoch)
 		paymentEndEpoch = state.SlashEpoch
 	} else if epoch < paymentEndEpoch {
 		paymentEndEpoch = epoch

--- a/actors/builtin/market/market_state.go
+++ b/actors/builtin/market/market_state.go
@@ -98,23 +98,20 @@ func (st *State) updatePendingDealState(rt Runtime, state *DealState, deal *Deal
 		return amountSlashed, epochUndefined, false
 	}
 
-	dealEnd := deal.EndEpoch
+	paymentEndEpoch := deal.EndEpoch
 	if everSlashed {
-		Assert(state.SlashEpoch <= dealEnd)
-		dealEnd = state.SlashEpoch
+		Assert(state.SlashEpoch <= paymentEndEpoch)
+		paymentEndEpoch = state.SlashEpoch
+	} else if epoch < paymentEndEpoch {
+		paymentEndEpoch = epoch
 	}
 
-	elapsedStart := deal.StartEpoch
-	if everUpdated && state.LastUpdatedEpoch > elapsedStart {
-		elapsedStart = state.LastUpdatedEpoch
+	paymentStartEpoch := deal.StartEpoch
+	if everUpdated && state.LastUpdatedEpoch > paymentStartEpoch {
+		paymentStartEpoch = state.LastUpdatedEpoch
 	}
 
-	elapsedEnd := dealEnd
-	if epoch < elapsedEnd {
-		elapsedEnd = epoch
-	}
-
-	numEpochsElapsed := elapsedEnd - elapsedStart
+	numEpochsElapsed := paymentEndEpoch - paymentStartEpoch
 
 	{
 		// Process deal payment for the elapsed epochs.

--- a/actors/builtin/market/market_state.go
+++ b/actors/builtin/market/market_state.go
@@ -208,34 +208,6 @@ func (st *State) deleteDeal(rt Runtime, dealID abi.DealID) {
 	}
 }
 
-// Deal start deadline elapsed without appearing in a proven sector.
-// Delete deal, slash a portion of provider's collateral, and unlock remaining collaterals
-// for both provider and client.
-func (st *State) processDealInitTimedOut(rt Runtime, et, lt *adt.BalanceTable, dealID abi.DealID, deal *DealProposal, state *DealState) abi.TokenAmount {
-	Assert(state.SectorStartEpoch == epochUndefined)
-
-	if err := st.unlockBalance(lt, deal.Client, deal.TotalStorageFee(), ClientStorageFee); err != nil {
-		rt.Abortf(exitcode.ErrIllegalState, "failure unlocking client storage fee: %s", err)
-	}
-	if err := st.unlockBalance(lt, deal.Client, deal.ClientCollateral, ClientCollateral); err != nil {
-		rt.Abortf(exitcode.ErrIllegalState, "failure unlocking client collateral: %s", err)
-	}
-
-	amountSlashed := collateralPenaltyForDealActivationMissed(deal.ProviderCollateral)
-	amountRemaining := big.Sub(deal.ProviderBalanceRequirement(), amountSlashed)
-
-	if err := st.slashBalance(et, lt, deal.Provider, amountSlashed, ProviderCollateral); err != nil {
-		rt.Abortf(exitcode.ErrIllegalState, "failed to slash balance: %s", err)
-	}
-
-	if err := st.unlockBalance(lt, deal.Provider, amountRemaining, ProviderCollateral); err != nil {
-		rt.Abortf(exitcode.ErrIllegalState, "failed to unlock deal provider balance: %s", err)
-	}
-
-	st.deleteDeal(rt, dealID)
-	return amountSlashed
-}
-
 // Normal expiration. Delete deal and unlock collaterals for both miner and client.
 func (st *State) processDealExpired(rt Runtime, deal *DealProposal, state *DealState, lt *adt.BalanceTable, dealID abi.DealID) {
 	Assert(state.SectorStartEpoch != epochUndefined)

--- a/actors/builtin/market/policy.go
+++ b/actors/builtin/market/policy.go
@@ -28,11 +28,6 @@ func dealClientCollateralBounds(pieceSize abi.PaddedPieceSize, duration abi.Chai
 	return abi.NewTokenAmount(0), abi.TotalFilecoin // PARAM_FINISH
 }
 
-// Penalty to provider deal collateral if the deadline expires before sector commitment.
-func collateralPenaltyForDealActivationMissed(providerCollateral abi.TokenAmount) abi.TokenAmount {
-	return providerCollateral // PARAM_FINISH
-}
-
 // Computes the weight for a deal proposal, which is a function of its size and duration.
 func DealWeight(proposal *DealProposal) abi.DealWeight {
 	dealDuration := big.NewInt(int64(proposal.Duration()))

--- a/actors/builtin/market/policy.go
+++ b/actors/builtin/market/policy.go
@@ -28,6 +28,11 @@ func dealClientCollateralBounds(pieceSize abi.PaddedPieceSize, duration abi.Chai
 	return abi.NewTokenAmount(0), abi.TotalFilecoin // PARAM_FINISH
 }
 
+// Penalty to provider deal collateral if the deadline expires before sector commitment.
+func collateralPenaltyForDealActivationMissed(providerCollateral abi.TokenAmount) abi.TokenAmount {
+	return providerCollateral // PARAM_FINISH
+}
+
 // Computes the weight for a deal proposal, which is a function of its size and duration.
 func DealWeight(proposal *DealProposal) abi.DealWeight {
 	dealDuration := big.NewInt(int64(proposal.Duration()))


### PR DESCRIPTION
Closes #614 
Closes #622 
Closes #623 
Closes #624 .

* We now time out deals if they are scheduled for cron tick but they haven't been activated.
* Delete deal state correctly when deal is deleted.
* Calculate the remaining amount to return to client after slashing correctly.
* Simplify calculation of payment for storage.
* Ensure transfer amount isn't negative.
* A deal can be slashed before it's start epoch.

@whyrusleeping Tests will be in a separate PR I am creating for Cron Tick Tests.