### PR TITLE
Feat/exponential baseline function

### DIFF
--- a/actors/builtin/reward/cbor_gen.go
+++ b/actors/builtin/reward/cbor_gen.go
@@ -13,7 +13,7 @@ import (
 
 var _ = xerrors.Errorf
 
-var lengthBufState = []byte{134}
+var lengthBufState = []byte{135}
 
 func (t *State) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -45,6 +45,11 @@ func (t *State) MarshalCBOR(w io.Writer) error {
 		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.EffectiveNetworkTime-1)); err != nil {
 			return err
 		}
+	}
+
+	// t.EffectiveBaselinePower (big.Int) (struct)
+	if err := t.EffectiveBaselinePower.MarshalCBOR(w); err != nil {
+		return err
 	}
 
 	// t.ThisEpochReward (big.Int) (struct)
@@ -84,7 +89,7 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 6 {
+	if extra != 7 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -130,6 +135,15 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 		}
 
 		t.EffectiveNetworkTime = abi.ChainEpoch(extraI)
+	}
+	// t.EffectiveBaselinePower (big.Int) (struct)
+
+	{
+
+		if err := t.EffectiveBaselinePower.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.EffectiveBaselinePower: %w", err)
+		}
+
 	}
 	// t.ThisEpochReward (big.Int) (struct)
 

--- a/actors/builtin/reward/reward_logic_test.go
+++ b/actors/builtin/reward/reward_logic_test.go
@@ -8,6 +8,7 @@ import (
 
 	abi "github.com/filecoin-project/specs-actors/actors/abi"
 	big "github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/stretchr/testify/assert"
 	"github.com/xorcare/golden"
 )
@@ -20,25 +21,21 @@ func q128ToF(x big.Int) float64 {
 }
 
 func TestComputeRTeta(t *testing.T) {
-	var oldBaselinePowerAt func(abi.ChainEpoch) abi.StoragePower
-
-	BaselinePowerAt, oldBaselinePowerAt = func(epoch abi.ChainEpoch) abi.StoragePower {
+	baselinePowerAt := func(epoch abi.ChainEpoch) abi.StoragePower {
 		return big.Mul(big.NewInt(int64(epoch+1)), big.NewInt(2048))
-	}, BaselinePowerAt
-	defer func() {
-		BaselinePowerAt = oldBaselinePowerAt
-	}()
+	}
 
-	assert.Equal(t, 0.5, q128ToF(computeRTheta(1, big.NewInt(2048+2*2048*0.5), big.NewInt(2048+2*2048))))
-	assert.Equal(t, 0.25, q128ToF(computeRTheta(1, big.NewInt(2048+2*2048*0.25), big.NewInt(2048+2*2048))))
+	assert.Equal(t, 0.5, q128ToF(computeRTheta(1, baselinePowerAt(1), big.NewInt(2048+2*2048*0.5), big.NewInt(2048+2*2048))))
+	assert.Equal(t, 0.25, q128ToF(computeRTheta(1, baselinePowerAt(1), big.NewInt(2048+2*2048*0.25), big.NewInt(2048+2*2048))))
 
 	cumsum15 := big.NewInt(0)
 	for i := abi.ChainEpoch(0); i < 16; i++ {
-		cumsum15 = big.Add(cumsum15, BaselinePowerAt(i))
+		cumsum15 = big.Add(cumsum15, baselinePowerAt(i))
 	}
 	assert.Equal(t, 15.25, q128ToF(computeRTheta(16,
-		big.Add(cumsum15, big.Div(BaselinePowerAt(16), big.NewInt(4))),
-		big.Add(cumsum15, BaselinePowerAt(16)))))
+		baselinePowerAt(16),
+		big.Add(cumsum15, big.Div(baselinePowerAt(16), big.NewInt(4))),
+		big.Add(cumsum15, baselinePowerAt(16)))))
 }
 
 func TestBaselineReward(t *testing.T) {
@@ -78,4 +75,78 @@ func TestSimpleRewrad(t *testing.T) {
 	}
 
 	golden.Assert(t, b.Bytes())
+}
+
+func TestBaselineRewardGrowth(t *testing.T) {
+
+	baselineInYears := func(start abi.StoragePower, x abi.ChainEpoch) abi.StoragePower {
+		baseline := start
+		for i := abi.ChainEpoch(0); i < x*builtin.EpochsInYear; i++ {
+			baseline = BaselinePowerFromPrev(baseline)
+		}
+		return baseline
+	}
+
+	// Baseline reward should have 200% growth rate
+	// This implies that for every year x, the baseline function should be:
+	// StartVal * 3^x.
+	//
+	// Error values for 1 years of growth were determined empirically with latest
+	// baseline power construction to set bounds in this test in order to
+	// 1. throw a test error if function changes and percent error goes up
+	// 2. serve as documentation of current error bounds
+	type growthTestCase struct {
+		StartVal abi.StoragePower
+		ErrBound float64
+	}
+	cases := []growthTestCase{
+		// 1 byte
+		{
+			abi.NewStoragePower(1),
+			1,
+		},
+		// GiB
+		{
+			abi.NewStoragePower(1 << 30),
+			1e-3,
+		},
+		// TiB
+		{
+			abi.NewStoragePower(1 << 40),
+			1e-6,
+		},
+		// PiB
+		{
+			abi.NewStoragePower(1 << 50),
+			1e-8,
+		},
+		// EiB
+		{
+			BaselineInitialValue,
+			1e-8,
+		},
+		// ZiB
+		{
+			big.Lsh(big.NewInt(1), 70),
+			1e-8,
+		},
+		// non power of 2 ~ 1 EiB
+		{
+			abi.NewStoragePower(513633559722596517),
+			1e-8,
+		},
+	}
+	for _, testCase := range cases {
+		years := int64(1)
+		end := baselineInYears(testCase.StartVal, abi.ChainEpoch(1))
+
+		multiplier := big.Exp(big.NewInt(3), big.NewInt(years)) // keeping this generalized in case we want to test more years
+		expected := big.Mul(testCase.StartVal, multiplier)
+		diff := big.Sub(expected, end)
+
+		perrFrac := gbig.NewRat(1, 1).SetFrac(diff.Int, expected.Int)
+		perr, _ := perrFrac.Float64()
+
+		assert.Less(t, perr, testCase.ErrBound)
+	}
 }


### PR DESCRIPTION
WIP exponential baseline function: x0 * e ^(k t)
- [x] implement exponential function using recurrence exp(n) = exponent * exp(n-1): `BaselinePowerNextEpoch`
- [x] track exp(ThisEpoch) and exp(EffectiveNetworkEpoch) in state
- [x] fix up calls of `BaselinePowerAt` to take in previous epoch baseline
- [x] set initial value to x0 (1 EiB)
- [x] track precision correctly within `BaselinePowerNextEpoch`
- [x] more documentation
- [x] fix tests + new tests

Exponent satisfying 200% growth rate calculated [here](https://www.wolframalpha.com/input/?i=Round%5BExp%5BLog%5B1%2B200%25%5D%2F%28%281+tropical+year%29%2F%2825+seconds%29%29%5D*2%5E128%5D) thanks to @davidad 