### PR TITLE
Inline small blocks into CIDs.

### DIFF
--- a/actors/abi/cid.go
+++ b/actors/abi/cid.go
@@ -10,9 +10,29 @@ const (
 	HashLength   = 32
 )
 
-// CidBuilder is the default CID builder for Filecoin.
-var CidBuilder cid.Builder = cid.V1Builder{
-	Codec:    cid.DagCBOR,
-	MhLength: HashLength,
-	MhType:   HashFunction,
+type cidBuilder struct {
+	codec uint64
 }
+
+func (cidBuilder) WithCodec(c uint64) cid.Builder {
+	return cidBuilder{codec: c}
+}
+
+func (b cidBuilder) GetCodec() uint64 {
+	return b.codec
+}
+
+func (b cidBuilder) Sum(data []byte) (cid.Cid, error) {
+	hf := HashFunction
+	if len(data) <= HashLength {
+		hf = mh.IDENTITY
+	}
+	return cid.V1Builder{Codec: b.codec, MhType: hf}.Sum(data)
+}
+
+// CidBuilder is the default CID builder for Filecoin.
+//
+// - The default codec is CBOR. This can be changed with CidBuilder.WithCodec.
+// - The default hash function is 256bit blake2b when the data is > 32 bytes
+//   long and the identity function when the data is <= 32 bytes long.
+var CidBuilder cid.Builder = cidBuilder{codec: cid.DagCBOR}


### PR DESCRIPTION
This should save us a blockstore access for all blocks smaller than 32 bytes (the inline limit). We could set the limit to be larger but this is a safe place to start.

WIP because this requires some changes in lotus.