### PR TITLE
recalculate sector intial pledge

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -458,10 +458,9 @@ func (a Actor) PreCommitSector(rt Runtime, params *SectorPreCommitInfo) *adt.Emp
 	}
 
 	// gather information from other actors
-	baselinePower, epochReward := requestCurrentEpochBaselinePowerAndReward(rt)
+	_, epochReward := requestCurrentEpochBaselinePowerAndReward(rt)
 	pwrTotal := requestCurrentTotalPower(rt)
 	dealWeight := requestDealWeight(rt, params.DealIDs, rt.CurrEpoch(), params.Expiration)
-	circulatingSupply := rt.TotalFilCircSupply()
 
 	store := adt.AsStore(rt)
 	var st State
@@ -505,7 +504,7 @@ func (a Actor) PreCommitSector(rt Runtime, params *SectorPreCommitInfo) *adt.Emp
 
 		sectorWeight := QAPowerForWeight(info.SectorSize, duration, dealWeight.DealWeight, dealWeight.VerifiedDealWeight)
 		depositReq := big.Max(
-			precommitDeposit(sectorWeight, pwrTotal.QualityAdjPower, baselinePower, pwrTotal.PledgeCollateral, epochReward, circulatingSupply),
+			PreCommitDepositForPower(epochReward, pwrTotal.QualityAdjPower, sectorWeight),
 			depositMinimum,
 		)
 		if availableBalance.LessThan(depositReq) {

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -697,7 +697,8 @@ func (a Actor) ConfirmSectorProofsValid(rt Runtime, params *builtin.ConfirmSecto
 		newSectorNos := make([]abi.SectorNumber, 0, len(preCommits))
 		for _, precommit := range preCommits {
 			// compute initial pledge
-			duration := precommit.Info.Expiration - rt.CurrEpoch()
+			activation := rt.CurrEpoch()
+			duration := precommit.Info.Expiration - activation
 			power := QAPowerForWeight(info.SectorSize, duration, precommit.DealWeight, precommit.VerifiedDealWeight)
 			initialPledge := InitialPledgeForPower(power, pwrTotal.QualityAdjPower, baselinePower,
 				pwrTotal.PledgeCollateral, epochReward, circulatingSupply)
@@ -710,7 +711,7 @@ func (a Actor) ConfirmSectorProofsValid(rt Runtime, params *builtin.ConfirmSecto
 				SealedCID:          precommit.Info.SealedCID,
 				DealIDs:            precommit.Info.DealIDs,
 				Expiration:         precommit.Info.Expiration,
-				Activation:         rt.CurrEpoch(),
+				Activation:         activation,
 				DealWeight:         precommit.DealWeight,
 				VerifiedDealWeight: precommit.VerifiedDealWeight,
 				InitialPledge:      initialPledge,

--- a/actors/builtin/miner/monies.go
+++ b/actors/builtin/miner/monies.go
@@ -12,6 +12,7 @@ import (
 // LockTarget = (LockTargetFactorNum / LockTargetFactorDenom) * FILCirculatingSupply(t)
 // PledgeShare(t) = sectorQAPower / max(BaselinePower(t), NetworkQAPower(t))
 // PARAM_FINISH
+var PreCommitDepositFactor = big.NewInt(20)
 var InitialPledgeFactor = big.NewInt(20)
 var LockTargetFactorNum = big.NewInt(3)
 var LockTargetFactorDenom = big.NewInt(10)
@@ -66,6 +67,12 @@ func PledgePenaltyForTermination(initialPledge abi.TokenAmount, sectorAge abi.Ch
 			big.Div(
 				big.Mul(initialPledge, cappedSectorAge),
 				big.Mul(InitialPledgeFactor, big.NewInt(builtin.EpochsInDay)))))
+}
+
+// Computes the PreCommit Deposit given sector qa weight and current network conditions.
+// PreCommit Deposit = 20 * BR(t)
+func PreCommitDepositForPower(epochTargetReward abi.TokenAmount, networkQAPower abi.StoragePower, qaSectorPower abi.StoragePower) abi.TokenAmount {
+	return big.Mul(PreCommitDepositFactor, ExpectedDayRewardForPower(epochTargetReward, networkQAPower, qaSectorPower))
 }
 
 // Computes the pledge requirement for committing new quality-adjusted power to the network, given the current

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -156,11 +156,6 @@ func QAPowerForSector(size abi.SectorSize, sector *SectorOnChainInfo) abi.Storag
 	return QAPowerForWeight(size, duration, sector.DealWeight, sector.VerifiedDealWeight)
 }
 
-// Deposit per sector required at pre-commitment, refunded after the commitment is proven (else burned).
-func precommitDeposit(qaSectorPower abi.StoragePower, networkQAPower abi.StoragePower, baselinePower abi.StoragePower, networkTotalPledge, epochTargetReward, circulatingSupply abi.TokenAmount) abi.TokenAmount {
-	return InitialPledgeForPower(qaSectorPower, networkQAPower, baselinePower, networkTotalPledge, epochTargetReward, circulatingSupply)
-}
-
 // Determine maximum number of deal miner's sector can hold
 func dealPerSectorLimit(size abi.SectorSize) uint64 {
 	return max64(256, uint64(size/DealLimitDenominator))


### PR DESCRIPTION
closes #522

### Motivation

Initial pledge actually does need to be calculated at prove commit time, and precommit deposit does not need to be as large as initial pledge.

### Proposed Changes

1. Introduce `PreCommitDepositForWeight` function in monies that depends on `ExpectedDayRewardForPower` but not on `InitialPledgeForPower` and delete the `precommitDeposit` function in miner_actor. Use the new function to compute a sectors `PreCommjitDeposit` in `PreCommitSector`.
2. Retrieve `baselinePower`, `epochReward`, `pwrTotal` and `circulatingSupply` at the beginning of `ConfirmSectorProofsValid` because we'll need them to compute initial pledge for sectors.
3. Use the `InitialPledgeForPower` function to compute the initial pledge for each sector. Set this in the `SectorOnChainInfo`. Also use it to compute the total pledge.
4. Sum `PreCommitDeposits` in `ConfirmSectorProofsValid` to unlock, since the `totalPledge` is no longer the correct value.
5. Change the sector's `Activation` to `rt.CurrEpoch()`. This keeps the total power calculations consistent with the total pledge calculations.