### PR TITLE
set minimum deal duration to 180 days and fix tests

### DIFF
--- a/actors/builtin/market/market_test.go
+++ b/actors/builtin/market/market_test.go
@@ -1504,7 +1504,7 @@ func TestCronTickDealExpiry(t *testing.T) {
 		// assert deal exists
 		actor.getDealProposal(rt, dealId)
 
-		// move the epoch to endEpoch+5(anything greater than endEpoch), so deal is processed at 150 & then at 151 which is it's end epoch
+		// move the epoch to endEpoch+5(anything greater than endEpoch), so deal is processed at 150 & then at it's end epoch
 		// total payment = (end - start)
 		current = endEpoch + 5
 		rt.SetEpoch(current)

--- a/actors/builtin/market/market_test.go
+++ b/actors/builtin/market/market_test.go
@@ -1623,7 +1623,7 @@ func TestCronTickDealExpiry(t *testing.T) {
 		deal := actor.getDealProposal(rt, dealId)
 
 		// move the current epoch so that deal is expired
-		rt.SetEpoch(startEpoch + 1000)
+		rt.SetEpoch(endEpoch + 100)
 		actor.cronTick(rt)
 		require.EqualValues(t, deal.ClientCollateral, actor.getEscrowBalance(rt, client))
 

--- a/actors/builtin/market/policy.go
+++ b/actors/builtin/market/policy.go
@@ -13,7 +13,7 @@ const DealUpdatesInterval = 100
 func dealDurationBounds(size abi.PaddedPieceSize) (min abi.ChainEpoch, max abi.ChainEpoch) {
 	// Cryptoeconomic modelling to date has used an assumption of a maximum deal duration of up to one year.
 	// It very likely can be much longer, but we're not sure yet.
-	return abi.ChainEpoch(0), abi.ChainEpoch(1 * builtin.EpochsInYear) // PARAM_FINISH
+	return abi.ChainEpoch(180 * builtin.EpochsInDay), abi.ChainEpoch(366 * builtin.EpochsInDay) // PARAM_FINISH
 }
 
 func dealPricePerEpochBounds(size abi.PaddedPieceSize, duration abi.ChainEpoch) (min abi.TokenAmount, max abi.TokenAmount) {


### PR DESCRIPTION
closes #735

### Motivation

Deal lifetime must be at least 180 days and no more than 366 days (one leap year). Set this bound and fix the tests..
