### PR TITLE
Feat/slice bound provecommits

### DIFF
--- a/actors/builtin/power/policy.go
+++ b/actors/builtin/power/policy.go
@@ -9,3 +9,6 @@ const ConsensusMinerMinMiners = 3
 
 // Minimum power of an individual miner to meet the threshold for leader election.
 var ConsensusMinerMinPower = abi.NewStoragePower(1 << 40) // PARAM_FINISH
+
+// Maximum number of prove commits a miner can submit in one epoch
+const MaxMinerProveCommitsPerEpoch = 8000

--- a/actors/runtime/exitcode/common.go
+++ b/actors/runtime/exitcode/common.go
@@ -16,6 +16,11 @@ const (
 	ErrIllegalState
 	// Indicates de/serialization failure within actor code.
 	ErrSerialization
+
+	// Common error codes stop here.  If you define a common error code above
+	// this value it will have conflicting interpretations
+	FirstActorSpecificExitCode = ExitCode(32)
+
 	// An error code intended to be replaced by different code structure or a more descriptive error.
 	ErrPlaceholder = ExitCode(1000)
 )

--- a/support/mock/mockrt.go
+++ b/support/mock/mockrt.go
@@ -66,6 +66,8 @@ type Runtime struct {
 	expectDeleteActor              *address.Address
 
 	logs []string
+	// Gas charged explicitly through rt.ChargeGas. Note: most charges are implicit
+	gasCharged int64
 }
 
 type expectRandomness struct {
@@ -891,6 +893,12 @@ func (rt *Runtime) ExpectLogsContain(substr string) {
 	rt.failTest("logs contain %d message(s) and do not contain \"%s\"", len(rt.logs), substr)
 }
 
+func (rt *Runtime) ExpectGasCharged(gas int64) {
+	if gas != rt.gasCharged {
+		rt.failTest("expected gas charged: %d, actual gas charged: %d", gas, rt.gasCharged)
+	}
+}
+
 func (rt *Runtime) Call(method interface{}, params interface{}) interface{} {
 	meth := reflect.ValueOf(method)
 	rt.verifyExportedMethodType(meth)
@@ -948,7 +956,9 @@ func (rt *Runtime) failTestNow(msg string, args ...interface{}) {
 	rt.t.FailNow()
 }
 
-func (rt *Runtime) ChargeGas(_ string, _, _ int64) {}
+func (rt *Runtime) ChargeGas(_ string, gas, _ int64) {
+	rt.gasCharged += gas
+}
 
 type ReturnWrapper struct {
 	V runtime.CBORMarshaler


### PR DESCRIPTION
Joint work with @acruikshank. Along with #632 this closes out the most critical non-miner slice bound work tracked in #416 

Note, given the gas charged per porep is ~130M and gas limit is somewhere in the range of 5-10B, there will only ever be ~100 poreps submitted per block (upper bound with extremely rare really big tipsets is 1000 poreps per block).  So the 8000 limit per miner will in practice never be hit.

With this change a miner who somehow was able to get more provecommits in a tipset than the serialization limit allows won't lose all gas for nothing but will fail early during prove commit before adding the porep info to power actor and avoid gas charging.  Porep infos already added will still be processed during cron.

@Kubuxu double checking in with you: is the upper bound of ~500 poreps per epoch good from a chain scalability perspective?  

