### PR TITLE
Partition testing

### DIFF
--- a/actors/builtin/miner/bitfield_queue_test.go
+++ b/actors/builtin/miner/bitfield_queue_test.go
@@ -239,7 +239,7 @@ func (bqe *bqExpectation) Equals(t *testing.T, q miner.BitfieldQueue) {
 	_, err := q.Root()
 	require.NoError(t, err)
 
-	require.Equal(t, uint64(len(bqe.expected)), q.Length())
+	assert.Equal(t, uint64(len(bqe.expected)), q.Length())
 
 	err = q.ForEach(func(epoch abi.ChainEpoch, bf *bitfield.BitField) error {
 		values, ok := bqe.expected[epoch]

--- a/actors/builtin/miner/partition_state.go
+++ b/actors/builtin/miner/partition_state.go
@@ -401,7 +401,7 @@ func (p *Partition) PopExpiredSectors(store adt.Store, until abi.ChainEpoch, qua
 	if p.Faults, err = bitfield.SubtractBitField(p.Faults, expiredSectors); err != nil {
 		return nil, err
 	}
-	p.LivePower = p.LivePower.Sub(popped.ActivePower)
+	p.LivePower = p.LivePower.Sub(popped.ActivePower.Add(popped.FaultyPower))
 	p.FaultyPower = p.FaultyPower.Sub(popped.FaultyPower)
 
 	// Record the epoch of any sectors expiring early, for termination fee calculation later.

--- a/actors/builtin/miner/partition_state.go
+++ b/actors/builtin/miner/partition_state.go
@@ -345,7 +345,7 @@ func (p *Partition) TerminateSectors(store adt.Store, epoch abi.ChainEpoch, sect
 	}
 
 	powerDelta := removed.ActivePower.Add(removed.FaultyPower)
-	p.LivePower = p.LivePower.Add(powerDelta)
+	p.LivePower = p.LivePower.Sub(powerDelta)
 	p.FaultyPower = p.FaultyPower.Sub(removed.FaultyPower)
 	p.RecoveringPower = p.RecoveringPower.Sub(removedRecovering)
 

--- a/actors/builtin/miner/partition_state.go
+++ b/actors/builtin/miner/partition_state.go
@@ -344,12 +344,12 @@ func (p *Partition) TerminateSectors(store adt.Store, epoch abi.ChainEpoch, sect
 		return NewPowerPairZero(), xerrors.Errorf("failed to add terminated sectors: %w", err)
 	}
 
-	powerDelta := removed.ActivePower.Add(removed.FaultyPower)
-	p.LivePower = p.LivePower.Sub(powerDelta)
+	powerRemoved := removed.ActivePower.Add(removed.FaultyPower)
+	p.LivePower = p.LivePower.Sub(powerRemoved)
 	p.FaultyPower = p.FaultyPower.Sub(removed.FaultyPower)
 	p.RecoveringPower = p.RecoveringPower.Sub(removedRecovering)
 
-	return powerDelta, nil
+	return powerRemoved, nil
 }
 
 // PopExpiredSectors traverses the expiration queue up to and including some epoch, and marks all expiring

--- a/actors/builtin/miner/partition_state_test.go
+++ b/actors/builtin/miner/partition_state_test.go
@@ -1,0 +1,88 @@
+package miner
+
+import (
+	"context"
+	"github.com/filecoin-project/go-bitfield"
+	"testing"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/specs-actors/actors/util/adt"
+	"github.com/filecoin-project/specs-actors/support/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPartitions(t *testing.T) {
+	sectors := []*SectorOnChainInfo{
+		testSector(2, 1, 50, 60, 1000),
+		testSector(3, 2, 51, 61, 1001),
+		testSector(7, 3, 52, 62, 1002),
+		testSector(8, 4, 53, 63, 1003),
+		testSector(11, 5, 54, 64, 1004),
+		testSector(13, 6, 55, 65, 1005),
+	}
+	sectorSize := abi.SectorSize(32 * 1 << 30)
+
+	t.Run("adds sectors and reports sector stats", func(t *testing.T) {
+		rt := mock.NewBuilder(context.Background(), address.Undef).Build(t)
+		partition := emptyPartition(t, rt)
+
+		power, err := partition.AddSectors(adt.AsStore(rt), sectors, sectorSize, QuantSpec{unit: 4, offset: 1})
+		require.NoError(t, err)
+
+		expectedPower := PowerForSectors(sectorSize, sectors)
+		assert.True(t, expectedPower.Equals(power))
+
+		assert.True(t, partition.FaultyPower.Equals(NewPowerPairZero()))
+		assert.True(t, partition.RecoveringPower.Equals(NewPowerPairZero()))
+		assert.True(t, partition.LivePower.Equals(expectedPower))
+		assert.True(t, expectedPower.Equals(partition.ActivePower()))
+
+		assertBitfieldEmpty(t, partition.Faults)
+		assertBitfieldEmpty(t, partition.Recoveries)
+		assertBitfieldEmpty(t, partition.Terminated)
+		assertBitfieldEquals(t, partition.Sectors, 1, 2, 3, 4, 5, 6)
+
+		active, err := partition.ActiveSectors()
+		require.NoError(t, err)
+		assertBitfieldEquals(t, active, 1, 2, 3, 4, 5, 6)
+
+		live, err := partition.LiveSectors()
+		require.NoError(t, err)
+		assertBitfieldEquals(t, live, 1, 2, 3, 4, 5, 6)
+	})
+
+	t.Run("adds faults", func(t *testing.T) {
+		rt := mock.NewBuilder(context.Background(), address.Undef).Build(t)
+		partition := emptyPartition(t, rt)
+
+		quantSpec := QuantSpec{unit: 4, offset: 1}
+		_, err := partition.AddSectors(adt.AsStore(rt), sectors, sectorSize, quantSpec)
+		require.NoError(t, err)
+
+		faults := bitfield.NewFromSet([]uint64{4, 5})
+		_, err = partition.AddFaults(adt.AsStore(rt), faults, selectSectors(t, sectors, faults), abi.ChainEpoch(1000), sectorSize, quantSpec)
+		require.NoError(t, err)
+	})
+}
+
+func selectSectors(t *testing.T, sectors []*SectorOnChainInfo, field *bitfield.BitField) []*SectorOnChainInfo {
+	included := []*SectorOnChainInfo{}
+	for _, s := range sectors {
+		set, err := field.IsSet(uint64(s.SectorNumber))
+		require.NoError(t, err)
+		if set {
+			included = append(included, s)
+		}
+	}
+	return included
+}
+
+func emptyPartition(t *testing.T, rt *mock.Runtime) *Partition {
+	store := adt.AsStore(rt)
+	root, err := adt.MakeEmptyArray(store).Root()
+	require.NoError(t, err)
+
+	return ConstructPartition(root)
+}

--- a/actors/builtin/miner/partition_state_test.go
+++ b/actors/builtin/miner/partition_state_test.go
@@ -25,8 +25,10 @@ func TestPartitions(t *testing.T) {
 	}
 	sectorSize := abi.SectorSize(32 << 30)
 
+	builder := mock.NewBuilder(context.Background(), address.Undef)
+
 	t.Run("adds sectors and reports sector stats", func(t *testing.T) {
-		rt := mock.NewBuilder(context.Background(), address.Undef).Build(t)
+		rt := builder.Build(t)
 		partition := emptyPartition(t, rt)
 
 		quantSpec := miner.NewQuantSpec(4, 1)
@@ -178,7 +180,6 @@ func TestPartitions(t *testing.T) {
 		_, err := partition.AddSectors(adt.AsStore(rt), sectors, sectorSize, quantSpec)
 		require.NoError(t, err)
 
-		// recovered power should equal power of recovery sectors
 		sectorsToMove := selectSectors(t, sectors, bf(2, 4, 6))
 		err = partition.RescheduleExpirations(adt.AsStore(rt), 18, sectorsToMove, sectorSize, quantSpec)
 		require.NoError(t, err)

--- a/actors/builtin/miner/partition_state_test.go
+++ b/actors/builtin/miner/partition_state_test.go
@@ -82,13 +82,13 @@ func TestPartitions(t *testing.T) {
 		_, store, partition := setup(t)
 
 		// make 4, 5 and 6 faulty
-		faultSet := bitfield.NewFromSet([]uint64{4, 5, 6})
+		faultSet := bf(4, 5, 6)
 		faultSectors := selectSectors(t, sectors, faultSet)
 		_, err := partition.AddFaults(store, faultSet, faultSectors, abi.ChainEpoch(7), sectorSize, quantSpec)
 		require.NoError(t, err)
 
 		// add 4 and 5 as recoveries
-		recoverSet := bitfield.NewFromSet([]uint64{4, 5})
+		recoverSet := bf(4, 5)
 		recoverSectors := selectSectors(t, sectors, recoverSet)
 		recoveredPower := miner.PowerForSectors(sectorSize, recoverSectors)
 		err = partition.AddRecoveries(recoverSet, recoveredPower)
@@ -101,13 +101,13 @@ func TestPartitions(t *testing.T) {
 		_, store, partition := setup(t)
 
 		// make 4, 5 and 6 faulty
-		faultSet := bitfield.NewFromSet([]uint64{4, 5, 6})
+		faultSet := bf(4, 5, 6)
 		faultSectors := selectSectors(t, sectors, faultSet)
 		_, err := partition.AddFaults(store, faultSet, faultSectors, abi.ChainEpoch(7), sectorSize, quantSpec)
 		require.NoError(t, err)
 
 		// add 4 and 5 as recoveries
-		recoverSet := bitfield.NewFromSet([]uint64{4, 5})
+		recoverSet := bf(4, 5)
 		recoverSectors := selectSectors(t, sectors, recoverSet)
 		recoveredPower := miner.PowerForSectors(sectorSize, recoverSectors)
 		err = partition.AddRecoveries(recoverSet, recoveredPower)
@@ -131,13 +131,13 @@ func TestPartitions(t *testing.T) {
 		rt, store, partition := setup(t)
 
 		// make 4, 5 and 6 faulty
-		faultSet := bitfield.NewFromSet([]uint64{4, 5, 6})
+		faultSet := bf(4, 5, 6)
 		faultSectors := selectSectors(t, sectors, faultSet)
 		_, err := partition.AddFaults(store, faultSet, faultSectors, abi.ChainEpoch(7), sectorSize, quantSpec)
 		require.NoError(t, err)
 
 		// add 4 and 5 as recoveries
-		recoverSet := bitfield.NewFromSet([]uint64{4, 5})
+		recoverSet := bf(4, 5)
 		recoverSectors := selectSectors(t, sectors, recoverSet)
 		recoveryPower := miner.PowerForSectors(sectorSize, recoverSectors)
 		err = partition.AddRecoveries(recoverSet, recoveryPower)
@@ -345,13 +345,13 @@ func TestPartitions(t *testing.T) {
 		rt, store, partition := setup(t)
 
 		// make 4, 5 and 6 faulty
-		faultSet := bitfield.NewFromSet([]uint64{4, 5, 6})
+		faultSet := bf(4, 5, 6)
 		faultSectors := selectSectors(t, sectors, faultSet)
 		_, err := partition.AddFaults(store, faultSet, faultSectors, abi.ChainEpoch(7), sectorSize, quantSpec)
 		require.NoError(t, err)
 
 		// add 4 and 5 as recoveries
-		recoverSet := bitfield.NewFromSet([]uint64{4, 5})
+		recoverSet := bf(4, 5)
 		recoverSectors := selectSectors(t, sectors, recoverSet)
 		recoveredPower := miner.PowerForSectors(sectorSize, recoverSectors)
 		err = partition.AddRecoveries(recoverSet, recoveredPower)
@@ -592,7 +592,7 @@ func checkPartitionInvariants(t *testing.T,
 		})
 		require.NoError(t, err)
 
-		earlyTerms := bitfield.NewFromSet(nil)
+		earlyTerms := bf()
 		for bit := range seenSectors {
 			earlyTerms.Set(bit)
 		}

--- a/actors/builtin/miner/partition_state_test.go
+++ b/actors/builtin/miner/partition_state_test.go
@@ -1,12 +1,13 @@
-package miner
+package miner_test
 
 import (
 	"context"
-	"github.com/filecoin-project/go-bitfield"
 	"testing"
 
 	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-bitfield"
 	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
 	"github.com/filecoin-project/specs-actors/support/mock"
 	"github.com/stretchr/testify/assert"
@@ -14,7 +15,7 @@ import (
 )
 
 func TestPartitions(t *testing.T) {
-	sectors := []*SectorOnChainInfo{
+	sectors := []*miner.SectorOnChainInfo{
 		testSector(2, 1, 50, 60, 1000),
 		testSector(3, 2, 51, 61, 1001),
 		testSector(7, 3, 52, 62, 1002),
@@ -28,47 +29,140 @@ func TestPartitions(t *testing.T) {
 		rt := mock.NewBuilder(context.Background(), address.Undef).Build(t)
 		partition := emptyPartition(t, rt)
 
-		power, err := partition.AddSectors(adt.AsStore(rt), sectors, sectorSize, QuantSpec{unit: 4, offset: 1})
+		power, err := partition.AddSectors(adt.AsStore(rt), sectors, sectorSize, miner.NewQuantSpec(4, 1))
 		require.NoError(t, err)
 
-		expectedPower := PowerForSectors(sectorSize, sectors)
+		expectedPower := miner.PowerForSectors(sectorSize, sectors)
 		assert.True(t, expectedPower.Equals(power))
 
-		assert.True(t, partition.FaultyPower.Equals(NewPowerPairZero()))
-		assert.True(t, partition.RecoveringPower.Equals(NewPowerPairZero()))
-		assert.True(t, partition.LivePower.Equals(expectedPower))
-		assert.True(t, expectedPower.Equals(partition.ActivePower()))
-
-		assertBitfieldEmpty(t, partition.Faults)
-		assertBitfieldEmpty(t, partition.Recoveries)
-		assertBitfieldEmpty(t, partition.Terminated)
-		assertBitfieldEquals(t, partition.Sectors, 1, 2, 3, 4, 5, 6)
-
-		active, err := partition.ActiveSectors()
-		require.NoError(t, err)
-		assertBitfieldEquals(t, active, 1, 2, 3, 4, 5, 6)
-
-		live, err := partition.LiveSectors()
-		require.NoError(t, err)
-		assertBitfieldEquals(t, live, 1, 2, 3, 4, 5, 6)
+		assertPartitionState(t, partition, sectors, sectorSize, bf(), bf(), bf())
 	})
 
 	t.Run("adds faults", func(t *testing.T) {
 		rt := mock.NewBuilder(context.Background(), address.Undef).Build(t)
 		partition := emptyPartition(t, rt)
 
-		quantSpec := QuantSpec{unit: 4, offset: 1}
+		quantSpec := miner.NewQuantSpec(4, 1)
 		_, err := partition.AddSectors(adt.AsStore(rt), sectors, sectorSize, quantSpec)
 		require.NoError(t, err)
 
-		faults := bitfield.NewFromSet([]uint64{4, 5})
-		_, err = partition.AddFaults(adt.AsStore(rt), faults, selectSectors(t, sectors, faults), abi.ChainEpoch(1000), sectorSize, quantSpec)
+		faultSet := bitfield.NewFromSet([]uint64{4, 5})
+		faultSectors := selectSectors(t, sectors, faultSet)
+		power, err := partition.AddFaults(adt.AsStore(rt), faultSet, faultSectors, abi.ChainEpoch(1000), sectorSize, quantSpec)
 		require.NoError(t, err)
+
+		expectedFaultyPower := miner.PowerForSectors(sectorSize, faultSectors)
+		assert.True(t, expectedFaultyPower.Equals(power))
+
+		assertPartitionState(t, partition, sectors, sectorSize, bf(4, 5), bf(), bf())
+	})
+
+	t.Run("adds recoveries", func(t *testing.T) {
+		rt := mock.NewBuilder(context.Background(), address.Undef).Build(t)
+		partition := emptyPartition(t, rt)
+
+		quantSpec := miner.NewQuantSpec(4, 1)
+		_, err := partition.AddSectors(adt.AsStore(rt), sectors, sectorSize, quantSpec)
+		require.NoError(t, err)
+
+		// make 4, 5 and 6 faulty
+		faultSet := bitfield.NewFromSet([]uint64{4, 5, 6})
+		faultSectors := selectSectors(t, sectors, faultSet)
+		_, err = partition.AddFaults(adt.AsStore(rt), faultSet, faultSectors, abi.ChainEpoch(1000), sectorSize, quantSpec)
+		require.NoError(t, err)
+
+		// add 4 and 5 as recoveries
+		recoverSet := bitfield.NewFromSet([]uint64{4, 5})
+		recoverSectors := selectSectors(t, sectors, recoverSet)
+		recoveredPower := miner.PowerForSectors(sectorSize, recoverSectors)
+		err = partition.AddRecoveries(recoverSet, recoveredPower)
+		require.NoError(t, err)
+
+		assertPartitionState(t, partition, sectors, sectorSize, bf(4, 5, 6), bf(4, 5), bf())
+	})
+
+	t.Run("recovers faults", func(t *testing.T) {
+		rt := mock.NewBuilder(context.Background(), address.Undef).Build(t)
+		partition := emptyPartition(t, rt)
+
+		quantSpec := miner.NewQuantSpec(4, 1)
+		_, err := partition.AddSectors(adt.AsStore(rt), sectors, sectorSize, quantSpec)
+		require.NoError(t, err)
+
+		// make 4, 5 and 6 faulty
+		faultSet := bitfield.NewFromSet([]uint64{4, 5, 6})
+		faultSectors := selectSectors(t, sectors, faultSet)
+		_, err = partition.AddFaults(adt.AsStore(rt), faultSet, faultSectors, abi.ChainEpoch(1000), sectorSize, quantSpec)
+		require.NoError(t, err)
+
+		// add 4 and 5 as recoveries
+		recoverSet := bitfield.NewFromSet([]uint64{4, 5})
+		recoverSectors := selectSectors(t, sectors, recoverSet)
+		recoveryPower := miner.PowerForSectors(sectorSize, recoverSectors)
+		err = partition.AddRecoveries(recoverSet, recoveryPower)
+		require.NoError(t, err)
+
+		// mark recoveries as recovered recover sectors
+		recoveredPower, err := partition.RecoverFaults(adt.AsStore(rt), recoverSet, recoverSectors, sectorSize, quantSpec)
+		require.NoError(t, err)
+
+		// recovered power should equal power of recovery sectors
+		assert.True(t, recoveryPower.Equals(recoveredPower))
+
+		// state should be as if recovered sectors were never faults
+		assertPartitionState(t, partition, sectors, sectorSize, bf(6), bf(), bf())
 	})
 }
 
-func selectSectors(t *testing.T, sectors []*SectorOnChainInfo, field *bitfield.BitField) []*SectorOnChainInfo {
-	included := []*SectorOnChainInfo{}
+func assertPartitionState(t *testing.T,
+	partition *miner.Partition,
+	sectors []*miner.SectorOnChainInfo,
+	sectorSize abi.SectorSize,
+	faults *bitfield.BitField,
+	recovering *bitfield.BitField,
+	terminations *bitfield.BitField) {
+
+	faultyPower := miner.PowerForSectors(sectorSize, selectSectors(t, sectors, faults))
+	assert.True(t, partition.FaultyPower.Equals(faultyPower))
+	recoveringPower := miner.PowerForSectors(sectorSize, selectSectors(t, sectors, recovering))
+	assert.True(t, partition.RecoveringPower.Equals(recoveringPower))
+	livePower := miner.PowerForSectors(sectorSize, sectors)
+	assert.True(t, partition.LivePower.Equals(livePower))
+	activePower := livePower.Sub(faultyPower)
+	assert.True(t, activePower.Equals(partition.ActivePower()))
+
+	allSectorIds := bf(sectorIDs(sectors)...)
+	assertBitfieldsEqual(t, faults, partition.Faults)
+	assertBitfieldsEqual(t, recovering, partition.Recoveries)
+	assertBitfieldsEqual(t, terminations, partition.Terminated)
+	assertBitfieldsEqual(t, allSectorIds, partition.Sectors)
+
+	live, err := partition.LiveSectors()
+	require.NoError(t, err)
+	assertBitfieldsEqual(t, allSectorIds, live)
+
+	expectedActiveIds, err := bitfield.SubtractBitField(allSectorIds, faults)
+	require.NoError(t, err)
+
+	active, err := partition.ActiveSectors()
+	require.NoError(t, err)
+	assertBitfieldsEqual(t, expectedActiveIds, active)
+}
+
+func sectorIDs(sectors []*miner.SectorOnChainInfo) []uint64 {
+	allSectorIds := make([]uint64, len(sectors))
+	for i, sector := range sectors {
+		allSectorIds[i] = uint64(sector.SectorNumber)
+	}
+	return allSectorIds
+}
+
+func bf(secNos ...uint64) *bitfield.BitField {
+	return bitfield.NewFromSet(secNos)
+}
+
+func selectSectors(t *testing.T, sectors []*miner.SectorOnChainInfo, field *bitfield.BitField) []*miner.SectorOnChainInfo {
+	included := []*miner.SectorOnChainInfo{}
 	for _, s := range sectors {
 		set, err := field.IsSet(uint64(s.SectorNumber))
 		require.NoError(t, err)
@@ -79,10 +173,31 @@ func selectSectors(t *testing.T, sectors []*SectorOnChainInfo, field *bitfield.B
 	return included
 }
 
-func emptyPartition(t *testing.T, rt *mock.Runtime) *Partition {
+func emptyPartition(t *testing.T, rt *mock.Runtime) *miner.Partition {
 	store := adt.AsStore(rt)
 	root, err := adt.MakeEmptyArray(store).Root()
 	require.NoError(t, err)
 
-	return ConstructPartition(root)
+	return miner.ConstructPartition(root)
+}
+
+func assertBitfieldsEqual(t *testing.T, bf1 *bitfield.BitField, bf2 *bitfield.BitField) {
+	count, err := bf2.Count()
+	require.NoError(t, err)
+
+	err = bf1.ForEach(func(v uint64) error {
+		other, err := bf2.First()
+		require.NoError(t, err)
+
+		assert.Equal(t, other, v)
+
+		bf2, err = bf2.Slice(1, count-1)
+		require.NoError(t, err)
+		count -= 1
+		return nil
+	})
+	require.NoError(t, err)
+
+	// assert no bits left in second bitfield.
+	assert.Equal(t, uint64(0), count)
 }

--- a/actors/builtin/miner/partition_state_test.go
+++ b/actors/builtin/miner/partition_state_test.go
@@ -23,7 +23,7 @@ func TestPartitions(t *testing.T) {
 		testSector(11, 5, 54, 64, 1004),
 		testSector(13, 6, 55, 65, 1005),
 	}
-	sectorSize := abi.SectorSize(32 * 1 << 30)
+	sectorSize := abi.SectorSize(32 << 30)
 
 	t.Run("adds sectors and reports sector stats", func(t *testing.T) {
 		rt := mock.NewBuilder(context.Background(), address.Undef).Build(t)

--- a/actors/builtin/miner/partition_state_test.go
+++ b/actors/builtin/miner/partition_state_test.go
@@ -518,6 +518,7 @@ func checkPartitionInvariants(t *testing.T,
 		seenSectors := make(map[abi.SectorNumber]bool)
 
 		expQ, err := miner.LoadExpirationQueue(store, partition.ExpirationsEpochs, quant)
+		require.NoError(t, err)
 
 		var exp miner.ExpirationSet
 		err = expQ.ForEach(&exp, func(epoch int64) error {
@@ -581,14 +582,14 @@ func checkPartitionInvariants(t *testing.T,
 		seenSectors := make(map[uint64]bool)
 
 		earlyQ, err := miner.LoadBitfieldQueue(store, partition.EarlyTerminated, quant)
+		require.NoError(t, err)
 
 		err = earlyQ.ForEach(func(_ abi.ChainEpoch, bf *bitfield.BitField) error {
-			bf.ForEach(func(i uint64) error {
+			return bf.ForEach(func(i uint64) error {
 				assert.False(t, seenSectors[i], "sector already seen")
 				seenSectors[i] = true
 				return nil
 			})
-			return nil
 		})
 		require.NoError(t, err)
 


### PR DESCRIPTION
### Motivation

Partition inherits some testing from miner actor but has none of its own. Quite a bit of logic happens here, so some unit tests are in order.

### Proposed Changes

1. Add tests for all exported methods of `Partition`.

### Bugs Found

1. `TerminateSectors` was adding removed power to `LivePower` rather than subtracting it. Fixed here.

Otherwise everything seems to be working.