### PR TITLE
set minimum sector expiration to 180 days

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -1884,6 +1884,12 @@ func processRecoveries(rt Runtime, st *State, store adt.Store, partition *Partit
 
 // Check expiry is exactly *the epoch before* the start of a proving period.
 func validateExpiration(rt Runtime, activation, expiration abi.ChainEpoch, sealProof abi.RegisteredSealProof) {
+	// expiration cannot be less than minimum after activation
+	if expiration-activation < MinSectorExpiration {
+		rt.Abortf(exitcode.ErrIllegalArgument, "invalid expiration %d, total sector lifetime (%d) must exceed %d after activation %d",
+			expiration, expiration-activation, MinSectorExpiration, activation)
+	}
+
 	// expiration cannot exceed MaxSectorExpirationExtension from now
 	if expiration > rt.CurrEpoch()+MaxSectorExpirationExtension {
 		rt.Abortf(exitcode.ErrIllegalArgument, "invalid expiration %d, cannot be more than %d past current epoch %d",

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -108,10 +108,13 @@ var FaultMaxAge = WPoStProvingPeriod * 14
 // key or allowing the owner account to submit PoSts while a key change is pending.
 const WorkerKeyChangeDelay = ChainFinality
 
+// Minimum number of epochs past the current epoch a sector may be set to expire.
+const MinSectorExpiration = 180 * builtin.EpochsInDay
+
 // Maximum number of epochs past the current epoch a sector may be set to expire.
 // The actual maximum extension will be the minimum of CurrEpoch + MaximumSectorExpirationExtension
 // and sector.ActivationEpoch+sealProof.SectorMaximumLifetime()
-const MaxSectorExpirationExtension = builtin.EpochsInYear
+const MaxSectorExpirationExtension = 366 * builtin.EpochsInDay
 
 // Ratio of sector size to maximum deals per sector.
 // The maximum number of deals is the sector size divided by this number (2^27)


### PR DESCRIPTION
closes #734

### Motivation

We need to enforce both a minimum and a maximum sector lifetime.

### Proposed Changes

1. Introduce `MinSectorExpiration` of `180*EpochsInDay` to miner policy.
2. Add check the sector meets minimum expiration criteria in miner actor `validateExpiration`.
3. Fix miner actor tests so that sectors that are supposed to be valid expire after at least 180 days.
4. Add test for minimum sector bound.