### PR TITLE
Allow errors to carry exit codes

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -1940,23 +1940,8 @@ func validateReplaceSector(rt Runtime, st *State, store adt.Store, params *Secto
 			params.ReplaceSectorNumber, replaceSector.Expiration, params.Expiration)
 	}
 
-	status, err := st.SectorStatus(store, params.ReplaceSectorDeadline, params.ReplaceSectorPartition, params.ReplaceSectorNumber)
-	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to check sector health %v", params.ReplaceSectorNumber)
-
-	switch status {
-	case SectorNotFound:
-		rt.Abortf(exitcode.ErrIllegalArgument, "sector %d not found at %d:%d (deadline:partition)",
-			params.ReplaceSectorNumber, params.ReplaceSectorDeadline, params.ReplaceSectorPartition,
-		)
-	case SectorFaulty:
-		rt.Abortf(exitcode.ErrIllegalArgument, "cannot replace faulty sector %d", params.ReplaceSectorNumber)
-	case SectorTerminated:
-		rt.Abortf(exitcode.ErrIllegalArgument, "cannot replace terminated sector %d", params.ReplaceSectorNumber)
-	case SectorHealthy:
-		// pass
-	default:
-		panic(fmt.Sprintf("unexpected sector status %d", status))
-	}
+	err = st.CheckSectorHealth(store, params.ReplaceSectorDeadline, params.ReplaceSectorPartition, params.ReplaceSectorNumber)
+	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to replace sector %v", params.ReplaceSectorNumber)
 
 	return replaceSector
 }

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -539,7 +539,7 @@ func TestCommitments(t *testing.T) {
 			// Phew!
 
 			rt.ReplaceState(st)
-			rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
+			rt.ExpectAbort(exitcode.ErrForbidden, func() {
 				actor.preCommitSector(rt, &params)
 			})
 			rt.ReplaceState(&prevState)

--- a/actors/builtin/shared.go
+++ b/actors/builtin/shared.go
@@ -27,10 +27,11 @@ func RequireSuccess(rt runtime.Runtime, e exitcode.ExitCode, msg string, args ..
 
 // Aborts with a formatted message if err is not nil.
 // The provided message will be suffixed by ": %s" and the provided args suffixed by the err.
-func RequireNoErr(rt runtime.Runtime, err error, code exitcode.ExitCode, msg string, args ...interface{}) {
+func RequireNoErr(rt runtime.Runtime, err error, defaultExitCode exitcode.ExitCode, msg string, args ...interface{}) {
 	if err != nil {
 		newMsg := msg + ": %s"
 		newArgs := append(args, err)
+		code := exitcode.Unwrap(err, defaultExitCode)
 		rt.Abortf(code, newMsg, newArgs...)
 	}
 }

--- a/actors/runtime/exitcode/exitcode.go
+++ b/actors/runtime/exitcode/exitcode.go
@@ -1,0 +1,96 @@
+package exitcode
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"golang.org/x/xerrors"
+)
+
+type ExitCode int64
+
+func (x ExitCode) IsSuccess() bool {
+	return x == Ok
+}
+
+func (x ExitCode) IsError() bool {
+	return !x.IsSuccess()
+}
+
+// Whether an exit code indicates a message send failure.
+// A send failure means that the caller's CallSeqNum is not incremented and the caller has not paid
+// gas fees for the message (because the caller doesn't exist or can't afford it).
+// A receipt with send failure does not indicate that the message (or another one carrying the same CallSeqNum)
+// could not apply in the future, against a different state.
+func (x ExitCode) IsSendFailure() bool {
+	return x == SysErrSenderInvalid || x == SysErrSenderStateInvalid
+}
+
+// A non-canonical string representation for human inspection.
+func (x ExitCode) String() string {
+	name, ok := names[x]
+	if ok {
+		return fmt.Sprintf("%s(%d)", name, x)
+	}
+	return strconv.FormatInt(int64(x), 10)
+}
+
+// Implement error to trigger Go compiler checking of exit code return values.
+func (x ExitCode) Error() string {
+	return x.String()
+}
+
+// Wrapf attaches an error message, and possibly an error, to the exit
+// code.
+//
+//    err := ErrIllegalArgument.Wrapf("my description: %w", err)
+//    exitcode.Unwrap(exitcode.ErrIllegalState, err) == exitcode.ErrIllegalArgument
+func (x ExitCode) Wrapf(msg string, args ...interface{}) error {
+	return &wrapped{
+		exitCode: x,
+		cause:    xerrors.Errorf(msg, args...),
+	}
+}
+
+type wrapped struct {
+	exitCode ExitCode
+	cause    error
+}
+
+func (w *wrapped) String() string {
+	return w.Error()
+}
+
+func (w *wrapped) Error() string {
+	// Don't include the exit code. That will be handled by the runtime and
+	// this error has likely been wrapped multiple times.
+	return w.cause.Error()
+}
+
+// implements the interface required by errors.As
+func (w *wrapped) As(target interface{}) bool {
+	return errors.As(w.exitCode, target) || errors.As(w.cause, target)
+}
+
+// implements the interface required by errors.Is
+func (w *wrapped) Is(target error) bool {
+	if _, ok := target.(ExitCode); ok {
+		// If the target is an exit code, make sure we shadow lower exit
+		// codes.
+		return w.exitCode == target
+	}
+	return errors.Is(w.cause, target)
+}
+
+// Unwrap extracts an exit code from an error, defaulting to the passed default
+// exit code.
+//
+//    err := ErrIllegalState.WithContext("my description: %w", err)
+//    exitcode.Unwrap(exitcode.ErrIllegalState, err) == exitcode.ErrIllegalArgument
+func Unwrap(err error, defaultExitCode ExitCode) (code ExitCode) {
+	if errors.As(err, &code) {
+		return code
+	}
+	return defaultExitCode
+}

--- a/actors/runtime/exitcode/exitcode_test.go
+++ b/actors/runtime/exitcode/exitcode_test.go
@@ -1,0 +1,39 @@
+package exitcode_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/xerrors"
+)
+
+func TestWithContext(t *testing.T) {
+	baseErr := errors.New("base error")
+	codedErr := exitcode.ErrForbidden.Wrapf("coded: %w", baseErr)
+	wrappedErr := xerrors.Errorf("wrapper: %w", codedErr)
+	shadowedErr := exitcode.ErrIllegalState.Wrapf("shadow: %w", codedErr)
+
+	// Test default.
+	assert.Equal(t, exitcode.Ok, exitcode.Unwrap(baseErr, exitcode.Ok))
+	assert.Equal(t, exitcode.ErrIllegalState, exitcode.Unwrap(baseErr, exitcode.ErrIllegalState))
+	assert.True(t, errors.Is(baseErr, baseErr))
+
+	// Test coded.
+	assert.Equal(t, exitcode.ErrForbidden, exitcode.Unwrap(codedErr, exitcode.Ok))
+	assert.True(t, errors.Is(wrappedErr, codedErr))
+	assert.False(t, errors.Is(codedErr, wrappedErr))
+	assert.False(t, errors.Is(wrappedErr, exitcode.Ok))
+
+	// Test wrapped
+	assert.Equal(t, exitcode.ErrForbidden, exitcode.Unwrap(wrappedErr, exitcode.Ok))
+	assert.True(t, errors.Is(wrappedErr, codedErr))
+	assert.True(t, errors.Is(wrappedErr, wrappedErr))
+	assert.False(t, errors.Is(wrappedErr, exitcode.Ok))
+
+	// Test shadowed
+	assert.Equal(t, exitcode.ErrIllegalState, exitcode.Unwrap(shadowedErr, exitcode.Ok))
+	assert.True(t, errors.Is(shadowedErr, exitcode.ErrIllegalState))
+	assert.False(t, errors.Is(shadowedErr, exitcode.ErrForbidden))
+}

--- a/actors/runtime/exitcode/reserved.go
+++ b/actors/runtime/exitcode/reserved.go
@@ -1,43 +1,5 @@
 package exitcode
 
-import (
-	"fmt"
-	"strconv"
-)
-
-type ExitCode int64
-
-func (x ExitCode) IsSuccess() bool {
-	return x == Ok
-}
-
-func (x ExitCode) IsError() bool {
-	return !x.IsSuccess()
-}
-
-// Whether an exit code indicates a message send failure.
-// A send failure means that the caller's CallSeqNum is not incremented and the caller has not paid
-// gas fees for the message (because the caller doesn't exist or can't afford it).
-// A receipt with send failure does not indicate that the message (or another one carrying the same CallSeqNum)
-// could not apply in the future, against a different state.
-func (x ExitCode) IsSendFailure() bool {
-	return x == SysErrSenderInvalid || x == SysErrSenderStateInvalid
-}
-
-// A non-canonical string representation for human inspection.
-func (x ExitCode) String() string {
-	name, ok := names[x]
-	if ok {
-		return fmt.Sprintf("%s(%d)", name, x)
-	}
-	return strconv.FormatInt(int64(x), 10)
-}
-
-// Implement error to trigger Go compiler checking of exit code return values.
-func (x ExitCode) Error() string {
-	return x.String()
-}
-
 // The system error codes are reserved for use by the runtime.
 // No actor may use one explicitly. Correspondingly, no runtime invocation should abort with an exit
 // code outside this list.


### PR DESCRIPTION
This will make it easier to push state transformations down into the miner's state object.

I've also pushed some error messages down a layer to simplify/remove error wrapping.

fixes #597