### PR TITLE
Check input cids

### DIFF
--- a/actors/abi/sector.go
+++ b/actors/abi/sector.go
@@ -230,8 +230,10 @@ type SealVerifyInfo struct {
 	Randomness            SealRandomness
 	InteractiveRandomness InteractiveSealRandomness
 	Proof                 []byte
-	SealedCID             cid.Cid // CommR
-	UnsealedCID           cid.Cid // CommD
+
+	// Safe because we get those from the miner actor
+	SealedCID             cid.Cid `checked:"true"` // CommR
+	UnsealedCID           cid.Cid `checked:"true"` // CommD
 }
 
 ///

--- a/actors/abi/sector.go
+++ b/actors/abi/sector.go
@@ -232,8 +232,8 @@ type SealVerifyInfo struct {
 	Proof                 []byte
 
 	// Safe because we get those from the miner actor
-	SealedCID             cid.Cid `checked:"true"` // CommR
-	UnsealedCID           cid.Cid `checked:"true"` // CommD
+	SealedCID   cid.Cid `checked:"true"` // CommR
+	UnsealedCID cid.Cid `checked:"true"` // CommD
 }
 
 ///

--- a/actors/builtin/init/init_actor.go
+++ b/actors/builtin/init/init_actor.go
@@ -42,7 +42,7 @@ func (a Actor) Constructor(rt runtime.Runtime, params *ConstructorParams) *adt.E
 }
 
 type ExecParams struct {
-	CodeCID           cid.Cid
+	CodeCID           cid.Cid `checked:"true"` // invalid CIDs won't get committed to the state tree
 	ConstructorParams []byte
 }
 

--- a/actors/builtin/market/deal.go
+++ b/actors/builtin/market/deal.go
@@ -14,7 +14,7 @@ import (
 
 var PieceCIDPrefix = cid.Prefix{
 	Version:  1,
-	Codec:    cid.Raw,
+	Codec:    cid.FilCommitmentUnsealed,
 	MhType:   mh.SHA2_256_TRUNC254_PADDED,
 	MhLength: 32,
 }

--- a/actors/builtin/market/deal.go
+++ b/actors/builtin/market/deal.go
@@ -12,6 +12,13 @@ import (
 	acrypto "github.com/filecoin-project/specs-actors/actors/crypto"
 )
 
+var PieceCIDPrefix = cid.Prefix{
+	Version:  1,
+	Codec:    cid.Raw,
+	MhType:   mh.SHA2_256_TRUNC254_PADDED,
+	MhLength: 32,
+}
+
 // Note: Deal Collateral is only released and returned to clients and miners
 // when the storage deal stops counting towards power. In the current iteration,
 // it will be released when the sector containing the storage deals expires,
@@ -21,7 +28,7 @@ import (
 // Note: ClientCollateralPerEpoch may not be needed and removed pending future confirmation.
 // There will be a Minimum value for both client and provider deal collateral.
 type DealProposal struct {
-	PieceCID     cid.Cid // CommP
+	PieceCID     cid.Cid `checked:"true"` // Checked in validateDeal, CommP
 	PieceSize    abi.PaddedPieceSize
 	VerifiedDeal bool
 	Client       addr.Address

--- a/actors/builtin/market/market_actor.go
+++ b/actors/builtin/market/market_actor.go
@@ -647,6 +647,14 @@ func validateDeal(rt Runtime, deal ClientDealProposal) {
 
 	proposal := deal.Proposal
 
+	if !proposal.PieceCID.Defined() {
+		rt.Abortf(exitcode.ErrIllegalArgument, "proposal PieceCID undefined")
+	}
+
+	if proposal.PieceCID.Prefix() != PieceCIDPrefix {
+		rt.Abortf(exitcode.ErrIllegalArgument, "proposal PieceCID had wrong prefix")
+	}
+
 	if proposal.EndEpoch <= proposal.StartEpoch {
 		rt.Abortf(exitcode.ErrIllegalArgument, "proposal end before proposal start")
 	}

--- a/actors/builtin/market/market_test.go
+++ b/actors/builtin/market/market_test.go
@@ -555,6 +555,12 @@ func TestPublishStorageDealsFailures(t *testing.T) {
 				},
 				exitCode: exitcode.ErrInsufficientFunds,
 			},
+			"bad piece CID": {
+				setup: func(_ *mock.Runtime, _ *marketActorTestHarness, d *market.DealProposal) {
+					d.PieceCID = tutil.MakeCID("random cid", nil)
+				},
+				exitCode: exitcode.ErrIllegalArgument,
+			},
 		}
 
 		for name, tc := range tcs {
@@ -1759,7 +1765,7 @@ func TestComputeDataCommitment(t *testing.T) {
 		p1 := abi.PieceInfo{Size: d1.PieceSize, PieceCID: d1.PieceCID}
 		p2 := abi.PieceInfo{Size: d2.PieceSize, PieceCID: d2.PieceCID}
 
-		c := tutil.MakeCID("100")
+		c := tutil.MakeCID("100", &market.PieceCIDPrefix)
 
 		rt.ExpectComputeUnsealedSectorCID(1, []abi.PieceInfo{p1, p2}, c, nil)
 		rt.SetCaller(provider, builtin.StorageMinerActorCodeID)
@@ -2357,7 +2363,7 @@ func (h *marketActorTestHarness) generateDealAndAddFunds(rt *mock.Runtime, clien
 }
 
 func generateDealProposal(client, provider address.Address, startEpoch, endEpoch abi.ChainEpoch) market.DealProposal {
-	pieceCid := tutil.MakeCID("1")
+	pieceCid := tutil.MakeCID("1", &market.PieceCIDPrefix)
 	pieceSize := abi.PaddedPieceSize(2048)
 	storagePerEpoch := big.NewInt(10)
 	clientCollateral := big.NewInt(10)

--- a/actors/builtin/miner/deadlines_test.go
+++ b/actors/builtin/miner/deadlines_test.go
@@ -47,7 +47,7 @@ func TestProvingPeriodDeadlines(t *testing.T) {
 		periodStart := abi.ChainEpoch(50000)
 		{
 			// Period not yet started
-			curr := periodStart-1
+			curr := periodStart - 1
 			di := miner.NewDeadlineInfo(periodStart, 0, curr)
 			assert.False(t, di.PeriodStarted()) // Not yet started
 			assert.False(t, di.PeriodElapsed())

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -429,6 +429,9 @@ func (a Actor) PreCommitSector(rt Runtime, params *SectorPreCommitInfo) *adt.Emp
 	if !params.SealedCID.Defined() {
 		rt.Abortf(exitcode.ErrIllegalArgument, "sealed CID undefined")
 	}
+	if params.SealedCID.Prefix() != SealedCIDPrefix {
+		rt.Abortf(exitcode.ErrIllegalArgument, "sealed CID had wrong prefix")
+	}
 	if params.SealRandEpoch >= rt.CurrEpoch() {
 		rt.Abortf(exitcode.ErrIllegalArgument, "seal challenge epoch %v must be before now %v", params.SealRandEpoch, rt.CurrEpoch())
 	}

--- a/actors/builtin/miner/miner_internal_test.go
+++ b/actors/builtin/miner/miner_internal_test.go
@@ -101,20 +101,20 @@ func TestFaultFeeInvariants(t *testing.T) {
 		ff := PledgePenaltyForDeclaredFault(epochReward, networkPower, faultySectorPower)
 		sp := PledgePenaltyForUndeclaredFault(epochReward, networkPower, faultySectorPower)
 		assert.True(t, sp.GreaterThan(ff))
-	}) 
+	})
 
-	 t.Run("Declared and Undeclared fault penalties are linear over sectorQAPower term", func(t *testing.T) {
+	t.Run("Declared and Undeclared fault penalties are linear over sectorQAPower term", func(t *testing.T) {
 		epochReward := abi.NewTokenAmount(1_000)
 		networkPower := abi.NewStoragePower(100 << 50)
 		faultySectorAPower := abi.NewStoragePower(1 << 50)
-		faultySectorBPower := abi.NewStoragePower(19 << 50)		
-		faultySectorCPower := abi.NewStoragePower(63 << 50)				
-		totalFaultPower := big.Add(big.Add(faultySectorAPower, faultySectorBPower), faultySectorCPower)		
+		faultySectorBPower := abi.NewStoragePower(19 << 50)
+		faultySectorCPower := abi.NewStoragePower(63 << 50)
+		totalFaultPower := big.Add(big.Add(faultySectorAPower, faultySectorBPower), faultySectorCPower)
 
 		// Declared faults
 		ffA := PledgePenaltyForDeclaredFault(epochReward, networkPower, faultySectorAPower)
-		ffB := PledgePenaltyForDeclaredFault(epochReward, networkPower, faultySectorBPower)		
-		ffC := PledgePenaltyForDeclaredFault(epochReward, networkPower, faultySectorCPower)				
+		ffB := PledgePenaltyForDeclaredFault(epochReward, networkPower, faultySectorBPower)
+		ffC := PledgePenaltyForDeclaredFault(epochReward, networkPower, faultySectorCPower)
 
 		ffAll := PledgePenaltyForDeclaredFault(epochReward, networkPower, totalFaultPower)
 
@@ -124,10 +124,10 @@ func TestFaultFeeInvariants(t *testing.T) {
 		assert.True(t, diff.GreaterThanEqual(big.Zero()))
 		assert.True(t, diff.LessThan(big.NewInt(3)))
 
-		// Undeclared faults		
+		// Undeclared faults
 		spA := PledgePenaltyForUndeclaredFault(epochReward, networkPower, faultySectorAPower)
-		spB := PledgePenaltyForUndeclaredFault(epochReward, networkPower, faultySectorBPower)		
-		spC := PledgePenaltyForUndeclaredFault(epochReward, networkPower, faultySectorCPower)				
+		spB := PledgePenaltyForUndeclaredFault(epochReward, networkPower, faultySectorBPower)
+		spC := PledgePenaltyForUndeclaredFault(epochReward, networkPower, faultySectorCPower)
 
 		spAll := PledgePenaltyForUndeclaredFault(epochReward, networkPower, totalFaultPower)
 
@@ -137,5 +137,5 @@ func TestFaultFeeInvariants(t *testing.T) {
 		assert.True(t, diff.GreaterThanEqual(big.Zero()))
 		assert.True(t, diff.LessThan(big.NewInt(3)))
 
-	 })
+	})
 }

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -101,7 +101,7 @@ type WorkerKeyChange struct {
 type SectorPreCommitInfo struct {
 	SealProof       abi.RegisteredSealProof
 	SectorNumber    abi.SectorNumber
-	SealedCID       cid.Cid // CommR
+	SealedCID       cid.Cid `checked:"true"` // CommR
 	SealRandEpoch   abi.ChainEpoch
 	DealIDs         []abi.DealID
 	Expiration      abi.ChainEpoch

--- a/actors/builtin/miner/miner_state_test.go
+++ b/actors/builtin/miner/miner_state_test.go
@@ -23,11 +23,11 @@ func TestPrecommittedSectorsStore(t *testing.T) {
 		harness := constructStateHarness(t, abi.ChainEpoch(0))
 		sectorNo := abi.SectorNumber(1)
 
-		pc1 := newSectorPreCommitOnChainInfo(sectorNo, tutils.MakeCID("1"), abi.NewTokenAmount(1), abi.ChainEpoch(1))
+		pc1 := newSectorPreCommitOnChainInfo(sectorNo, tutils.MakeCID("1", &miner.SealedCIDPrefix), abi.NewTokenAmount(1), abi.ChainEpoch(1))
 		harness.putPreCommit(pc1)
 		assert.Equal(t, pc1, harness.getPreCommit(sectorNo))
 
-		pc2 := newSectorPreCommitOnChainInfo(sectorNo, tutils.MakeCID("2"), abi.NewTokenAmount(1), abi.ChainEpoch(1))
+		pc2 := newSectorPreCommitOnChainInfo(sectorNo, tutils.MakeCID("2", &miner.SealedCIDPrefix), abi.NewTokenAmount(1), abi.ChainEpoch(1))
 		harness.putPreCommit(pc2)
 		assert.Equal(t, pc2, harness.getPreCommit(sectorNo))
 
@@ -54,8 +54,8 @@ func TestSectorsStore(t *testing.T) {
 		harness := constructStateHarness(t, abi.ChainEpoch(0))
 
 		sectorNo := abi.SectorNumber(1)
-		sectorInfo1 := newSectorOnChainInfo(sectorNo, tutils.MakeCID("1"), big.NewInt(1), abi.ChainEpoch(1))
-		sectorInfo2 := newSectorOnChainInfo(sectorNo, tutils.MakeCID("2"), big.NewInt(2), abi.ChainEpoch(2))
+		sectorInfo1 := newSectorOnChainInfo(sectorNo, tutils.MakeCID("1", &miner.SealedCIDPrefix), big.NewInt(1), abi.ChainEpoch(1))
+		sectorInfo2 := newSectorOnChainInfo(sectorNo, tutils.MakeCID("2", &miner.SealedCIDPrefix), big.NewInt(2), abi.ChainEpoch(2))
 
 		harness.putSector(sectorInfo1)
 		assert.True(t, harness.hasSectorNo(sectorNo))
@@ -96,7 +96,7 @@ func TestSectorsStore(t *testing.T) {
 		// put all the sectors in the store
 		for _, s := range sectorNos {
 			i := int64(0)
-			harness.putSector(newSectorOnChainInfo(abi.SectorNumber(s), tutils.MakeCID(fmt.Sprintf("%d", i)), big.NewInt(i), abi.ChainEpoch(i)))
+			harness.putSector(newSectorOnChainInfo(abi.SectorNumber(s), tutils.MakeCID(fmt.Sprintf("%d", i), &miner.SealedCIDPrefix), big.NewInt(i), abi.ChainEpoch(i)))
 			i++
 		}
 

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -81,7 +81,7 @@ func TestConstruction(t *testing.T) {
 		rt.ExpectSend(worker, builtin.MethodsAccount.PubkeyAddress, nil, big.Zero(), &workerKey, exitcode.Ok)
 		// Register proving period cron.
 		rt.ExpectSend(builtin.StoragePowerActorAddr, builtin.MethodsPower.EnrollCronEvent,
- 			makeDeadlineCronEventParams(t, provingPeriodStart-1), big.Zero(), nil, exitcode.Ok)
+			makeDeadlineCronEventParams(t, provingPeriodStart-1), big.Zero(), nil, exitcode.Ok)
 		ret := rt.Call(actor.Constructor, &params)
 
 		assert.Nil(t, ret)
@@ -2408,7 +2408,7 @@ func fixedHasher(target uint64) func([]byte) [32]byte {
 
 func expectQueryNetworkInfo(rt *mock.Runtime, expectedTotalPower *power.CurrentTotalPowerReturn, expectedReward big.Int) {
 	rwdRet := reward.ThisEpochRewardReturn{
-		ThisEpochReward: expectedReward,
+		ThisEpochReward:        expectedReward,
 		ThisEpochBaselinePower: big.Zero(),
 	}
 	rt.ExpectSend(

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -243,6 +243,14 @@ func TestCommitments(t *testing.T) {
 		})
 		rt.Reset()
 
+		// Bad sealed CID
+		rt.ExpectAbortConstainsMessage(exitcode.ErrIllegalArgument, "sealed CID had wrong prefix", func() {
+			pc := actor.makePreCommit(101, challengeEpoch, deadline.PeriodEnd(), nil)
+			pc.SealedCID = tutil.MakeCID("Random Data", nil)
+			actor.preCommitSector(rt, pc)
+		})
+		rt.Reset()
+
 		// Bad seal proof type
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			pc := actor.makePreCommit(101, challengeEpoch, deadline.PeriodEnd(), nil)
@@ -1672,7 +1680,7 @@ type proveCommitConf struct {
 
 func (h *actorHarness) proveCommitSector(rt *mock.Runtime, precommit *miner.SectorPreCommitInfo, precommitEpoch abi.ChainEpoch,
 	params *miner.ProveCommitSectorParams) {
-	commd := cbg.CborCid(tutil.MakeCID("commd"))
+	commd := cbg.CborCid(tutil.MakeCID("commd", &market.PieceCIDPrefix))
 	sealRand := abi.SealRandomness([]byte{1, 2, 3, 4})
 	sealIntRand := abi.InteractiveSealRandomness([]byte{5, 6, 7, 8})
 	interactiveEpoch := precommitEpoch + miner.PreCommitChallengeDelay
@@ -2281,7 +2289,7 @@ func (h *actorHarness) makePreCommit(sectorNo abi.SectorNumber, challenge, expir
 	return &miner.SectorPreCommitInfo{
 		SealProof:     h.sealProofType,
 		SectorNumber:  sectorNo,
-		SealedCID:     tutil.MakeCID("commr"),
+		SealedCID:     tutil.MakeCID("commr", &miner.SealedCIDPrefix),
 		SealRandEpoch: challenge,
 		DealIDs:       dealIDs,
 		Expiration:    expiration,

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -3,6 +3,9 @@ package miner
 import (
 	"fmt"
 
+	"github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+
 	abi "github.com/filecoin-project/specs-actors/actors/abi"
 	big "github.com/filecoin-project/specs-actors/actors/abi/big"
 	builtin "github.com/filecoin-project/specs-actors/actors/builtin"
@@ -54,6 +57,13 @@ const NewSectorsPerPeriodMax = 128 << 10
 
 // Epochs after which chain state is final.
 const ChainFinality = abi.ChainEpoch(900)
+
+var SealedCIDPrefix = cid.Prefix{
+	Version:  1,
+	Codec:    cid.Raw,
+	MhType:   mh.POSEIDON_BLS12_381_A1_FC1,
+	MhLength: 32,
+}
 
 // List of proof types which can be used when creating new miner actors
 var SupportedProofTypes = map[abi.RegisteredSealProof]struct{}{

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -60,7 +60,7 @@ const ChainFinality = abi.ChainEpoch(900)
 
 var SealedCIDPrefix = cid.Prefix{
 	Version:  1,
-	Codec:    cid.Raw,
+	Codec:    cid.FilCommitmentSealed,
 	MhType:   mh.POSEIDON_BLS12_381_A1_FC1,
 	MhLength: 32,
 }

--- a/actors/builtin/power/power_test.go
+++ b/actors/builtin/power/power_test.go
@@ -507,7 +507,7 @@ func (h *spActorHarness) constructAndVerify(rt *mock.Runtime) {
 	assert.Equal(h.t, abi.NewStoragePower(0), st.TotalQABytesCommitted)
 	assert.Equal(h.t, abi.NewTokenAmount(0), st.TotalPledgeCollateral)
 	assert.Equal(h.t, abi.NewStoragePower(0), st.ThisEpochRawBytePower)
-	assert.Equal(h.t, abi.NewStoragePower(0), st.ThisEpochQualityAdjPower)	
+	assert.Equal(h.t, abi.NewStoragePower(0), st.ThisEpochQualityAdjPower)
 	assert.Equal(h.t, abi.NewTokenAmount(0), st.ThisEpochPledgeCollateral)
 	assert.Equal(h.t, abi.ChainEpoch(0), st.FirstCronEpoch)
 	assert.Equal(h.t, int64(0), st.MinerCount)

--- a/actors/builtin/power/power_test.go
+++ b/actors/builtin/power/power_test.go
@@ -16,6 +16,8 @@ import (
 	big "github.com/filecoin-project/specs-actors/actors/abi/big"
 	builtin "github.com/filecoin-project/specs-actors/actors/builtin"
 	initact "github.com/filecoin-project/specs-actors/actors/builtin/init"
+	market "github.com/filecoin-project/specs-actors/actors/builtin/market"
+	mineract "github.com/filecoin-project/specs-actors/actors/builtin/miner"
 	power "github.com/filecoin-project/specs-actors/actors/builtin/power"
 	vmr "github.com/filecoin-project/specs-actors/actors/runtime"
 	exitcode "github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
@@ -410,8 +412,8 @@ func TestSubmitPoRepForBulkVerify(t *testing.T) {
 	t.Run("registers porep and charges gas", func(t *testing.T) {
 		rt := builder.Build(t)
 		actor.constructAndVerify(rt)
-		commR := tutil.MakeCID("commR")
-		commD := tutil.MakeCID("commD")
+		commR := tutil.MakeCID("commR", &mineract.SealedCIDPrefix)
+		commD := tutil.MakeCID("commD", &market.PieceCIDPrefix)
 		sealInfo := &abi.SealVerifyInfo{
 			SealedCID:   commR,
 			UnsealedCID: commD,
@@ -440,8 +442,8 @@ func TestSubmitPoRepForBulkVerify(t *testing.T) {
 
 		sealInfo := func(i int) *abi.SealVerifyInfo {
 			var sealInfo abi.SealVerifyInfo
-			sealInfo.SealedCID = tutil.MakeCID(fmt.Sprintf("commR-%d", i))
-			sealInfo.UnsealedCID = tutil.MakeCID(fmt.Sprintf("commD-%d", i))
+			sealInfo.SealedCID = tutil.MakeCID(fmt.Sprintf("commR-%d", i), &mineract.SealedCIDPrefix)
+			sealInfo.UnsealedCID = tutil.MakeCID(fmt.Sprintf("commD-%d", i), &market.PieceCIDPrefix)
 			return &sealInfo
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/ipfs/go-log v1.0.0 // indirect
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1
 	github.com/minio/sha256-simd v0.1.1 // indirect
-	github.com/multiformats/go-multihash v0.0.13
+	github.com/multiformats/go-multihash v0.0.14
 	github.com/pkg/errors v0.9.1
 	github.com/polydawn/refmt v0.0.0-20190809202753-05966cbd336a // indirect
 	github.com/smartystreets/assertions v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,8 @@ github.com/multiformats/go-multihash v0.0.10 h1:lMoNbh2Ssd9PUF74Nz008KGzGPlfeV6w
 github.com/multiformats/go-multihash v0.0.10/go.mod h1:YSLudS+Pi8NHE7o6tb3D8vrpKa63epEDmG8nTduyAew=
 github.com/multiformats/go-multihash v0.0.13 h1:06x+mk/zj1FoMsgNejLpy6QTvJqlSt/BhLEy87zidlc=
 github.com/multiformats/go-multihash v0.0.13/go.mod h1:VdAWLKTwram9oKAatUcLxBNUjdtcVwxObEQBtRfuyjc=
+github.com/multiformats/go-multihash v0.0.14 h1:QoBceQYQQtNUuf6s7wHxnE2c8bhbMqhfGzNI032se/I=
+github.com/multiformats/go-multihash v0.0.14/go.mod h1:VdAWLKTwram9oKAatUcLxBNUjdtcVwxObEQBtRfuyjc=
 github.com/multiformats/go-varint v0.0.2 h1:6sUvyh2YHpJCb8RZ6eYzj6iJQ4+chWYmyIHxszqlPTA=
 github.com/multiformats/go-varint v0.0.2/go.mod h1:3Ls8CIEsrijN6+B7PbrXRPxHRPuXSrVKRY101jdMZYE=
 github.com/multiformats/go-varint v0.0.5 h1:XVZwSo04Cs3j/jS0uAEPpT3JY6DzMcVLLoWOSnCxOjg=

--- a/support/mock/exports.go
+++ b/support/mock/exports.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/ipfs/go-cid"
 )
 
 func CheckActorExports(t *testing.T, act interface{ Exports() []interface{} }) {
@@ -16,9 +18,51 @@ func CheckActorExports(t *testing.T, act interface{ Exports() []interface{} }) {
 			continue
 		}
 
-		t.Run(fmt.Sprintf("metdod%d", i), func(t *testing.T) {
+		t.Run(fmt.Sprintf("method%d-type", i), func(t *testing.T) {
 			mrt := Runtime{t: t}
 			mrt.verifyExportedMethodType(reflect.ValueOf(m))
 		})
+
+		t.Run(fmt.Sprintf("method%d-unsafe-input", i), func(t *testing.T) {
+			paramsType := reflect.ValueOf(m).Type().In(1)
+			checkUnsafeInputs(t, paramsType.String(), paramsType)
+		})
+	}
+}
+
+var tCID = reflect.TypeOf(new(cid.Cid)).Elem()
+
+func checkUnsafeInputs(t *testing.T, name string, typ reflect.Type) {
+	switch typ.Kind() {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		fallthrough
+	case reflect.Map:
+		fallthrough
+	case reflect.Ptr:
+		checkUnsafeInputs(t, name + ".elem", typ.Elem())
+
+	case reflect.Struct:
+		if typ == tCID {
+			t.Fatal("method has unchecked CID input at ", name)
+		}
+
+		for i := 0; i < typ.NumField(); i++ {
+			f := typ.Field(i)
+
+			if f.Tag.Get("checked") == "true" {
+				if f.Type != tCID {
+					t.Fatal("expected checked value to be cid.Cid")
+				}
+
+				continue
+			}
+
+			checkUnsafeInputs(t, name + "." + f.Name, f.Type)
+		}
+
+	case reflect.Interface:
+		t.Fatal("method has unsafe interface{} input parameter")
 	}
 }

--- a/support/mock/exports.go
+++ b/support/mock/exports.go
@@ -41,7 +41,7 @@ func checkUnsafeInputs(t *testing.T, name string, typ reflect.Type) {
 	case reflect.Map:
 		fallthrough
 	case reflect.Ptr:
-		checkUnsafeInputs(t, name + ".elem", typ.Elem())
+		checkUnsafeInputs(t, name+".elem", typ.Elem())
 
 	case reflect.Struct:
 		if typ == tCID {
@@ -59,7 +59,7 @@ func checkUnsafeInputs(t *testing.T, name string, typ reflect.Type) {
 				continue
 			}
 
-			checkUnsafeInputs(t, name + "." + f.Name, f.Type)
+			checkUnsafeInputs(t, name+"."+f.Name, f.Type)
 		}
 
 	case reflect.Interface:

--- a/support/testing/cid.go
+++ b/support/testing/cid.go
@@ -8,10 +8,25 @@ import (
 var DefaultHashFunction = uint64(mh.BLAKE2B_MIN + 31)
 var DefaultCidBuilder = cid.V1Builder{Codec: cid.DagCBOR, MhType: DefaultHashFunction}
 
-func MakeCID(input string) cid.Cid {
+func MakeCID(input string, prefix *cid.Prefix) cid.Cid {
 	c, err := DefaultCidBuilder.Sum([]byte(input))
 	if err != nil {
 		panic(err)
 	}
+
+	if prefix != nil {
+		h, err := mh.Decode(c.Hash())
+		if err != nil {
+			panic(err)
+		}
+
+		ph, err := mh.Encode(h.Digest, prefix.MhType)
+		if err != nil {
+			panic(err)
+		}
+
+		return cid.NewCidV1(prefix.Codec, ph)
+	}
+
 	return c
 }


### PR DESCRIPTION
Filecoin VM assumes that all CIDs accessible from the state tree, other than ones with the `mh.SHA2_256_TRUNC254_PADDED`/`mh.POSEIDON_BLS12_381_A1_FC1` multihashes, are part of the state tree, and that every VM has access to them.

Getting unexpected CIDs into the state tree is currently a chain-halting bug, this PR should fix all instances of this problem, and make it harder to anciently introduce again