### PR TITLE
Feat/ip no vest

### DIFF
--- a/actors/builtin/methods.go
+++ b/actors/builtin/methods.go
@@ -92,13 +92,12 @@ var MethodsMiner = struct {
 	OnDeferredCronEvent      abi.MethodNum
 	CheckSectorProven        abi.MethodNum
 	AddLockedFund            abi.MethodNum
-	AddPledgeDeposit         abi.MethodNum
 	ReportConsensusFault     abi.MethodNum
 	WithdrawBalance          abi.MethodNum
 	ConfirmSectorProofsValid abi.MethodNum
 	ChangeMultiaddrs         abi.MethodNum
 	CompactPartitions        abi.MethodNum
-}{MethodConstructor, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}
+}{MethodConstructor, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19}
 
 var MethodsVerifiedRegistry = struct {
 	Constructor       abi.MethodNum

--- a/actors/builtin/methods.go
+++ b/actors/builtin/methods.go
@@ -92,12 +92,13 @@ var MethodsMiner = struct {
 	OnDeferredCronEvent      abi.MethodNum
 	CheckSectorProven        abi.MethodNum
 	AddLockedFund            abi.MethodNum
+	AddPledgeDeposit         abi.MethodNum
 	ReportConsensusFault     abi.MethodNum
 	WithdrawBalance          abi.MethodNum
 	ConfirmSectorProofsValid abi.MethodNum
 	ChangeMultiaddrs         abi.MethodNum
 	CompactPartitions        abi.MethodNum
-}{MethodConstructor, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19}
+}{MethodConstructor, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}
 
 var MethodsVerifiedRegistry = struct {
 	Constructor       abi.MethodNum

--- a/actors/builtin/miner/cbor_gen.go
+++ b/actors/builtin/miner/cbor_gen.go
@@ -8,14 +8,14 @@ import (
 
 	"github.com/filecoin-project/go-bitfield"
 	"github.com/filecoin-project/specs-actors/actors/abi"
-	"github.com/ipfs/go-cid"
+	cid "github.com/ipfs/go-cid"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	xerrors "golang.org/x/xerrors"
 )
 
 var _ = xerrors.Errorf
 
-var lengthBufState = []byte{140}
+var lengthBufState = []byte{141}
 
 func (t *State) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -41,6 +41,11 @@ func (t *State) MarshalCBOR(w io.Writer) error {
 
 	// t.LockedFunds (big.Int) (struct)
 	if err := t.LockedFunds.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.InitialPledgeDeposits (big.Int) (struct)
+	if err := t.InitialPledgeDeposits.MarshalCBOR(w); err != nil {
 		return err
 	}
 
@@ -116,7 +121,7 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 12 {
+	if extra != 13 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -147,6 +152,15 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 
 		if err := t.LockedFunds.UnmarshalCBOR(br); err != nil {
 			return xerrors.Errorf("unmarshaling t.LockedFunds: %w", err)
+		}
+
+	}
+	// t.InitialPledgeDeposits (big.Int) (struct)
+
+	{
+
+		if err := t.InitialPledgeDeposits.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.InitialPledgeDeposits: %w", err)
 		}
 
 	}

--- a/actors/builtin/miner/cbor_gen.go
+++ b/actors/builtin/miner/cbor_gen.go
@@ -15,7 +15,7 @@ import (
 
 var _ = xerrors.Errorf
 
-var lengthBufState = []byte{141}
+var lengthBufState = []byte{140}
 
 func (t *State) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -41,11 +41,6 @@ func (t *State) MarshalCBOR(w io.Writer) error {
 
 	// t.LockedFunds (big.Int) (struct)
 	if err := t.LockedFunds.MarshalCBOR(w); err != nil {
-		return err
-	}
-
-	// t.InitialPledgeDeposits (big.Int) (struct)
-	if err := t.InitialPledgeDeposits.MarshalCBOR(w); err != nil {
 		return err
 	}
 
@@ -121,7 +116,7 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 13 {
+	if extra != 12 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -152,15 +147,6 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 
 		if err := t.LockedFunds.UnmarshalCBOR(br); err != nil {
 			return xerrors.Errorf("unmarshaling t.LockedFunds: %w", err)
-		}
-
-	}
-	// t.InitialPledgeDeposits (big.Int) (struct)
-
-	{
-
-		if err := t.InitialPledgeDeposits.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.InitialPledgeDeposits: %w", err)
 		}
 
 	}

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -1756,7 +1756,7 @@ func handleProvingDeadline(rt Runtime) {
 			penaltyTarget := PledgePenaltyForDeclaredFault(epochReward, pwrTotal.QualityAdjPower, faultyPower)
 			penaltyFromVesting, penaltyFromBalance, err := st.PenalizeFundsInPriorityOrder(store, currEpoch, penaltyTarget, availableBalance)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to unlock penalty")
-			availableBalance = big.Sub(availableBalance, penaltyFromBalance)
+			availableBalance = big.Sub(availableBalance, penaltyFromBalance) //nolint:ineffassign
 			penaltyTotal = big.Sum(penaltyTotal, penaltyFromVesting, penaltyFromBalance)
 			pledgeDelta = big.Sum(pledgeDelta, penaltyFromVesting.Neg())
 		}
@@ -2314,11 +2314,6 @@ func resolveWorkerAddress(rt Runtime, raw addr.Address) addr.Address {
 		}
 	}
 	return resolved
-}
-
-func burnFundsAndNotifyPledgeChange(rt Runtime, amt abi.TokenAmount) {
-	burnFunds(rt, amt)
-	notifyPledgeChanged(rt, amt.Neg())
 }
 
 func burnFunds(rt Runtime, amt abi.TokenAmount) {

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -19,6 +19,9 @@ import (
 
 // Balance of Miner Actor should be greater than or equal to
 // the sum of PreCommitDeposits and LockedFunds.
+// It is possible for balance to fall below the sum of
+// PCD, LF and InitialPledgeRequirements, and this is a bad
+// state (IP Debt) that limits a miner actor's behavior (i.e. no balance withdrawals)
 // Excess balance as computed by st.GetAvailableBalance will be
 // withdrawable or usable for pre-commit deposit or pledge lock-up.
 type State struct {
@@ -1090,9 +1093,9 @@ func (st *State) CheckVestedFunds(store adt.Store, currEpoch abi.ChainEpoch) (ab
 
 // Unclaimed funds that are not locked -- includes funds used to cover initial pledge requirement
 func (st *State) GetUnlockedBalance(actorBalance abi.TokenAmount) abi.TokenAmount {
-	availableBal := big.Subtract(actorBalance, st.LockedFunds, st.PreCommitDeposits)
-	Assert(availableBal.GreaterThanEqual(big.Zero()))
-	return availableBal
+	unlockedBalance := big.Subtract(actorBalance, st.LockedFunds, st.PreCommitDeposits)
+	Assert(unlockedBalance.GreaterThanEqual(big.Zero()))
+	return unlockedBalance
 }
 
 // Unclaimed funds.  Actor balance - (locked funds, precommit deposit, ip requirement)

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -1114,9 +1114,10 @@ func (st *State) CheckVestedFunds(store adt.Store, currEpoch abi.ChainEpoch) (ab
 	return amountUnlocked, nil
 }
 
-// This can be negative if InitialPledgeRequirements are not met
 func (st *State) GetAvailableBalance(actorBalance abi.TokenAmount) abi.TokenAmount {
-	return big.Subtract(actorBalance, st.LockedFunds, st.PreCommitDeposits, st.InitialPledgeRequirement)
+	availableBal := big.Subtract(actorBalance, st.LockedFunds, st.PreCommitDeposits, st.InitialPledgeDeposits)
+	Assert(availableBal.GreaterThanEqual(big.Zero()))
+	return availableBal
 }
 
 // Returns a quantization spec that quantizes values to the last epoch in each deadline.

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -1452,7 +1452,7 @@ func TestWithdrawBalance(t *testing.T) {
 		// prove one sector to establish collateral and locked funds
 		actor.commitAndProveSectors(rt, 1, 181, nil)
 
-		// alter lock funds to simulate vesting since last prove
+		// alter initial pledge requirement to simulate undercollateralization
 		st := getState(rt)
 		st.InitialPledgeRequirement = big.Mul(big.NewInt(300000), st.InitialPledgeRequirement)
 		rt.ReplaceState(st)

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -448,11 +448,10 @@ func TestCommitments(t *testing.T) {
 			newSector.Expiration: {uint64(0)},
 		}, dQueue)
 
-		// Old sector's pledge still locked (not penalized), but no longer contributes to minimum requirement.
+		// Old sector gone from pledge requirement and deposit
 		assert.Equal(t, st.InitialPledgeRequirement, newSector.InitialPledge)
-//		assert.Equal(t, st.LockedFunds, big.Mul(big.NewInt(4), faultPenalty))
-//		assert.Equal(t, st.InitialPledgeDeposits, big.Sum(oldSector.InitialPledge, newSector.InitialPledge))
-		assert.Equal(t, st.LockedFunds, big.Sum(oldSector.InitialPledge, newSector.InitialPledge, faultPenalty.Neg()))
+		assert.Equal(t, st.InitialPledgeDeposits, newSector.InitialPledge)
+		assert.Equal(t, st.LockedFunds, big.Mul(big.NewInt(4), faultPenalty)) // from manual fund addition above - 1 fault penalty
 	})
 
 	t.Run("invalid committed capacity upgrade rejected", func(t *testing.T) {


### PR DESCRIPTION
Closes #757 

# ⚠️  Design decisions please review ⚠️ 

- ~miner actor now tracks IP funds locked in state, InitialPledgeDeposits, as well as existing requirement number~
- ~reward (add locked funds) pays locked funds to InitialPledgeDeposits if below requirement~
- fees are paid first from unvested locked funds in the vesting table, then from IP
  - ~this PR does not draw from free balance -- but it could be modified to do so upon request~
- committed capacity upgraded sectors see their pledge released from deposit upon expiry.  Before this their pledge stayed in the vesting table until it vested 

# Progress
- [x] Track IP funds
- [x] Reward pays to pledge deposit during IP debt
- [x] Fees are paid out of IP when unvested funds exhausted
- [x] Tests fixed
- [ ] Test 
- [x] ack / nack from @anorth and maybe @zixuanzh on the above design decisions.
