### PR TITLE
Move deadline mutations into deadline methods

### DIFF
--- a/actors/builtin/miner/deadline_state_test.go
+++ b/actors/builtin/miner/deadline_state_test.go
@@ -306,7 +306,7 @@ func TestDeadlines(t *testing.T) {
 
 		sectorArr := sectorsArr(t, rt, sectors)
 
-		postResult1, err := dl.ProcessWindowedPoSt(store, sectorArr, sectorSize, quantSpec, 13, []miner.PoStPartition{
+		postResult1, err := dl.RecordProvenSectors(store, sectorArr, sectorSize, quantSpec, 13, []miner.PoStPartition{
 			{Index: 0, Skipped: bf()},
 			{Index: 1, Skipped: bf()},
 		})
@@ -325,7 +325,7 @@ func TestDeadlines(t *testing.T) {
 				bf(9),
 			).assert(t, rt, dl)
 
-		postResult2, err := dl.ProcessWindowedPoSt(store, sectorArr, sectorSize, quantSpec, 13, []miner.PoStPartition{
+		postResult2, err := dl.RecordProvenSectors(store, sectorArr, sectorSize, quantSpec, 13, []miner.PoStPartition{
 			{Index: 1, Skipped: bf()}, // ignore already posted partitions
 			{Index: 2, Skipped: bf()},
 		})
@@ -344,7 +344,7 @@ func TestDeadlines(t *testing.T) {
 				bf(9),
 			).assert(t, rt, dl)
 
-		newFaultyPower, failedRecoveryPower, err := dl.ProcessPoSt(store, quantSpec, 13)
+		newFaultyPower, failedRecoveryPower, err := dl.ProcessDeadlineEnd(store, quantSpec, 13)
 		require.NoError(t, err)
 
 		// No power change on successful post.

--- a/actors/builtin/miner/expiration_queue_test.go
+++ b/actors/builtin/miner/expiration_queue_test.go
@@ -2,6 +2,7 @@ package miner_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/filecoin-project/go-address"
@@ -10,6 +11,7 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
 	"github.com/filecoin-project/specs-actors/support/mock"
+	tutil "github.com/filecoin-project/specs-actors/support/testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -639,6 +641,7 @@ func testSector(expiration, number, weight, vweight, pledge int64) *miner.Sector
 		DealWeight:         big.NewInt(weight),
 		VerifiedDealWeight: big.NewInt(vweight),
 		InitialPledge:      abi.NewTokenAmount(pledge),
+		SealedCID:          tutil.MakeCID(fmt.Sprintf("commR-%d", number), &miner.SealedCIDPrefix),
 	}
 }
 

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -1096,6 +1096,7 @@ func (a Actor) DeclareFaults(rt Runtime, params *DeclareFaultsParams) *adt.Empty
 			forDl, ok := partitionsByDeadline[decl.Deadline]
 			if !ok {
 				forDl = make(map[uint64]*bitfield.BitField, 1)
+				partitionsByDeadline[decl.Deadline] = forDl
 				deadlinesToLoad = append(deadlinesToLoad, decl.Deadline)
 			}
 			sectors := decl.Sectors
@@ -1203,6 +1204,7 @@ func (a Actor) DeclareFaultsRecovered(rt Runtime, params *DeclareFaultsRecovered
 			forDl, ok := partitionsByDeadline[decl.Deadline]
 			if !ok {
 				forDl = make(map[uint64]*bitfield.BitField, 1)
+				partitionsByDeadline[decl.Deadline] = forDl
 				deadlinesToLoad = append(deadlinesToLoad, decl.Deadline)
 			}
 			sectors := decl.Sectors

--- a/actors/builtin/miner/sectors.go
+++ b/actors/builtin/miner/sectors.go
@@ -64,6 +64,11 @@ func (sa Sectors) Store(infos ...*SectorOnChainInfo) error {
 			return fmt.Errorf("failed to store sector %d: %w", info.SectorNumber, err)
 		}
 	}
+
+	if sa.Length() > SectorsMax {
+		return xerrors.Errorf("too many sectors")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This refactor pushes state changes down into the state & deadline objects, out of the miner actor itself.

This PR should be reviewed commit by commit.