### PR TITLE
Restore CC upgrade test; fix power and pledge errors in deadline cron

### DIFF
--- a/actors/builtin/miner/partition_state.go
+++ b/actors/builtin/miner/partition_state.go
@@ -537,25 +537,25 @@ func NewPowerPair(raw, qa abi.StoragePower) PowerPair {
 	return PowerPair{Raw: raw, QA: qa}
 }
 
-func (pp *PowerPair) IsZero() bool {
+func (pp PowerPair) IsZero() bool {
 	return pp.Raw.IsZero() && pp.QA.IsZero()
 }
 
-func (pp *PowerPair) Add(other PowerPair) PowerPair {
+func (pp PowerPair) Add(other PowerPair) PowerPair {
 	return PowerPair{
 		Raw: big.Add(pp.Raw, other.Raw),
 		QA:  big.Add(pp.QA, other.QA),
 	}
 }
 
-func (pp *PowerPair) Sub(other PowerPair) PowerPair {
+func (pp PowerPair) Sub(other PowerPair) PowerPair {
 	return PowerPair{
 		Raw: big.Sub(pp.Raw, other.Raw),
 		QA:  big.Sub(pp.QA, other.QA),
 	}
 }
 
-func (pp *PowerPair) Neg() PowerPair {
+func (pp PowerPair) Neg() PowerPair {
 	return PowerPair{
 		Raw: pp.Raw.Neg(),
 		QA:  pp.QA.Neg(),


### PR DESCRIPTION
I also discovered the incorrect `LivePower` update fixed in #740.

This results on one additional but not-so-redudant write of the deadline partitions root in the deadline cron. We could resolve it by smashing together the different jobs of the cron handler, or with patterns to let us hold more in the air easily, but I'm not worried about it in the grand scheme of things right now.

I think these errors would be less likely as we push logic into the state/deadline. I opted for the direct fix here rather than larger refactor so I can focus on more tests.