### PR TITLE
add tests for expiration set and queue 

### DIFF
--- a/actors/builtin/miner/bitfield_queue_test.go
+++ b/actors/builtin/miner/bitfield_queue_test.go
@@ -259,3 +259,9 @@ func assertBitfieldEquals(t *testing.T, bf *bitfield.BitField, values ...uint64)
 	})
 	require.NoError(t, err)
 }
+
+func assertBitfieldEmpty(t *testing.T, bf *bitfield.BitField) {
+	empty, err := bf.IsEmpty()
+	require.NoError(t, err)
+	assert.True(t, empty)
+}

--- a/actors/builtin/miner/bitfield_queue_test.go
+++ b/actors/builtin/miner/bitfield_queue_test.go
@@ -57,7 +57,8 @@ func TestBitfieldQueue(t *testing.T) {
 		queue := emptyBitfieldQueueWithQuantizing(t, QuantSpec{unit: 5, offset: 3})
 
 		for _, val := range []uint64{0, 2, 3, 4, 7, 8, 9} {
-			queue.AddToQueueValues(abi.ChainEpoch(val), val)
+			err := queue.AddToQueueValues(abi.ChainEpoch(val), val)
+			require.NoError(t, err)
 		}
 
 		// expect values to only be set on quantization boundaries

--- a/actors/builtin/miner/bitfield_queue_test.go
+++ b/actors/builtin/miner/bitfield_queue_test.go
@@ -53,6 +53,21 @@ func TestBitfieldQueue(t *testing.T) {
 			Equals(t, queue)
 	})
 
+	t.Run("quantizes added epochs according to quantization spec", func(t *testing.T) {
+		queue := emptyBitfieldQueueWithQuantizing(t, QuantSpec{unit: 5, offset: 3})
+
+		for _, val := range []uint64{0, 2, 3, 4, 7, 8, 9} {
+			queue.AddToQueueValues(abi.ChainEpoch(val), val)
+		}
+
+		// expect values to only be set on quantization boundaries
+		ExpectBQ().
+			Add(abi.ChainEpoch(3), 0, 2, 3).
+			Add(abi.ChainEpoch(8), 4, 7, 8).
+			Add(abi.ChainEpoch(13), 9).
+			Equals(t, queue)
+	})
+
 	t.Run("merges values withing same epoch", func(t *testing.T) {
 		queue := emptyBitfieldQueue(t)
 

--- a/actors/builtin/miner/expiration_queue.go
+++ b/actors/builtin/miner/expiration_queue.go
@@ -443,7 +443,7 @@ func (q ExpirationQueue) PopUntil(until abi.ChainEpoch) (*ExpirationSet, error) 
 		onTimeSectors = append(onTimeSectors, thisValue.OnTimeSectors)
 		earlySectors = append(earlySectors, thisValue.EarlySectors)
 		activePower = activePower.Add(thisValue.ActivePower)
-		faultyPower = faultyPower.Add(thisValue.ActivePower)
+		faultyPower = faultyPower.Add(thisValue.FaultyPower)
 		onTimePledge = big.Add(onTimePledge, thisValue.OnTimePledge)
 		return nil
 	}); err != nil && err != stopErr {

--- a/actors/builtin/miner/expiration_queue.go
+++ b/actors/builtin/miner/expiration_queue.go
@@ -268,7 +268,7 @@ func (q ExpirationQueue) RescheduleAllAsFaults(faultExpiration abi.ChainEpoch) e
 // Removes sectors from any queue entries in which they appear that are earlier then their scheduled expiration epoch,
 // and schedules them at their expected termination epoch.
 // Pledge for the sectors is re-added as on-time.
-// Power for the sectors is changes from faulty to active (whether rescheduled or not).
+// Power for the sectors is changed from faulty to active (whether rescheduled or not).
 // Returns the newly-recovered power. Fails if any sectors are not found in the queue.
 func (q ExpirationQueue) RescheduleRecovered(sectors []*SectorOnChainInfo, ssize abi.SectorSize) (PowerPair, error) {
 	remaining := make(map[abi.SectorNumber]struct{}, len(sectors))

--- a/actors/builtin/miner/expiration_queue.go
+++ b/actors/builtin/miner/expiration_queue.go
@@ -404,7 +404,6 @@ func (q ExpirationQueue) RemoveSectors(sectors []*SectorOnChainInfo, faults *abi
 					es.ActivePower = es.ActivePower.Sub(power)
 					removed.ActivePower = removed.ActivePower.Add(power)
 				}
-				es.OnTimePledge = big.Sub(es.OnTimePledge, sector.InitialPledge)
 				if _, r := recoveringMap[sno]; r {
 					recoveringPower = recoveringPower.Add(power)
 				}

--- a/actors/builtin/miner/expiration_queue_test.go
+++ b/actors/builtin/miner/expiration_queue_test.go
@@ -1,8 +1,12 @@
 package miner
 
 import (
+	"context"
+	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-bitfield"
 	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/specs-actors/actors/util/adt"
+	"github.com/filecoin-project/specs-actors/support/mock"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -164,33 +168,168 @@ func TestExpirationSet(t *testing.T) {
 	})
 }
 
+func TestExpirationQueue(t *testing.T) {
+	sectors := []*SectorOnChainInfo{
+		testSector(2, 1, 50, 60, 1000),
+		testSector(3, 2, 51, 61, 1001),
+		testSector(7, 3, 52, 62, 1002),
+		testSector(8, 4, 53, 63, 1003),
+		testSector(11, 5, 54, 64, 1004),
+		testSector(13, 6, 55, 65, 1005),
+	}
+	sectorSize := abi.SectorSize(32 * 1 << 30)
+
+	t.Run("added sectors can be popped off queue", func(t *testing.T) {
+		queue := emptyExprirationQueue(t)
+		queue.AddActiveSectors(sectors, sectorSize)
+
+		// default test quantizing of 1 means every sector is in its own expriation group
+		assert.Equal(t, len(sectors), int(queue.Length()))
+
+		_, err := queue.Root()
+		require.NoError(t, err)
+
+		// pop off sectors up to and including epoch 8
+		set, err := queue.PopUntil(7)
+		require.NoError(t, err)
+
+		// only 3 sectors remain
+		assert.Equal(t, 3, int(queue.Length()))
+
+		assertBitfieldEquals(t, set.OnTimeSectors, 1, 2, 3)
+		assertBitfieldEmpty(t, set.EarlySectors)
+
+		activePower := PowerForSectors(sectorSize, sectors[:3])
+		faultyPower := NewPowerPairZero()
+
+		assert.Equal(t, big.NewInt(3003), set.OnTimePledge) // sum of first 3 sector pledges
+		assert.True(t, activePower.Equals(set.ActivePower))
+		assert.True(t, faultyPower.Equals(set.FaultyPower))
+
+		// pop off rest up to and including epoch 8
+		set, err = queue.PopUntil(20)
+		require.NoError(t, err)
+
+		assertBitfieldEquals(t, set.OnTimeSectors, 4, 5, 6)
+		assertBitfieldEmpty(t, set.EarlySectors)
+
+		activePower = PowerForSectors(sectorSize, sectors[3:])
+		faultyPower = NewPowerPairZero()
+
+		assert.Equal(t, big.NewInt(3012), set.OnTimePledge) // sum of last 3 sector pledges
+		assert.True(t, activePower.Equals(set.ActivePower))
+		assert.True(t, faultyPower.Equals(set.FaultyPower))
+
+		// queue is now empty
+		assert.Equal(t, 0, int(queue.Length()))
+	})
+
+	t.Run("quantizes added sectors by expiration", func(t *testing.T) {
+		queue := emptyExpirationQueueWithQuantizing(t, QuantSpec{unit: 5, offset: 3})
+		queue.AddActiveSectors(sectors, sectorSize)
+
+		// work around caching issues in amt
+		_, err := queue.Root()
+		require.NoError(t, err)
+
+		// quantizing spec means sectors should be grouped into 3 sets expiring at 3, 8 and 13
+		assert.Equal(t, 3, int(queue.Length()))
+
+		// set popped before first quantized sector should be empty
+		set, err := queue.PopUntil(2)
+		require.NoError(t, err)
+		assertBitfieldEmpty(t, set.OnTimeSectors)
+		assert.Equal(t, 3, int(queue.Length()))
+
+		// first 2 sectors will be in first set popped off at quantization offset (3)
+		set, err = queue.PopUntil(3)
+		require.NoError(t, err)
+		assertBitfieldEquals(t, set.OnTimeSectors, 1, 2)
+		assert.Equal(t, 2, int(queue.Length()))
+
+		_, err = queue.Root()
+		require.NoError(t, err)
+
+		// no sectors will be popped off in quantization interval
+		set, err = queue.PopUntil(7)
+		require.NoError(t, err)
+		assertBitfieldEmpty(t, set.OnTimeSectors)
+		assert.Equal(t, 2, int(queue.Length()))
+
+		// next 2 sectors will be in first set popped off after quantization interval (8)
+		set, err = queue.PopUntil(8)
+		require.NoError(t, err)
+		assertBitfieldEquals(t, set.OnTimeSectors, 3, 4)
+		assert.Equal(t, 1, int(queue.Length()))
+
+		_, err = queue.Root()
+		require.NoError(t, err)
+
+		// no sectors will be popped off in quantization interval
+		set, err = queue.PopUntil(12)
+		require.NoError(t, err)
+		assertBitfieldEmpty(t, set.OnTimeSectors)
+		assert.Equal(t, 1, int(queue.Length()))
+
+		// rest of sectors will be in first set popped off after quantization interval (13)
+		set, err = queue.PopUntil(13)
+		require.NoError(t, err)
+		assertBitfieldEquals(t, set.OnTimeSectors, 5, 6)
+		assert.Equal(t, 0, int(queue.Length()))
+	})
+
+	t.Run("reschedules sectors to expire later", func(t *testing.T) {
+		queue := emptyExprirationQueue(t)
+		queue.AddActiveSectors(sectors, sectorSize)
+
+		_, err := queue.Root()
+		require.NoError(t, err)
+
+		queue.RescheduleExpirations(abi.ChainEpoch(20), sectors[:3], sectorSize)
+
+		_, err = queue.Root()
+		require.NoError(t, err)
+
+		// expect 3 rescheduled sectors to be bundled into 1 group
+		assert.Equal(t, 4, int(queue.Length()))
+
+		// rescheduled sectors are no longer scheduled before epoch 8
+		set, err := queue.PopUntil(7)
+		require.NoError(t, err)
+		assertBitfieldEmpty(t, set.OnTimeSectors)
+		assert.Equal(t, 4, int(queue.Length()))
+
+		// pop off sectors before new expiration and expect only the rescheduled group to remain
+		_, err = queue.PopUntil(19)
+		require.NoError(t, err)
+		assert.Equal(t, 1, int(queue.Length()))
+
+		// pop off rescheduled sectors
+		set, err = queue.PopUntil(20)
+		require.NoError(t, err)
+		assert.Equal(t, 0, int(queue.Length()))
+
+		// expect all sector stats from first 3 sectors to belong to new expiration group
+		assertBitfieldEquals(t, set.OnTimeSectors, 1, 2, 3)
+		assertBitfieldEmpty(t, set.EarlySectors)
+
+		activePower := PowerForSectors(sectorSize, sectors[:3])
+		faultyPower := NewPowerPairZero()
+
+		assert.Equal(t, big.NewInt(3003), set.OnTimePledge)
+		assert.True(t, activePower.Equals(set.ActivePower))
+		assert.True(t, faultyPower.Equals(set.FaultyPower))
+	})
+}
+
 func TestExpirations(t *testing.T) {
 	quant := QuantSpec{unit: 10, offset: 3}
-	sectors := []*SectorOnChainInfo{{
-		Expiration:         7, // 7 -> 13
-		SectorNumber:       1,
-		DealWeight:         big.Zero(),
-		VerifiedDealWeight: big.Zero(),
-		InitialPledge:      big.Zero(),
-	}, {
-		Expiration:         8, // 8 -> 13
-		SectorNumber:       2,
-		DealWeight:         big.Zero(),
-		VerifiedDealWeight: big.Zero(),
-		InitialPledge:      big.Zero(),
-	}, {
-		Expiration:         14, // 14 -> 23
-		SectorNumber:       3,
-		DealWeight:         big.Zero(),
-		VerifiedDealWeight: big.Zero(),
-		InitialPledge:      big.Zero(),
-	}, {
-		Expiration:         13, // 13 -> 13
-		SectorNumber:       4,
-		DealWeight:         big.Zero(),
-		VerifiedDealWeight: big.Zero(),
-		InitialPledge:      big.Zero(),
-	}}
+	sectors := []*SectorOnChainInfo{
+		testSector(7, 1, 0, 0, 0),
+		testSector(8, 2, 0, 0, 0),
+		testSector(14, 3, 0, 0, 0),
+		testSector(13, 4, 0, 0, 0),
+	}
 	result := groupSectorsByExpiration(2048, sectors, quant)
 	expected := []*sectorEpochSet{{
 		epoch:   13,
@@ -216,9 +355,34 @@ func TestExpirationsEmpty(t *testing.T) {
 	require.Equal(t, expected, result)
 }
 
+func testSector(expiration, number, weight, vweight, pledge int64) *SectorOnChainInfo {
+	return &SectorOnChainInfo{
+		Expiration:         abi.ChainEpoch(expiration),
+		SectorNumber:       abi.SectorNumber(number),
+		DealWeight:         big.NewInt(weight),
+		VerifiedDealWeight: big.NewInt(vweight),
+		InitialPledge:      abi.NewTokenAmount(pledge),
+	}
+}
+
 func assertSectorSet(t *testing.T, expected, actual *sectorEpochSet) {
 	assert.Equal(t, expected.epoch, actual.epoch)
 	assert.Equal(t, expected.sectors, actual.sectors)
 	assert.True(t, expected.power.Equals(actual.power), "expected %v, actual %v", expected.power, actual.power)
 	assert.True(t, expected.pledge.Equals(actual.pledge), "expected %v, actual %v", expected.pledge, actual.pledge)
+}
+
+func emptyExpirationQueueWithQuantizing(t *testing.T, quant QuantSpec) ExpirationQueue {
+	rt := mock.NewBuilder(context.Background(), address.Undef).Build(t)
+	store := adt.AsStore(rt)
+	root, err := adt.MakeEmptyArray(store).Root()
+	require.NoError(t, err)
+
+	queue, err := LoadExpirationQueue(store, root, quant)
+	require.NoError(t, err)
+	return queue
+}
+
+func emptyExprirationQueue(t *testing.T) ExpirationQueue {
+	return emptyExpirationQueueWithQuantizing(t, NoQuantization)
 }

--- a/actors/builtin/miner/expiration_queue_test.go
+++ b/actors/builtin/miner/expiration_queue_test.go
@@ -182,6 +182,7 @@ func TestExpirationQueue(t *testing.T) {
 	t.Run("added sectors can be popped off queue", func(t *testing.T) {
 		queue := emptyExpirationQueue(t)
 		secNums, power, pledge, err := queue.AddActiveSectors(sectors, sectorSize)
+		require.NoError(t, err)
 		assertBitfieldEquals(t, secNums, 1, 2, 3, 4, 5, 6)
 		assert.True(t, power.Equals(PowerForSectors(sectorSize, sectors)))
 		assert.Equal(t, abi.NewTokenAmount(6015), pledge)
@@ -227,6 +228,7 @@ func TestExpirationQueue(t *testing.T) {
 	t.Run("quantizes added sectors by expiration", func(t *testing.T) {
 		queue := emptyExpirationQueueWithQuantizing(t, QuantSpec{unit: 5, offset: 3})
 		secNums, power, pledge, err := queue.AddActiveSectors(sectors, sectorSize)
+		require.NoError(t, err)
 		assertBitfieldEquals(t, secNums, 1, 2, 3, 4, 5, 6)
 		assert.True(t, power.Equals(PowerForSectors(sectorSize, sectors)))
 		assert.Equal(t, abi.NewTokenAmount(6015), pledge)
@@ -528,6 +530,7 @@ func TestExpirationQueue(t *testing.T) {
 			toRemove,
 			toAdd,
 			sectorSize)
+		require.NoError(t, err)
 		assertBitfieldEquals(t, removed, 1, 2, 4)
 		assertBitfieldEquals(t, added, 3, 5)
 		addedPower := PowerForSectors(sectorSize, toAdd)

--- a/actors/builtin/miner/expiration_queue_test.go
+++ b/actors/builtin/miner/expiration_queue_test.go
@@ -1,6 +1,8 @@
 package miner
 
 import (
+	"github.com/filecoin-project/go-bitfield"
+	"github.com/filecoin-project/specs-actors/actors/abi"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,6 +10,159 @@ import (
 
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
 )
+
+func TestExpirationSet(t *testing.T) {
+	onTimeSectors := bitfield.NewFromSet([]uint64{5, 8, 9})
+	earlySectors := bitfield.NewFromSet([]uint64{2, 3})
+	onTimePledge := abi.NewTokenAmount(1000)
+	activePower := NewPowerPair(abi.NewStoragePower(1<<13), abi.NewStoragePower(1<<14))
+	faultyPower := NewPowerPair(abi.NewStoragePower(1<<11), abi.NewStoragePower(1<<12))
+
+	t.Run("adds sectors and power to empty set", func(t *testing.T) {
+		set := NewExpirationSetEmpty()
+
+		err := set.Add(onTimeSectors, earlySectors, onTimePledge, activePower, faultyPower)
+		require.NoError(t, err)
+
+		assertBitfieldEquals(t, set.OnTimeSectors, 5, 8, 9)
+		assertBitfieldEquals(t, set.EarlySectors, 2, 3)
+		assert.Equal(t, onTimePledge, set.OnTimePledge)
+		assert.True(t, activePower.Equals(set.ActivePower))
+		assert.True(t, faultyPower.Equals(set.FaultyPower))
+	})
+
+	t.Run("adds sectors and power to non-empty set", func(t *testing.T) {
+		set := NewExpirationSet(onTimeSectors, earlySectors, onTimePledge, activePower, faultyPower)
+
+		err := set.Add(
+			bitfield.NewFromSet([]uint64{6, 7, 11}),
+			bitfield.NewFromSet([]uint64{1, 4}),
+			abi.NewTokenAmount(300),
+			NewPowerPair(abi.NewStoragePower(3*(1<<13)), abi.NewStoragePower(3*(1<<14))),
+			NewPowerPair(abi.NewStoragePower(3*(1<<11)), abi.NewStoragePower(3*(1<<12))),
+		)
+		require.NoError(t, err)
+
+		assertBitfieldEquals(t, set.OnTimeSectors, 5, 6, 7, 8, 9, 11)
+		assertBitfieldEquals(t, set.EarlySectors, 1, 2, 3, 4)
+		assert.Equal(t, abi.NewTokenAmount(1300), set.OnTimePledge)
+		active := NewPowerPair(abi.NewStoragePower(1<<15), abi.NewStoragePower(1<<16))
+		assert.True(t, active.Equals(set.ActivePower))
+		faulty := NewPowerPair(abi.NewStoragePower(1<<13), abi.NewStoragePower(1<<14))
+		assert.True(t, faulty.Equals(set.FaultyPower))
+	})
+
+	t.Run("removes sectors and power set", func(t *testing.T) {
+		set := NewExpirationSet(onTimeSectors, earlySectors, onTimePledge, activePower, faultyPower)
+
+		err := set.Remove(
+			bitfield.NewFromSet([]uint64{9}),
+			bitfield.NewFromSet([]uint64{2}),
+			abi.NewTokenAmount(800),
+			NewPowerPair(abi.NewStoragePower(3*(1<<11)), abi.NewStoragePower(3*(1<<12))),
+			NewPowerPair(abi.NewStoragePower(3*(1<<9)), abi.NewStoragePower(3*(1<<10))),
+		)
+		require.NoError(t, err)
+
+		assertBitfieldEquals(t, set.OnTimeSectors, 5, 8)
+		assertBitfieldEquals(t, set.EarlySectors, 3)
+		assert.Equal(t, abi.NewTokenAmount(200), set.OnTimePledge)
+		active := NewPowerPair(abi.NewStoragePower(1<<11), abi.NewStoragePower(1<<12))
+		assert.True(t, active.Equals(set.ActivePower))
+		faulty := NewPowerPair(abi.NewStoragePower(1<<9), abi.NewStoragePower(1<<10))
+		assert.True(t, faulty.Equals(set.FaultyPower))
+	})
+
+	t.Run("remove fails when pledge underflows", func(t *testing.T) {
+		set := NewExpirationSet(onTimeSectors, earlySectors, onTimePledge, activePower, faultyPower)
+
+		err := set.Remove(
+			bitfield.NewFromSet([]uint64{9}),
+			bitfield.NewFromSet([]uint64{2}),
+			abi.NewTokenAmount(1200),
+			NewPowerPair(abi.NewStoragePower(3*(1<<11)), abi.NewStoragePower(3*(1<<12))),
+			NewPowerPair(abi.NewStoragePower(3*(1<<9)), abi.NewStoragePower(3*(1<<10))),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "pledge underflow")
+	})
+
+	t.Run("remove fails to remove sectors it does not contain", func(t *testing.T) {
+		set := NewExpirationSet(onTimeSectors, earlySectors, onTimePledge, activePower, faultyPower)
+
+		// remove unknown active sector 12
+		err := set.Remove(
+			bitfield.NewFromSet([]uint64{12}),
+			bitfield.NewFromSet([]uint64{}),
+			abi.NewTokenAmount(0),
+			NewPowerPair(abi.NewStoragePower(3*(1<<11)), abi.NewStoragePower(3*(1<<12))),
+			NewPowerPair(abi.NewStoragePower(3*(1<<9)), abi.NewStoragePower(3*(1<<10))),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not contained")
+
+		// remove faulty sector 8, that is active in the set
+		err = set.Remove(
+			bitfield.NewFromSet([]uint64{0}),
+			bitfield.NewFromSet([]uint64{8}),
+			abi.NewTokenAmount(0),
+			NewPowerPair(abi.NewStoragePower(3*(1<<11)), abi.NewStoragePower(3*(1<<12))),
+			NewPowerPair(abi.NewStoragePower(3*(1<<9)), abi.NewStoragePower(3*(1<<10))),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not contained")
+	})
+
+	t.Run("remove fails when active or fault qa power underflows", func(t *testing.T) {
+		set := NewExpirationSet(onTimeSectors, earlySectors, onTimePledge, activePower, faultyPower)
+
+		// active removed power > active power
+		err := set.Remove(
+			bitfield.NewFromSet([]uint64{9}),
+			bitfield.NewFromSet([]uint64{2}),
+			abi.NewTokenAmount(200),
+			NewPowerPair(abi.NewStoragePower(3*(1<<12)), abi.NewStoragePower(3*(1<<13))),
+			NewPowerPair(abi.NewStoragePower(3*(1<<9)), abi.NewStoragePower(3*(1<<10))),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "power underflow")
+
+		set = NewExpirationSet(onTimeSectors, earlySectors, onTimePledge, activePower, faultyPower)
+
+		// faulty removed power > faulty power
+		err = set.Remove(
+			bitfield.NewFromSet([]uint64{9}),
+			bitfield.NewFromSet([]uint64{2}),
+			abi.NewTokenAmount(200),
+			NewPowerPair(abi.NewStoragePower(3*(1<<11)), abi.NewStoragePower(3*(1<<12))),
+			NewPowerPair(abi.NewStoragePower(3*(1<<10)), abi.NewStoragePower(3*(1<<11))),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "power underflow")
+	})
+
+	t.Run("set is empty when all sectors removed", func(t *testing.T) {
+		set := NewExpirationSetEmpty()
+
+		empty, err := set.IsEmpty()
+		require.NoError(t, err)
+		assert.True(t, empty)
+
+		err = set.Add(onTimeSectors, earlySectors, onTimePledge, activePower, faultyPower)
+		require.NoError(t, err)
+
+		empty, err = set.IsEmpty()
+		require.NoError(t, err)
+		assert.False(t, empty)
+
+		err = set.Remove(onTimeSectors, earlySectors, onTimePledge, activePower, faultyPower)
+		require.NoError(t, err)
+
+		empty, err = set.IsEmpty()
+		require.NoError(t, err)
+		assert.True(t, empty)
+	})
+}
 
 func TestExpirations(t *testing.T) {
 	quant := QuantSpec{unit: 10, offset: 3}

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,5 @@ require (
 	github.com/warpfork/go-wish v0.0.0-20190328234359-8b3e70f8e830 // indirect
 	github.com/whyrusleeping/cbor-gen v0.0.0-20200710004633-5379fc63235d
 	github.com/xorcare/golden v0.6.0
-	golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456 // indirect
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
 )

--- a/go.sum
+++ b/go.sum
@@ -151,9 +151,8 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190219092855-153ac476189d/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456 h1:ng0gs1AKnRRuEMZoTLLlbOd+C17zUDepwGQBb/n+JVg=
-golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
### Motivation

`ExpirationSet` and `ExpirationQueue` need testing.

### Issues found

1. `PopUntil` inaccurately returned `FaultyPower` as `ActivePower`
2. `RemoveSectors` double counted (or erroneously single counted from early sectors) `OnTimePledge` when removing it from an ExpirationSet