### PR TITLE
unlock termination fees before burning

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -2157,14 +2157,14 @@ func unlockUndeclaredLateFaultPenalty(st *State, store adt.Store, sectorSize abi
 	return st.UnlockUnvestedFunds(store, currEpoch, fee)
 }
 
-func unlockTerminationPenalty(st *State, store adt.Store, sectorSize abi.SectorSize, curEpoch abi.ChainEpoch, epochTargetReward abi.TokenAmount, networkQAPower abi.StoragePower, sectors []*SectorOnChainInfo) (abi.TokenAmount, error) {
+func unlockTerminationPenalty(st *State, store adt.Store, sectorSize abi.SectorSize, currEpoch abi.ChainEpoch, epochTargetReward abi.TokenAmount, networkQAPower abi.StoragePower, sectors []*SectorOnChainInfo) (abi.TokenAmount, error) {
 	totalFee := big.Zero()
 	for _, s := range sectors {
 		sectorPower := QAPowerForSector(sectorSize, s)
-		fee := PledgePenaltyForTermination(s.InitialPledge, curEpoch-s.Activation, epochTargetReward, networkQAPower, sectorPower)
+		fee := PledgePenaltyForTermination(s.InitialPledge, currEpoch-s.Activation, epochTargetReward, networkQAPower, sectorPower)
 		totalFee = big.Add(fee, totalFee)
 	}
-	return totalFee, nil
+	return st.UnlockUnvestedFunds(store, currEpoch, totalFee)
 }
 
 // Returns the sum of the raw byte and quality-adjusted power for sectors.

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -1207,7 +1207,7 @@ func TestTerminateSectors(t *testing.T) {
 		sector := commitSector(t, rt)
 		var initialLockedFunds abi.TokenAmount
 
-		// A miner will path the minimum of termination fee and locked funds. Add some locked funds to ensure
+		// A miner will pay the minimum of termination fee and locked funds. Add some locked funds to ensure
 		// correct fee calculation is used.
 		actor.addLockedFund(rt, big.NewInt(1<<61))
 

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -1207,7 +1207,8 @@ func TestTerminateSectors(t *testing.T) {
 		sector := commitSector(t, rt)
 		var initialLockedFunds abi.TokenAmount
 
-		// simplify math by adding enough locked funds (~1FIL) to fully penalize terminated sectors
+		// A miner will path the minimum of termination fee and locked funds. Add some locked funds to ensure
+		// correct fee calculation is used.
 		actor.addLockedFund(rt, big.NewInt(1<<61))
 
 		{

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -850,7 +850,7 @@ func TestProveCommit(t *testing.T) {
 		actor.proveCommitSectorAndConfirm(rt, precommit, precommitEpoch, makeProveCommit(actor.nextSectorNo), proveCommitConf{})
 	})
 
-	t.Run ("drop invalid prove commit while processing valid one", func (t *testing.T) { 
+	t.Run("drop invalid prove commit while processing valid one", func(t *testing.T) {
 		rt := builder.Build(t)
 		actor.constructAndVerify(rt)
 
@@ -866,15 +866,15 @@ func TestProveCommit(t *testing.T) {
 		actor.preCommitSector(rt, precommitB)
 		sectorNoB := actor.nextSectorNo
 
-		// handle both prove commits in the same epoch 
+		// handle both prove commits in the same epoch
 		info := actor.getInfo(rt)
 		rt.SetEpoch(precommitEpoch + miner.MaxSealDuration[info.SealProofType] - 1)
 
 		actor.proveCommitSector(rt, precommitA, precommitEpoch, makeProveCommit(sectorNoA))
 		actor.proveCommitSector(rt, precommitB, precommitEpoch, makeProveCommit(sectorNoB))
 
-		conf := proveCommitConf {
-			verifyDealsExit: map[abi.SectorNumber]exitcode.ExitCode{ 
+		conf := proveCommitConf{
+			verifyDealsExit: map[abi.SectorNumber]exitcode.ExitCode{
 				sectorNoA: exitcode.ErrIllegalArgument,
 			},
 		}
@@ -1205,6 +1205,10 @@ func TestTerminateSectors(t *testing.T) {
 	t.Run("removes sector with correct accounting", func(t *testing.T) {
 		rt := builder.Build(t)
 		sector := commitSector(t, rt)
+		var initialLockedFunds abi.TokenAmount
+
+		// simplify math by adding enough locked funds (~1FIL) to fully penalize terminated sectors
+		actor.addLockedFund(rt, big.NewInt(1<<61))
 
 		{
 			// Verify that a sector expiration was registered.
@@ -1215,6 +1219,7 @@ func TestTerminateSectors(t *testing.T) {
 			require.NoError(t, err)
 			assert.Len(t, expiringSectorNos, 1)
 			assert.Equal(t, sector.SectorNumber, abi.SectorNumber(expiringSectorNos[0]))
+			initialLockedFunds = st.LockedFunds
 		}
 
 		sectorSize, err := sector.SealProof.SectorSize()
@@ -1241,6 +1246,9 @@ func TestTerminateSectors(t *testing.T) {
 			_, found, err := st.GetSector(rt.AdtStore(), sector.SectorNumber)
 			require.NoError(t, err)
 			assert.False(t, found)
+
+			// expect fee to have been unlocked and burnt
+			assert.Equal(t, big.Sub(initialLockedFunds, expectedFee), st.LockedFunds)
 
 			// expect pledge requirement to have been decremented
 			assert.Equal(t, big.Zero(), st.InitialPledgeRequirement)
@@ -1567,48 +1575,48 @@ type proveCommitConf struct {
 
 func (h *actorHarness) proveCommitSector(rt *mock.Runtime, precommit *miner.SectorPreCommitInfo, precommitEpoch abi.ChainEpoch,
 	params *miner.ProveCommitSectorParams) {
-		commd := cbg.CborCid(tutil.MakeCID("commd"))
-		sealRand := abi.SealRandomness([]byte{1, 2, 3, 4})
-		sealIntRand := abi.InteractiveSealRandomness([]byte{5, 6, 7, 8})
-		interactiveEpoch := precommitEpoch + miner.PreCommitChallengeDelay
-	
-		// Prepare for and receive call to ProveCommitSector
-		{
-			cdcParams := market.ComputeDataCommitmentParams{
-				DealIDs:    precommit.DealIDs,
-				SectorType: precommit.SealProof,
-			}
-			rt.ExpectSend(builtin.StorageMarketActorAddr, builtin.MethodsMarket.ComputeDataCommitment, &cdcParams, big.Zero(), &commd, exitcode.Ok)
+	commd := cbg.CborCid(tutil.MakeCID("commd"))
+	sealRand := abi.SealRandomness([]byte{1, 2, 3, 4})
+	sealIntRand := abi.InteractiveSealRandomness([]byte{5, 6, 7, 8})
+	interactiveEpoch := precommitEpoch + miner.PreCommitChallengeDelay
+
+	// Prepare for and receive call to ProveCommitSector
+	{
+		cdcParams := market.ComputeDataCommitmentParams{
+			DealIDs:    precommit.DealIDs,
+			SectorType: precommit.SealProof,
 		}
-		{
-			var buf bytes.Buffer
-			err := rt.Receiver().MarshalCBOR(&buf)
-			require.NoError(h.t, err)
-			rt.ExpectGetRandomness(crypto.DomainSeparationTag_SealRandomness, precommit.SealRandEpoch, buf.Bytes(), abi.Randomness(sealRand))
-			rt.ExpectGetRandomness(crypto.DomainSeparationTag_InteractiveSealChallengeSeed, interactiveEpoch, buf.Bytes(), abi.Randomness(sealIntRand))
+		rt.ExpectSend(builtin.StorageMarketActorAddr, builtin.MethodsMarket.ComputeDataCommitment, &cdcParams, big.Zero(), &commd, exitcode.Ok)
+	}
+	{
+		var buf bytes.Buffer
+		err := rt.Receiver().MarshalCBOR(&buf)
+		require.NoError(h.t, err)
+		rt.ExpectGetRandomness(crypto.DomainSeparationTag_SealRandomness, precommit.SealRandEpoch, buf.Bytes(), abi.Randomness(sealRand))
+		rt.ExpectGetRandomness(crypto.DomainSeparationTag_InteractiveSealChallengeSeed, interactiveEpoch, buf.Bytes(), abi.Randomness(sealIntRand))
+	}
+	{
+		actorId, err := addr.IDFromAddress(h.receiver)
+		require.NoError(h.t, err)
+		seal := abi.SealVerifyInfo{
+			SectorID: abi.SectorID{
+				Miner:  abi.ActorID(actorId),
+				Number: precommit.SectorNumber,
+			},
+			SealedCID:             precommit.SealedCID,
+			SealProof:             precommit.SealProof,
+			Proof:                 params.Proof,
+			DealIDs:               precommit.DealIDs,
+			Randomness:            sealRand,
+			InteractiveRandomness: sealIntRand,
+			UnsealedCID:           cid.Cid(commd),
 		}
-		{
-			actorId, err := addr.IDFromAddress(h.receiver)
-			require.NoError(h.t, err)
-			seal := abi.SealVerifyInfo{
-				SectorID: abi.SectorID{
-					Miner:  abi.ActorID(actorId),
-					Number: precommit.SectorNumber,
-				},
-				SealedCID:             precommit.SealedCID,
-				SealProof:             precommit.SealProof,
-				Proof:                 params.Proof,
-				DealIDs:               precommit.DealIDs,
-				Randomness:            sealRand,
-				InteractiveRandomness: sealIntRand,
-				UnsealedCID:           cid.Cid(commd),
-			}
-			rt.ExpectSend(builtin.StoragePowerActorAddr, builtin.MethodsPower.SubmitPoRepForBulkVerify, &seal, abi.NewTokenAmount(0), nil, exitcode.Ok)
-		}
-		rt.SetCaller(h.worker, builtin.AccountActorCodeID)
-		rt.ExpectValidateCallerAny()
-		rt.Call(h.a.ProveCommitSector, params)
-		rt.Verify()
+		rt.ExpectSend(builtin.StoragePowerActorAddr, builtin.MethodsPower.SubmitPoRepForBulkVerify, &seal, abi.NewTokenAmount(0), nil, exitcode.Ok)
+	}
+	rt.SetCaller(h.worker, builtin.AccountActorCodeID)
+	rt.ExpectValidateCallerAny()
+	rt.Call(h.a.ProveCommitSector, params)
+	rt.Verify()
 }
 
 func (h *actorHarness) confirmSectorProofsValid(rt *mock.Runtime, conf proveCommitConf, precommitEpoch abi.ChainEpoch, precommits ...*miner.SectorPreCommitInfo) {
@@ -1633,7 +1641,7 @@ func (h *actorHarness) confirmSectorProofsValid(rt *mock.Runtime, conf proveComm
 	// expected pledge is the sum of precommit deposits
 	if len(validPrecommits) > 0 {
 		expectPledge := big.Zero()
-		
+
 		expectQAPower := big.Zero()
 		expectRawPower := big.Zero()
 		for _, precommit := range validPrecommits {

--- a/actors/builtin/power/power_actor.go
+++ b/actors/builtin/power/power_actor.go
@@ -2,7 +2,6 @@ package power
 
 import (
 	"bytes"
-	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-address"
 	addr "github.com/filecoin-project/go-address"

--- a/actors/builtin/power/power_actor.go
+++ b/actors/builtin/power/power_actor.go
@@ -2,6 +2,7 @@ package power
 
 import (
 	"bytes"
+	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-address"
 	addr "github.com/filecoin-project/go-address"


### PR DESCRIPTION
### Motivation

Termination fees are supposed to be paid out of unlocked funds. We have been paying these fees without first unlocking them. This PR unlocks the funds before sending them to the burnt actor.

### Proposed changes

1. Unlock termination fees before burning them
2. Test that we have unlocked the fees.
3. Lint some whitespace issues from a previous commit.

### NOTES:

Since a sector's initial pledge is the undeclared fault fee (SP) and the termination fee is (at max) the late undeclared fault fee (2*SP), there is no guarantee that the miner will have enough locked funds to pay the expected termination fee. In the case where the miner does not have sufficient funds:

1. The method will not abort.
2. All locked funds will be burnt
3. Unlocked available funds will not be touched.

This is consistent with other methods that charge fees from locked funds.

Some unlinted changes appear to have been checked into master. My linter auto-corrected these and those whitespace changes account for most of the lines in this PR.