### PR TITLE
Balance table treats absent entries as zero, never stores zeros

### DIFF
--- a/actors/util/adt/balancetable.go
+++ b/actors/util/adt/balancetable.go
@@ -1,17 +1,16 @@
 package adt
 
 import (
-	"errors"
-	"fmt"
-
 	addr "github.com/filecoin-project/go-address"
 	cid "github.com/ipfs/go-cid"
+	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
 )
 
-// A specialization of a map of addresses to token amounts.
+// A specialization of a map of addresses to (positive) token amounts.
+// Absent keys implicitly have a balance of zero.
 type BalanceTable Map
 
 // Interprets a store as balance table with root `r`.
@@ -32,59 +31,36 @@ func (t *BalanceTable) Root() (cid.Cid, error) {
 	return (*Map)(t).Root()
 }
 
-// Gets the balance for a key. The entry must have been previously initialized.
-func (t *BalanceTable) Get(key addr.Address) (abi.TokenAmount, bool, error) {
+// Gets the balance for a key, which is zero if they key has never been added to.
+func (t *BalanceTable) Get(key addr.Address) (abi.TokenAmount, error) {
 	var value abi.TokenAmount
 	found, err := (*Map)(t).Get(AddrKey(key), &value)
 	if !found || err != nil {
 		value = big.Zero()
 	}
 
-	return value, found, err
+	return value, err
 }
 
-// Has checks if the balance for a key exists
-func (t *BalanceTable) Has(key addr.Address) (bool, error) {
-	var value abi.TokenAmount
-	return (*Map)(t).Get(AddrKey(key), &value)
-}
-
-// Adds an amount to a balance. The entry must have been previously initialized.
+// Adds an amount to a balance, requiring the resulting balance to be non-negative.
 func (t *BalanceTable) Add(key addr.Address, value abi.TokenAmount) error {
-	prev, found, err := t.Get(key)
+	prev, err := t.Get(key)
 	if err != nil {
 		return err
 	}
-	if !found {
-		return ErrNotFound{t.lastCid, key}
-	}
 	sum := big.Add(prev, value)
+	if sum.Sign() < 0 {
+		return xerrors.Errorf("adding %v to balance %v would give negative: %v", value, prev, sum)
+	}
 	return (*Map)(t).Put(AddrKey(key), &sum)
 }
 
-// Adds an amount to a balance. Create entry if not exists
-func (t *BalanceTable) AddCreate(key addr.Address, value abi.TokenAmount) error {
-	var prev abi.TokenAmount
-	found, err := (*Map)(t).Get(AddrKey(key), &prev)
-	if err != nil {
-		return err
-	}
-	if found {
-		value = big.Add(prev, value)
-	}
-
-	return (*Map)(t).Put(AddrKey(key), &value)
-}
-
 // Subtracts up to the specified amount from a balance, without reducing the balance below some minimum.
-// Returns the amount subtracted (always positive or zero).
+// Returns the amount subtracted.
 func (t *BalanceTable) SubtractWithMinimum(key addr.Address, req abi.TokenAmount, floor abi.TokenAmount) (abi.TokenAmount, error) {
-	prev, found, err := t.Get(key)
+	prev, err := t.Get(key)
 	if err != nil {
 		return big.Zero(), err
-	}
-	if !found {
-		return big.Zero(), ErrNotFound{t.lastCid, key}
 	}
 
 	available := big.Max(big.Zero(), big.Sub(prev, floor))
@@ -98,17 +74,17 @@ func (t *BalanceTable) SubtractWithMinimum(key addr.Address, req abi.TokenAmount
 	return sub, nil
 }
 
-// MustSubtract subtracts the given amount from the account's balance
-// returns an error if account isn't created or if it has insufficient balance
+// MustSubtract subtracts the given amount from the account's balance.
+// Returns an error if the account has insufficient balance
 func (t *BalanceTable) MustSubtract(key addr.Address, req abi.TokenAmount) error {
-	subst, err := t.SubtractWithMinimum(key, req, big.Zero())
+	prev, err := t.Get(key)
 	if err != nil {
 		return err
 	}
-	if !subst.Equals(req) {
-		return errors.New("couldn't subtract the requested amount")
+	if req.GreaterThan(prev) {
+		return xerrors.New("couldn't subtract the requested amount")
 	}
-	return nil
+	return t.Add(key, req.Neg())
 }
 
 // Returns the total balance held by this BalanceTable
@@ -120,14 +96,4 @@ func (t *BalanceTable) Total() (abi.TokenAmount, error) {
 		return nil
 	})
 	return total, err
-}
-
-// Error type returned when an expected key is absent.
-type ErrNotFound struct {
-	Root cid.Cid
-	Key  interface{}
-}
-
-func (e ErrNotFound) Error() string {
-	return fmt.Sprintf("no key %v in map root %v", e.Key, e.Root)
 }

--- a/actors/util/adt/balancetable.go
+++ b/actors/util/adt/balancetable.go
@@ -49,8 +49,11 @@ func (t *BalanceTable) Add(key addr.Address, value abi.TokenAmount) error {
 		return err
 	}
 	sum := big.Add(prev, value)
-	if sum.Sign() < 0 {
+	sign := sum.Sign()
+	if sign < 0 {
 		return xerrors.Errorf("adding %v to balance %v would give negative: %v", value, prev, sum)
+	} else if sign == 0 && !prev.IsZero() {
+		return (*Map)(t).Delete(AddrKey(key))
 	}
 	return (*Map)(t).Put(AddrKey(key), &sum)
 }

--- a/actors/util/adt/balancetable_test.go
+++ b/actors/util/adt/balancetable_test.go
@@ -36,7 +36,7 @@ func TestBalanceTable(t *testing.T) {
 
 		err = bt.Add(addr, abi.NewTokenAmount(10))
 		assert.NoError(t, err)
-		amount,  err := bt.Get(addr)
+		amount, err := bt.Get(addr)
 		assert.NoError(t, err)
 		assert.Equal(t, abi.NewTokenAmount(10), amount)
 
@@ -46,7 +46,6 @@ func TestBalanceTable(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, abi.NewTokenAmount(30), amount)
 
-
 		// Add negative to subtract.
 		err = bt.Add(addr, abi.NewTokenAmount(-30))
 		assert.NoError(t, err)
@@ -55,6 +54,7 @@ func TestBalanceTable(t *testing.T) {
 		assert.Equal(t, abi.NewTokenAmount(0), amount)
 		// The zero entry is not stored.
 		found, err := ((*adt.Map)(bt)).Get(adt.AddrKey(addr), nil)
+		require.NoError(t, err)
 		require.False(t, found)
 	})
 
@@ -89,6 +89,7 @@ func TestBalanceTable(t *testing.T) {
 
 		// The zero entry is not stored.
 		found, err := ((*adt.Map)(bt)).Get(adt.AddrKey(addr), nil)
+		require.NoError(t, err)
 		require.False(t, found)
 	})
 

--- a/actors/util/adt/balancetable_test.go
+++ b/actors/util/adt/balancetable_test.go
@@ -26,93 +26,58 @@ func TestBalanceTable(t *testing.T) {
 		return bt
 	}
 
-	t.Run("AddCreate adds or creates", func(t *testing.T) {
+	t.Run("Add adds or creates", func(t *testing.T) {
 		addr := tutil.NewIDAddr(t, 100)
 		bt := buildBalanceTable()
 
-		has, err := bt.Has(addr)
+		prev, err := bt.Get(addr)
 		assert.NoError(t, err)
-		assert.False(t, has)
+		assert.Equal(t, big.Zero(), prev)
 
-		err = bt.AddCreate(addr, abi.NewTokenAmount(10))
+		err = bt.Add(addr, abi.NewTokenAmount(10))
 		assert.NoError(t, err)
 
-		amount, found, err := bt.Get(addr)
-		require.True(t, found)
+		amount,  err := bt.Get(addr)
 		assert.NoError(t, err)
 		assert.Equal(t, abi.NewTokenAmount(10), amount)
 
-		err = bt.AddCreate(addr, abi.NewTokenAmount(20))
+		err = bt.Add(addr, abi.NewTokenAmount(20))
 		assert.NoError(t, err)
 
-		amount, found, err = bt.Get(addr)
-		require.True(t, found)
+		amount, err = bt.Get(addr)
 		assert.NoError(t, err)
 		assert.Equal(t, abi.NewTokenAmount(30), amount)
 	})
 
-	t.Run("Add works only if account has been created", func(t *testing.T) {
+	t.Run("Must subtract fails if account balance is insufficient", func(t *testing.T) {
 		addr := tutil.NewIDAddr(t, 100)
 		bt := buildBalanceTable()
 
-		// fail if account hasnt been created
-		require.Error(t, bt.Add(addr, abi.NewTokenAmount(10)))
-
-		// now create account -> add should work
-		require.NoError(t, bt.AddCreate(addr, abi.NewTokenAmount(10)))
-		require.NoError(t, bt.Add(addr, abi.NewTokenAmount(5)))
-		bal, found, err := bt.Get(addr)
-		require.True(t, found)
-		require.NoError(t, err)
-		require.Equal(t, abi.NewTokenAmount(15), bal)
-	})
-
-	t.Run("Get works only if account has been created", func(t *testing.T) {
-		addr := tutil.NewIDAddr(t, 100)
-		bt := buildBalanceTable()
-
-		// found is false if account hasnt been created
-		bal, found, err := bt.Get(addr)
-		require.False(t, found)
-		require.NoError(t, err)
-		require.Equal(t, big.Zero(), bal)
-
-		// now create account -> get should work
-		require.NoError(t, bt.AddCreate(addr, abi.NewTokenAmount(10)))
-		bal, found, err = bt.Get(addr)
-		require.True(t, found)
-		require.NoError(t, err)
-		require.Equal(t, abi.NewTokenAmount(10), bal)
-	})
-
-	t.Run("Must subtract fails if account not created or balance is insufficient", func(t *testing.T) {
-		addr := tutil.NewIDAddr(t, 100)
-		bt := buildBalanceTable()
-
-		// fail if account hasnt been created
-		require.Error(t, bt.MustSubtract(addr, abi.NewTokenAmount(0)))
-
-		// create account -> should work now
-		require.NoError(t, bt.AddCreate(addr, abi.NewTokenAmount(0)))
+		// Ok to subtract zero from nothing
 		require.NoError(t, bt.MustSubtract(addr, abi.NewTokenAmount(0)))
 
+		// Fail to subtract something from nothing
+		require.Error(t, bt.MustSubtract(addr, abi.NewTokenAmount(1)))
+
 		require.NoError(t, bt.Add(addr, abi.NewTokenAmount(5)))
-		// error if insufficient balance -> however, balance is still subtracted
-		// TODO Is that correct ?
-		// https://github.com/filecoin-project/specs-actors/issues/652
+
+		// Fail to subtract more than available
 		require.Error(t, bt.MustSubtract(addr, abi.NewTokenAmount(6)))
-		bal, found, err := bt.Get(addr)
-		require.True(t, found)
+		bal, err := bt.Get(addr)
+		require.NoError(t, err)
+		require.Equal(t, abi.NewTokenAmount(5), bal)
+
+		// Ok to subtract less than available
+		require.NoError(t, bt.MustSubtract(addr, abi.NewTokenAmount(4)))
+		bal, err = bt.Get(addr)
+		require.NoError(t, err)
+		require.Equal(t, abi.NewTokenAmount(1), bal)
+		// ...and the rest
+		require.NoError(t, bt.MustSubtract(addr, abi.NewTokenAmount(1)))
+		bal, err = bt.Get(addr)
 		require.NoError(t, err)
 		require.Equal(t, abi.NewTokenAmount(0), bal)
 
-		// balance is sufficient -> should work
-		require.NoError(t, bt.Add(addr, abi.NewTokenAmount(5)))
-		require.NoError(t, bt.MustSubtract(addr, abi.NewTokenAmount(4)))
-		bal, found, err = bt.Get(addr)
-		require.True(t, found)
-		require.NoError(t, err)
-		require.Equal(t, abi.NewTokenAmount(1), bal)
 	})
 
 	t.Run("Total returns total amount tracked", func(t *testing.T) {
@@ -136,7 +101,7 @@ func TestBalanceTable(t *testing.T) {
 		}
 
 		for _, tc := range testCases {
-			err = bt.AddCreate(tc.addr, abi.NewTokenAmount(tc.amount))
+			err = bt.Add(tc.addr, abi.NewTokenAmount(tc.amount))
 			assert.NoError(t, err)
 
 			total, err = bt.Total()
@@ -159,28 +124,36 @@ func TestSubtractWithMinimum(t *testing.T) {
 	addr := tutil.NewIDAddr(t, 100)
 	zeroAmt := abi.NewTokenAmount(0)
 
-	t.Run("fails when account does not exist", func(t *testing.T) {
+	t.Run("ok with zero balance", func(t *testing.T) {
 		bt := buildBalanceTable()
 		s, err := bt.SubtractWithMinimum(addr, zeroAmt, zeroAmt)
-		require.Error(t, err)
+		require.NoError(t, err)
 		require.EqualValues(t, zeroAmt, s)
 	})
 
 	t.Run("withdraw available when account does not have sufficient balance", func(t *testing.T) {
 		bt := buildBalanceTable()
-		require.NoError(t, bt.AddCreate(addr, abi.NewTokenAmount(5)))
+		require.NoError(t, bt.Add(addr, abi.NewTokenAmount(5)))
 
 		s, err := bt.SubtractWithMinimum(addr, abi.NewTokenAmount(2), abi.NewTokenAmount(4))
 		require.NoError(t, err)
 		require.EqualValues(t, abi.NewTokenAmount(1), s)
+
+		remaining, err := bt.Get(addr)
+		require.NoError(t, err)
+		require.EqualValues(t, abi.NewTokenAmount(4), remaining)
 	})
 
 	t.Run("account has sufficient balance", func(t *testing.T) {
 		bt := buildBalanceTable()
-		require.NoError(t, bt.AddCreate(addr, abi.NewTokenAmount(5)))
+		require.NoError(t, bt.Add(addr, abi.NewTokenAmount(5)))
 
 		s, err := bt.SubtractWithMinimum(addr, abi.NewTokenAmount(3), abi.NewTokenAmount(2))
 		require.NoError(t, err)
 		require.EqualValues(t, abi.NewTokenAmount(3), s)
+
+		remaining, err := bt.Get(addr)
+		require.NoError(t, err)
+		require.EqualValues(t, abi.NewTokenAmount(2), remaining)
 	})
 }

--- a/actors/util/adt/balancetable_test.go
+++ b/actors/util/adt/balancetable_test.go
@@ -36,17 +36,26 @@ func TestBalanceTable(t *testing.T) {
 
 		err = bt.Add(addr, abi.NewTokenAmount(10))
 		assert.NoError(t, err)
-
 		amount,  err := bt.Get(addr)
 		assert.NoError(t, err)
 		assert.Equal(t, abi.NewTokenAmount(10), amount)
 
 		err = bt.Add(addr, abi.NewTokenAmount(20))
 		assert.NoError(t, err)
-
 		amount, err = bt.Get(addr)
 		assert.NoError(t, err)
 		assert.Equal(t, abi.NewTokenAmount(30), amount)
+
+
+		// Add negative to subtract.
+		err = bt.Add(addr, abi.NewTokenAmount(-30))
+		assert.NoError(t, err)
+		amount, err = bt.Get(addr)
+		assert.NoError(t, err)
+		assert.Equal(t, abi.NewTokenAmount(0), amount)
+		// The zero entry is not stored.
+		found, err := ((*adt.Map)(bt)).Get(adt.AddrKey(addr), nil)
+		require.False(t, found)
 	})
 
 	t.Run("Must subtract fails if account balance is insufficient", func(t *testing.T) {
@@ -78,6 +87,9 @@ func TestBalanceTable(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, abi.NewTokenAmount(0), bal)
 
+		// The zero entry is not stored.
+		found, err := ((*adt.Map)(bt)).Get(adt.AddrKey(addr), nil)
+		require.False(t, found)
 	})
 
 	t.Run("Total returns total amount tracked", func(t *testing.T) {


### PR DESCRIPTION
This is motivated by #784. I think this is a much more robust way of cleaning up empty accounts.

Minor conflicts with #775, but please let this land first.