### PR TITLE
Store BR in sector info and use it in sector termination penalty calculation

### DIFF
--- a/actors/builtin/miner/cbor_gen.go
+++ b/actors/builtin/miner/cbor_gen.go
@@ -1634,7 +1634,7 @@ func (t *SectorPreCommitInfo) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
-var lengthBufSectorOnChainInfo = []byte{137}
+var lengthBufSectorOnChainInfo = []byte{138}
 
 func (t *SectorOnChainInfo) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -1720,6 +1720,11 @@ func (t *SectorOnChainInfo) MarshalCBOR(w io.Writer) error {
 	if err := t.InitialPledge.MarshalCBOR(w); err != nil {
 		return err
 	}
+
+	// t.ExpectedDayReward (big.Int) (struct)
+	if err := t.ExpectedDayReward.MarshalCBOR(w); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -1737,7 +1742,7 @@ func (t *SectorOnChainInfo) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 9 {
+	if extra != 10 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -1899,6 +1904,15 @@ func (t *SectorOnChainInfo) UnmarshalCBOR(r io.Reader) error {
 
 		if err := t.InitialPledge.UnmarshalCBOR(br); err != nil {
 			return xerrors.Errorf("unmarshaling t.InitialPledge: %w", err)
+		}
+
+	}
+	// t.ExpectedDayReward (big.Int) (struct)
+
+	{
+
+		if err := t.ExpectedDayReward.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.ExpectedDayReward: %w", err)
 		}
 
 	}

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -1029,6 +1029,8 @@ func (a Actor) TerminateSectors(rt Runtime, params *TerminateSectorsParams) *Ter
 			removedPower, err := deadline.TerminateSectors(store, currEpoch, byPartition, info.SectorSize, quant)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to terminate sectors in deadline %d", dlIdx)
 
+			st.EarlyTerminations.Set(dlIdx)
+
 			powerDelta = powerDelta.Sub(removedPower)
 
 			err = deadlines.UpdateDeadline(store, dlIdx, deadline)
@@ -1053,11 +1055,6 @@ func (a Actor) TerminateSectors(rt Runtime, params *TerminateSectorsParams) *Ter
 	}
 
 	requestUpdatePower(rt, powerDelta)
-
-	// Pledge requirement is not released until termination fee is paid.
-	// The termination fee is paid later, in early-termination queue processing.
-	// We could charge at least the undeclared fault fee here, which is a lower bound on the penalty.
-	// https://github.com/filecoin-project/specs-actors/issues/674
 
 	return &TerminateSectorsReturn{Done: !more}
 }

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -706,6 +706,7 @@ func (a Actor) ConfirmSectorProofsValid(rt Runtime, params *builtin.ConfirmSecto
 			activation := rt.CurrEpoch()
 			duration := precommit.Info.Expiration - activation
 			power := QAPowerForWeight(info.SectorSize, duration, precommit.DealWeight, precommit.VerifiedDealWeight)
+			dayReward := ExpectedDayRewardForPower(rewardStats.ThisEpochRewardSmoothed, pwrTotal.QualityAdjPowerSmoothed, power)
 			initialPledge := InitialPledgeForPower(power, rewardStats.ThisEpochBaselinePower, pwrTotal.PledgeCollateral,
 				rewardStats.ThisEpochRewardSmoothed, pwrTotal.QualityAdjPowerSmoothed, circulatingSupply)
 
@@ -721,6 +722,7 @@ func (a Actor) ConfirmSectorProofsValid(rt Runtime, params *builtin.ConfirmSecto
 				DealWeight:         precommit.DealWeight,
 				VerifiedDealWeight: precommit.VerifiedDealWeight,
 				InitialPledge:      initialPledge,
+				ExpectedDayReward:  dayReward,
 			}
 			newSectors = append(newSectors, &newSectorInfo)
 			newSectorNos = append(newSectorNos, newSectorInfo.SectorNumber)
@@ -2409,7 +2411,7 @@ func terminationPenalty(sectorSize abi.SectorSize, currEpoch abi.ChainEpoch, rew
 	totalFee := big.Zero()
 	for _, s := range sectors {
 		sectorPower := QAPowerForSector(sectorSize, s)
-		fee := PledgePenaltyForTermination(s.InitialPledge, currEpoch-s.Activation, rewardEstimate, networkQAPowerEstimate, sectorPower)
+		fee := PledgePenaltyForTermination(s.InitialPledge, s.ExpectedDayReward, currEpoch-s.Activation, rewardEstimate, networkQAPowerEstimate, sectorPower)
 		totalFee = big.Add(fee, totalFee)
 	}
 	return totalFee

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -2408,7 +2408,7 @@ func terminationPenalty(sectorSize abi.SectorSize, currEpoch abi.ChainEpoch, rew
 	totalFee := big.Zero()
 	for _, s := range sectors {
 		sectorPower := QAPowerForSector(sectorSize, s)
-		fee := PledgePenaltyForTermination(s.InitialPledge, s.ExpectedDayReward, currEpoch-s.Activation, rewardEstimate, networkQAPowerEstimate, sectorPower)
+		fee := PledgePenaltyForTermination(s.ExpectedDayReward, currEpoch-s.Activation, rewardEstimate, networkQAPowerEstimate, sectorPower)
 		totalFee = big.Add(fee, totalFee)
 	}
 	return totalFee

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -137,6 +137,7 @@ type SectorOnChainInfo struct {
 	DealWeight         abi.DealWeight  // Integral of active deals over sector lifetime
 	VerifiedDealWeight abi.DealWeight  // Integral of active verified deals over sector lifetime
 	InitialPledge      abi.TokenAmount // Pledge collected to commit this sector
+	ExpectedDayReward  abi.TokenAmount // Expect daily reward for sector computed at activation time
 }
 
 // Location of a specific sector

--- a/actors/builtin/miner/miner_state_test.go
+++ b/actors/builtin/miner/miner_state_test.go
@@ -726,6 +726,7 @@ func newSectorOnChainInfo(sectorNo abi.SectorNumber, sealed cid.Cid, weight big.
 		DealWeight:         weight,
 		VerifiedDealWeight: weight,
 		InitialPledge:      abi.NewTokenAmount(0),
+		ExpectedDayReward:  abi.NewTokenAmount(0),
 	}
 }
 

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -1408,7 +1408,7 @@ func TestTerminateSectors(t *testing.T) {
 		{
 			st := getState(rt)
 
-			// expect sector to be marked as terminated but no longer early in partition
+			// expect sector to be marked as terminated and the early termination queue to be empty (having been fully processed)
 			deadlines, err := st.LoadDeadlines(rt.AdtStore())
 			require.NoError(t, err)
 			dlIdx, pIdx, err := miner.FindSector(rt.AdtStore(), deadlines, sector.SectorNumber)

--- a/actors/builtin/miner/monies.go
+++ b/actors/builtin/miner/monies.go
@@ -27,6 +27,9 @@ var DeclaredFaultFactorDenom = big.NewInt(100)
 var UndeclaredFaultFactorNum = big.NewInt(5)
 var UndeclaredFaultFactorDenom = big.NewInt(1)
 
+// Maximum number of days of BR a terminated sector can be penalized
+const TerminationLifetimeCap = abi.ChainEpoch(70)
+
 // This is the BR(t) value of the given sector for the current epoch.
 // It is the expected reward this sector would pay out over a one day period.
 // BR(t) = CurrEpochReward(t) * SectorQualityAdjustedPower * EpochsInDay / TotalNetworkQualityAdjustedPower(t)
@@ -59,16 +62,16 @@ func PledgePenaltyForUndeclaredFault(rewardEstimate, networkQAPowerEstimate *smo
 
 // Penalty to locked pledge collateral for the termination of a sector before scheduled expiry.
 // SectorAge is the time between the sector's activation and termination.
-func PledgePenaltyForTermination(initialPledge abi.TokenAmount, dayReward abi.TokenAmount, sectorAge abi.ChainEpoch, rewardEstimate, networkQAPowerEstimate *smoothing.FilterEstimate, qaSectorPower abi.StoragePower) abi.TokenAmount {
-	// max(SP(t), IP + BR(StartEpoch)*min(SectorAgeInDays, 180))
+func PledgePenaltyForTermination(dayRewardAtActivation abi.TokenAmount, sectorAge abi.ChainEpoch, rewardEstimate, networkQAPowerEstimate *smoothing.FilterEstimate, qaSectorPower abi.StoragePower) abi.TokenAmount {
+	// max(SP(t), 20*BR(StartEpoch) + BR(StartEpoch)*min(SectorAgeInDays, 70))
 	// and sectorAgeInDays = sectorAge / EpochsInDay
-	cappedSectorAge := big.NewInt(int64(minEpoch(sectorAge, 180*builtin.EpochsInDay)))
+	cappedSectorAge := big.NewInt(int64(minEpoch(sectorAge, TerminationLifetimeCap*builtin.EpochsInDay)))
 	return big.Max(
 		PledgePenaltyForUndeclaredFault(rewardEstimate, networkQAPowerEstimate, qaSectorPower),
 		big.Add(
-			initialPledge,
+			big.Mul(InitialPledgeFactor, dayRewardAtActivation),
 			big.Div(
-				big.Mul(dayReward, cappedSectorAge),
+				big.Mul(dayRewardAtActivation, cappedSectorAge),
 				big.NewInt(builtin.EpochsInDay))))
 }
 

--- a/actors/builtin/miner/monies.go
+++ b/actors/builtin/miner/monies.go
@@ -59,9 +59,8 @@ func PledgePenaltyForUndeclaredFault(rewardEstimate, networkQAPowerEstimate *smo
 
 // Penalty to locked pledge collateral for the termination of a sector before scheduled expiry.
 // SectorAge is the time between the sector's activation and termination.
-func PledgePenaltyForTermination(initialPledge abi.TokenAmount, sectorAge abi.ChainEpoch, rewardEstimate, networkQAPowerEstimate *smoothing.FilterEstimate, qaSectorPower abi.StoragePower) abi.TokenAmount {
+func PledgePenaltyForTermination(initialPledge abi.TokenAmount, dayReward abi.TokenAmount, sectorAge abi.ChainEpoch, rewardEstimate, networkQAPowerEstimate *smoothing.FilterEstimate, qaSectorPower abi.StoragePower) abi.TokenAmount {
 	// max(SP(t), IP + BR(StartEpoch)*min(SectorAgeInDays, 180))
-	// where BR(StartEpoch)=IP/InitialPledgeFactor
 	// and sectorAgeInDays = sectorAge / EpochsInDay
 	cappedSectorAge := big.NewInt(int64(minEpoch(sectorAge, 180*builtin.EpochsInDay)))
 	return big.Max(
@@ -69,8 +68,8 @@ func PledgePenaltyForTermination(initialPledge abi.TokenAmount, sectorAge abi.Ch
 		big.Add(
 			initialPledge,
 			big.Div(
-				big.Mul(initialPledge, cappedSectorAge),
-				big.Mul(InitialPledgeFactor, big.NewInt(builtin.EpochsInDay)))))
+				big.Mul(dayReward, cappedSectorAge),
+				big.NewInt(builtin.EpochsInDay))))
 }
 
 // Computes the PreCommit Deposit given sector qa weight and current network conditions.

--- a/actors/builtin/miner/monies_test.go
+++ b/actors/builtin/miner/monies_test.go
@@ -27,9 +27,10 @@ func TestPledgePenaltyForTermination(t *testing.T) {
 	t.Run("when undeclared fault fee exceeds expected reward, returns undeclaraed fault fee", func(t *testing.T) {
 		// small pledge and means undeclared penalty will be bigger
 		initialPledge := abi.NewTokenAmount(1 << 10)
+		dayReward := big.Div(initialPledge, miner.InitialPledgeFactor)
 		sectorAge := 20 * abi.ChainEpoch(builtin.EpochsInDay)
 
-		fee := miner.PledgePenaltyForTermination(initialPledge, sectorAge, rewardEstimate, powerEstimate, qaSectorPower)
+		fee := miner.PledgePenaltyForTermination(initialPledge, dayReward, sectorAge, rewardEstimate, powerEstimate, qaSectorPower)
 
 		assert.Equal(t, undeclaredPenalty, fee)
 	})
@@ -37,10 +38,11 @@ func TestPledgePenaltyForTermination(t *testing.T) {
 	t.Run("when expected reward exceeds undeclared fault fee, returns expected reward", func(t *testing.T) {
 		// initialPledge equal to undeclaredPenalty guarantees expected reward is greater
 		initialPledge := undeclaredPenalty
+		dayReward := big.Div(initialPledge, miner.InitialPledgeFactor)
 		sectorAgeInDays := int64(20)
 		sectorAge := abi.ChainEpoch(sectorAgeInDays * builtin.EpochsInDay)
 
-		fee := miner.PledgePenaltyForTermination(initialPledge, sectorAge, rewardEstimate, powerEstimate, qaSectorPower)
+		fee := miner.PledgePenaltyForTermination(initialPledge, dayReward, sectorAge, rewardEstimate, powerEstimate, qaSectorPower)
 
 		// expect fee to be pledge * br * age where br = pledge/initialPledgeFactor
 		expectedFee := big.Add(
@@ -53,10 +55,11 @@ func TestPledgePenaltyForTermination(t *testing.T) {
 
 	t.Run("sector age is capped", func(t *testing.T) {
 		initialPledge := undeclaredPenalty
+		dayReward := big.Div(initialPledge, miner.InitialPledgeFactor)
 		sectorAgeInDays := 500
 		sectorAge := abi.ChainEpoch(sectorAgeInDays * builtin.EpochsInDay)
 
-		fee := miner.PledgePenaltyForTermination(initialPledge, sectorAge, rewardEstimate, powerEstimate, qaSectorPower)
+		fee := miner.PledgePenaltyForTermination(initialPledge, dayReward, sectorAge, rewardEstimate, powerEstimate, qaSectorPower)
 
 		// expect fee to be pledge * br * age where br = pledge/initialPledgeFactor
 		expectedFee := big.Add(

--- a/actors/builtin/miner/monies_test.go
+++ b/actors/builtin/miner/monies_test.go
@@ -30,7 +30,7 @@ func TestPledgePenaltyForTermination(t *testing.T) {
 		dayReward := big.Div(initialPledge, miner.InitialPledgeFactor)
 		sectorAge := 20 * abi.ChainEpoch(builtin.EpochsInDay)
 
-		fee := miner.PledgePenaltyForTermination(initialPledge, dayReward, sectorAge, rewardEstimate, powerEstimate, qaSectorPower)
+		fee := miner.PledgePenaltyForTermination(dayReward, sectorAge, rewardEstimate, powerEstimate, qaSectorPower)
 
 		assert.Equal(t, undeclaredPenalty, fee)
 	})
@@ -42,7 +42,7 @@ func TestPledgePenaltyForTermination(t *testing.T) {
 		sectorAgeInDays := int64(20)
 		sectorAge := abi.ChainEpoch(sectorAgeInDays * builtin.EpochsInDay)
 
-		fee := miner.PledgePenaltyForTermination(initialPledge, dayReward, sectorAge, rewardEstimate, powerEstimate, qaSectorPower)
+		fee := miner.PledgePenaltyForTermination(dayReward, sectorAge, rewardEstimate, powerEstimate, qaSectorPower)
 
 		// expect fee to be pledge * br * age where br = pledge/initialPledgeFactor
 		expectedFee := big.Add(
@@ -59,13 +59,13 @@ func TestPledgePenaltyForTermination(t *testing.T) {
 		sectorAgeInDays := 500
 		sectorAge := abi.ChainEpoch(sectorAgeInDays * builtin.EpochsInDay)
 
-		fee := miner.PledgePenaltyForTermination(initialPledge, dayReward, sectorAge, rewardEstimate, powerEstimate, qaSectorPower)
+		fee := miner.PledgePenaltyForTermination(dayReward, sectorAge, rewardEstimate, powerEstimate, qaSectorPower)
 
 		// expect fee to be pledge * br * age where br = pledge/initialPledgeFactor
 		expectedFee := big.Add(
 			initialPledge,
 			big.Div(
-				big.Mul(initialPledge, big.NewInt(180)),
+				big.Mul(initialPledge, big.NewInt(int64(miner.TerminationLifetimeCap))),
 				miner.InitialPledgeFactor))
 		assert.Equal(t, expectedFee, fee)
 	})


### PR DESCRIPTION
closes #701 

### Motivation

Termination fees are a function of expected day reward (BR) evaluated at activation. We had been using the simple relationship between `InitialPledge` and BR to derive BR(start). That simple relationship has gone away, so we now need to store BR in sector info and use it in the terminate sector penalty calculation.

### Proposed Changes

1. Add `ExpectedDayReward` field to `SectorOnChainInfo`.
2. Set this field in `ConfirmSectorProofsValid` when sector is activated.
3. Add `dayReward` as a parameter to `PledgePenaltyForTermination` and use it instead of dividing initial pledge by `IniitialPledgeFactor` (which is no longer correct).
4. Restore test to test TerminateSector to confirm the fee calculation is working.

### Bonus bug

Restoring the terminate sector test exposed a bug in miner.TerminateSectors. It was not adding the indices of the deadlines containing the terminated sectors to its `EarlyTerminations` bitfield. This prevented it from correctly processing the termination including charging the termination fee. This is fixed in this PR.