### PR TITLE
Specs Actors Params Audit 

### DIFF
--- a/actors/abi/sector.go
+++ b/actors/abi/sector.go
@@ -183,6 +183,13 @@ func (p RegisteredSealProof) RegisteredWindowPoStProof() (RegisteredPoStProof, e
 	return info.WindowPoStProof, nil
 }
 
+
+// PARAM_SPEC
+// The maximum duration (activation to expiration) of a sector sealed with SDR.
+// Motivation: This gurantees that SDR is secure in the cost model for WindowPoSt and in the time model for WinningPoSt
+// This is based on estimation of hardware latency improvement and hardware and software cost reduction.
+const SectorMaximumLifetimeSDR = ChainEpoch(1_262_277 * 5)
+
 // SectorMaximumLifetime is the maximum duration a sector sealed with this proof may exist between activation and expiration
 func (p RegisteredSealProof) SectorMaximumLifetime() (ChainEpoch, error) {
 	info, ok := SealProofInfos[p]

--- a/actors/abi/sector.go
+++ b/actors/abi/sector.go
@@ -183,10 +183,8 @@ func (p RegisteredSealProof) RegisteredWindowPoStProof() (RegisteredPoStProof, e
 	return info.WindowPoStProof, nil
 }
 
-
-// PARAM_SPEC
-// The maximum duration (activation to expiration) of a sector sealed with SDR.
-// Motivation: This gurantees that SDR is secure in the cost model for WindowPoSt and in the time model for WinningPoSt
+// The maximum duration a sector sealed with this proof may exist between activation and expiration.
+// This ensures that SDR is secure in the cost model for Window PoSt and in the time model for Winning PoSt
 // This is based on estimation of hardware latency improvement and hardware and software cost reduction.
 const SectorMaximumLifetimeSDR = ChainEpoch(1_262_277 * 5)
 
@@ -238,6 +236,8 @@ func (p RegisteredPoStProof) WindowPoStPartitionSectors() (uint64, error) {
 	}
 	return sp.WindowPoStPartitionSectors()
 }
+
+
 
 ///
 /// Sealing

--- a/actors/builtin/market/market_test.go
+++ b/actors/builtin/market/market_test.go
@@ -507,8 +507,8 @@ func TestPublishStorageDeals(t *testing.T) {
 		// given power and circ supply cancel this should be 5*dealqapower / 100
 		dealSize := abi.PaddedPieceSize(2048) // generateDealProposal's deal size
 		providerCollateral := big.Div(
-			big.Mul(big.NewInt(int64(dealSize)), market.ProvCollateralPercentSupplyNum),
-			market.ProvCollateralPercentSupplyDenom,
+			big.Mul(big.NewInt(int64(dealSize)), market.ProviderCollateralSupplyTarget.Numerator),
+			market.ProviderCollateralSupplyTarget.Denominator,
 		)
 		deal := actor.generateDealWithCollateralAndAddFunds(rt, client, mAddr, providerCollateral, clientCollateral, startEpoch, endEpoch)
 		rt.SetCirculatingSupply(actor.networkQAPower) // convenient for these two numbers to cancel out
@@ -679,8 +679,8 @@ func TestPublishStorageDealsFailures(t *testing.T) {
 					rt.SetCirculatingSupply(h.networkQAPower)
 					dealSize := big.NewInt(2048) // default deal size used
 					providerMin := big.Div(
-						big.Mul(dealSize, market.ProvCollateralPercentSupplyNum),
-						market.ProvCollateralPercentSupplyDenom,
+						big.Mul(dealSize, market.ProviderCollateralSupplyTarget.Numerator),
+						market.ProviderCollateralSupplyTarget.Denominator,
 					)
 					d.ProviderCollateral = big.Sub(providerMin, big.NewInt(1))
 				},

--- a/actors/builtin/market/policy.go
+++ b/actors/builtin/market/policy.go
@@ -6,30 +6,30 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 )
 
-// PARAM_SPEC
-// The number of blocks between payouts for deals
-const DealUpdatesInterval = builtin.EpochsInDay
+// The number of epochs between payment and other state processing for deals.
+const DealUpdatesInterval = builtin.EpochsInDay // PARAM_SPEC
 
-// PARAM_SPEC
 // The percentage of normalized cirulating
 // supply that must be covered by provider collateral in a deal
-var ProvCollateralPercentSupplyNum = big.NewInt(5)
-var ProvCollateralPercentSupplyDenom = big.NewInt(100)
+var ProviderCollateralSupplyTarget = builtin.BigFrac{
+	Numerator: big.NewInt(5), // PARAM_SPEC
+	Denominator: big.NewInt(100),
+}
+//var ProvCollateralPercentSupplyNum = big.NewInt(5)
+//var ProvCollateralPercentSupplyDenom = big.NewInt(100)
 
-// PARAM_SPEC
-// Minimum Deal Duration
-var DealMinDuration = abi.ChainEpoch(180 * builtin.EpochsInDay)
+// Minimum deal duration.
+var DealMinDuration = abi.ChainEpoch(180 * builtin.EpochsInDay) // PARAM_SPEC
 
-// PARAM_SPEC
-// Maximum Deal Duration
-var DealMaxDuration = abi.ChainEpoch(540 * builtin.EpochsInDay)
+// Maximum deal duration
+var DealMaxDuration = abi.ChainEpoch(540 * builtin.EpochsInDay) // PARAM_SPEC
 
 // Bounds (inclusive) on deal duration
-func dealDurationBounds(size abi.PaddedPieceSize) (min abi.ChainEpoch, max abi.ChainEpoch) {
+func dealDurationBounds(_ abi.PaddedPieceSize) (min abi.ChainEpoch, max abi.ChainEpoch) {
 	return DealMinDuration, DealMaxDuration // PARAM_FINISH
 }
 
-func dealPricePerEpochBounds(size abi.PaddedPieceSize, duration abi.ChainEpoch) (min abi.TokenAmount, max abi.TokenAmount) {
+func dealPricePerEpochBounds(_ abi.PaddedPieceSize, _ abi.ChainEpoch) (min abi.TokenAmount, max abi.TokenAmount) {
 	return abi.NewTokenAmount(0), abi.TotalFilecoin // PARAM_FINISH
 }
 
@@ -38,8 +38,8 @@ func DealProviderCollateralBounds(pieceSize abi.PaddedPieceSize, verified bool, 
 	// normalizedCirculatingSupply = FILCirculatingSupply * dealPowerShare
 	// dealPowerShare = dealQAPower / max(BaselinePower(t), NetworkQAPower(t), dealQAPower)
 
-	lockTargetNum := big.Mul(ProvCollateralPercentSupplyNum, networkCirculatingSupply)
-	lockTargetDenom := ProvCollateralPercentSupplyDenom
+	lockTargetNum := big.Mul(ProviderCollateralSupplyTarget.Numerator, networkCirculatingSupply)
+	lockTargetDenom := ProviderCollateralSupplyTarget.Denominator
 
 	qaPower := dealQAPower(pieceSize, verified)
 	powerShareNum := qaPower
@@ -51,7 +51,7 @@ func DealProviderCollateralBounds(pieceSize abi.PaddedPieceSize, verified bool, 
 	return minCollateral, abi.TotalFilecoin // PARAM_FINISH
 }
 
-func DealClientCollateralBounds(pieceSize abi.PaddedPieceSize, duration abi.ChainEpoch) (min abi.TokenAmount, max abi.TokenAmount) {
+func DealClientCollateralBounds(_ abi.PaddedPieceSize, _ abi.ChainEpoch) (min abi.TokenAmount, max abi.TokenAmount) {
 	return abi.NewTokenAmount(0), abi.TotalFilecoin // PARAM_FINISH
 }
 

--- a/actors/builtin/market/policy.go
+++ b/actors/builtin/market/policy.go
@@ -6,20 +6,27 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 )
 
-// DealUpdatesInterval is the number of blocks between payouts for deals
+// PARAM_SPEC
+// The number of blocks between payouts for deals
 const DealUpdatesInterval = builtin.EpochsInDay
 
-// ProvCollateralPercentSupplyNum is the numerator of the percentage of normalized cirulating
-// supply that must be covered by provider collateral
+// PARAM_SPEC
+// The percentage of normalized cirulating
+// supply that must be covered by provider collateral in a deal
 var ProvCollateralPercentSupplyNum = big.NewInt(5)
-
-// ProvCollateralPercentSupplyDenom is the denominator of the percentage of normalized cirulating
-// supply that must be covered by provider collateral
 var ProvCollateralPercentSupplyDenom = big.NewInt(100)
+
+// PARAM_SPEC
+// Minimum Deal Duration
+var DealMinDuration = abi.ChainEpoch(180 * builtin.EpochsInDay)
+
+// PARAM_SPEC
+// Maximum Deal Duration
+var DealMaxDuration = abi.ChainEpoch(540 * builtin.EpochsInDay)
 
 // Bounds (inclusive) on deal duration
 func dealDurationBounds(size abi.PaddedPieceSize) (min abi.ChainEpoch, max abi.ChainEpoch) {
-	return abi.ChainEpoch(180 * builtin.EpochsInDay), abi.ChainEpoch(540 * builtin.EpochsInDay) // PARAM_FINISH
+	return DealMinDuration, DealMaxDuration // PARAM_FINISH
 }
 
 func dealPricePerEpochBounds(size abi.PaddedPieceSize, duration abi.ChainEpoch) (min abi.TokenAmount, max abi.TokenAmount) {

--- a/actors/builtin/market/policy.go
+++ b/actors/builtin/market/policy.go
@@ -12,11 +12,9 @@ const DealUpdatesInterval = builtin.EpochsInDay // PARAM_SPEC
 // The percentage of normalized cirulating
 // supply that must be covered by provider collateral in a deal
 var ProviderCollateralSupplyTarget = builtin.BigFrac{
-	Numerator: big.NewInt(5), // PARAM_SPEC
+	Numerator:   big.NewInt(5), // PARAM_SPEC
 	Denominator: big.NewInt(100),
 }
-//var ProvCollateralPercentSupplyNum = big.NewInt(5)
-//var ProvCollateralPercentSupplyDenom = big.NewInt(100)
 
 // Minimum deal duration.
 var DealMinDuration = abi.ChainEpoch(180 * builtin.EpochsInDay) // PARAM_SPEC

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -2225,6 +2225,12 @@ func PowerForSectors(ssize abi.SectorSize, sectors []*SectorOnChainInfo) PowerPa
 	}
 }
 
+func ConsensusFaultActive(info *MinerInfo, currEpoch abi.ChainEpoch) bool {
+	// For penalization period to last for exactly finality epochs
+	// consensus faults are active until currEpoch exceeds ConsensusFaultElapsed
+	return currEpoch <= info.ConsensusFaultElapsed
+}
+
 func getMinerInfo(rt Runtime, st *State) *MinerInfo {
 	info, err := st.GetInfo(adt.AsStore(rt))
 	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "could not read miner info")

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -2177,7 +2177,7 @@ func TestExtendSectorExpiration(t *testing.T) {
 				require.NoError(t, err)
 				var partition miner.Partition
 				require.NoError(t, partitions.ForEach(&partition, func(partIdx int64) error {
-					oldSectorNos, err := partition.Sectors.All(miner.SectorsMax)
+					oldSectorNos, err := partition.Sectors.All(miner.AddressedSectorsMax)
 					require.NoError(t, err)
 
 					// filter out even-numbered sectors.
@@ -3263,7 +3263,7 @@ func (h *actorHarness) collectDeadlineExpirations(rt *mock.Runtime, deadline *mi
 	require.NoError(h.t, err)
 	expirations := map[abi.ChainEpoch][]uint64{}
 	_ = queue.ForEach(func(epoch abi.ChainEpoch, bf bitfield.BitField) error {
-		expanded, err := bf.All(miner.SectorsMax)
+		expanded, err := bf.All(miner.AddressedSectorsMax)
 		require.NoError(h.t, err)
 		expirations[epoch] = expanded
 		return nil

--- a/actors/builtin/miner/monies.go
+++ b/actors/builtin/miner/monies.go
@@ -4,25 +4,42 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
-	exitcode "github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 	"github.com/filecoin-project/specs-actors/actors/util/math"
 	"github.com/filecoin-project/specs-actors/actors/util/smoothing"
 )
 
-// PARAM_FINISH
-var PreCommitDepositFactor = 20
-var InitialPledgeFactor = 20
+// Projection period of expected sector block reward for deposit required to pre-commit a sector.
+// This deposit is lost if the pre-commitment is not timely followed up by a commitment proof.
+var PreCommitDepositFactor = 20 // PARAM_SPEC PARAM_FINISH
 var PreCommitDepositProjectionPeriod = abi.ChainEpoch(PreCommitDepositFactor) * builtin.EpochsInDay
-var InitialPledgeProjectionPeriod = abi.ChainEpoch(InitialPledgeFactor) * builtin.EpochsInDay
-var LockTargetFactorNum = big.NewInt(3)
-var LockTargetFactorDenom = big.NewInt(10)
 
+// Projection period of expected sector block rewards for storage pledge required to commit a sector.
+// This pledge is lost if a sector is terminated before its full committed lifetime.
+var InitialPledgeFactor = 20 // PARAM_SPEC PARAM_FINISH
+var InitialPledgeProjectionPeriod = abi.ChainEpoch(InitialPledgeFactor) * builtin.EpochsInDay
+
+// Multiplier of share of circulating money supply for consensus pledge required to commit a sector.
+// This pledge is lost if a sector is terminated before its full committed lifetime.
+var InitialPledgeLockTarget = BigFrac{
+	numerator:   big.NewInt(3), // PARAM_SPEC PARAM_FINISH
+	denominator: big.NewInt(10),
+}
+
+// Projection period of expected daily sector block reward penalised when a fault is declared "on time".
+// This guarantees that a miner pays back at least the expected block reward earned since the last successful PoSt.
+// The network conservatively assumes the sector was faulty since the last time it was proven.
+// This penalty is currently overly punitive for continued faults.
 // FF = BR(t, DeclaredFaultProjectionPeriod)
-// projection period of 2.14 days:  2880 * 2.14 = 6163.2.  Rounded to nearest epoch 6163
-var DeclaredFaultFactorNum = 214
+var DeclaredFaultFactorNum = 214 // PARAM_SPEC
 var DeclaredFaultFactorDenom = 100
 var DeclaredFaultProjectionPeriod = abi.ChainEpoch((builtin.EpochsInDay * DeclaredFaultFactorNum) / DeclaredFaultFactorDenom)
 
+// PARAM_SPEC
+// Amount of fee for faults that have not been declared on time.
+// Motivation: This fee is higher than FF for two reasons:
+// (1) it guarantees that a miner is incentivized to declare a fault early
+// (2) A miner stores less than (1-spacegap) of a sector, does not not declare it as faulty and hopes to get challenged on the stored parts. SP guarantees that on expectation this strategy would not earn positive rewards.
 // SP = BR(t, UndeclaredFaultProjectionPeriod)
 var UndeclaredFaultProjectionPeriod = abi.ChainEpoch(5) * builtin.EpochsInDay
 
@@ -107,8 +124,8 @@ func PreCommitDepositForPower(rewardEstimate, networkQAPowerEstimate *smoothing.
 func InitialPledgeForPower(qaPower, baselinePower abi.StoragePower, rewardEstimate, networkQAPowerEstimate *smoothing.FilterEstimate, circulatingSupply abi.TokenAmount) abi.TokenAmount {
 	ipBase := ExpectedRewardForPower(rewardEstimate, networkQAPowerEstimate, qaPower, InitialPledgeProjectionPeriod)
 
-	lockTargetNum := big.Mul(LockTargetFactorNum, circulatingSupply)
-	lockTargetDenom := LockTargetFactorDenom
+	lockTargetNum := big.Mul(InitialPledgeLockTarget.numerator, circulatingSupply)
+	lockTargetDenom := InitialPledgeLockTarget.denominator
 	pledgeShareNum := qaPower
 	networkQAPower := networkQAPowerEstimate.Estimate()
 	pledgeShareDenom := big.Max(big.Max(networkQAPower, baselinePower), qaPower) // use qaPower in case others are 0

--- a/actors/builtin/miner/monies.go
+++ b/actors/builtin/miner/monies.go
@@ -38,7 +38,7 @@ var DeclaredFaultProjectionPeriod = abi.ChainEpoch((builtin.EpochsInDay * Declar
 // Projection period of expected daily sector block reward penalised when a fault is not declared in advance.
 // This fee is higher than the declared fault fee for two reasons:
 // (1) it incentivizes a miner to declare a fault early;
-// (2) when a miner stores less than (1-spacegap) of a sector, does not not declare it as faulty,
+// (2) when a miner stores less than (1-spacegap) of a sector, does not declare it as faulty,
 //     and hopes to be challenged on the stored parts, it means the miner would not be expected to earn positive rewards.
 // SP = BR(t, UndeclaredFaultProjectionPeriod)
 var UndeclaredFaultProjectionPeriod = abi.ChainEpoch(5) * builtin.EpochsInDay // PARAM_SPEC
@@ -51,7 +51,9 @@ const ConsensusFaultFactor = 5
 
 // The projected block reward a sector would earn over some period.
 // Also known as "BR(t)".
-// BR(t) = ProjectedReward(t) * SectorQualityAdjustedPower / TotalNetworkQualityAdjustedPower
+// BR(t) = ProjectedRewardFraction(t) * SectorQualityAdjustedPower
+// ProjectedRewardFraction(t) is the sum of estimated reward over estimated total power
+// over all epochs in the projection period [t t+projectionDuration]
 func ExpectedRewardForPower(rewardEstimate, networkQAPowerEstimate *smoothing.FilterEstimate, qaSectorPower abi.StoragePower, projectionDuration abi.ChainEpoch) abi.TokenAmount {
 	networkQAPowerSmoothed := networkQAPowerEstimate.Estimate()
 	if networkQAPowerSmoothed.IsZero() {

--- a/actors/builtin/miner/partition_state_test.go
+++ b/actors/builtin/miner/partition_state_test.go
@@ -1062,7 +1062,7 @@ func bf(secNos ...uint64) bitfield.BitField {
 }
 
 func selectSectors(t *testing.T, sectors []*miner.SectorOnChainInfo, field bitfield.BitField) []*miner.SectorOnChainInfo {
-	toInclude, err := field.AllMap(miner.SectorsMax)
+	toInclude, err := field.AllMap(miner.AddressedSectorsMax)
 	require.NoError(t, err)
 
 	included := []*miner.SectorOnChainInfo{}
@@ -1085,7 +1085,7 @@ func emptyPartition(t *testing.T, store adt.Store) *miner.Partition {
 }
 
 func rescheduleSectors(t *testing.T, target abi.ChainEpoch, sectors []*miner.SectorOnChainInfo, filter bitfield.BitField) []*miner.SectorOnChainInfo {
-	toReschedule, err := filter.AllMap(miner.SectorsMax)
+	toReschedule, err := filter.AllMap(miner.AddressedSectorsMax)
 	require.NoError(t, err)
 	output := make([]*miner.SectorOnChainInfo, len(sectors))
 	for i, sector := range sectors {

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -245,9 +245,8 @@ var consensusFaultReporterShareGrowthRate = BigFrac{
 // PARAM_SPEC
 // Maximum share of slasher's reward
 var consensusFaultMaxReporterShare = BigFrac{
-	// PARAM_FINISH
 	numerator:   big.NewInt(1),
-	denominator: big.NewInt(4),
+	denominator: big.NewInt(20),
 }
 
 // Specification for a linear vesting schedule.

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -11,21 +11,20 @@ import (
 	builtin "github.com/filecoin-project/specs-actors/actors/builtin"
 	. "github.com/filecoin-project/specs-actors/actors/util"
 )
-// PARAM_SPEC
+
 // The period over which a miner's active sectors are expected to be proven via WindowPoSt.
-// Motivation: This guarantees that (1) user data is proven once a day, (2) user data is stored for 24h by a rational miner (due to WindowPoSt cost assumption).
-var WPoStProvingPeriod = abi.ChainEpoch(builtin.EpochsInDay) // 24 hours
+// This guarantees that (1) user data is proven daily, (2) user data is stored for 24h by a rational miner
+// (due to Window PoSt cost assumption).
+var WPoStProvingPeriod = abi.ChainEpoch(builtin.EpochsInDay) // 24 hours PARAM_SPEC
 
-// PARAM_SPEC
-// The period between the opening and the closing of a WindowPoSt deadline in which the miner is expected to provide a WindowPoSt proof.
-// Motivation: This guarantees that a miner has enough time to propagate a WindowPoSt for the current deadline.
-// Usage: This is used to calculate the opening and close of a deadline window and to calculate the number of deadlines in a proving period.
-var WPoStChallengeWindow = abi.ChainEpoch(30 * 60 / builtin.EpochDurationSeconds) // 30 minutes (48 per day)
+// The period between the opening and the closing of a WindowPoSt deadline in which the miner is expected to
+// provide a Window PoSt proof.
+// This provides a miner enough time to compute and propagate a Window PoSt proof.
+var WPoStChallengeWindow = abi.ChainEpoch(30 * 60 / builtin.EpochDurationSeconds) // 30 minutes (48 per day) PARAM_SPEC
 
-// PARAM_SPEC
 // The number of non-overlapping PoSt deadlines in a proving period.
-// Motivation: This guarantees that a miner can spread their WindowPoSt duties across a proving period, instead of submitting a single large WindowPoSt submission.
-const WPoStPeriodDeadlines = uint64(48)
+// This spreads a miner's Window PoSt work across a proving period.
+const WPoStPeriodDeadlines = uint64(48) // PARAM_SPEC
 
 // MaxPartitionsPerDeadline is the maximum number of partitions that will be assigned to a deadline.
 // For a minimum storage of upto 1Eib, we need 300 partitions per deadline.
@@ -38,44 +37,35 @@ func init() {
 	if WPoStProvingPeriod%WPoStChallengeWindow != 0 {
 		panic(fmt.Sprintf("incompatible proving period %d and challenge window %d", WPoStProvingPeriod, WPoStChallengeWindow))
 	}
+	// Check that WPoStPeriodDeadlines is consistent with the proving period and challenge window.
 	if abi.ChainEpoch(WPoStPeriodDeadlines)*WPoStChallengeWindow != WPoStProvingPeriod {
 		panic(fmt.Sprintf("incompatible proving period %d and challenge window %d", WPoStProvingPeriod, WPoStChallengeWindow))
 	}
 }
 
-// PARAM_SPEC
-// The maximum number of sectors that a miner can have (and implicitly the maximum number of faults, recoveries, etc.)
-// Note that when sectors are terminated they count towards SectorsMax until cleanup.
-// Motivation: This guarantees that actors operations per miner are bounded.
-// TODO raise this number, carefully
-// https://github.com/filecoin-project/specs-actors/issues/470
-const SectorsMax = 32 << 20 // PARAM_FINISH
-
-// PARAM_SPEC
 // The maximum number of partitions that can be loaded in a single invocation.
 // This limits the number of simultaneous fault, recovery, or sector-extension declarations.
 // We set this to same as MaxPartitionsPerDeadline so we can process that many partitions every deadline.
 const AddressedPartitionsMax = MaxPartitionsPerDeadline
 
-// PARAM_SPEC
 // The maximum number of sector infos that can be loaded in a single invocation.
-const AddressedSectorsMax = 10_000
+// This limits the amount of state to be read in a single message execution.
+const AddressedSectorsMax = 10_000 // PARAM_SPEC
 
 // Libp2p peer info limits.
 const (
-	// MaxPeerIDLength is the maximum length allowed for any on-chain peer ID. Most
-	// Peer IDs should be less than 50 bytes.
-	MaxPeerIDLength = 128
+	// MaxPeerIDLength is the maximum length allowed for any on-chain peer ID.
+	// Most Peer IDs are expected to be less than 50 bytes.
+	MaxPeerIDLength = 128 // PARAM_SPEC
 
-	// MaxMultiaddrData is the maximum amount of data that can be stored in
-	// multiaddrs.
-	MaxMultiaddrData = 1024
+	// MaxMultiaddrData is the maximum amount of data that can be stored in multiaddrs.
+	MaxMultiaddrData = 1024 // PARAM_SPEC
 )
 
-// Maximum bytes in a single prove-commit proof.
+// Maximum size of a single prove-commit proof, in bytes.
 const MaxProveCommitSize = 1024
 
-// Maximum number of control addresses
+// Maximum number of control addresses a miner may register.
 const MaxControlAddresses = 10
 
 // The maximum number of partitions that may be required to be loaded in a single invocation,
@@ -84,14 +74,11 @@ func loadPartitionsSectorsMax(partitionSectorCount uint64) uint64 {
 	return min64(AddressedSectorsMax/partitionSectorCount, AddressedPartitionsMax)
 }
 
-// The maximum number of new sectors that may be staged by a miner during a single proving period.
-const NewSectorsPerPeriodMax = 128 << 10
-
-// PARAM_SPEC
 // Epochs after which chain state is final with overwhelming probability (hence the likelihood of two fork of this size is negligible)
-// Motivation: This is a conservative value that is chosen via simulations of all known attacks.
-const ChainFinality = abi.ChainEpoch(1400)
+// This is a conservative value that is chosen via simulations of all known attacks.
+const ChainFinality = abi.ChainEpoch(1400) // PARAM_SPEC
 
+// Prefix for sealed sector CIDs (CommR).
 var SealedCIDPrefix = cid.Prefix{
 	Version:  1,
 	Codec:    cid.FilCommitmentSealed,
@@ -99,74 +86,65 @@ var SealedCIDPrefix = cid.Prefix{
 	MhLength: 32,
 }
 
-// List of proof types which can be used when creating new miner actors
+// List of proof types which may be used when creating a new miner actor.
+// This is mutable to allow configuration of testing and development networks.
 var SupportedProofTypes = map[abi.RegisteredSealProof]struct{}{
 	abi.RegisteredSealProof_StackedDrg32GiBV1: {},
 	abi.RegisteredSealProof_StackedDrg64GiBV1: {},
 }
 
-// Maximum delay to allow between precommit and provecommit
-// Dependent on algorithm and sector size
+// Maximum delay to allow between sector pre-commit and subsequent proof.
+// The allowable delay depends on seal proof algorithm.
 var MaxProveCommitDuration = map[abi.RegisteredSealProof]abi.ChainEpoch{
-	abi.RegisteredSealProof_StackedDrg32GiBV1:  abi.ChainEpoch(10000), // PARAM_FINISH
+	abi.RegisteredSealProof_StackedDrg32GiBV1:  abi.ChainEpoch(10000), // PARAM_SPEC PARAM_FINISH
 	abi.RegisteredSealProof_StackedDrg2KiBV1:   abi.ChainEpoch(10000),
 	abi.RegisteredSealProof_StackedDrg8MiBV1:   abi.ChainEpoch(10000),
 	abi.RegisteredSealProof_StackedDrg512MiBV1: abi.ChainEpoch(10000),
 	abi.RegisteredSealProof_StackedDrg64GiBV1:  abi.ChainEpoch(10000),
 }
 
-// Maximum delay between challenge and precommit
-var MaxPreCommitRandomnessLookback = abi.ChainEpoch(10000)
+// Maximum delay between challenge and pre-commitment.
+// This prevents a miner sealing sectors far in advance of committing them to the chain, thus committing to a
+// particular chain.
+var MaxPreCommitRandomnessLookback = abi.ChainEpoch(10000) // PARAM_SPEC
 
-// PARAM_SPEC
-// Number of epochs between publishing the precommit and when the challenge for interactive PoRep is drawn.
-// Motivation: This guarantees that (1) a miner cannot predict a future challenge (2) a miner cannot do a long fork in the past to insert a precommit after seeing a challenge.
-var PreCommitChallengeDelay = abi.ChainEpoch(150)
+// Number of epochs between publishing a sector pre-commitment and when the challenge for interactive PoRep is drawn.
+// This (1) prevents a miner predicting a challenge before staking their pre-commit deposit, and
+// (2) prevents a miner attempting a long fork in the past to insert a pre-commitment after seeing the challenge.
+var PreCommitChallengeDelay = abi.ChainEpoch(150) // PARAM_SPEC
 
-// Lookback from the current epoch for state view for leader elections.
-const ElectionLookback = abi.ChainEpoch(1) // PARAM_FINISH
-
-// PARAM_SPEC
 // Lookback from the deadline's challenge window opening from which to sample chain randomness for the WindowPoSt challenge seed.
-// This lookback exists so that deadline windows can be non-overlapping (which make the programming simpler)
-// Motivation: A miner can start the WindowPoSt computation without waiting for chain stability. This value cannot be too large since it could compromise the rationality of honest storage (due to WindowPoSt cost assumptions)
-const WPoStChallengeLookback = abi.ChainEpoch(20)
+// This means that deadline windows can be non-overlapping (which make the programming simpler) without requiring a
+// miner to wait for chain stability during the challenge window.
+// This value cannot be too large lest it compromise the rationality of honest storage (from Window PoSt cost assumptions).
+const WPoStChallengeLookback = abi.ChainEpoch(20) // PARAM_SPEC
 
-// PARAM_SPEC
 // Minimum period between fault declaration and the next deadline opening.
 // If the number of epochs between fault declaration and deadline's challenge window opening is lower than FaultDeclarationCutoff,
 // the fault declaration is considered invalid for that deadline.
-// Motivation: This guarantees that a miner is not likely to successfully fork the chain and declare a fault after seeing the challenges.
-const FaultDeclarationCutoff = WPoStChallengeLookback + 50
+// This guarantees that a miner is not likely to successfully fork the chain and declare a fault after seeing the challenges.
+const FaultDeclarationCutoff = WPoStChallengeLookback + 50 // PARAM_SPEC
 
-// PARAM_SPEC
 // The maximum age of a fault before the sector is terminated.
-// Motivation: This guarantees to clients that a Filecoin miner cannot lose the file for longer than 14 days.
-var FaultMaxAge = WPoStProvingPeriod * 14
+// This bounds the time a miner can lose client's data before sacrificing pledge and deal collateral.
+var FaultMaxAge = WPoStProvingPeriod * 14 // PARAM_SPEC
 
-// PARAM_SPEC
 // Staging period for a miner worker key change.
-// Future improvement: Finality is a harsh delay for a miner who has lost their worker key, as the miner will miss Window PoSts until
-// it can be changed. It's the only safe value, though. We may implement a mitigation mechanism such as a second
-// key or allowing the owner account to submit PoSts while a key change is pending.
-// Motivation: This guarantees that a miner cannot choose a more favorable worker key that wins leader elections.
-const WorkerKeyChangeDelay = ChainFinality
+// This delay prevents a miner choosing a more favorable worker key that wins leader elections.
+const WorkerKeyChangeDelay = ChainFinality // PARAM_SPEC
 
-// PARAM_SPEC
 // Minimum number of epochs past the current epoch a sector may be set to expire.
-const MinSectorExpiration = 180 * builtin.EpochsInDay
+const MinSectorExpiration = 180 * builtin.EpochsInDay // PARAM_SPEC
 
-// PARAM_SPEC
-// A sector extension can be a maximum number of epochs past the current epoch.
-// A sector may be extended multiple times, however, the maximum extension will be the minimum of
-// CurrEpoch + MaximumSectorExpirationExtension and sector.ActivationEpoch+sealProof.SectorMaximumLifetime()
-const MaxSectorExpirationExtension = 540 * builtin.EpochsInDay
+// The maximum number of epochs past the current epoch that sector lifetime may be extended.
+// A sector may be extended multiple times, however, the total maximum lifetime is also bounded by
+// the associated seal proof's maximum lifetime.
+const MaxSectorExpirationExtension = 540 * builtin.EpochsInDay // PARAM_SPEC
 
-// PARAM_SPEC
-// Ratio of sector size to maximum deals per sector.
+// Ratio of sector size to maximum number of deals per sector.
 // The maximum number of deals is the sector size divided by this number (2^27)
 // which limits 32GiB sectors to 256 deals and 64GiB sectors to 512
-const DealLimitDenominator = 134217728
+const DealLimitDenominator = 134217728 // PARAM_SPEC
 
 // Number of epochs after a consensus fault for which a miner is ineligible
 // for permissioned actor methods and winning block elections.
@@ -204,13 +182,13 @@ func QualityForWeight(size abi.SectorSize, duration abi.ChainEpoch, dealWeight, 
 	return big.Div(big.Div(scaledUpWeightedSumSpaceTime, sectorSpaceTime), builtin.QualityBaseMultiplier)
 }
 
-// Returns the power for a sector size and weight.
+// The power for a sector size, committed duration, and weight.
 func QAPowerForWeight(size abi.SectorSize, duration abi.ChainEpoch, dealWeight, verifiedWeight abi.DealWeight) abi.StoragePower {
 	quality := QualityForWeight(size, duration, dealWeight, verifiedWeight)
 	return big.Rsh(big.Mul(big.NewIntUnsigned(uint64(size)), quality), builtin.SectorQualityPrecision)
 }
 
-// Returns the quality-adjusted power for a sector.
+// The quality-adjusted power for a sector.
 func QAPowerForSector(size abi.SectorSize, sector *SectorOnChainInfo) abi.StoragePower {
 	duration := sector.Expiration - sector.Activation
 	return QAPowerForWeight(size, duration, sector.DealWeight, sector.VerifiedDealWeight)
@@ -221,32 +199,22 @@ func SectorDealsMax(size abi.SectorSize) uint64 {
 	return max64(256, uint64(size/DealLimitDenominator))
 }
 
-type BigFrac struct {
-	numerator   big.Int
-	denominator big.Int
+// Initial share of consensus fault penalty allocated as reward to the reporter.
+var consensusFaultReporterInitialShare = builtin.BigFrac{
+	Numerator:   big.NewInt(1), // PARAM_FINISH PARAM_SPEC
+	Denominator: big.NewInt(1000),
 }
 
-// PARAM_SPEC
-// Initial share of a slasher's reward
-var consensusFaultReporterInitialShare = BigFrac{
-	// PARAM_FINISH
-	numerator:   big.NewInt(1),
-	denominator: big.NewInt(1000),
+// Per-epoch growth rate of the consensus fault reporter reward.
+var consensusFaultReporterShareGrowthRate = builtin.BigFrac{
+	Numerator:   big.NewInt(101251), 	// PARAM_FINISH PARAM_SPEC
+	Denominator: big.NewInt(100000),
 }
 
-// PARAM_SPEC
-// Growth rate of a slasher's reward
-var consensusFaultReporterShareGrowthRate = BigFrac{
-	// PARAM_FINISH
-	numerator:   big.NewInt(101251),
-	denominator: big.NewInt(100000),
-}
-
-// PARAM_SPEC
-// Maximum share of slasher's reward
-var consensusFaultMaxReporterShare = BigFrac{
-	numerator:   big.NewInt(1),
-	denominator: big.NewInt(20),
+// Maximum share of consensus fault penalty allocated as reporter reward.
+var consensusFaultMaxReporterShare = builtin.BigFrac{
+	Numerator:   big.NewInt(1), // PARAM_SPEC
+	Denominator: big.NewInt(20),
 }
 
 // Specification for a linear vesting schedule.
@@ -257,21 +225,19 @@ type VestSpec struct {
 	Quantization abi.ChainEpoch // Maximum precision of vesting table (limits cardinality of table).
 }
 
-// PARAM_SPEC
-var RewardVestingSpec = VestSpec{
+// The vesting schedule for block rewards earned by a block producer.
+var RewardVestingSpec = VestSpec{ // PARAM_SPEC
 	InitialDelay: abi.ChainEpoch(20 * builtin.EpochsInDay),  // PARAM_FINISH
 	VestPeriod:   abi.ChainEpoch(180 * builtin.EpochsInDay), // PARAM_FINISH
 	StepDuration: abi.ChainEpoch(1 * builtin.EpochsInDay),   // PARAM_FINISH
 	Quantization: 12 * builtin.EpochsInHour,                 // PARAM_FINISH
 }
 
-// When a user (called slasher) reports a consensus fault, they earn a share of the miner's current balance
+// When an actor reports a consensus fault, they earn a share of the penalty paid by the miner.
 // This amount is:  Min(initialShare * growthRate^elapsed, maxReporterShare) * collateral
-// Given current parameter choice, the longer a slasher waits, the higher their reward.
-// There it a maximum of reward to be earned.
+// The reward grows over time until a maximum, forming an auction for the report.
 func RewardForConsensusSlashReport(elapsedEpoch abi.ChainEpoch, collateral abi.TokenAmount) abi.TokenAmount {
 	// High level description
-	// PARAM_FINISH
 	// var growthRate = SLASHER_SHARE_GROWTH_RATE_NUM / SLASHER_SHARE_GROWTH_RATE_DENOM
 	// var multiplier = growthRate^elapsedEpoch
 	// var slasherProportion = min(INITIAL_SLASHER_SHARE * multiplier, 1.0)
@@ -286,17 +252,18 @@ func RewardForConsensusSlashReport(elapsedEpoch abi.ChainEpoch, collateral abi.T
 
 	// The following is equivalent to: slasherShare = growthRate^elapsed
 	// slasherShareNumerator = growthRateNumerator^elapsed
-	slasherShareNumerator := big.Exp(consensusFaultReporterShareGrowthRate.numerator, elapsed)
+	slasherShareNumerator := big.Exp(consensusFaultReporterShareGrowthRate.Numerator, elapsed)
 	// slasherShareDenominator = growthRateDenominator^elapsed
-	slasherShareDenominator := big.Exp(consensusFaultReporterShareGrowthRate.denominator, elapsed)
+	slasherShareDenominator := big.Exp(consensusFaultReporterShareGrowthRate.Denominator, elapsed)
 
 	// The following is equivalent to: reward = slasherShare * initialShare * collateral
 	// num = slasherShareNumerator * initialShareNumerator * collateral
-	num := big.Mul(big.Mul(slasherShareNumerator, consensusFaultReporterInitialShare.numerator), collateral)
+	num := big.Mul(big.Mul(slasherShareNumerator, consensusFaultReporterInitialShare.Numerator), collateral)
 	// denom = slasherShareDenominator * initialShareDenominator
-	denom := big.Mul(slasherShareDenominator, consensusFaultReporterInitialShare.denominator)
+	denom := big.Mul(slasherShareDenominator, consensusFaultReporterInitialShare.Denominator)
 
 	// The following is equivalent to: Min(reward, collateral * maxReporterShare)
 	// Min(rewardNum/rewardDenom, maxReporterShareNum/maxReporterShareDen*collateral)
-	return big.Min(big.Div(num, denom), big.Div(big.Mul(collateral, consensusFaultMaxReporterShare.numerator), consensusFaultMaxReporterShare.denominator))
+	return big.Min(big.Div(num, denom), big.Div(big.Mul(collateral, consensusFaultMaxReporterShare.Numerator),
+		consensusFaultMaxReporterShare.Denominator))
 }

--- a/actors/builtin/miner/sectors.go
+++ b/actors/builtin/miner/sectors.go
@@ -69,11 +69,6 @@ func (sa Sectors) Store(infos ...*SectorOnChainInfo) error {
 			return fmt.Errorf("failed to store sector %d: %w", info.SectorNumber, err)
 		}
 	}
-
-	if sa.Length() > SectorsMax {
-		return xerrors.Errorf("too many sectors")
-	}
-
 	return nil
 }
 

--- a/actors/builtin/network.go
+++ b/actors/builtin/network.go
@@ -6,8 +6,10 @@ import (
 	big "github.com/filecoin-project/specs-actors/actors/abi/big"
 )
 
+// PARAM_SPEC
 // The duration of a chain epoch.
-// This is used for deriving epoch-denominated periods that are more naturally expressed in clock time.
+// Motivation: It guarantees that a block is propagated and WinningPoSt can be successfully done in time all supported miners.
+// Usage: It is used for deriving epoch-denominated periods that are more naturally expressed in clock time.
 // TODO: In lieu of a real configuration mechanism for this value, we'd like to make it a var so that implementations
 // can override it at runtime. Doing so requires changing all the static references to it in this repo to go through
 // late-binding function calls, or they'll see the "wrong" value.
@@ -20,7 +22,10 @@ const SecondsInDay = 24 * SecondsInHour
 const EpochsInHour = SecondsInHour / EpochDurationSeconds
 const EpochsInDay = SecondsInDay / EpochDurationSeconds
 
-// The expected number of block producers in each epoch.
+// PARAM_SPEC
+// Expected number of block quality in an epoch (e.g. 1 block with block quality 5, or 5 blocks with quality 1)
+// Motivation: It ensures that there is enough on-chain throughput
+// Usage: It is used to calculate the block reward.
 var ExpectedLeadersPerEpoch = int64(5)
 
 func init() {

--- a/actors/builtin/power/policy.go
+++ b/actors/builtin/power/policy.go
@@ -4,25 +4,23 @@ import (
 	abi "github.com/filecoin-project/specs-actors/actors/abi"
 )
 
-// PARAM_SPEC
-// This is a switch for turning on the minimum miner size requirement.
-// When this number of miners of minimum miner size is reached, minimum miner size is enforce.
-const ConsensusMinerMinMiners = 4
+// The number of miners that must meet the consensus minimum miner power before that minimum power is enforced
+// as a condition of leader election.
+// This ensures a network still functions before any miners reach that threshold.
+const ConsensusMinerMinMiners = 4 // PARAM_SPEC
 
-// PARAM_SPEC
-// Minimum miner size, the minimum power of an individual miner to meet the threshold for leader election (in bytes).
+// The minimum power of an individual miner to meet the threshold for leader election (in bytes).
 // Motivation:
 // - Limits sybil generation
 // - Improves consensus fault detection
 // - Guarantees a minimum fee for consensus faults
 // - Ensures that a specific soundness for the power table
-// Future: we can consensus fault fee and sybil generation with crypto econ mechanic and we can mantain the target soundness by increasing the challenges for small miners.
-var ConsensusMinerMinPower = abi.NewStoragePower(100 << 40) // PARAM_FINISH
+// Note: We may be able to reduce this in the future, addressing consensus faults with more complicated penalties,
+// sybil generation with crypto-economic mechanism, and PoSt soundness by increasing the challenges for small miners.
+var ConsensusMinerMinPower = abi.NewStoragePower(100 << 40) // PARAM_SPEC PARAM_FINISH
 
-// PARAM_SPEC
-// Maximum number of prove commits a miner can submit in one epoch
+// Maximum number of prove-commits each miner can submit in one epoch.
 //
-// We bound this to 200 to limit the number of prove partitions we may need to update in a given epoch to 200.
-//
-// To support onboarding 1EiB/year, we need to allow at least 32 prove commits per epoch.
-const MaxMinerProveCommitsPerEpoch = 200
+// This limits the number of proof partitions we may need to load in the cron call path.
+// Onboarding 1EiB/year requires at least 32 prove-commits per epoch.
+const MaxMinerProveCommitsPerEpoch = 200 // PARAM_SPEC

--- a/actors/builtin/power/policy.go
+++ b/actors/builtin/power/policy.go
@@ -4,12 +4,22 @@ import (
 	abi "github.com/filecoin-project/specs-actors/actors/abi"
 )
 
-// Minimum number of registered miners for the minimum miner size limit to effectively limit consensus power.
-const ConsensusMinerMinMiners = 3
+// PARAM_SPEC
+// This is a switch for turning on the minimum miner size requirement.
+// When this number of miners of minimum miner size is reached, minimum miner size is enforce.
+const ConsensusMinerMinMiners = 4
 
-// Minimum power of an individual miner to meet the threshold for leader election.
-var ConsensusMinerMinPower = abi.NewStoragePower(1 << 40) // PARAM_FINISH
+// PARAM_SPEC
+// Minimum miner size, the minimum power of an individual miner to meet the threshold for leader election (in bytes).
+// Motivation:
+// - Limits sybil generation
+// - Improves consensus fault detection
+// - Guarantees a minimum fee for consensus faults
+// - Ensures that a specific soundness for the power table
+// Future: we can consensus fault fee and sybil generation with crypto econ mechanic and we can mantain the target soundness by increasing the challenges for small miners.
+var ConsensusMinerMinPower = abi.NewStoragePower(100 << 40) // PARAM_FINISH
 
+// PARAM_SPEC
 // Maximum number of prove commits a miner can submit in one epoch
 //
 // We bound this to 200 to limit the number of prove partitions we may need to update in a given epoch to 200.

--- a/actors/builtin/shared.go
+++ b/actors/builtin/shared.go
@@ -6,12 +6,18 @@ import (
 	addr "github.com/filecoin-project/go-address"
 
 	abi "github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/specs-actors/actors/abi/big"
 	runtime "github.com/filecoin-project/specs-actors/actors/runtime"
 	exitcode "github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 	autil "github.com/filecoin-project/specs-actors/actors/util"
 )
 
 ///// Code shared by multiple built-in actors. /////
+
+type BigFrac struct {
+	Numerator   big.Int
+	Denominator big.Int
+}
 
 // Aborts with an ErrIllegalArgument if predicate is not true.
 func RequireParam(rt runtime.Runtime, predicate bool, msg string, args ...interface{}) {


### PR DESCRIPTION
We are auditing the parameters, making sure that they have the correct values and the correct description. We are writing in front on all of them the `Filecoin Parameter:` prefix so that they will be easy to search in the future.

Closes #699

### Cryptoecon
Moved here: https://github.com/filecoin-project/specs-actors/issues/793

### Missing parameters
Parameters that I am not seeing:
- [ ] MaxPoStChainReference
- [ ] MinSectorExpiration

### Spec Actors (todo)
- AddressedSectorsMax
  - [ ] Checked value
  - [x] Checked usage
- WPoStPeriodDeadlines ([notes](https://hackmd.io/478poL-pQdq_qRKFEHTLTw?view))
  - [x] Value is correct/Proposed change
  - [ ] Check usage (pending confirmation of usage in [handleProvingDeadline](https://github.com/filecoin-project/specs-actors/blob/param-audit/actors/builtin/miner/miner_actor.go#L1740) and https://github.com/filecoin-project/specs-actors/issues/792) and part of [NewDeadlineInfo](https://github.com/filecoin-project/specs-actors/blob/param-audit/actors/builtin/miner/deadlines.go#L95-L106)
- ChainFinality
  - [x] Value is correct/Proposed change
  - [ ] [Used to determine SealRandomness validity](https://github.com/filecoin-project/specs-actors/blob/60a2ae96d2e656e2c4536a8f1ee905834e758912/actors/builtin/miner/miner_actor.go#L2335) (this is pending this change: https://github.com/filecoin-project/specs-actors/issues/672)
  - [x] [To set WorkerKeyChangeDelay](https://github.com/filecoin-project/specs-actors/blob/60a2ae96d2e656e2c4536a8f1ee905834e758912/actors/builtin/miner/policy.go#L99)
- [RegisteredSealProof.SectorMaximumLifetime()](https://github.com/filecoin-project/specs-actors/blob/60a2ae96d2e656e2c4536a8f1ee905834e758912/actors/abi/sector.go#L206-L211) (SDR)
  - [ ] Check value (current value of 5 years seem incorrect) (TODO: @nicola, @Irenegia, @lucaniz)
- MaxSealDuration
  - [ ] Checked value (TODO: @anorth will do the proposed change or @nicola will improve current value)
  - [x] Propose that this should be changed to https://github.com/filecoin-project/specs-actors/issues/672
- ConsensusMinerMinMiners
  - [ ] Checked value (TODO: @nicola pending https://github.com/filecoin-project/research-private/issues/297)
  - [ ] [CurrentTotalPower calculation](https://github.com/filecoin-project/specs-actors/blob/param-audit/actors/builtin/power/power_state.go#L268-L273)
  - [x] [MinerNominalPowerMeetsConsensusMinimum calculation](https://github.com/filecoin-project/specs-actors/blob/param-audit/actors/builtin/power/power_state.go#L85-L108)

### Spec Actors (done)
- InitialPledgeFactor
  - [x] Checked value
  - [x] Correctly used in [TerminationFee calculation](https://github.com/filecoin-project/specs-actors/blob/365408676dbb8442a5ce35a26a36460629a6163e/actors/builtin/miner/monies.go#L57-L69) (pending resolution of https://github.com/filecoin-project/specs-actors/issues/777, https://github.com/filecoin-project/specs-actors/issues/701)
- AddressedPartitionsMax
  - [x] Checked value
  - [x] Checked usage
- MinDealDuration
  - [x] Checked Value
  - [x] Checked usage in `validateDeal`
- MaxDealDuration
  - [x] Checked Value
  - [x] Checked usage in `validateDeal`
- DealUpdatesInterval
  - [x] Checked value (value does not have audit constraints)
  - [x] Checked usage in `updatePendingDealState`
- ConsensusMinerMinPower
  - [x] Checked value
  - [x] Pending clarification on unit
  - [x] Pending minimum miner size reduction
  - [x] [MinerNominalPowerMeetsConsensusMinimum calculation](https://github.com/filecoin-project/specs-actors/blob/param-audit/actors/builtin/power/power_state.go#L85-L108)
  - [x] [AddToClaim calculation](https://github.com/filecoin-project/specs-actors/blob/365408676dbb8442a5ce35a26a36460629a6163e/actors/builtin/power/power_state.go#L110-L152)
- FaultMaxAge
  - [x] Value is correct/Proposed change
  - [x] Used for setting an termination Cron for SkippedFaults (?) (see [here](https://github.com/filecoin-project/specs-actors/blob/60a2ae96d2e656e2c4536a8f1ee905834e758912/actors/builtin/miner/miner_actor.go#L297) and [here](https://github.com/filecoin-project/specs-actors/blob/60a2ae96d2e656e2c4536a8f1ee905834e758912/actors/builtin/miner/partition_state.go#L134))
  - [x] Used for setting termination Cron for DeclaredFaults (?) (see [here](https://github.com/filecoin-project/specs-actors/blob/60a2ae96d2e656e2c4536a8f1ee905834e758912/actors/builtin/miner/miner_actor.go#L1101) and [here](https://github.com/filecoin-project/specs-actors/blob/60a2ae96d2e656e2c4536a8f1ee905834e758912/actors/builtin/miner/miner_actor.go#L1134))
  - [x] Used for setting termination Cron for DetectedFaults (?) (see [here](https://github.com/filecoin-project/specs-actors/blob/60a2ae96d2e656e2c4536a8f1ee905834e758912/actors/builtin/miner/miner_actor.go#L1611))
- EpochDurationSeconds:
  - [x] Value is correct/Proposed change
  - [x] [WindowPost calculation](https://github.com/filecoin-project/specs-actors/blob/60a2ae96d2e656e2c4536a8f1ee905834e758912/actors/builtin/miner/policy.go#L16)
  - [x] [Checking that if in 1 hours there is a integer number of epochs](https://github.com/filecoin-project/specs-actors/blob/927d2adfe03fc01d18898e5d70cd5dd573ca58bb/actors/builtin/network.go#L25)
- ExpectedLeadersPerEpoch
  - [x] Value is correct/Proposed change
  - [x] ~Possibly change name to ExpectedQualityPerEpoch~
  - [x] [Reward Calculation](https://github.com/filecoin-project/specs-actors/blob/e5b62bf0f506ec6ea3899fa94dcd4dd701ad51e5/actors/builtin/reward/reward_actor.go#L74)
- WPoStProvingPeriod
  - [x] Value is correct/Proposed change
  - [x] [Calculating WPoStPeriodDeadlines](https://github.com/filecoin-project/specs-actors/blob/60a2ae96d2e656e2c4536a8f1ee905834e758912/actors/builtin/miner/policy.go#L19)
  - [x] [Calculating PeriodEnd and NextPeriodStart](https://github.com/filecoin-project/specs-actors/blob/60a2ae96d2e656e2c4536a8f1ee905834e758912/actors/builtin/miner/deadlines.go#L64-L70)
  - [x] [Resetting the next proving period](https://github.com/filecoin-project/specs-actors/blob/60a2ae96d2e656e2c4536a8f1ee905834e758912/actors/builtin/miner/miner_actor.go#L1705-L1710)
- WPoStChallengeWindow
  - [x] Value is correct/Proposed change
  - [x] ~Possibly rename into: WPoStDeadlineWindow~
  - [x] [Calculate WPoStPeriodDeadlines](https://github.com/filecoin-project/specs-actors/blob/60a2ae96d2e656e2c4536a8f1ee905834e758912/actors/builtin/miner/policy.go#L16)
  - [x] [Calculate Open and Close of a deadline](https://github.com/filecoin-project/specs-actors/blob/60a2ae96d2e656e2c4536a8f1ee905834e758912/actors/builtin/miner/deadlines.go#L84-L92)
- WPoStChallengeLookback:
  - [x] Value is correct/Proposed change (pending resolution of: https://github.com/filecoin-project/research-private/issues/279)
- SectorsMax
  - [x] Value is correct/Proposed change
  - [x] Clarification on active or total
  - [x] Change request on sector max depending on proof type
- NewSectorsPerPeriodMax
  - [x] [Not used, it should be removed](https://github.com/filecoin-project/specs-actors/blob/param-audit/actors/builtin/miner/policy.go#L57)
- PreCommitChallengeDelay
  - [x] Value is correct/Proposed change
  - [x] [Compute the delay in the epoch in which the interactive randomness is chosen](https://github.com/filecoin-project/specs-actors/blob/60a2ae96d2e656e2c4536a8f1ee905834e758912/actors/builtin/miner/miner_actor.go#L571)
- ElectionLookback
  - [x] [Parameter is never used and seems to be used incorrectly in a test](https://github.com/filecoin-project/specs-actors/blob/60a2ae96d2e656e2c4536a8f1ee905834e758912/actors/builtin/miner/miner_test.go#L2236-L2240)
- FaultDeclarationCutoff
  - [x] Value is correct/Proposed change
  - [x] [Used to calculate FaultCutoff deadline](https://github.com/filecoin-project/specs-actors/blob/60a2ae96d2e656e2c4536a8f1ee905834e758912/actors/builtin/miner/deadlines.go#L92)
- WorkerKeyChangeDelay
  - [x] Checked value
  - [x] [ChangeWorkerAddress](https://github.com/filecoin-project/specs-actors/blob/60a2ae96d2e656e2c4536a8f1ee905834e758912/actors/builtin/miner/miner_actor.go#L155-L175) 
- QualityBaseMultiplier
  - [x] Checked value
- DealWeightMultiplier
  - [x] Checked value
- VerifiedDealWeightMultiplier
  - [x] Checked value
- DealLimitDenominator
  - [x] Checked value (clarification requested)(possible update tracked here: https://github.com/filecoin-project/research-private/issues/306)
  - [x] [DealPerSectorLimit](https://github.com/filecoin-project/specs-actors/blob/60a2ae96d2e656e2c4536a8f1ee905834e758912/actors/builtin/miner/policy.go#L153-L156) function
- consensusFaultMaxReporterShare
  - [x] Checked value
  - [x] Correct usage in RewardForConsensusSlashReport
- MaxMinerProveCommitsPerEpoch
  - [x] Checked value
  - [x] [SubmitBulkPorep verify calculation](https://github.com/filecoin-project/specs-actors/blob/365408676dbb8442a5ce35a26a36460629a6163e/actors/builtin/power/power_actor.go#L279-L318)
  - [x] Correcly used in [InitialPledgeForPower](https://github.com/filecoin-project/specs-actors/blob/365408676dbb8442a5ce35a26a36460629a6163e/actors/builtin/miner/monies.go#L75-L88) (TODO: @irenegia, @lucaniz)
- SectorQualityPrecision
  - [x] Checked value
  - [x] [Used for scaling up quality](https://github.com/filecoin-project/specs-actors/blob/60a2ae96d2e656e2c4536a8f1ee905834e758912/actors/builtin/miner/policy.go#L131)
- DeclaredFaultFactorNum
  - [x] Checked value
  - [x] Usage
- DeclaredFaultFactorDenom
  - [x] Checked value
  - [x] Usage
- UndeclaredFaultFactorNum
  - [x] Checked value
  - [x] Usage
- UndeclaredFaultFactorDenom
  - [x] Checked value
  - [x] Usage