### PR TITLE
limit deals in sectors

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -381,6 +381,11 @@ func (a Actor) PreCommitSector(rt Runtime, params *SectorPreCommitInfo) *adt.Emp
 			rt.Abortf(exitcode.ErrIllegalArgument, "sector seal proof %v must match miner seal proof type %d", params.SealProof, info.SealProofType)
 		}
 
+		maxDealLimit := dealPerSectorLimit(info.SectorSize)
+		if uint64(len(params.DealIDs)) > maxDealLimit {
+			rt.Abortf(exitcode.ErrIllegalArgument, "too many deals for sector %d > %d", len(params.DealIDs), maxDealLimit)
+		}
+
 		_, preCommitFound, err := st.GetPrecommittedSector(store, params.SectorNumber)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to check pre-commit %v", params.SectorNumber)
 		if preCommitFound {

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -2197,6 +2197,13 @@ func min64(a, b uint64) uint64 {
 	return b
 }
 
+func max64(a, b uint64) uint64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
 func minEpoch(a, b abi.ChainEpoch) abi.ChainEpoch {
 	if a < b {
 		return a

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -578,7 +578,7 @@ func TestCommitments(t *testing.T) {
 
 		makeDealIDs := func(n int) []abi.DealID {
 			ids := make([]abi.DealID, n)
-			for i, _ := range ids {
+			for i := range ids {
 				ids[i] = abi.DealID(i)
 			}
 			return ids

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -588,7 +588,7 @@ func TestCommitments(t *testing.T) {
 		sectorNo := abi.SectorNumber(100)
 
 		dealLimits := map[abi.RegisteredSealProof]int{
-			abi.RegisteredSealProof_StackedDrg2KiBV1:  1,
+			abi.RegisteredSealProof_StackedDrg2KiBV1:  256,
 			abi.RegisteredSealProof_StackedDrg32GiBV1: 256,
 			abi.RegisteredSealProof_StackedDrg64GiBV1: 512,
 		}

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -33,7 +33,7 @@ var testPid abi.PeerID
 var testMultiaddrs []abi.Multiaddrs
 
 // A balance for use in tests where the miner's low balance is not interesting.
-var bigBalance = big.Mul(big.NewInt(1000), big.NewInt(1e18))
+var bigBalance = big.Mul(big.NewInt(10000), big.NewInt(1e18))
 
 func init() {
 	testPid = abi.PeerID("peerID")
@@ -43,9 +43,8 @@ func init() {
 		{2},
 	}
 
-	miner.SupportedProofTypes = map[abi.RegisteredSealProof]struct{}{
-		abi.RegisteredSealProof_StackedDrg2KiBV1: {},
-	}
+	// permit 2KiB sectors in tests
+	miner.SupportedProofTypes[abi.RegisteredSealProof_StackedDrg2KiBV1] = struct{}{}
 }
 
 func TestExports(t *testing.T) {
@@ -69,7 +68,7 @@ func TestConstruction(t *testing.T) {
 		params := miner.ConstructorParams{
 			OwnerAddr:     owner,
 			WorkerAddr:    worker,
-			SealProofType: abi.RegisteredSealProof_StackedDrg2KiBV1,
+			SealProofType: abi.RegisteredSealProof_StackedDrg32GiBV1,
 			PeerId:        testPid,
 			Multiaddrs:    testMultiaddrs,
 		}
@@ -94,9 +93,9 @@ func TestConstruction(t *testing.T) {
 		assert.Equal(t, params.WorkerAddr, info.Worker)
 		assert.Equal(t, params.PeerId, info.PeerId)
 		assert.Equal(t, params.Multiaddrs, info.Multiaddrs)
-		assert.Equal(t, abi.RegisteredSealProof_StackedDrg2KiBV1, info.SealProofType)
-		assert.Equal(t, abi.SectorSize(2048), info.SectorSize)
-		assert.Equal(t, uint64(2), info.WindowPoStPartitionSectors)
+		assert.Equal(t, abi.RegisteredSealProof_StackedDrg32GiBV1, info.SealProofType)
+		assert.Equal(t, abi.SectorSize(1<<35), info.SectorSize)
+		assert.Equal(t, uint64(2349), info.WindowPoStPartitionSectors)
 		assert.Equal(t, provingPeriodStart, st.ProvingPeriodStart)
 
 		assert.Equal(t, big.Zero(), st.PreCommitDeposits)
@@ -158,7 +157,7 @@ func TestCommitments(t *testing.T) {
 
 		// Make a good commitment for the proof to target.
 		sectorNo := abi.SectorNumber(100)
-		precommit := makePreCommit(sectorNo, precommitEpoch-1, deadline.PeriodEnd(), nil)
+		precommit := actor.makePreCommit(sectorNo, precommitEpoch-1, deadline.PeriodEnd(), nil)
 		actor.preCommitSector(rt, precommit)
 
 		// assert precommit exists and meets expectations
@@ -227,23 +226,23 @@ func TestCommitments(t *testing.T) {
 		oldSector := actor.commitAndProveSectors(rt, 1, 100, nil)[0]
 
 		// Good commitment.
-		actor.preCommitSector(rt, makePreCommit(101, challengeEpoch, deadline.PeriodEnd(), nil))
+		actor.preCommitSector(rt, actor.makePreCommit(101, challengeEpoch, deadline.PeriodEnd(), nil))
 
 		// Duplicate pre-commit sector ID
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
-			actor.preCommitSector(rt, makePreCommit(101, challengeEpoch, deadline.PeriodEnd(), nil))
+			actor.preCommitSector(rt, actor.makePreCommit(101, challengeEpoch, deadline.PeriodEnd(), nil))
 		})
 		rt.Reset()
 
 		// Sector ID already committed
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
-			actor.preCommitSector(rt, makePreCommit(oldSector.SectorNumber, challengeEpoch, deadline.PeriodEnd(), nil))
+			actor.preCommitSector(rt, actor.makePreCommit(oldSector.SectorNumber, challengeEpoch, deadline.PeriodEnd(), nil))
 		})
 		rt.Reset()
 
 		// Bad seal proof type
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
-			pc := makePreCommit(101, challengeEpoch, deadline.PeriodEnd(), nil)
+			pc := actor.makePreCommit(101, challengeEpoch, deadline.PeriodEnd(), nil)
 			pc.SealProof = abi.RegisteredSealProof_StackedDrg8MiBV1
 			actor.preCommitSector(rt, pc)
 		})
@@ -252,7 +251,7 @@ func TestCommitments(t *testing.T) {
 		// Expires at current epoch
 		rt.SetEpoch(deadline.PeriodEnd())
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
-			actor.preCommitSector(rt, makePreCommit(101, challengeEpoch, deadline.PeriodEnd(), nil))
+			actor.preCommitSector(rt, actor.makePreCommit(101, challengeEpoch, deadline.PeriodEnd(), nil))
 		})
 		rt.Reset()
 
@@ -260,7 +259,7 @@ func TestCommitments(t *testing.T) {
 		expiration := deadline.PeriodEnd()
 		rt.SetEpoch(expiration + 1)
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
-			actor.preCommitSector(rt, makePreCommit(101, challengeEpoch, deadline.PeriodEnd(), nil))
+			actor.preCommitSector(rt, actor.makePreCommit(101, challengeEpoch, deadline.PeriodEnd(), nil))
 		})
 		rt.Reset()
 
@@ -268,7 +267,7 @@ func TestCommitments(t *testing.T) {
 		expiration = deadline.PeriodEnd() - 1
 		rt.SetEpoch(precommitEpoch)
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
-			actor.preCommitSector(rt, makePreCommit(101, challengeEpoch, expiration, nil))
+			actor.preCommitSector(rt, actor.makePreCommit(101, challengeEpoch, expiration, nil))
 		})
 		rt.Reset()
 
@@ -276,7 +275,7 @@ func TestCommitments(t *testing.T) {
 		rt.SetEpoch(precommitEpoch)
 		expiration = deadline.PeriodEnd() + miner.WPoStProvingPeriod*(miner.MaxSectorExpirationExtension/miner.WPoStProvingPeriod+1)
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
-			actor.preCommitSector(rt, makePreCommit(101, challengeEpoch, deadline.PeriodEnd()-1, nil))
+			actor.preCommitSector(rt, actor.makePreCommit(101, challengeEpoch, deadline.PeriodEnd()-1, nil))
 		})
 	})
 
@@ -294,7 +293,7 @@ func TestCommitments(t *testing.T) {
 		actor.epochReward = big.Div(actor.epochReward, big.NewInt(2))
 
 		challengeEpoch := rt.Epoch() - 1
-		upgradeParams := makePreCommit(200, challengeEpoch, oldSector.Expiration, []abi.DealID{1})
+		upgradeParams := actor.makePreCommit(200, challengeEpoch, oldSector.Expiration, []abi.DealID{1})
 		upgradeParams.ReplaceCapacity = true
 		upgradeParams.ReplaceSector = oldSector.SectorNumber
 		upgrade := actor.preCommitSector(rt, upgradeParams)
@@ -371,7 +370,7 @@ func TestCommitments(t *testing.T) {
 		oldSectors := actor.commitAndProveSectors(rt, 2, 100, [][]abi.DealID{nil, {10}})
 
 		challengeEpoch := rt.Epoch() - 1
-		upgradeParams := makePreCommit(200, challengeEpoch, oldSectors[0].Expiration, []abi.DealID{20})
+		upgradeParams := actor.makePreCommit(200, challengeEpoch, oldSectors[0].Expiration, []abi.DealID{20})
 		upgradeParams.ReplaceCapacity = true
 		upgradeParams.ReplaceSector = oldSectors[0].SectorNumber
 
@@ -441,7 +440,7 @@ func TestCommitments(t *testing.T) {
 
 		// Pre-commit a sector to replace the existing one
 		challengeEpoch := rt.Epoch() - 1
-		upgradeParams := makePreCommit(200, challengeEpoch, oldSector.Expiration, []abi.DealID{20})
+		upgradeParams := actor.makePreCommit(200, challengeEpoch, oldSector.Expiration, []abi.DealID{20})
 		upgradeParams.ReplaceCapacity = true
 		upgradeParams.ReplaceSector = oldSector.SectorNumber
 
@@ -499,7 +498,7 @@ func TestCommitments(t *testing.T) {
 
 		// Make a good commitment for the proof to target.
 		sectorNo := abi.SectorNumber(100)
-		precommit := makePreCommit(sectorNo, precommitEpoch-1, deadline.PeriodEnd(), nil)
+		precommit := actor.makePreCommit(sectorNo, precommitEpoch-1, deadline.PeriodEnd(), nil)
 		actor.preCommitSector(rt, precommit)
 
 		// Sector pre-commitment missing.
@@ -568,10 +567,11 @@ func TestCommitments(t *testing.T) {
 func TestWindowPost(t *testing.T) {
 	periodOffset := abi.ChainEpoch(100)
 	actor := newHarness(t, periodOffset)
+	actor.setProofType(abi.RegisteredSealProof_StackedDrg2KiBV1)
 	precommitEpoch := abi.ChainEpoch(1)
 	builder := builderForHarness(actor).
 		WithEpoch(precommitEpoch).
-		WithBalance(bigBalance, big.Zero())
+		WithBalance(big.Mul(bigBalance, bigBalance), big.Zero())
 
 	t.Run("test proof", func(t *testing.T) {
 		rt := builder.Build(t)
@@ -829,7 +829,7 @@ func TestProveCommit(t *testing.T) {
 		expiration := 100*miner.WPoStProvingPeriod + periodOffset - 1
 		precommitEpoch := rt.Epoch() + 1
 		rt.SetEpoch(precommitEpoch)
-		precommit := makePreCommit(actor.nextSectorNo, rt.Epoch()-1, expiration, nil)
+		precommit := actor.makePreCommit(actor.nextSectorNo, rt.Epoch()-1, expiration, nil)
 		actor.preCommitSector(rt, precommit)
 
 		// alter lock funds to simulate vesting since last prove
@@ -858,11 +858,11 @@ func TestProveCommit(t *testing.T) {
 		expiration := 100*miner.WPoStProvingPeriod + periodOffset - 1
 		precommitEpoch := rt.Epoch() + 1
 		rt.SetEpoch(precommitEpoch)
-		precommitA := makePreCommit(actor.nextSectorNo, rt.Epoch()-1, expiration, nil)
+		precommitA := actor.makePreCommit(actor.nextSectorNo, rt.Epoch()-1, expiration, nil)
 		actor.preCommitSector(rt, precommitA)
 		sectorNoA := actor.nextSectorNo
 		actor.nextSectorNo++
-		precommitB := makePreCommit(actor.nextSectorNo, rt.Epoch()-1, expiration, nil)
+		precommitB := actor.makePreCommit(actor.nextSectorNo, rt.Epoch()-1, expiration, nil)
 		actor.preCommitSector(rt, precommitB)
 		sectorNoB := actor.nextSectorNo
 
@@ -1131,8 +1131,8 @@ func TestExtendSectorExpiration(t *testing.T) {
 		maxLifetime := sector.SealProof.SectorMaximumLifetime()
 
 		// extend sector until just below threshold
-		extension := miner.WPoStProvingPeriod * (miner.MaxSectorExpirationExtension/miner.WPoStProvingPeriod - 1)
-		expiration := rt.Epoch() + extension
+		expiration := sector.Activation + sector.SealProof.SectorMaximumLifetime()
+		extension := expiration - rt.Epoch()
 		for ; expiration-sector.Activation < maxLifetime; expiration += extension {
 			params := &miner.ExtendSectorExpirationParams{
 				SectorNumber:  sector.SectorNumber,
@@ -1381,7 +1381,7 @@ type actorHarness struct {
 }
 
 func newHarness(t testing.TB, provingPeriodOffset abi.ChainEpoch) *actorHarness {
-	sealProofType := abi.RegisteredSealProof_StackedDrg2KiBV1
+	sealProofType := abi.RegisteredSealProof_StackedDrg32GiBV1
 	sectorSize, err := sealProofType.SectorSize()
 	require.NoError(t, err)
 	partitionSectors, err := sealProofType.WindowPoStPartitionSectors()
@@ -1409,6 +1409,15 @@ func newHarness(t testing.TB, provingPeriodOffset abi.ChainEpoch) *actorHarness 
 		networkRawPower: abi.NewStoragePower(1 << 50),
 		networkQAPower:  abi.NewStoragePower(1 << 50),
 	}
+}
+
+func (h *actorHarness) setProofType(proof abi.RegisteredSealProof) {
+	var err error
+	h.sealProofType = proof
+	h.sectorSize, err = proof.SectorSize()
+	require.NoError(h.t, err)
+	h.partitionSize, err = proof.WindowPoStPartitionSectors()
+	require.NoError(h.t, err)
 }
 
 func (h *actorHarness) constructAndVerify(rt *mock.Runtime) {
@@ -1694,7 +1703,7 @@ func (h *actorHarness) commitAndProveSectors(rt *mock.Runtime, n int, lifetimePe
 		if dealIDs != nil {
 			sectorDealIDs = dealIDs[i]
 		}
-		precommit := makePreCommit(sectorNo, precommitEpoch-1, expiration, sectorDealIDs)
+		precommit := h.makePreCommit(sectorNo, precommitEpoch-1, expiration, sectorDealIDs)
 		h.preCommitSector(rt, precommit)
 		precommits[i] = precommit
 		h.nextSectorNo++
@@ -1746,7 +1755,7 @@ func (h *actorHarness) submitWindowPoSt(rt *mock.Runtime, deadline *miner.Deadli
 	}
 	rt.ExpectSend(builtin.StoragePowerActorAddr, builtin.MethodsPower.CurrentTotalPower, nil, big.Zero(), &pwrTotal, exitcode.Ok)
 
-	var registeredPoStProof, err = abi.RegisteredSealProof_StackedDrg2KiBV1.RegisteredWindowPoStProof()
+	var registeredPoStProof, err = h.sealProofType.RegisteredWindowPoStProof()
 	require.NoError(h.t, err)
 
 	proofs := make([]abi.PoStProof, 1) // Number of proofs doesn't depend on partition count
@@ -2175,6 +2184,17 @@ func (h *actorHarness) claimParamsForSectors(sectors []*miner.SectorOnChainInfo,
 	}
 }
 
+func (h *actorHarness) makePreCommit(sectorNo abi.SectorNumber, challenge, expiration abi.ChainEpoch, dealIDs []abi.DealID) *miner.SectorPreCommitInfo {
+	return &miner.SectorPreCommitInfo{
+		SealProof:     h.sealProofType,
+		SectorNumber:  sectorNo,
+		SealedCID:     tutil.MakeCID("commr"),
+		SealRandEpoch: challenge,
+		DealIDs:       dealIDs,
+		Expiration:    expiration,
+	}
+}
+
 //
 // Higher-level orchestration
 //
@@ -2214,17 +2234,6 @@ func makeProvingPeriodCronEventParams(t testing.TB, epoch abi.ChainEpoch) *power
 	return &power.EnrollCronEventParams{
 		EventEpoch: epoch,
 		Payload:    buf.Bytes(),
-	}
-}
-
-func makePreCommit(sectorNo abi.SectorNumber, challenge, expiration abi.ChainEpoch, dealIDs []abi.DealID) *miner.SectorPreCommitInfo {
-	return &miner.SectorPreCommitInfo{
-		SealProof:     abi.RegisteredSealProof_StackedDrg2KiBV1,
-		SectorNumber:  sectorNo,
-		SealedCID:     tutil.MakeCID("commr"),
-		SealRandEpoch: challenge,
-		DealIDs:       dealIDs,
-		Expiration:    expiration,
 	}
 }
 

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -617,7 +617,7 @@ func TestWindowPost(t *testing.T) {
 	precommitEpoch := abi.ChainEpoch(1)
 	builder := builderForHarness(actor).
 		WithEpoch(precommitEpoch).
-		WithBalance(big.Mul(bigBalance, bigBalance), big.Zero())
+		WithBalance(bigBalance, big.Zero())
 
 	t.Run("test proof", func(t *testing.T) {
 		rt := builder.Build(t)

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -99,6 +99,9 @@ const WorkerKeyChangeDelay = ChainFinality
 // and sector.ActivationEpoch+sealProof.SectorMaximumLifetime()
 const MaxSectorExpirationExtension = builtin.EpochsInYear
 
+// Ratio of sector size to maximum deals per sector
+const DealLimitDenominator = 134217728
+
 var QualityBaseMultiplier = big.NewInt(10)         // PARAM_FINISH
 var DealWeightMultiplier = big.NewInt(11)          // PARAM_FINISH
 var VerifiedDealWeightMultiplier = big.NewInt(100) // PARAM_FINISH
@@ -140,6 +143,15 @@ func QAPowerForSector(size abi.SectorSize, sector *SectorOnChainInfo) abi.Storag
 func precommitDeposit(qaSectorPower abi.StoragePower, networkQAPower abi.StoragePower, networkTotalPledge, epochTargetReward, circulatingSupply abi.TokenAmount) abi.TokenAmount {
 	return InitialPledgeForPower(qaSectorPower, networkQAPower, networkTotalPledge, epochTargetReward, circulatingSupply)
 }
+
+// Determine maximum number of deal miner's sector can hold
+//func dealPerSectorLimit(size abi.SectorSize) uint64 {
+//	maxDeals := uint64(size / DealLimitDenominator)
+//	if maxDeals == 0 {
+//		maxDeals = 1
+//	}
+//	return maxDeals
+//}
 
 type BigFrac struct {
 	numerator   big.Int

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -145,13 +145,13 @@ func precommitDeposit(qaSectorPower abi.StoragePower, networkQAPower abi.Storage
 }
 
 // Determine maximum number of deal miner's sector can hold
-//func dealPerSectorLimit(size abi.SectorSize) uint64 {
-//	maxDeals := uint64(size / DealLimitDenominator)
-//	if maxDeals == 0 {
-//		maxDeals = 1
-//	}
-//	return maxDeals
-//}
+func dealPerSectorLimit(size abi.SectorSize) uint64 {
+	maxDeals := uint64(size / DealLimitDenominator)
+	if maxDeals == 0 {
+		maxDeals = 1
+	}
+	return maxDeals
+}
 
 type BigFrac struct {
 	numerator   big.Int

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -99,7 +99,9 @@ const WorkerKeyChangeDelay = ChainFinality
 // and sector.ActivationEpoch+sealProof.SectorMaximumLifetime()
 const MaxSectorExpirationExtension = builtin.EpochsInYear
 
-// Ratio of sector size to maximum deals per sector
+// Ratio of sector size to maximum deals per sector.
+// The maximum number of deals is the sector size divided by this number (2^27)
+// which limits 32GiB sectors to 256 deals and 64GiB sectors to 512
 const DealLimitDenominator = 134217728
 
 var QualityBaseMultiplier = big.NewInt(10)         // PARAM_FINISH
@@ -146,11 +148,7 @@ func precommitDeposit(qaSectorPower abi.StoragePower, networkQAPower abi.Storage
 
 // Determine maximum number of deal miner's sector can hold
 func dealPerSectorLimit(size abi.SectorSize) uint64 {
-	maxDeals := uint64(size / DealLimitDenominator)
-	if maxDeals == 0 {
-		maxDeals = 1
-	}
-	return maxDeals
+	return max64(256, uint64(size/DealLimitDenominator))
 }
 
 type BigFrac struct {


### PR DESCRIPTION
partially addresses #416

### Motivation
If a miner attempts to put too many (8k) deals in a sector, the `PreCommitSector` will fail because the `DealID`slice in the `SectorOnChainInfo` won't marshal into CBOR. Having this many deals in a sector would require an average deal size that is far too low even for TB sectors, anyway.

We will limit the deals in a sector so that average deal size must be above 128MiB. Specifically, this is no more than 256 deals for 32GiB sectors and 512GiB sectors. For sector sizes less than 128MiB we will allow 1 deal.

### Proposed Changes

1. Make the default StackedDRG32GiB the default seal proof type in tests with the option to change it.
2. Add `dealPerSectorLimit` function to policy.
3. Impose limit on deals per sector in `PrecommitSector`.
4. Test.