### PR TITLE
change WPoStChallengeWindow to 30 mins of epochs

### DIFF
--- a/actors/builtin/miner/cbor_gen.go
+++ b/actors/builtin/miner/cbor_gen.go
@@ -654,7 +654,7 @@ func (t *Deadlines) MarshalCBOR(w io.Writer) error {
 
 	scratch := make([]byte, 9)
 
-	// t.Due ([36]*bitfield.BitField) (array)
+	// t.Due ([48]*bitfield.BitField) (array)
 	if len(t.Due) > cbg.MaxLength {
 		return xerrors.Errorf("Slice value in field t.Due was too long")
 	}
@@ -688,7 +688,7 @@ func (t *Deadlines) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
-	// t.Due ([36]*bitfield.BitField) (array)
+	// t.Due ([48]*bitfield.BitField) (array)
 
 	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
 	if err != nil {
@@ -703,11 +703,11 @@ func (t *Deadlines) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("expected cbor array")
 	}
 
-	if extra != 36 {
-		return fmt.Errorf("expected array to have 36 elements")
+	if extra != 48 {
+		return fmt.Errorf("expected array to have 48 elements")
 	}
 
-	t.Due = [36]*bitfield.BitField{}
+	t.Due = [48]*bitfield.BitField{}
 
 	for i := 0; i < int(extra); i++ {
 

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -13,7 +13,7 @@ import (
 const WPoStProvingPeriod = abi.ChainEpoch(builtin.EpochsInDay) // 24 hours
 
 // The duration of a deadline's challenge window, the period before a deadline when the challenge is available.
-const WPoStChallengeWindow = abi.ChainEpoch(40 * 60 / builtin.EpochDurationSeconds) // 40 minutes (36 per day)
+const WPoStChallengeWindow = abi.ChainEpoch(30 * 60 / builtin.EpochDurationSeconds) // 30 minutes (48 per day)
 
 // The number of non-overlapping PoSt deadlines in each proving period.
 const WPoStPeriodDeadlines = uint64(WPoStProvingPeriod / WPoStChallengeWindow)


### PR DESCRIPTION
closes #637

### Motivation

PoSt proofs are sped up, so we we can reduce the PoSt Challenge window from 40 minutes to 30 minutes.

### Proposed Changes

1. Change the `WPoStChallengeWindow` constant to represent 30 minutes worth of epochs. This affects the size of `deadlines.Due`, which forces a change in the miner's cbor encoding.

This parameter is already covered in various ways in the tests.