### PR TITLE
Convenience baselineforepoch

### DIFF
--- a/actors/builtin/reward/reward_logic.go
+++ b/actors/builtin/reward/reward_logic.go
@@ -104,3 +104,16 @@ func computeBaselineSupply(theta big.Int) big.Int {
 
 	return big.Mul(BaselineTotal, oneSub) // Q.0 * Q.128 => Q.128
 }
+
+// SlowConvenientBaselineForEpoch computes baseline power for use in epoch t
+// by calculating the value of ThisEpochBaselinePower that shows up in block at t - 1
+// It multiplies ~t times so it should not be used in actor code directly.  It is exported as
+// convenience for consuming node.
+func SlowConvenientBaselineForEpoch(targetEpoch abi.ChainEpoch) abi.StoragePower {
+	baseline := InitBaselinePower()
+	baseline = BaselinePowerFromPrev(baseline) // value in genesis block (for epoch 1)
+	for i := abi.ChainEpoch(1); i < targetEpoch; i++ {
+		baseline = BaselinePowerFromPrev(baseline) // value in block i (for epoch i+1)
+	}
+	return baseline
+}


### PR DESCRIPTION
Requested for lotus integration.

Convenience function of baseline given epoch.  It does as many multiplications as the epoch you want the baseline for so its not as fast as it could be but from tests I think its still on the order of seconds for epochs in the 9 years category so should be fine.

If we want something faster the right way is to read reward actor state to jump ahead.  Also it can be computed ahead / memoized in the consumer if it comes to that.