### PR TITLE
Central CID builder

### DIFF
--- a/actors/abi/cid.go
+++ b/actors/abi/cid.go
@@ -1,0 +1,38 @@
+package abi
+
+import (
+	"github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+)
+
+const (
+	inlineCidLimit = 32 // 32 bytes
+	hashFunction   = uint64(mh.BLAKE2B_MIN + 31)
+)
+
+type cidBuilder struct {
+	codec uint64
+}
+
+func (cidBuilder) WithCodec(c uint64) cid.Builder {
+	return cidBuilder{codec: c}
+}
+
+func (b cidBuilder) GetCodec() uint64 {
+	return b.codec
+}
+
+func (b cidBuilder) Sum(data []byte) (cid.Cid, error) {
+	hf := hashFunction
+	if len(data) <= inlineCidLimit {
+		hf = mh.IDENTITY
+	}
+	return cid.V1Builder{Codec: b.codec, MhType: hf}.Sum(data)
+}
+
+// CidBuilder is the default CID builder for Filecoin.
+//
+// - The default codec is CBOR. This can be changed with CidBuilder.WithCodec.
+// - The default hash function is 256bit blake2b when the data is > 32 bytes
+//   long and the identity function when the data is <= 32 bytes long.
+var CidBuilder cid.Builder = cidBuilder{codec: cid.DagCBOR}

--- a/actors/abi/cid.go
+++ b/actors/abi/cid.go
@@ -6,33 +6,13 @@ import (
 )
 
 const (
-	inlineCidLimit = 32 // 32 bytes
-	hashFunction   = uint64(mh.BLAKE2B_MIN + 31)
+	hashFunction = uint64(mh.BLAKE2B_MIN + 31)
+	hashLength   = 32
 )
 
-type cidBuilder struct {
-	codec uint64
-}
-
-func (cidBuilder) WithCodec(c uint64) cid.Builder {
-	return cidBuilder{codec: c}
-}
-
-func (b cidBuilder) GetCodec() uint64 {
-	return b.codec
-}
-
-func (b cidBuilder) Sum(data []byte) (cid.Cid, error) {
-	hf := hashFunction
-	if len(data) <= inlineCidLimit {
-		hf = mh.IDENTITY
-	}
-	return cid.V1Builder{Codec: b.codec, MhType: hf}.Sum(data)
-}
-
 // CidBuilder is the default CID builder for Filecoin.
-//
-// - The default codec is CBOR. This can be changed with CidBuilder.WithCodec.
-// - The default hash function is 256bit blake2b when the data is > 32 bytes
-//   long and the identity function when the data is <= 32 bytes long.
-var CidBuilder cid.Builder = cidBuilder{codec: cid.DagCBOR}
+var CidBuilder cid.Builder = cid.V1Builder{
+	Codec:    cid.DagCBOR,
+	MhLength: hashLength,
+	MhType:   hashFunction,
+}

--- a/actors/abi/cid.go
+++ b/actors/abi/cid.go
@@ -6,13 +6,13 @@ import (
 )
 
 const (
-	hashFunction = uint64(mh.BLAKE2B_MIN + 31)
-	hashLength   = 32
+	HashFunction = uint64(mh.BLAKE2B_MIN + 31)
+	HashLength   = 32
 )
 
 // CidBuilder is the default CID builder for Filecoin.
 var CidBuilder cid.Builder = cid.V1Builder{
 	Codec:    cid.DagCBOR,
-	MhLength: hashLength,
-	MhType:   hashFunction,
+	MhLength: HashLength,
+	MhType:   HashFunction,
 }

--- a/actors/builtin/market/deal.go
+++ b/actors/builtin/market/deal.go
@@ -72,23 +72,11 @@ func (p *DealProposal) ProviderBalanceRequirement() abi.TokenAmount {
 }
 
 func (p *DealProposal) Cid() (cid.Cid, error) {
-	buf := new(bytes.Buffer)
-	if err := p.MarshalCBOR(buf); err != nil {
+	var buf bytes.Buffer
+	if err := p.MarshalCBOR(&buf); err != nil {
 		return cid.Undef, err
 	}
-	b := buf.Bytes()
-
-	mhType := uint64(mh.BLAKE2B_MIN + 31)
-	mhLen := -1
-
-	hash, err := mh.Sum(b, mhType, mhLen)
-	if err != nil {
-		return cid.Undef, err
-	}
-
-	c := cid.NewCidV1(cid.DagCBOR, hash)
-
-	return c, nil
+	return abi.CidBuilder.Sum(buf.Bytes())
 }
 
 type DealState struct {

--- a/actors/builtin/market/deal.go
+++ b/actors/builtin/market/deal.go
@@ -72,8 +72,8 @@ func (p *DealProposal) ProviderBalanceRequirement() abi.TokenAmount {
 }
 
 func (p *DealProposal) Cid() (cid.Cid, error) {
-	var buf bytes.Buffer
-	if err := p.MarshalCBOR(&buf); err != nil {
+	buf := new(bytes.Buffer)
+	if err := p.MarshalCBOR(buf); err != nil {
 		return cid.Undef, err
 	}
 	return abi.CidBuilder.Sum(buf.Bytes())

--- a/support/mock/mockrt.go
+++ b/support/mock/mockrt.go
@@ -12,7 +12,6 @@ import (
 	"github.com/filecoin-project/go-address"
 	addr "github.com/filecoin-project/go-address"
 	cid "github.com/ipfs/go-cid"
-	mh "github.com/multiformats/go-multihash"
 
 	abi "github.com/filecoin-project/specs-actors/actors/abi"
 	big "github.com/filecoin-project/specs-actors/actors/abi/big"
@@ -146,12 +145,6 @@ var _ runtime.StateHandle = &Runtime{}
 var typeOfRuntimeInterface = reflect.TypeOf((*runtime.Runtime)(nil)).Elem()
 var typeOfCborUnmarshaler = reflect.TypeOf((*runtime.CBORUnmarshaler)(nil)).Elem()
 var typeOfCborMarshaler = reflect.TypeOf((*runtime.CBORMarshaler)(nil)).Elem()
-
-var cidBuilder = cid.V1Builder{
-	Codec:    cid.DagCBOR,
-	MhType:   mh.SHA2_256,
-	MhLength: 0, // default
-}
 
 ///// Implementation of the runtime API /////
 
@@ -405,7 +398,7 @@ func (rt *Runtime) Put(o runtime.CBORMarshaler) cid.Cid {
 		rt.Abortf(exitcode.SysErrSerialization, err.Error())
 	}
 	data := r.Bytes()
-	key, err := cidBuilder.Sum(data)
+	key, err := abi.CidBuilder.Sum(data)
 	if err != nil {
 		rt.Abortf(exitcode.SysErrSerialization, err.Error())
 	}

--- a/support/mock/mockrt.go
+++ b/support/mock/mockrt.go
@@ -548,8 +548,8 @@ func (rt *Runtime) VerifySeal(seal abi.SealVerifyInfo) error {
 	return nil
 }
 
-func (rt *Runtime) BatchVerifySeals(vis map[address.Address][]abi.SealVerifyInfo) (map[address.Address][]bool, error) {
-	out := make(map[address.Address][]bool)
+func (rt *Runtime) BatchVerifySeals(vis map[addr.Address][]abi.SealVerifyInfo) (map[addr.Address][]bool, error) {
+	out := make(map[addr.Address][]bool)
 	for k, v := range vis { //nolint:nomaprange
 		validations := make([]bool, len(v))
 		for i := range validations {
@@ -749,7 +749,7 @@ func (rt *Runtime) ExpectCreateActor(codeId cid.Cid, address addr.Address) {
 	}
 }
 
-func (rt *Runtime) ExpectDeleteActor(beneficiary address.Address) {
+func (rt *Runtime) ExpectDeleteActor(beneficiary addr.Address) {
 	rt.expectDeleteActor = &beneficiary
 }
 

--- a/support/mock/mockrt.go
+++ b/support/mock/mockrt.go
@@ -391,7 +391,7 @@ func (rt *Runtime) get(c cid.Cid) ([]byte, bool) {
 	if prefix.MhType == multihash.IDENTITY {
 		decoded, err := multihash.Decode(c.Hash())
 		if err != nil {
-			rt.Abortf(exitcode.SysErrSerialization, "failed to parse cid %s: %s", c, err)
+			rt.Abortf(exitcode.SysErrSerialization, "failed to parse identity cid %s: %s", c, err)
 		}
 		data = decoded.Digest
 	} else if stored, found := rt.store[c]; found {

--- a/support/mock/mockrt.go
+++ b/support/mock/mockrt.go
@@ -9,10 +9,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/filecoin-project/go-address"
 	addr "github.com/filecoin-project/go-address"
 	cid "github.com/ipfs/go-cid"
-	"github.com/multiformats/go-multihash"
+	mh "github.com/multiformats/go-multihash"
 
 	abi "github.com/filecoin-project/specs-actors/actors/abi"
 	big "github.com/filecoin-project/specs-actors/actors/abi/big"
@@ -63,7 +62,7 @@ type Runtime struct {
 	expectComputeUnsealedSectorCID *expectComputeUnsealedSectorCID
 	expectVerifyPoSt               *expectVerifyPoSt
 	expectVerifyConsensusFault     *expectVerifyConsensusFault
-	expectDeleteActor              *address.Address
+	expectDeleteActor              *addr.Address
 
 	logs []string
 	// Gas charged explicitly through rt.ChargeGas. Note: most charges are implicit
@@ -388,8 +387,8 @@ func (rt *Runtime) get(c cid.Cid) ([]byte, bool) {
 	}
 
 	var data []byte
-	if prefix.MhType == multihash.IDENTITY {
-		decoded, err := multihash.Decode(c.Hash())
+	if prefix.MhType == mh.IDENTITY {
+		decoded, err := mh.Decode(c.Hash())
 		if err != nil {
 			rt.Abortf(exitcode.SysErrSerialization, "failed to parse identity cid %s: %s", c, err)
 		}
@@ -404,8 +403,7 @@ func (rt *Runtime) get(c cid.Cid) ([]byte, bool) {
 
 // Puts raw data into the state, but only if it's not "inlined" into the CID.
 func (rt *Runtime) put(c cid.Cid, data []byte) {
-	// Store it only if we need to. Doing this in tests ensure
-	if c.Prefix().MhType != multihash.IDENTITY {
+	if c.Prefix().MhType != mh.IDENTITY {
 		rt.store[c] = data
 	}
 }


### PR DESCRIPTION
This is an alternative to https://github.com/filecoin-project/specs-actors/pull/783 which doesn't actually change the state structure.

Instead, this PR:

1. Adds proper support for inline CIDs (but doesn't actually crate them) so we can benchmark them without having to keep this patch lying around out-of-tree.
2. Centralizes the CID builder logic so we can change it easily.