### PR TITLE
Revert "Market: Remove Zero balance accounts (#719)"

### DIFF
--- a/actors/builtin/market/market_actor.go
+++ b/actors/builtin/market/market_actor.go
@@ -100,10 +100,6 @@ func (a Actor) WithdrawBalance(rt Runtime, params *WithdrawBalanceParams) *adt.E
 		ex, err := msm.escrowTable.SubtractWithMinimum(nominal, params.Amount, minBalance)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to subtract form escrow table")
 
-		// remove account if escrow balance is now zero
-		err, code = msm.removeAccountIfNoBalance(nominal)
-		builtin.RequireNoErr(rt, err, code, "failed to remove balance")
-
 		err = msm.commitState()
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to flush state")
 
@@ -499,10 +495,6 @@ func (a Actor) CronTick(rt Runtime, params *adt.EmptyValue) *adt.EmptyValue {
 						builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to delete deal")
 					}
 
-					// remove provider account if escrow balance is now zero.
-					err, code := msm.removeAccountIfNoBalance(deal.Provider)
-					builtin.RequireNoErr(rt, err, code, "failed to remove provider account")
-
 					pdErr := msm.pendingDeals.Delete(adt.CidKey(dcid))
 					builtin.RequireNoErr(rt, pdErr, exitcode.ErrIllegalState, "failed to delete pending proposal")
 
@@ -538,14 +530,6 @@ func (a Actor) CronTick(rt Runtime, params *adt.EmptyValue) *adt.EmptyValue {
 
 					updatesNeeded[nextEpoch] = append(updatesNeeded[nextEpoch], dealID)
 				}
-
-				// remove provider account if escrow balance is now zero
-				err, code := msm.removeAccountIfNoBalance(deal.Provider)
-				builtin.RequireNoErr(rt, err, code, "failed to remove provider account")
-
-				// remove client account if escrow balance is now zero
-				err, code = msm.removeAccountIfNoBalance(deal.Client)
-				builtin.RequireNoErr(rt, err, code, "failed to remove client account")
 
 				return nil
 			}); err != nil {

--- a/actors/builtin/market/market_balances.go
+++ b/actors/builtin/market/market_balances.go
@@ -104,36 +104,6 @@ func (m *marketStateMutation) maybeLockBalance(addr addr.Address, amount abi.Tok
 	return nil, exitcode.Ok
 }
 
-func (m *marketStateMutation) removeAccountIfNoBalance(addr addr.Address) (error, exitcode.ExitCode) {
-	bal, err, code := getBalance(m.escrowTable, addr)
-	if err != nil {
-		return xerrors.Errorf("failed to get escrow balance: %w", err), code
-	}
-
-	if bal.Equals(big.Zero()) {
-		prev, err := m.escrowTable.Remove(addr)
-		if err != nil {
-			return xerrors.Errorf("failed to remove account: %w", err), exitcode.ErrIllegalState
-		}
-		AssertMsg(prev.Equals(big.Zero()), "previous escrow balance should be zero")
-
-		// remove locked balance account
-		bal, err, code = getBalance(m.lockedTable, addr)
-		if err != nil {
-			return xerrors.Errorf("failed to get locked balance: %w", err), code
-		}
-		if bal.Equals(big.Zero()) {
-			prev, err = m.lockedTable.Remove(addr)
-			if err != nil {
-				return xerrors.Errorf("failed to remove locked account: %w", err), exitcode.ErrIllegalState
-			}
-			AssertMsg(prev.Equals(big.Zero()), "previous locked balance should be zero")
-		}
-	}
-
-	return nil, exitcode.Ok
-}
-
 func getBalance(bt *adt.BalanceTable, a addr.Address) (abi.TokenAmount, error, exitcode.ExitCode) {
 	ret, found, err := bt.Get(a)
 	if err != nil {

--- a/actors/builtin/market/market_test.go
+++ b/actors/builtin/market/market_test.go
@@ -287,8 +287,8 @@ func TestMarketActor(t *testing.T) {
 			expectedAmount := abi.NewTokenAmount(20)
 			actor.withdrawClientBalance(rt, client, withdrawAmount, expectedAmount)
 
-			// account will be removed since balance is now zero
-			actor.assertAccountRemoved(rt, client)
+			rt.GetState(&st)
+			assert.Equal(t, abi.NewTokenAmount(0), actor.getEscrowBalance(rt, client))
 		})
 
 		t.Run("worker withdrawing more than escrow balance limits to available funds", func(t *testing.T) {
@@ -303,8 +303,8 @@ func TestMarketActor(t *testing.T) {
 			actualWithdrawn := abi.NewTokenAmount(20)
 			actor.withdrawProviderBalance(rt, withdrawAmount, actualWithdrawn, minerAddrs)
 
-			// account will be removed since balance is now zero
-			actor.assertAccountRemoved(rt, provider)
+			rt.GetState(&st)
+			assert.Equal(t, abi.NewTokenAmount(0), actor.getEscrowBalance(rt, provider))
 		})
 
 		t.Run("balance after withdrawal must ALWAYS be greater than or equal to locked amount", func(t *testing.T) {
@@ -1397,9 +1397,8 @@ func TestCronTickTimedoutDeals(t *testing.T) {
 
 		require.Equal(t, cEscrow, actor.getEscrowBalance(rt, client))
 		require.Equal(t, big.Zero(), actor.getLockedBalance(rt, client))
-
-		// provider account should be deleted as balance will be zero
-		actor.assertAccountRemoved(rt, provider)
+		require.Equal(t, big.Zero(), actor.getEscrowBalance(rt, provider))
+		require.Equal(t, big.Zero(), actor.getLockedBalance(rt, provider))
 
 		actor.assertDealDeleted(rt, dealId, d)
 	})
@@ -1468,12 +1467,9 @@ func TestCronTickTimedoutDeals(t *testing.T) {
 		rt.ExpectSend(builtin.BurntFundsActorAddr, builtin.MethodSend, nil, expectedBurn, nil, exitcode.Ok)
 		actor.cronTick(rt)
 
-		actor.assertDealDeleted(rt, dealIds[0], &deal1)
-		actor.assertDealDeleted(rt, dealIds[1], &deal2)
-		actor.assertDealDeleted(rt, dealIds[2], &deal3)
+		// a second cron tick for the same epoch should not change anything
+		actor.cronTickNoChange(rt, client, provider)
 
-		// provider account should be deleted as balance will be zero
-		actor.assertAccountRemoved(rt, provider)
 		actor.assertDealDeleted(rt, dealIds[0], &deal1)
 		actor.assertDealDeleted(rt, dealIds[1], &deal2)
 		actor.assertDealDeleted(rt, dealIds[2], &deal3)
@@ -1616,21 +1612,6 @@ func TestCronTickDealExpiry(t *testing.T) {
 		// deal should be deleted
 		actor.assertDealDeleted(rt, dealId, deal)
 	})
-
-	t.Run("all payments are made for a deal -> deal expires -> client withdraws collateral and client account is removed", func(t *testing.T) {
-		rt, actor := basicMarketSetup(t, owner, provider, worker, client)
-		dealId := actor.publishAndActivateDeal(rt, client, mAddrs, startEpoch, endEpoch, 0, sectorExpiry)
-		deal := actor.getDealProposal(rt, dealId)
-
-		// move the current epoch so that deal is expired
-		rt.SetEpoch(startEpoch + 1000)
-		actor.cronTick(rt)
-		require.EqualValues(t, deal.ClientCollateral, actor.getEscrowBalance(rt, client))
-
-		// client withdraws collateral -> account should be removed as it now has zero balance
-		actor.withdrawClientBalance(rt, client, deal.ClientCollateral, deal.ClientCollateral)
-		actor.assertAccountRemoved(rt, client)
-	})
 }
 
 func TestCronTickDealSlashing(t *testing.T) {
@@ -1693,14 +1674,6 @@ func TestCronTickDealSlashing(t *testing.T) {
 				cronTickEpoch:    abi.ChainEpoch(25), // deal has expired
 				payment:          abi.NewTokenAmount(50),
 			},
-			"deal is slashed just BEFORE the end epoch": {
-				dealStart:        abi.ChainEpoch(10),
-				dealEnd:          abi.ChainEpoch(20),
-				activationEpoch:  abi.ChainEpoch(5),
-				terminationEpoch: abi.ChainEpoch(19),
-				cronTickEpoch:    abi.ChainEpoch(19),
-				payment:          abi.NewTokenAmount(90), // (19 - 10) * 10
-			},
 			"deal slash epoch must NOT be greater than current epoch": {
 				dealStart:        abi.ChainEpoch(10),
 				dealEnd:          abi.ChainEpoch(20),
@@ -1709,6 +1682,14 @@ func TestCronTickDealSlashing(t *testing.T) {
 				cronTickEpoch:    abi.ChainEpoch(10), // deal has expired
 				payment:          abi.NewTokenAmount(50),
 				assertionMsg:     "current epoch less than slash epoch",
+			},
+			"deal is slashed just BEFORE the end epoch": {
+				dealStart:        abi.ChainEpoch(10),
+				dealEnd:          abi.ChainEpoch(20),
+				activationEpoch:  abi.ChainEpoch(5),
+				terminationEpoch: abi.ChainEpoch(19),
+				cronTickEpoch:    abi.ChainEpoch(19),
+				payment:          abi.NewTokenAmount(90), // (19 - 10) * 10
 			},
 		}
 
@@ -1734,19 +1715,8 @@ func TestCronTickDealSlashing(t *testing.T) {
 					require.EqualValues(t, d.ProviderCollateral, slashed)
 					actor.assertDealDeleted(rt, dealId, d)
 
-					// if there has been no payment, provider will have zero balance and hence should be slashed
-					if tc.payment.Equals(big.Zero()) {
-						actor.assertAccountRemoved(rt, provider)
-						// client balances should not change
-						cLocked := actor.getLockedBalance(rt, client)
-						cEscrow := actor.getEscrowBalance(rt, client)
-						actor.cronTick(rt)
-						require.EqualValues(t, cEscrow, actor.getEscrowBalance(rt, client))
-						require.EqualValues(t, cLocked, actor.getLockedBalance(rt, client))
-					} else {
-						// running cron tick again dosen't do anything
-						actor.cronTickNoChange(rt, client, provider)
-					}
+					// running cron tick again dosen't do anything
+					actor.cronTickNoChange(rt, client, provider)
 				} else {
 					rt.ExpectAssertionFailure(tc.assertionMsg, func() {
 						rt.ExpectValidateCallerAddr(builtin.CronActorAddr)
@@ -2260,10 +2230,8 @@ func (h *marketActorTestHarness) cronTickNoChange(rt *mock.Runtime, client, prov
 
 	require.EqualValues(h.t, cEscrow, h.getEscrowBalance(rt, client))
 	require.EqualValues(h.t, cLocked, h.getLockedBalance(rt, client))
-
 	require.EqualValues(h.t, pEscrow, h.getEscrowBalance(rt, provider))
 	require.EqualValues(h.t, pLocked, h.getLockedBalance(rt, provider))
-
 }
 
 func (h *marketActorTestHarness) cronTickAndAssertBalances(rt *mock.Runtime, client, provider address.Address,
@@ -2316,20 +2284,10 @@ func (h *marketActorTestHarness) cronTickAndAssertBalances(rt *mock.Runtime, cli
 
 	h.cronTick(rt)
 
-	// zero balance accounts should be removed
-	if updatedClientEscrow.Equals(big.Zero()) {
-		h.assertAccountRemoved(rt, client)
-	} else {
-		require.EqualValues(h.t, updatedClientEscrow, h.getEscrowBalance(rt, client))
-		require.EqualValues(h.t, updatedClientLocked, h.getLockedBalance(rt, client))
-	}
-
-	if updatedProviderEscrow.Equals(big.Zero()) {
-		h.assertAccountRemoved(rt, provider)
-	} else {
-		require.Equal(h.t, updatedProviderLocked, h.getLockedBalance(rt, provider))
-		require.Equal(h.t, updatedProviderEscrow.Int64(), h.getEscrowBalance(rt, provider).Int64())
-	}
+	require.EqualValues(h.t, updatedClientEscrow, h.getEscrowBalance(rt, client))
+	require.EqualValues(h.t, updatedClientLocked, h.getLockedBalance(rt, client))
+	require.Equal(h.t, updatedProviderLocked, h.getLockedBalance(rt, provider))
+	require.Equal(h.t, updatedProviderEscrow.Int64(), h.getEscrowBalance(rt, provider).Int64())
 
 	return
 }
@@ -2449,24 +2407,6 @@ func (h *marketActorTestHarness) getDealProposal(rt *mock.Runtime, dealID abi.De
 	require.NotNil(h.t, d)
 
 	return d
-}
-
-func (h *marketActorTestHarness) assertAccountRemoved(rt *mock.Runtime, addr address.Address) {
-	var st market.State
-	rt.GetState(&st)
-
-	et, err := adt.AsBalanceTable(adt.AsStore(rt), st.EscrowTable)
-	require.NoError(h.t, err)
-
-	_, f, err := et.Get(addr)
-	require.NoError(h.t, err)
-	require.False(h.t, f)
-
-	lt, err := adt.AsBalanceTable(adt.AsStore(rt), st.LockedTable)
-	require.NoError(h.t, err)
-	_, f, err = lt.Get(addr)
-	require.NoError(h.t, err)
-	require.False(h.t, f)
 }
 
 func (h *marketActorTestHarness) getEscrowBalance(rt *mock.Runtime, addr address.Address) abi.TokenAmount {

--- a/actors/util/adt/balancetable.go
+++ b/actors/util/adt/balancetable.go
@@ -122,23 +122,6 @@ func (t *BalanceTable) Total() (abi.TokenAmount, error) {
 	return total, err
 }
 
-// Removes an entry from the table, returning the prior value. The entry must have been previously initialized.
-func (t *BalanceTable) Remove(key addr.Address) (abi.TokenAmount, error) {
-	prev, found, err := t.Get(key)
-	if err != nil {
-		return big.Zero(), err
-	}
-	if !found {
-		return big.Zero(), ErrNotFound{t.lastCid, key}
-	}
-
-	err = (*Map)(t).Delete(AddrKey(key))
-	if err != nil {
-		return big.Zero(), err
-	}
-	return prev, nil
-}
-
 // Error type returned when an expected key is absent.
 type ErrNotFound struct {
 	Root cid.Cid

--- a/actors/util/adt/balancetable_test.go
+++ b/actors/util/adt/balancetable_test.go
@@ -184,38 +184,3 @@ func TestSubtractWithMinimum(t *testing.T) {
 		require.EqualValues(t, abi.NewTokenAmount(3), s)
 	})
 }
-
-func TestRemove(t *testing.T) {
-	buildBalanceTable := func() *adt.BalanceTable {
-		rt := mock.NewBuilder(context.Background(), address.Undef).Build(t)
-		store := adt.AsStore(rt)
-		emptyMap := adt.MakeEmptyMap(store)
-
-		bt, err := adt.AsBalanceTable(store, tutil.MustRoot(t, emptyMap))
-		require.NoError(t, err)
-		return bt
-	}
-
-	addr := tutil.NewIDAddr(t, 100)
-	bt := buildBalanceTable()
-
-	// remove will give error if account has not been created
-	bal, err := bt.Remove(addr)
-	require.Error(t, err)
-	require.Equal(t, big.Zero(), bal)
-
-	// now create account -> remove should work
-	require.NoError(t, bt.AddCreate(addr, abi.NewTokenAmount(10)))
-	bal, found, err := bt.Get(addr)
-	require.True(t, found)
-	require.NoError(t, err)
-	require.Equal(t, abi.NewTokenAmount(10), bal)
-
-	amt, err := bt.Remove(addr)
-	require.NoError(t, err)
-	require.EqualValues(t, abi.NewTokenAmount(10), amt)
-
-	_, found, err = bt.Get(addr)
-	require.NoError(t, err)
-	require.False(t, found)
-}


### PR DESCRIPTION
This reverts commit cb5fd859feeea4d48c0c0561317ac331e96d8c6a.

We will want some of the changes back, but the specific mechanism of removing zero balances probably differently.

FYI @aarshkshah1992 this was causing failures in devnets.