### PR TITLE
Assert that payments are non-negative

### DIFF
--- a/actors/builtin/multisig/multisig_actor.go
+++ b/actors/builtin/multisig/multisig_actor.go
@@ -141,6 +141,10 @@ func (a Actor) Propose(rt vmr.Runtime, params *ProposeParams) *ProposeReturn {
 	rt.ValidateImmediateCallerType(builtin.CallerTypesSignable...)
 	callerAddr := rt.Message().Caller()
 
+	if params.Value.Sign() < 0 {
+		rt.Abortf(exitcode.ErrIllegalArgument, "proposed value must be non-negative, was %v", params.Value)
+	}
+
 	var txnID TxnID
 	var st State
 	var txn *Transaction

--- a/actors/builtin/paych/paych_actor.go
+++ b/actors/builtin/paych/paych_actor.go
@@ -172,6 +172,10 @@ func (pca Actor) UpdateChannelState(rt vmr.Runtime, params *UpdateChannelStatePa
 		rt.Abortf(exitcode.ErrIllegalArgument, "this voucher has expired!")
 	}
 
+	if sv.Amount.Sign() < 0 {
+		rt.Abortf(exitcode.ErrIllegalArgument, "voucher amount must be non-negative, was %v", sv.Amount)
+	}
+
 	if len(sv.SecretPreimage) > 0 {
 		hashedSecret := rt.Syscalls().HashBlake2b(params.Secret)
 		if !bytes.Equal(hashedSecret[:], sv.SecretPreimage) {

--- a/actors/builtin/paych/paych_test.go
+++ b/actors/builtin/paych/paych_test.go
@@ -146,7 +146,7 @@ func TestPaymentChannelActor_CreateLane(t *testing.T) {
 		{desc: "fails if new send balance is negative", targetCode: builtin.AccountActorCodeID,
 			amt: -1, paymentChannel: paychAddr, epoch: 1, tlmin: 1, tlmax: 0,
 			sig: sig, verifySig: true,
-			expExitCode: exitcode.ErrIllegalState},
+			expExitCode: exitcode.ErrIllegalArgument},
 		{desc: "fails if signature not valid", targetCode: builtin.AccountActorCodeID,
 			amt: 1, paymentChannel: paychAddr, epoch: 1, tlmin: 1, tlmax: 0,
 			sig: nil, verifySig: true,


### PR DESCRIPTION
I'm not sure if anything can actually go wrong in either of these cases, but this seems like something we shouldn't allow.

Q: ~Assert non-negative instead of positive?~
A: yes (done)