### PR TITLE
Fix off-by-one in fault expiration epoch calculation

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -300,7 +300,7 @@ func (a Actor) SubmitWindowedPoSt(rt Runtime, params *SubmitWindowedPoStParams) 
 		partitions, err := deadline.PartitionsArray(store)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deadline %d partitions", params.Deadline)
 
-		faultExpiration := currDeadline.Close + FaultMaxAge
+		faultExpiration := currDeadline.Last() + FaultMaxAge
 
 		partitionIdxs := make([]uint64, 0, len(params.Partitions))
 		allSectors := make([]*abi.BitField, 0, len(params.Partitions))
@@ -1134,7 +1134,7 @@ func (a Actor) DeclareFaults(rt Runtime, params *DeclareFaultsParams) *adt.Empty
 			// Record partitions with some fault, for subsequently indexing in the deadline.
 			// Duplicate entries don't matter, they'll be stored in a bitfield (a set).
 			partitionsWithFault := make([]uint64, 0, len(declsByDeadline))
-			faultExpirationEpoch := targetDeadline.Close + FaultMaxAge
+			faultExpirationEpoch := targetDeadline.Last() + FaultMaxAge
 
 			for _, decl := range declsByDeadline[dlIdx] {
 				key := PartitionKey{dlIdx, decl.Partition}
@@ -1696,7 +1696,7 @@ func handleProvingDeadline(rt Runtime) {
 
 		{
 			// Detect and penalize missing proofs.
-			faultExpiration := dlInfo.Close + FaultMaxAge
+			faultExpiration := dlInfo.Last() + FaultMaxAge
 			penalizePowerTotal := big.Zero()
 
 			partitions, err := deadline.PartitionsArray(store)


### PR DESCRIPTION
The intent of the fault expiration epoch is to line up with an end-of-deadline cron, which happens at the end of the last epoch in a deadline. Confusion led me to instead schedule it for the first epoch of the next deadline, which would have the practical effect of delaying processing for one more proving period.

We haven't yet recovered enough tests to exercise this.

FYI @nicola 