### PR TITLE
Disable nomaprange linter plugin, failing on some systems

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,13 +1,14 @@
 linters-settings:
   custom:
-    nomaprange:
-      path: .nomaprange.so
-      description: Checks for range over maps
-      original-url: github.com/Kubuxu/go-no-map-range
+    # 2020-07-13 @anorth disabled, local build failing with "Unable to load custom analyzer nomaprange:.nomaprange.so, plugin: not implemented"
+    #nomaprange:
+    #  path: .nomaprange.so
+    #  description: Checks for range over maps
+    #  original-url: github.com/Kubuxu/go-no-map-range
 
 linters:
   enable:
-    - nomaprange
+    #- nomaprange
 
 run:
   skip-dirs-use-default: false


### PR DESCRIPTION
When building master on my local MacBook Pro, lint failed with the new plugin.

```
[~/p/f/specs-actors](anorth/nomaprange)$ make
go build ./...
golangci-lint run ./...
ERRO Unable to load custom analyzer nomaprange:.nomaprange.so, plugin: not implemented
ERRO Running error: no such linter "nomaprange"
make: *** [lint] Error 3
```

Unfortunately I don't have time to debug this right now, will return to it after #599.

FYI @Kubuxu thank you, sorry I didn't have time to investigate right away.