### PR TITLE
process power actor cron tasks set in the past

### DIFF
--- a/actors/builtin/power/cbor_gen.go
+++ b/actors/builtin/power/cbor_gen.go
@@ -79,13 +79,13 @@ func (t *State) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("failed to write cid field t.CronEventQueue: %w", err)
 	}
 
-	// t.FirstCronTask (abi.ChainEpoch) (int64)
-	if t.FirstCronTask >= 0 {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.FirstCronTask)); err != nil {
+	// t.FirstCronEpoch (abi.ChainEpoch) (int64)
+	if t.FirstCronEpoch >= 0 {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.FirstCronEpoch)); err != nil {
 			return err
 		}
 	} else {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.FirstCronTask-1)); err != nil {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.FirstCronEpoch-1)); err != nil {
 			return err
 		}
 	}
@@ -236,7 +236,7 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 		t.CronEventQueue = c
 
 	}
-	// t.FirstCronTask (abi.ChainEpoch) (int64)
+	// t.FirstCronEpoch (abi.ChainEpoch) (int64)
 	{
 		maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
 		var extraI int64
@@ -259,7 +259,7 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 			return fmt.Errorf("wrong type for int64 field: %d", maj)
 		}
 
-		t.FirstCronTask = abi.ChainEpoch(extraI)
+		t.FirstCronEpoch = abi.ChainEpoch(extraI)
 	}
 	// t.Claims (cid.Cid) (struct)
 

--- a/actors/builtin/power/cbor_gen.go
+++ b/actors/builtin/power/cbor_gen.go
@@ -79,13 +79,13 @@ func (t *State) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("failed to write cid field t.CronEventQueue: %w", err)
 	}
 
-	// t.LastEpochTick (abi.ChainEpoch) (int64)
-	if t.LastEpochTick >= 0 {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.LastEpochTick)); err != nil {
+	// t.FirstCronTask (abi.ChainEpoch) (int64)
+	if t.FirstCronTask >= 0 {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.FirstCronTask)); err != nil {
 			return err
 		}
 	} else {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.LastEpochTick-1)); err != nil {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.FirstCronTask-1)); err != nil {
 			return err
 		}
 	}
@@ -236,7 +236,7 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 		t.CronEventQueue = c
 
 	}
-	// t.LastEpochTick (abi.ChainEpoch) (int64)
+	// t.FirstCronTask (abi.ChainEpoch) (int64)
 	{
 		maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
 		var extraI int64
@@ -259,7 +259,7 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 			return fmt.Errorf("wrong type for int64 field: %d", maj)
 		}
 
-		t.LastEpochTick = abi.ChainEpoch(extraI)
+		t.FirstCronTask = abi.ChainEpoch(extraI)
 	}
 	// t.Claims (cid.Cid) (struct)
 

--- a/actors/builtin/power/power_actor.go
+++ b/actors/builtin/power/power_actor.go
@@ -420,7 +420,7 @@ func (a Actor) processDeferredCronEvents(rt Runtime) error {
 	rt.State().Transaction(&st, func() interface{} {
 		store := adt.AsStore(rt)
 
-		for epoch := st.FirstCronTask; epoch <= rtEpoch; epoch++ {
+		for epoch := st.FirstCronEpoch; epoch <= rtEpoch; epoch++ {
 			epochEvents, err := st.loadCronEvents(store, epoch)
 			if err != nil {
 				return errors.Wrapf(err, "failed to load cron events at %v", epoch)
@@ -436,7 +436,7 @@ func (a Actor) processDeferredCronEvents(rt Runtime) error {
 			}
 		}
 
-		st.FirstCronTask = rtEpoch + 1
+		st.FirstCronEpoch = rtEpoch + 1
 		return nil
 	})
 	failedMinerCrons := make([]addr.Address, 0)

--- a/actors/builtin/power/power_actor.go
+++ b/actors/builtin/power/power_actor.go
@@ -420,7 +420,7 @@ func (a Actor) processDeferredCronEvents(rt Runtime) error {
 	rt.State().Transaction(&st, func() interface{} {
 		store := adt.AsStore(rt)
 
-		for epoch := st.LastEpochTick + 1; epoch <= rtEpoch; epoch++ {
+		for epoch := st.FirstCronTask; epoch <= rtEpoch; epoch++ {
 			epochEvents, err := st.loadCronEvents(store, epoch)
 			if err != nil {
 				return errors.Wrapf(err, "failed to load cron events at %v", epoch)
@@ -436,7 +436,7 @@ func (a Actor) processDeferredCronEvents(rt Runtime) error {
 			}
 		}
 
-		st.LastEpochTick = rtEpoch
+		st.FirstCronTask = rtEpoch + 1
 		return nil
 	})
 	failedMinerCrons := make([]addr.Address, 0)

--- a/actors/builtin/power/power_actor.go
+++ b/actors/builtin/power/power_actor.go
@@ -180,6 +180,11 @@ func (a Actor) EnrollCronEvent(rt Runtime, params *EnrollCronEventParams) *adt.E
 		CallbackPayload: params.Payload,
 	}
 
+	// Ensure it is not possible to enter a large negative number which would cause problems in cron processing.
+	if params.EventEpoch < 0 {
+		rt.Abortf(exitcode.ErrIllegalArgument, "cron event epoch %d cannot be less than zero", params.EventEpoch)
+	}
+
 	var st State
 	rt.State().Transaction(&st, func() interface{} {
 		err := st.appendCronEvent(adt.AsStore(rt), params.EventEpoch, &minerEvent)

--- a/actors/builtin/power/power_state.go
+++ b/actors/builtin/power/power_state.go
@@ -28,8 +28,8 @@ type State struct {
 	// A queue of events to be triggered by cron, indexed by epoch.
 	CronEventQueue cid.Cid // Multimap, (HAMT[ChainEpoch]AMT[CronEvent]
 
-	// Last chain epoch OnEpochTickEnd was called on
-	LastEpochTick abi.ChainEpoch
+	// First epoch in which a cron task may be stored.
+	FirstCronTask abi.ChainEpoch
 
 	// Claimed power for each miner.
 	Claims cid.Cid // Map, HAMT[address]Claim
@@ -59,7 +59,7 @@ func ConstructState(emptyMapCid, emptyMMapCid cid.Cid) *State {
 		TotalQualityAdjPower:    abi.NewStoragePower(0),
 		TotalQABytesCommitted:   abi.NewStoragePower(0),
 		TotalPledgeCollateral:   abi.NewTokenAmount(0),
-		LastEpochTick:           -1,
+		FirstCronTask:           0,
 		CronEventQueue:          emptyMapCid,
 		Claims:                  emptyMapCid,
 		MinerCount:              0,

--- a/actors/builtin/power/power_state.go
+++ b/actors/builtin/power/power_state.go
@@ -29,6 +29,7 @@ type State struct {
 	CronEventQueue cid.Cid // Multimap, (HAMT[ChainEpoch]AMT[CronEvent]
 
 	// First epoch in which a cron task may be stored.
+	// Cron will iterate every epoch between this and the current epoch inclusively to find tasks to execute.
 	FirstCronEpoch abi.ChainEpoch
 
 	// Claimed power for each miner.

--- a/actors/builtin/power/power_state.go
+++ b/actors/builtin/power/power_state.go
@@ -29,7 +29,7 @@ type State struct {
 	CronEventQueue cid.Cid // Multimap, (HAMT[ChainEpoch]AMT[CronEvent]
 
 	// First epoch in which a cron task may be stored.
-	FirstCronTask abi.ChainEpoch
+	FirstCronEpoch abi.ChainEpoch
 
 	// Claimed power for each miner.
 	Claims cid.Cid // Map, HAMT[address]Claim
@@ -59,7 +59,7 @@ func ConstructState(emptyMapCid, emptyMMapCid cid.Cid) *State {
 		TotalQualityAdjPower:    abi.NewStoragePower(0),
 		TotalQABytesCommitted:   abi.NewStoragePower(0),
 		TotalPledgeCollateral:   abi.NewTokenAmount(0),
-		FirstCronTask:           0,
+		FirstCronEpoch:          0,
 		CronEventQueue:          emptyMapCid,
 		Claims:                  emptyMapCid,
 		MinerCount:              0,
@@ -168,9 +168,9 @@ func (st *State) appendCronEvent(store adt.Store, epoch abi.ChainEpoch, event *C
 		return err
 	}
 
-	// if event is in past, alter FirstCronTask so it will be found.
-	if epoch < st.FirstCronTask {
-		st.FirstCronTask = epoch
+	// if event is in past, alter FirstCronEpoch so it will be found.
+	if epoch < st.FirstCronEpoch {
+		st.FirstCronEpoch = epoch
 	}
 
 	err = mmap.Add(epochKey(epoch), event)

--- a/actors/builtin/power/power_state.go
+++ b/actors/builtin/power/power_state.go
@@ -168,6 +168,11 @@ func (st *State) appendCronEvent(store adt.Store, epoch abi.ChainEpoch, event *C
 		return err
 	}
 
+	// if event is in past, alter FirstCronTask so it will be found.
+	if epoch < st.FirstCronTask {
+		st.FirstCronTask = epoch
+	}
+
 	err = mmap.Add(epochKey(epoch), event)
 	if err != nil {
 		return errors.Wrapf(err, "failed to store cron event at epoch %v for miner %v", epoch, event)

--- a/actors/builtin/power/power_test.go
+++ b/actors/builtin/power/power_test.go
@@ -351,6 +351,16 @@ func TestCron(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("fails to enroll if epoch is negative", func(t *testing.T) {
+		rt := builder.Build(t)
+		actor.constructAndVerify(rt)
+
+		// enroll a cron task at epoch 2 (which is in the past)
+		rt.ExpectAbortConstainsMessage(exitcode.ErrIllegalArgument, "epoch -2 cannot be less than zero", func() {
+			actor.enrollCronEvent(rt, miner1, -2, []byte{0x1, 0x3})
+		})
+	})
+
 	t.Run("handles failed call", func(t *testing.T) {
 		rt := builder.Build(t)
 		actor.constructAndVerify(rt)

--- a/actors/builtin/power/power_test.go
+++ b/actors/builtin/power/power_test.go
@@ -499,7 +499,7 @@ func (h *spActorHarness) constructAndVerify(rt *mock.Runtime) {
 	assert.Equal(h.t, abi.NewStoragePower(0), st.TotalQualityAdjPower)
 	assert.Equal(h.t, abi.NewStoragePower(0), st.TotalQABytesCommitted)
 	assert.Equal(h.t, abi.NewTokenAmount(0), st.TotalPledgeCollateral)
-	assert.Equal(h.t, abi.ChainEpoch(0), st.FirstCronTask)
+	assert.Equal(h.t, abi.ChainEpoch(0), st.FirstCronEpoch)
 	assert.Equal(h.t, int64(0), st.MinerCount)
 	assert.Equal(h.t, int64(0), st.MinerAboveMinPowerCount)
 

--- a/actors/builtin/power/power_test.go
+++ b/actors/builtin/power/power_test.go
@@ -348,6 +348,7 @@ func TestCron(t *testing.T) {
 			t.Errorf("Unexpected bitfield at epoch %d", i)
 			return nil
 		})
+		require.NoError(t, err)
 	})
 
 	t.Run("handles failed call", func(t *testing.T) {

--- a/actors/builtin/power/power_test.go
+++ b/actors/builtin/power/power_test.go
@@ -161,16 +161,16 @@ func TestPowerAndPledgeAccounting(t *testing.T) {
 
 		actor.createMinerBasic(rt, owner, owner, miner1)
 		actor.createMinerBasic(rt, owner, owner, miner2)
-		actor.createMinerBasic(rt, owner, owner, miner3)		
-		actor.createMinerBasic(rt, owner, owner, miner4)				
+		actor.createMinerBasic(rt, owner, owner, miner3)
+		actor.createMinerBasic(rt, owner, owner, miner4)
 		actor.createMinerBasic(rt, owner, owner, miner5)
 
 		actor.updateClaimedPower(rt, miner1, div(smallPowerUnit, 2), smallPowerUnit)
-		actor.updateClaimedPower(rt, miner2, div(smallPowerUnit, 2), smallPowerUnit)		
-		actor.updateClaimedPower(rt, miner3, div(smallPowerUnit, 2), smallPowerUnit)				
+		actor.updateClaimedPower(rt, miner2, div(smallPowerUnit, 2), smallPowerUnit)
+		actor.updateClaimedPower(rt, miner3, div(smallPowerUnit, 2), smallPowerUnit)
 
 		actor.updateClaimedPower(rt, miner4, div(powerUnit, 2), powerUnit)
-		actor.updateClaimedPower(rt, miner5, div(powerUnit, 2), powerUnit)		
+		actor.updateClaimedPower(rt, miner5, div(powerUnit, 2), powerUnit)
 
 		// Below threshold small miner power is counted
 		expectedTotalBelow := big.Sum(mul(smallPowerUnit, 3), mul(powerUnit, 2))
@@ -186,7 +186,7 @@ func TestPowerAndPledgeAccounting(t *testing.T) {
 		assert.Equal(t, int64(3), st.MinerAboveMinPowerCount)
 
 		// Less than 3 miners above threshold again small miner power is counted again
-	
+
 		actor.updateClaimedPower(rt, miner3, div(delta.Neg(), 2), delta.Neg())
 		actor.expectTotalPower(rt, div(expectedTotalBelow, 2), expectedTotalBelow)
 	})
@@ -198,8 +198,8 @@ func TestPowerAndPledgeAccounting(t *testing.T) {
 
 		actor.createMinerBasic(rt, owner, owner, miner1)
 		actor.createMinerBasic(rt, owner, owner, miner2)
-		actor.createMinerBasic(rt, owner, owner, miner3)		
-		actor.createMinerBasic(rt, owner, owner, miner4)				
+		actor.createMinerBasic(rt, owner, owner, miner3)
+		actor.createMinerBasic(rt, owner, owner, miner4)
 
 		actor.updateClaimedPower(rt, miner1, powerUnit, powerUnit)
 		actor.updateClaimedPower(rt, miner2, powerUnit, powerUnit)
@@ -222,7 +222,7 @@ func TestPowerAndPledgeAccounting(t *testing.T) {
 
 		actor.createMinerBasic(rt, owner, owner, miner1)
 		actor.createMinerBasic(rt, owner, owner, miner2)
-		actor.createMinerBasic(rt, owner, owner, miner3)		
+		actor.createMinerBasic(rt, owner, owner, miner3)
 
 		actor.updateClaimedPower(rt, miner1, powerUnit, big.Zero())
 		actor.updateClaimedPower(rt, miner2, powerUnit, big.Zero())
@@ -243,7 +243,7 @@ func TestPowerAndPledgeAccounting(t *testing.T) {
 
 		actor.createMinerBasic(rt, owner, owner, miner1)
 		actor.createMinerBasic(rt, owner, owner, miner2)
-		actor.createMinerBasic(rt, owner, owner, miner3)	
+		actor.createMinerBasic(rt, owner, owner, miner3)
 
 		actor.updateClaimedPower(rt, miner1, powerUnit, powerUnit)
 		actor.updateClaimedPower(rt, miner2, powerUnit, powerUnit)
@@ -369,9 +369,9 @@ func TestSubmitPoRepForBulkVerify(t *testing.T) {
 		rt := builder.Build(t)
 		actor.constructAndVerify(rt)
 		commR := tutil.MakeCID("commR")
-		commD := tutil.MakeCID("commD")		
+		commD := tutil.MakeCID("commD")
 		sealInfo := &abi.SealVerifyInfo{
-			SealedCID: commR,
+			SealedCID:   commR,
 			UnsealedCID: commD,
 		}
 		actor.submitPoRepForBulkVerify(rt, miner, sealInfo)
@@ -392,7 +392,7 @@ func TestSubmitPoRepForBulkVerify(t *testing.T) {
 		assert.Equal(t, commR, storedSealInfo.SealedCID)
 	})
 
-	t.Run("aborts when too many poreps", func(t *testing.T){
+	t.Run("aborts when too many poreps", func(t *testing.T) {
 		rt := builder.Build(t)
 		actor.constructAndVerify(rt)
 
@@ -413,7 +413,7 @@ func TestSubmitPoRepForBulkVerify(t *testing.T) {
 		})
 
 		// Gas only charged for successful submissions
-		rt.ExpectGasCharged(power.GasOnSubmitVerifySeal*power.MaxMinerProveCommitsPerEpoch)
+		rt.ExpectGasCharged(power.GasOnSubmitVerifySeal * power.MaxMinerProveCommitsPerEpoch)
 	})
 }
 
@@ -461,7 +461,7 @@ func (h *spActorHarness) constructAndVerify(rt *mock.Runtime) {
 	assert.Equal(h.t, abi.NewStoragePower(0), st.TotalQualityAdjPower)
 	assert.Equal(h.t, abi.NewStoragePower(0), st.TotalQABytesCommitted)
 	assert.Equal(h.t, abi.NewTokenAmount(0), st.TotalPledgeCollateral)
-	assert.Equal(h.t, abi.ChainEpoch(-1), st.LastEpochTick)
+	assert.Equal(h.t, abi.ChainEpoch(0), st.FirstCronTask)
 	assert.Equal(h.t, int64(0), st.MinerCount)
 	assert.Equal(h.t, int64(0), st.MinerAboveMinPowerCount)
 


### PR DESCRIPTION
closes #413

### Motivation

Currently consensus processes may conspire so that a miner actor will end up scheduling a cron task in the power actor for an epoch that precedes the power actors last cron tick. If this happens the task will not be run and the data structure holding it will never be removed from power actor state.

### Proposed Changes

1. Rename `power.State.LastCronTick` to `power.State.FirstCronEpoch` and alter its value to be the first epoch _after_ the last cron (or 0).
2. Add logic to move set `FirstCronEpoch` back if a task is set to an epoch at or before the last Cron tick.
3. Test that this allows tasks run in the past to execute on the next tick and that these tasks are garbage collected.