### PR TITLE
increase PreCommitChallengeDelay to 150

### DIFF
--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -1007,13 +1007,16 @@ func TestProvingPeriodCron(t *testing.T) {
 		// advance to end of proving period to add sectors to proving set
 		st := getState(rt)
 		deadline := st.DeadlineInfo(rt.Epoch())
-		nextCron := deadline.NextPeriodStart() - 1
+		nextCron := deadline.NextPeriodStart() + miner.WPoStProvingPeriod - 1
+		rt.SetEpoch(deadline.PeriodEnd())
 		actor.onProvingPeriodCron(rt, &cronConfig{
 			expectedEntrollment: nextCron,
 			newSectors:          true,
 		})
 
 		// advance to next deadline where we expect the first sectors to appear
+		st = getState(rt)
+		deadline = st.DeadlineInfo(rt.Epoch() + 1)
 		rt.SetEpoch(deadline.Close + 1)
 		deadline = st.DeadlineInfo(rt.Epoch())
 

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -69,7 +69,7 @@ var MaxSealDuration = map[abi.RegisteredSealProof]abi.ChainEpoch{
 
 // Number of epochs between publishing the precommit and when the challenge for interactive PoRep is drawn
 // used to ensure it is not predictable by miner.
-const PreCommitChallengeDelay = abi.ChainEpoch(10)
+const PreCommitChallengeDelay = abi.ChainEpoch(150)
 
 // Lookback from the current epoch for state view for leader elections.
 const ElectionLookback = abi.ChainEpoch(1) // PARAM_FINISH


### PR DESCRIPTION
closes #598

### Motivation 

Security concerns dictate we need a longer delay between pre- and prove-commit

### Proposed changes

1. Change `PreCommitChallengeDelay` to 150
2. Fix a test using some dodgy timing logic which broke because the commit got pushed into the next proving period.