### PR TITLE
Clean-ups while auditing code coverage.

### DIFF
--- a/actors/builtin/cron/cron_test.go
+++ b/actors/builtin/cron/cron_test.go
@@ -84,6 +84,11 @@ func TestEpochTick(t *testing.T) {
 		actor.epochTickAndVerify(rt)
 	})
 
+	t.Run("built-in entries", func(t *testing.T) {
+		bie := cron.BuiltInEntries()
+		assert.True(t, len(bie) > 0)
+	})
+
 }
 
 type cronHarness struct {

--- a/actors/builtin/init/init_actor.go
+++ b/actors/builtin/init/init_actor.go
@@ -32,9 +32,7 @@ type ConstructorParams struct {
 func (a Actor) Constructor(rt runtime.Runtime, params *ConstructorParams) *adt.EmptyValue {
 	rt.ValidateImmediateCallerIs(builtin.SystemActorAddr)
 	emptyMap, err := adt.MakeEmptyMap(adt.AsStore(rt)).Root()
-	if err != nil {
-		rt.Abortf(exitcode.ErrIllegalState, "failed to construct state: %v", err)
-	}
+	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to construct state")
 
 	st := ConstructState(emptyMap, params.NetworkName)
 	rt.State().Create(st)
@@ -70,9 +68,7 @@ func (a Actor) Exec(rt runtime.Runtime, params *ExecParams) *ExecReturn {
 	var st State
 	idAddr := rt.State().Transaction(&st, func() interface{} {
 		idAddr, err := st.MapAddressToNewID(adt.AsStore(rt), uniqueAddress)
-		if err != nil {
-			rt.Abortf(exitcode.ErrIllegalState, "exec failed: %v", err)
-		}
+		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to allocate ID address")
 		return idAddr
 	}).(addr.Address)
 

--- a/actors/builtin/init/init_test.go
+++ b/actors/builtin/init/init_test.go
@@ -48,6 +48,9 @@ func TestExec(t *testing.T) {
 			actor.execAndVerify(rt, builtin.StoragePowerActorCodeID, []byte{})
 		})
 		rt.ExpectAbort(exitcode.ErrForbidden, func() {
+			actor.execAndVerify(rt, builtin.StorageMinerActorCodeID, []byte{})
+		})
+		rt.ExpectAbort(exitcode.ErrForbidden, func() {
 			actor.execAndVerify(rt, cid.Undef, []byte{})
 		})
 	})

--- a/actors/builtin/market/market_actor.go
+++ b/actors/builtin/market/market_actor.go
@@ -1,12 +1,11 @@
 package market
 
 import (
-	"fmt"
 	"sort"
 
 	addr "github.com/filecoin-project/go-address"
 	cbg "github.com/whyrusleeping/cbor-gen"
-	xerrors "golang.org/x/xerrors"
+	"golang.org/x/xerrors"
 
 	abi "github.com/filecoin-project/specs-actors/actors/abi"
 	big "github.com/filecoin-project/specs-actors/actors/abi/big"
@@ -48,19 +47,13 @@ func (a Actor) Constructor(rt Runtime, _ *adt.EmptyValue) *adt.EmptyValue {
 	rt.ValidateImmediateCallerIs(builtin.SystemActorAddr)
 
 	emptyArray, err := adt.MakeEmptyArray(adt.AsStore(rt)).Root()
-	if err != nil {
-		rt.Abortf(exitcode.ErrIllegalState, "failed to create storage market state: %v", err)
-	}
+	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to create state")
 
 	emptyMap, err := adt.MakeEmptyMap(adt.AsStore(rt)).Root()
-	if err != nil {
-		rt.Abortf(exitcode.ErrIllegalState, "failed to create storage market state: %v", err)
-	}
+	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to create state")
 
 	emptyMSet, err := MakeEmptySetMultimap(adt.AsStore(rt)).Root()
-	if err != nil {
-		rt.Abortf(exitcode.ErrIllegalState, "failed to create storage market state: %v", err)
-	}
+	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to create state")
 
 	st := ConstructState(emptyArray, emptyMap, emptyMSet)
 	rt.State().Create(st)
@@ -330,14 +323,10 @@ func (a Actor) ActivateDeals(rt Runtime, params *ActivateDealsParams) *adt.Empty
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to get dealId %d", dealID)
 
 			propc, err := proposal.Cid()
-			if err != nil {
-				rt.Abortf(exitcode.ErrIllegalState, "get proposal cid %v", err)
-			}
+			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to calculate proposal CID")
 
 			has, err := msm.pendingDeals.Get(adt.CidKey(propc), nil)
-			if err != nil {
-				rt.Abortf(exitcode.ErrIllegalState, "no pending proposal for  %v", err)
-			}
+			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to get pending proposal %v", propc)
 
 			if !has {
 				rt.Abortf(exitcode.ErrIllegalState, "tried to active deal that was not in the pending set (%s)", propc)
@@ -411,9 +400,7 @@ func (a Actor) OnMinerSectorsTerminate(rt Runtime, params *OnMinerSectorsTermina
 
 		for _, dealID := range params.DealIDs {
 			deal, found, err := msm.dealProposals.Get(dealID)
-			if err != nil {
-				rt.Abortf(exitcode.ErrIllegalState, "get deal: %v", err)
-			}
+			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to get deal proposal %v", dealID)
 			// deal could have terminated and hence deleted before the sector is terminated.
 			// we should simply continue instead of aborting execution here if a deal is not found.
 			if !found {
@@ -428,11 +415,9 @@ func (a Actor) OnMinerSectorsTerminate(rt Runtime, params *OnMinerSectorsTermina
 			}
 
 			state, found, err := msm.dealStates.Get(dealID)
-			if err != nil {
-				rt.Abortf(exitcode.ErrIllegalState, "get deal: %v", err)
-			}
+			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to get deal state %v", dealID)
 			if !found {
-				rt.Abortf(exitcode.ErrIllegalArgument, "no state found for deal in sector being terminated")
+				rt.Abortf(exitcode.ErrIllegalArgument, "no state for deal %v", dealID)
 			}
 
 			// if a deal is already slashed, we don't need to do anything here.
@@ -444,9 +429,8 @@ func (a Actor) OnMinerSectorsTerminate(rt Runtime, params *OnMinerSectorsTermina
 			// actual releasing of locked funds for the client and slashing of provider collateral happens in CronTick.
 			state.SlashEpoch = params.Epoch
 
-			if err := msm.dealStates.Set(dealID, state); err != nil {
-				rt.Abortf(exitcode.ErrIllegalState, "set deal: %v", err)
-			}
+			err = msm.dealStates.Set(dealID, state)
+			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to set deal state %v", dealID)
 		}
 
 		err = msm.commitState()
@@ -473,14 +457,12 @@ func (a Actor) CronTick(rt Runtime, _ *adt.EmptyValue) *adt.EmptyValue {
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load state")
 
 		for i := st.LastCron + 1; i <= rt.CurrEpoch(); i++ {
-			if err := msm.dealsByEpoch.ForEach(i, func(dealID abi.DealID) error {
+			err = msm.dealsByEpoch.ForEach(i, func(dealID abi.DealID) error {
 				deal, err := getDealProposal(msm.dealProposals, dealID)
 				builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to get dealId %d", dealID)
 
 				dcid, err := deal.Cid()
-				if err != nil {
-					return xerrors.Errorf("failed to get cid for deal proposal: %w", err)
-				}
+				builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to calculate CID for proposal %v", dealID)
 
 				state, found, err := msm.dealStates.Get(dealID)
 				builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to get deal state")
@@ -515,7 +497,7 @@ func (a Actor) CronTick(rt Runtime, _ *adt.EmptyValue) *adt.EmptyValue {
 					builtin.RequireNoErr(rt, pdErr, exitcode.ErrIllegalState, "failed to delete pending proposal")
 				}
 
-				slashAmount, nextEpoch, removeDeal := msm.updatePendingDealState(rt, state, deal, dealID, rt.CurrEpoch())
+				slashAmount, nextEpoch, removeDeal := msm.updatePendingDealState(rt, state, deal, rt.CurrEpoch())
 				Assert(slashAmount.GreaterThanEqual(big.Zero()))
 				if removeDeal {
 					AssertMsg(nextEpoch == epochUndefined, "next scheduled epoch should be undefined as deal has been removed")
@@ -536,10 +518,11 @@ func (a Actor) CronTick(rt Runtime, _ *adt.EmptyValue) *adt.EmptyValue {
 				}
 
 				return nil
-			}); err != nil {
-				builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to iterate deals for epoch")
-			}
-			builtin.RequireNoErr(rt, msm.dealsByEpoch.RemoveAll(i), exitcode.ErrIllegalState, "failed to delete deals from set")
+			})
+			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to iterate deal ops")
+
+			err = msm.dealsByEpoch.RemoveAll(i)
+			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to delete deal ops for epoch %v", i)
 		}
 
 		// Iterate changes in sorted order to ensure that loads/stores
@@ -553,9 +536,8 @@ func (a Actor) CronTick(rt Runtime, _ *adt.EmptyValue) *adt.EmptyValue {
 		sort.Slice(changedEpochs, func(i, j int) bool { return changedEpochs[i] < changedEpochs[j] })
 
 		for _, epoch := range changedEpochs {
-			if err := msm.dealsByEpoch.PutMany(epoch, updatesNeeded[epoch]); err != nil {
-				rt.Abortf(exitcode.ErrIllegalState, "failed to reinsert deal IDs into epoch set: %s", err)
-			}
+			err = msm.dealsByEpoch.PutMany(epoch, updatesNeeded[epoch])
+			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to reinsert deal IDs for epoch %v", epoch)
 		}
 
 		st.LastCron = rt.CurrEpoch()
@@ -595,14 +577,14 @@ func deleteDealProposalAndState(dealId abi.DealID, states *DealMetaArray, propos
 	removeState bool) error {
 	if removeProposal {
 		if err := proposals.Delete(uint64(dealId)); err != nil {
-			return fmt.Errorf("failed to delete deal proposal: %w", err)
+			return xerrors.Errorf("failed to delete deal proposal: %w", err)
 		}
 
 	}
 
 	if removeState {
 		if err := states.Delete(dealId); err != nil {
-			return fmt.Errorf("failed to delete deal state: %w", err)
+			return xerrors.Errorf("failed to delete deal state: %w", err)
 		}
 	}
 
@@ -620,7 +602,7 @@ func ValidateDealsForActivation(st *State, store adt.Store, dealIDs []abi.DealID
 
 	proposals, err := AsDealProposalArray(store, st.Proposals)
 	if err != nil {
-		return big.Int{}, big.Int{}, fmt.Errorf("failed to load dealProposals: %w", err)
+		return big.Int{}, big.Int{}, xerrors.Errorf("failed to load dealProposals: %w", err)
 	}
 
 	totalDealSpaceTime := big.Zero()
@@ -628,13 +610,13 @@ func ValidateDealsForActivation(st *State, store adt.Store, dealIDs []abi.DealID
 	for _, dealID := range dealIDs {
 		proposal, found, err := proposals.Get(dealID)
 		if err != nil {
-			return big.Int{}, big.Int{}, fmt.Errorf("failed to load deal %d: %w", dealID, err)
+			return big.Int{}, big.Int{}, xerrors.Errorf("failed to load deal %d: %w", dealID, err)
 		}
 		if !found {
-			return big.Int{}, big.Int{}, fmt.Errorf("dealId %d not found", dealID)
+			return big.Int{}, big.Int{}, exitcode.ErrNotFound.Wrapf("no such deal %d", dealID)
 		}
 		if err = validateDealCanActivate(proposal, minerAddr, sectorExpiry, currEpoch); err != nil {
-			return big.Int{}, big.Int{}, fmt.Errorf("cannot activate deal %d: %w", dealID, err)
+			return big.Int{}, big.Int{}, xerrors.Errorf("cannot activate deal %d: %w", dealID, err)
 		}
 
 		// Compute deal weight
@@ -654,13 +636,13 @@ func ValidateDealsForActivation(st *State, store adt.Store, dealIDs []abi.DealID
 
 func validateDealCanActivate(proposal *DealProposal, minerAddr addr.Address, sectorExpiration, currEpoch abi.ChainEpoch) error {
 	if proposal.Provider != minerAddr {
-		return fmt.Errorf("proposal has provider %v, must be %v", proposal.Provider, minerAddr)
+		return exitcode.ErrForbidden.Wrapf("proposal has provider %v, must be %v", proposal.Provider, minerAddr)
 	}
 	if currEpoch > proposal.StartEpoch {
-		return fmt.Errorf("proposal start epoch %d has already elapsed at %d", proposal.StartEpoch, currEpoch)
+		return exitcode.ErrIllegalArgument.Wrapf("proposal start epoch %d has already elapsed at %d", proposal.StartEpoch, currEpoch)
 	}
 	if proposal.EndEpoch > sectorExpiration {
-		return fmt.Errorf("proposal expiration %d exceeds sector expiration %d", proposal.EndEpoch, sectorExpiration)
+		return exitcode.ErrIllegalArgument.Wrapf("proposal expiration %d exceeds sector expiration %d", proposal.EndEpoch, sectorExpiration)
 	}
 	return nil
 }
@@ -744,10 +726,10 @@ func escrowAddress(rt Runtime, address addr.Address) (nominal addr.Address, reci
 func getDealProposal(proposals *DealArray, dealID abi.DealID) (*DealProposal, error) {
 	proposal, found, err := proposals.Get(dealID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load proposal: %w", err)
+		return nil, xerrors.Errorf("failed to load proposal: %w", err)
 	}
 	if !found {
-		return nil, fmt.Errorf("deal %d not found", dealID)
+		return nil, exitcode.ErrNotFound.Wrapf("no such deal %d", dealID)
 	}
 
 	return proposal, nil

--- a/actors/builtin/market/market_state.go
+++ b/actors/builtin/market/market_state.go
@@ -2,7 +2,6 @@ package market
 
 import (
 	"bytes"
-	"fmt"
 
 	"github.com/ipfs/go-cid"
 	xerrors "golang.org/x/xerrors"
@@ -82,8 +81,7 @@ func ConstructState(emptyArrayCid, emptyMapCid, emptyMSetCid cid.Cid) *State {
 // Deal state operations
 ////////////////////////////////////////////////////////////////////////////////
 
-func (m *marketStateMutation) updatePendingDealState(rt Runtime, state *DealState, deal *DealProposal, dealID abi.DealID, epoch abi.ChainEpoch) (amountSlashed abi.TokenAmount,
-	nextEpoch abi.ChainEpoch, removeDeal bool) {
+func (m *marketStateMutation) updatePendingDealState(rt Runtime, state *DealState, deal *DealProposal, epoch abi.ChainEpoch) (amountSlashed abi.TokenAmount, nextEpoch abi.ChainEpoch, removeDeal bool) {
 	amountSlashed = abi.NewTokenAmount(0)
 
 	everUpdated := state.LastUpdatedEpoch != epochUndefined
@@ -284,7 +282,7 @@ func (m *marketStateMutation) build() (*marketStateMutation, error) {
 	if m.proposalPermit != Invalid {
 		proposals, err := AsDealProposalArray(m.store, m.st.Proposals)
 		if err != nil {
-			return nil, fmt.Errorf("failed to load deal proposals: %w", err)
+			return nil, xerrors.Errorf("failed to load deal proposals: %w", err)
 		}
 		m.dealProposals = proposals
 	}
@@ -292,7 +290,7 @@ func (m *marketStateMutation) build() (*marketStateMutation, error) {
 	if m.statePermit != Invalid {
 		states, err := AsDealStateArray(m.store, m.st.States)
 		if err != nil {
-			return nil, fmt.Errorf("failed to load deal state: %w", err)
+			return nil, xerrors.Errorf("failed to load deal state: %w", err)
 		}
 		m.dealStates = states
 	}
@@ -300,7 +298,7 @@ func (m *marketStateMutation) build() (*marketStateMutation, error) {
 	if m.lockedPermit != Invalid {
 		lt, err := adt.AsBalanceTable(m.store, m.st.LockedTable)
 		if err != nil {
-			return nil, fmt.Errorf("failed to load locked table: %w", err)
+			return nil, xerrors.Errorf("failed to load locked table: %w", err)
 		}
 		m.lockedTable = lt
 		m.totalClientLockedCollateral = m.st.TotalClientLockedCollateral.Copy()
@@ -311,7 +309,7 @@ func (m *marketStateMutation) build() (*marketStateMutation, error) {
 	if m.escrowPermit != Invalid {
 		et, err := adt.AsBalanceTable(m.store, m.st.EscrowTable)
 		if err != nil {
-			return nil, fmt.Errorf("failed to load escrow table: %w", err)
+			return nil, xerrors.Errorf("failed to load escrow table: %w", err)
 		}
 		m.escrowTable = et
 	}
@@ -319,7 +317,7 @@ func (m *marketStateMutation) build() (*marketStateMutation, error) {
 	if m.pendingPermit != Invalid {
 		pending, err := adt.AsMap(m.store, m.st.PendingProposals)
 		if err != nil {
-			return nil, fmt.Errorf("failed to load pending proposals: %w", err)
+			return nil, xerrors.Errorf("failed to load pending proposals: %w", err)
 		}
 		m.pendingDeals = pending
 	}
@@ -327,7 +325,7 @@ func (m *marketStateMutation) build() (*marketStateMutation, error) {
 	if m.dpePermit != Invalid {
 		dbe, err := AsSetMultimap(m.store, m.st.DealOpsByEpoch)
 		if err != nil {
-			return nil, fmt.Errorf("failed to load deals by epoch: %w", err)
+			return nil, xerrors.Errorf("failed to load deals by epoch: %w", err)
 		}
 		m.dealsByEpoch = dbe
 	}
@@ -371,19 +369,19 @@ func (m *marketStateMutation) commitState() error {
 	var err error
 	if m.proposalPermit == WritePermission {
 		if m.st.Proposals, err = m.dealProposals.Root(); err != nil {
-			return fmt.Errorf("failed to flush deal dealProposals: %w", err)
+			return xerrors.Errorf("failed to flush deal dealProposals: %w", err)
 		}
 	}
 
 	if m.statePermit == WritePermission {
 		if m.st.States, err = m.dealStates.Root(); err != nil {
-			return fmt.Errorf("failed to flush deal states: %w", err)
+			return xerrors.Errorf("failed to flush deal states: %w", err)
 		}
 	}
 
 	if m.lockedPermit == WritePermission {
 		if m.st.LockedTable, err = m.lockedTable.Root(); err != nil {
-			return fmt.Errorf("failed to flush locked table: %w", err)
+			return xerrors.Errorf("failed to flush locked table: %w", err)
 		}
 		m.st.TotalClientLockedCollateral = m.totalClientLockedCollateral.Copy()
 		m.st.TotalProviderLockedCollateral = m.totalProviderLockedCollateral.Copy()
@@ -392,23 +390,22 @@ func (m *marketStateMutation) commitState() error {
 
 	if m.escrowPermit == WritePermission {
 		if m.st.EscrowTable, err = m.escrowTable.Root(); err != nil {
-			return fmt.Errorf("failed to flush escrow table: %w", err)
+			return xerrors.Errorf("failed to flush escrow table: %w", err)
 		}
 	}
 
 	if m.pendingPermit == WritePermission {
 		if m.st.PendingProposals, err = m.pendingDeals.Root(); err != nil {
-			return fmt.Errorf("failed to flush pending deals: %w", err)
+			return xerrors.Errorf("failed to flush pending deals: %w", err)
 		}
 	}
 
 	if m.dpePermit == WritePermission {
 		if m.st.DealOpsByEpoch, err = m.dealsByEpoch.Root(); err != nil {
-			return fmt.Errorf("failed to flush deals by epoch: %w", err)
+			return xerrors.Errorf("failed to flush deals by epoch: %w", err)
 		}
 	}
 
 	m.st.NextID = m.nextDealId
-
 	return nil
 }

--- a/actors/builtin/market/market_test.go
+++ b/actors/builtin/market/market_test.go
@@ -990,7 +990,7 @@ func TestActivateDealFailures(t *testing.T) {
 
 			rt.ExpectValidateCallerType(builtin.StorageMinerActorCodeID)
 			rt.SetCaller(provider, builtin.StorageMinerActorCodeID)
-			rt.ExpectAbort(exitcode.ErrIllegalState, func() {
+			rt.ExpectAbort(exitcode.ErrForbidden, func() {
 				rt.Call(actor.ActivateDeals, params)
 			})
 
@@ -1020,7 +1020,7 @@ func TestActivateDealFailures(t *testing.T) {
 
 			rt.ExpectValidateCallerType(builtin.StorageMinerActorCodeID)
 			rt.SetCaller(provider, builtin.StorageMinerActorCodeID)
-			rt.ExpectAbort(exitcode.ErrIllegalState, func() {
+			rt.ExpectAbort(exitcode.ErrNotFound, func() {
 				rt.Call(actor.ActivateDeals, params)
 			})
 
@@ -1054,7 +1054,7 @@ func TestActivateDealFailures(t *testing.T) {
 			rt.ExpectValidateCallerType(builtin.StorageMinerActorCodeID)
 			rt.SetCaller(provider, builtin.StorageMinerActorCodeID)
 			rt.SetEpoch(startEpoch + 1)
-			rt.ExpectAbort(exitcode.ErrIllegalState, func() {
+			rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 				rt.Call(actor.ActivateDeals, mkActivateDealParams(sectorExpiry, dealId))
 			})
 
@@ -1067,7 +1067,7 @@ func TestActivateDealFailures(t *testing.T) {
 
 			rt.ExpectValidateCallerType(builtin.StorageMinerActorCodeID)
 			rt.SetCaller(provider, builtin.StorageMinerActorCodeID)
-			rt.ExpectAbort(exitcode.ErrIllegalState, func() {
+			rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 				rt.Call(actor.ActivateDeals, mkActivateDealParams(endEpoch-1, dealId))
 			})
 
@@ -1346,7 +1346,7 @@ func TestCronTick(t *testing.T) {
 
 		// move the current epoch to the start epoch of the deal
 		rt.SetEpoch(startEpoch)
-		rt.ExpectAbort(exitcode.ErrIllegalState, func() {
+		rt.ExpectAbort(exitcode.ErrNotFound, func() {
 			actor.cronTick(rt)
 		})
 	})
@@ -2187,7 +2187,7 @@ func TestComputeDataCommitment(t *testing.T) {
 		param := &market.ComputeDataCommitmentParams{DealIDs: []abi.DealID{1}, SectorType: 1}
 		rt.SetCaller(provider, builtin.StorageMinerActorCodeID)
 		rt.ExpectValidateCallerType(builtin.StorageMinerActorCodeID)
-		rt.ExpectAbort(exitcode.ErrIllegalState, func() {
+		rt.ExpectAbort(exitcode.ErrNotFound, func() {
 			rt.Call(actor.ComputeDataCommitment, param)
 		})
 	})
@@ -2280,7 +2280,7 @@ func TestVerifyDealsForActivation(t *testing.T) {
 		param := &market.VerifyDealsForActivationParams{DealIDs: []abi.DealID{1}, SectorStart: sectorStart, SectorExpiry: sectorExpiry}
 		rt.SetCaller(provider, builtin.StorageMinerActorCodeID)
 		rt.ExpectValidateCallerType(builtin.StorageMinerActorCodeID)
-		rt.ExpectAbort(exitcode.ErrIllegalState, func() {
+		rt.ExpectAbort(exitcode.ErrNotFound, func() {
 			rt.Call(actor.VerifyDealsForActivation, param)
 		})
 	})
@@ -2294,7 +2294,7 @@ func TestVerifyDealsForActivation(t *testing.T) {
 		rt.SetCaller(provider2, builtin.StorageMinerActorCodeID)
 
 		rt.ExpectValidateCallerType(builtin.StorageMinerActorCodeID)
-		rt.ExpectAbort(exitcode.ErrIllegalState, func() {
+		rt.ExpectAbort(exitcode.ErrForbidden, func() {
 			rt.Call(actor.VerifyDealsForActivation, param)
 		})
 	})
@@ -2306,7 +2306,7 @@ func TestVerifyDealsForActivation(t *testing.T) {
 
 		rt.SetCaller(provider, builtin.StorageMinerActorCodeID)
 		rt.ExpectValidateCallerType(builtin.StorageMinerActorCodeID)
-		rt.ExpectAbort(exitcode.ErrIllegalState, func() {
+		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			rt.Call(actor.VerifyDealsForActivation, param)
 		})
 	})
@@ -2318,7 +2318,7 @@ func TestVerifyDealsForActivation(t *testing.T) {
 
 		rt.SetCaller(provider, builtin.StorageMinerActorCodeID)
 		rt.ExpectValidateCallerType(builtin.StorageMinerActorCodeID)
-		rt.ExpectAbort(exitcode.ErrIllegalState, func() {
+		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			rt.Call(actor.VerifyDealsForActivation, param)
 		})
 	})

--- a/actors/builtin/paych/paych_test.go
+++ b/actors/builtin/paych/paych_test.go
@@ -142,7 +142,7 @@ func TestPaymentChannelActor_CreateLane(t *testing.T) {
 		{desc: "fails if balance too low", targetCode: builtin.AccountActorCodeID,
 			amt: 10, paymentChannel: paychAddr, epoch: 1, tlmin: 1, tlmax: 0,
 			sig: sig, verifySig: true,
-			expExitCode: exitcode.ErrIllegalState},
+			expExitCode: exitcode.ErrIllegalArgument},
 		{desc: "fails if new send balance is negative", targetCode: builtin.AccountActorCodeID,
 			amt: -1, paymentChannel: paychAddr, epoch: 1, tlmin: 1, tlmax: 0,
 			sig: sig, verifySig: true,
@@ -380,7 +380,7 @@ func TestActor_UpdateChannelStateMergeFailure(t *testing.T) {
 		{
 			name: "fails: not enough funds in channel to cover voucher",
 			lane: 1, balance: 1, voucherNonce: 10, mergeNonce: 10,
-			expExitCode: exitcode.ErrIllegalState,
+			expExitCode: exitcode.ErrIllegalArgument,
 		},
 		{
 			name: "fails: voucher cannot merge lanes into its own lane",

--- a/actors/builtin/power/power_actor.go
+++ b/actors/builtin/power/power_actor.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	addr "github.com/filecoin-project/go-address"
-	errors "github.com/pkg/errors"
-	xerrors "golang.org/x/xerrors"
 
 	abi "github.com/filecoin-project/specs-actors/actors/abi"
 	big "github.com/filecoin-project/specs-actors/actors/abi/big"
@@ -25,12 +23,6 @@ type SectorTermination int64
 
 const (
 	ErrTooManyProveCommits = exitcode.FirstActorSpecificExitCode + iota
-)
-
-const (
-	SectorTerminationExpired SectorTermination = iota // Implicit termination after all deals expire
-	SectorTerminationManual                           // Unscheduled explicit termination by the miner
-	SectorTerminationFaulty                           // Implicit termination due to unrecovered fault
 )
 
 type Actor struct{}
@@ -76,13 +68,9 @@ func (a Actor) Constructor(rt Runtime, _ *adt.EmptyValue) *adt.EmptyValue {
 	rt.ValidateImmediateCallerIs(builtin.SystemActorAddr)
 
 	emptyMap, err := adt.MakeEmptyMap(adt.AsStore(rt)).Root()
-	if err != nil {
-		rt.Abortf(exitcode.ErrIllegalState, "failed to create storage power state: %v", err)
-	}
+	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to construct state")
 	emptyMMapCid, err := adt.MakeEmptyMultimap(adt.AsStore(rt)).Root()
-	if err != nil {
-		rt.Abortf(exitcode.ErrIllegalState, "failed to get empty multimap cid")
-	}
+	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to construct state")
 
 	st := ConstructState(emptyMap, emptyMMapCid)
 	rt.State().Create(st)
@@ -114,9 +102,8 @@ func (a Actor) CreateMiner(rt Runtime, params *CreateMinerParams) *CreateMinerRe
 	}
 	ctorParamBuf := new(bytes.Buffer)
 	err := ctorParams.MarshalCBOR(ctorParamBuf)
-	if err != nil {
-		rt.Abortf(exitcode.ErrPlaceholder, "failed to serialize miner constructor params %v: %v", ctorParams, err)
-	}
+	builtin.RequireNoErr(rt, err, exitcode.ErrSerialization, "failed to serialize miner constructor params %v", ctorParams)
+
 	ret, code := rt.Send(
 		builtin.InitActorAddr,
 		builtin.MethodsInit.Exec,
@@ -129,9 +116,7 @@ func (a Actor) CreateMiner(rt Runtime, params *CreateMinerParams) *CreateMinerRe
 	builtin.RequireSuccess(rt, code, "failed to init new actor")
 	var addresses initact.ExecReturn
 	err = ret.Into(&addresses)
-	if err != nil {
-		rt.Abortf(exitcode.ErrIllegalState, "unmarshaling exec return value: %v", err)
-	}
+	builtin.RequireNoErr(rt, err, exitcode.ErrSerialization, "failed to unmarshal exec return value %v", ret)
 
 	var st State
 	rt.State().Transaction(&st, func() interface{} {
@@ -139,9 +124,8 @@ func (a Actor) CreateMiner(rt Runtime, params *CreateMinerParams) *CreateMinerRe
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load claims")
 
 		err = setClaim(claims, addresses.IDAddress, &Claim{abi.NewStoragePower(0), abi.NewStoragePower(0)})
-		if err != nil {
-			rt.Abortf(exitcode.ErrIllegalState, "failed to put power in claimed table while creating miner: %v", err)
-		}
+		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to put power in claimed table while creating miner")
+
 		st.MinerCount += 1
 
 		st.Claims, err = claims.Root()
@@ -219,17 +203,10 @@ func (a Actor) EnrollCronEvent(rt Runtime, params *EnrollCronEventParams) *adt.E
 func (a Actor) OnEpochTickEnd(rt Runtime, _ *adt.EmptyValue) *adt.EmptyValue {
 	rt.ValidateImmediateCallerIs(builtin.CronActorAddr)
 
-	if err := a.processDeferredCronEvents(rt); err != nil {
-		rt.Abortf(exitcode.ErrIllegalState, "Failed to process deferred cron events: %v", err)
-	}
-
-	if err := a.processBatchProofVerifies(rt); err != nil {
-		rt.Abortf(exitcode.ErrIllegalState, "failed to process batch proof verification: %s", err)
-	}
+	a.processDeferredCronEvents(rt)
+	a.processBatchProofVerifies(rt)
 
 	var st State
-	rt.State().Readonly(&st)
-
 	rt.State().Transaction(&st, func() interface{} {
 		// update next epoch's power and pledge values
 		// this must come before the next epoch's rewards are calculated
@@ -277,11 +254,9 @@ func (a Actor) OnConsensusFault(rt Runtime, pledgeAmount *abi.TokenAmount) *adt.
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load claims")
 
 		claim, powerOk, err := getClaim(claims, minerAddr)
-		if err != nil {
-			rt.Abortf(exitcode.ErrIllegalState, "failed to read claimed power for fault: %v", err)
-		}
+		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to read claimed power for fault")
 		if !powerOk {
-			rt.Abortf(exitcode.ErrIllegalArgument, "miner %v not registered (already slashed?)", minerAddr)
+			rt.Abortf(exitcode.ErrNotFound, "miner %v not registered (already slashed?)", minerAddr)
 		}
 		Assert(claim.RawBytePower.GreaterThanEqual(big.Zero()))
 		Assert(claim.QualityAdjPower.GreaterThanEqual(big.Zero()))
@@ -323,9 +298,7 @@ func (a Actor) SubmitPoRepForBulkVerify(rt Runtime, sealInfo *abi.SealVerifyInfo
 		} else {
 			var err error
 			mmap, err = adt.AsMultimap(adt.AsStore(rt), *st.ProofValidationBatch)
-			if err != nil {
-				rt.Abortf(exitcode.ErrIllegalState, "failed to load proof batching set: %s", err)
-			}
+			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load proof batch set")
 		}
 
 		arr, found, err := mmap.Get(adt.AddrKey(minerAddr))
@@ -334,14 +307,12 @@ func (a Actor) SubmitPoRepForBulkVerify(rt Runtime, sealInfo *abi.SealVerifyInfo
 			rt.Abortf(ErrTooManyProveCommits, "miner %s attempting to prove commit over %d sectors in epoch", minerAddr, MaxMinerProveCommitsPerEpoch)
 		}
 
-		if err := mmap.Add(adt.AddrKey(minerAddr), sealInfo); err != nil {
-			rt.Abortf(exitcode.ErrIllegalState, "failed to insert proof into set: %s", err)
-		}
+		err = mmap.Add(adt.AddrKey(minerAddr), sealInfo)
+		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to insert proof into batch")
 
 		mmrc, err := mmap.Root()
-		if err != nil {
-			rt.Abortf(exitcode.ErrIllegalState, "failed to flush proofs batch map: %s", err)
-		}
+		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to flush proofs batch")
+
 		rt.ChargeGas("OnSubmitVerifySeal", GasOnSubmitVerifySeal, 0)
 		st.ProofValidationBatch = &mmrc
 		return nil
@@ -378,7 +349,7 @@ func (a Actor) CurrentTotalPower(rt Runtime, _ *adt.EmptyValue) *CurrentTotalPow
 // Method utility functions
 ////////////////////////////////////////////////////////////////////////////////
 
-func (a Actor) processBatchProofVerifies(rt Runtime) error {
+func (a Actor) processBatchProofVerifies(rt Runtime) {
 	var st State
 
 	var miners []address.Address
@@ -390,15 +361,11 @@ func (a Actor) processBatchProofVerifies(rt Runtime) error {
 			return nil
 		}
 		mmap, err := adt.AsMultimap(store, *st.ProofValidationBatch)
-		if err != nil {
-			rt.Abortf(exitcode.ErrIllegalState, "failed to load proofs validation batch: %s", err)
-		}
+		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load proofs validation batch")
 
 		err = mmap.ForAll(func(k string, arr *adt.Array) error {
 			a, err := address.NewFromBytes([]byte(k))
-			if err != nil {
-				return xerrors.Errorf("failed to parse address key: %w", err)
-			}
+			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to parse address key")
 
 			miners = append(miners, a)
 
@@ -408,25 +375,19 @@ func (a Actor) processBatchProofVerifies(rt Runtime) error {
 				infos = append(infos, svi)
 				return nil
 			})
-			if err != nil {
-				return xerrors.Errorf("failed to iterate over proof verify array for miner %s: %w", a, err)
-			}
+			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to iterate over proof verify array for miner %s", a)
+
 			verifies[a] = infos
 			return nil
 		})
-		if err != nil {
-			rt.Abortf(exitcode.ErrIllegalState, "failed to iterate proof batch: %s", err)
-		}
+		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to iterate proof batch")
 
 		st.ProofValidationBatch = nil
-
 		return nil
 	})
 
 	res, err := rt.Syscalls().BatchVerifySeals(verifies)
-	if err != nil {
-		rt.Abortf(exitcode.ErrIllegalState, "failed to batch verify: %s", err)
-	}
+	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to batch verify")
 
 	for _, m := range miners {
 		vres, ok := res[m]
@@ -460,11 +421,9 @@ func (a Actor) processBatchProofVerifies(rt Runtime) error {
 			abi.NewTokenAmount(0),
 		)
 	}
-
-	return nil
 }
 
-func (a Actor) processDeferredCronEvents(rt Runtime) error {
+func (a Actor) processDeferredCronEvents(rt Runtime) {
 	rtEpoch := rt.CurrEpoch()
 
 	var cronEvents []CronEvent
@@ -475,17 +434,13 @@ func (a Actor) processDeferredCronEvents(rt Runtime) error {
 
 		for epoch := st.FirstCronEpoch; epoch <= rtEpoch; epoch++ {
 			epochEvents, err := loadCronEvents(events, epoch)
-			if err != nil {
-				return errors.Wrapf(err, "failed to load cron events at %v", epoch)
-			}
+			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load cron events at %v", epoch)
 
 			cronEvents = append(cronEvents, epochEvents...)
 
 			if len(epochEvents) > 0 {
 				err = events.RemoveAll(epochKey(epoch))
-				if err != nil {
-					return errors.Wrapf(err, "failed to clear cron events at %v", epoch)
-				}
+				builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to clear cron events at %v", epoch)
 			}
 		}
 
@@ -493,7 +448,6 @@ func (a Actor) processDeferredCronEvents(rt Runtime) error {
 
 		st.CronEventQueue, err = events.Root()
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to flush events")
-
 		return nil
 	})
 	failedMinerCrons := make([]addr.Address, 0)
@@ -542,5 +496,4 @@ func (a Actor) processDeferredCronEvents(rt Runtime) error {
 
 		return nil
 	})
-	return nil
 }

--- a/actors/builtin/power/power_state.go
+++ b/actors/builtin/power/power_state.go
@@ -11,6 +11,7 @@ import (
 
 	abi "github.com/filecoin-project/specs-actors/actors/abi"
 	big "github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 	. "github.com/filecoin-project/specs-actors/actors/util"
 	adt "github.com/filecoin-project/specs-actors/actors/util/adt"
 	"github.com/filecoin-project/specs-actors/actors/util/smoothing"
@@ -146,7 +147,7 @@ func (st *State) addToClaim(claims *adt.Map, miner addr.Address, power abi.Stora
 		return fmt.Errorf("failed to get claim: %w", err)
 	}
 	if !ok {
-		return errors.Errorf("no claim for actor %v", miner)
+		return exitcode.ErrNotFound.Wrapf("no claim for actor %v", miner)
 	}
 
 	// TotalBytes always update directly
@@ -207,7 +208,7 @@ func (st *State) appendCronEvent(events *adt.Multimap, epoch abi.ChainEpoch, eve
 	}
 
 	if err := events.Add(epochKey(epoch), event); err != nil {
-		return errors.Wrapf(err, "failed to store cron event at epoch %v for miner %v", epoch, event)
+		return xerrors.Errorf("failed to store cron event at epoch %v for miner %v: %w", epoch, event, err)
 	}
 
 	return nil
@@ -233,7 +234,7 @@ func setClaim(claims *adt.Map, a addr.Address, claim *Claim) error {
 	Assert(claim.QualityAdjPower.GreaterThanEqual(big.Zero()))
 
 	if err := claims.Put(AddrKey(a), claim); err != nil {
-		return errors.Wrapf(err, "failed to put claim with address %s power %v", a, claim)
+		return xerrors.Errorf("failed to put claim with address %s power %v: %w", a, claim, err)
 	}
 
 	return nil

--- a/actors/builtin/power/power_test.go
+++ b/actors/builtin/power/power_test.go
@@ -149,7 +149,7 @@ func TestUpdateClaimedPowerFailures(t *testing.T) {
 		rt.SetCaller(miner, builtin.StorageMinerActorCodeID)
 		rt.ExpectValidateCallerType(builtin.StorageMinerActorCodeID)
 
-		rt.ExpectAbort(exitcode.ErrIllegalState, func() {
+		rt.ExpectAbort(exitcode.ErrNotFound, func() {
 			rt.Call(ac.UpdateClaimedPower, &params)
 		})
 
@@ -318,7 +318,7 @@ func TestOnConsensusFault(t *testing.T) {
 		rt, ac := basicPowerSetup(t)
 		pledge := abi.NewTokenAmount(10)
 
-		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
+		rt.ExpectAbort(exitcode.ErrNotFound, func() {
 			ac.onConsensusFault(rt, miner, &pledge)
 		})
 

--- a/actors/builtin/reward/reward_actor.go
+++ b/actors/builtin/reward/reward_actor.go
@@ -62,7 +62,7 @@ func (a Actor) AwardBlockReward(rt vmr.Runtime, params *AwardBlockRewardParams) 
 
 	minerAddr, ok := rt.ResolveAddress(params.Miner)
 	if !ok {
-		rt.Abortf(exitcode.ErrIllegalState, "failed to resolve given owner address")
+		rt.Abortf(exitcode.ErrNotFound, "failed to resolve given owner address")
 	}
 
 	priorBalance := rt.CurrentBalance()

--- a/actors/builtin/verifreg/verified_registry_test.go
+++ b/actors/builtin/verifreg/verified_registry_test.go
@@ -443,7 +443,7 @@ func TestUseBytes(t *testing.T) {
 		dSize2 := verifreg.MinVerifiedDealSize
 		param := &verifreg.UseBytesParams{clientAddr, dSize2}
 
-		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
+		rt.ExpectAbort(exitcode.ErrNotFound, func() {
 			ac.useBytes(rt, param.Address, param.DealSize, nil)
 
 		})
@@ -481,7 +481,7 @@ func TestUseBytes(t *testing.T) {
 		dSize2 := verifreg.MinVerifiedDealSize
 		param := &verifreg.UseBytesParams{clientAddr, dSize2}
 
-		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
+		rt.ExpectAbort(exitcode.ErrNotFound, func() {
 			ac.useBytes(rt, param.Address, param.DealSize, nil)
 
 		})


### PR DESCRIPTION
While auditing for #596 I fixed up easy/spurious missing coverage spots and fixed some exit codes.

- Use builtin.RequireNoErr() in some "impossible" error cases.
- Define some better exit codes using the new exitcode.Wrapf.