### PR TITLE
Update deadline expiration bitfield when rescheduling expirations due to faults

### DIFF
--- a/actors/builtin/miner/bitfield_queue_test.go
+++ b/actors/builtin/miner/bitfield_queue_test.go
@@ -267,22 +267,3 @@ func (bqe *bqExpectation) Equals(t *testing.T, q miner.BitfieldQueue) {
 	})
 	require.NoError(t, err)
 }
-
-func assertBitfieldEquals(t *testing.T, bf *bitfield.BitField, values ...uint64) {
-	count, err := bf.Count()
-	require.NoError(t, err)
-	require.Equal(t, len(values), int(count))
-
-	err = bf.ForEach(func(v uint64) error {
-		assert.Equal(t, values[0], v)
-		values = values[1:]
-		return nil
-	})
-	require.NoError(t, err)
-}
-
-func assertBitfieldEmpty(t *testing.T, bf *bitfield.BitField) {
-	empty, err := bf.IsEmpty()
-	require.NoError(t, err)
-	assert.True(t, empty)
-}

--- a/actors/builtin/miner/bitfield_test.go
+++ b/actors/builtin/miner/bitfield_test.go
@@ -1,0 +1,36 @@
+package miner_test
+
+import (
+	"testing"
+
+	"github.com/filecoin-project/go-bitfield"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func assertBitfieldsEqual(t *testing.T, expected *bitfield.BitField, actual *bitfield.BitField) {
+	const maxDiff = 100
+
+	missing, err := bitfield.SubtractBitField(expected, actual)
+	require.NoError(t, err)
+	unexpected, err := bitfield.SubtractBitField(actual, expected)
+	require.NoError(t, err)
+
+	missingSet, err := missing.All(maxDiff)
+	require.NoError(t, err, "more than %d missing bits expected", maxDiff)
+	assert.Empty(t, missingSet, "expected missing bits")
+
+	unexpectedSet, err := unexpected.All(maxDiff)
+	require.NoError(t, err, "more than %d unexpected bits", maxDiff)
+	assert.Empty(t, unexpectedSet, "unexpected bits set")
+}
+
+func assertBitfieldEquals(t *testing.T, actual *bitfield.BitField, expected ...uint64) {
+	assertBitfieldsEqual(t, actual, bf(expected...))
+}
+
+func assertBitfieldEmpty(t *testing.T, bf *bitfield.BitField) {
+	empty, err := bf.IsEmpty()
+	require.NoError(t, err)
+	assert.True(t, empty)
+}

--- a/actors/builtin/miner/deadline_state_test.go
+++ b/actors/builtin/miner/deadline_state_test.go
@@ -79,7 +79,7 @@ func TestDeadlines(t *testing.T) {
 		}, sectorSize, quantSpec)
 		require.NoError(t, err)
 
-		expectedPower := miner.PowerForSectors(sectorSize, selectSectors(t, sectors, bf(1, 3, 6)))
+		expectedPower := sectorPower(t, 1, 3, 6)
 		require.True(t, expectedPower.Equals(removedPower), "dlState to remove power for terminated sectors")
 
 		dlState.withTerminations(1, 3, 6).
@@ -147,7 +147,7 @@ func TestDeadlines(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		expectedPower := miner.PowerForSectors(sectorSize, selectSectors(t, sectors, bf(5, 6)))
+		expectedPower := sectorPower(t, 5, 6)
 		assert.True(t, faultyPower.Equals(expectedPower))
 
 		dlState.withFaults(5, 6).
@@ -437,10 +437,10 @@ func (s expectedDeadlineState) assert(t *testing.T, rt *mock.Runtime, dl *miner.
 		t, rt, dl, s.quant, s.sectorSize, s.partitionSize, s.sectors,
 	)
 
-	assertBitfieldsEqual(t, faults, orEmpty(s.faults))
-	assertBitfieldsEqual(t, recoveries, orEmpty(s.recovering))
-	assertBitfieldsEqual(t, terminations, orEmpty(s.terminations))
-	assertBitfieldsEqual(t, dl.PostSubmissions, orEmpty(s.posts))
+	assertBitfieldsEqual(t, orEmpty(s.faults), faults)
+	assertBitfieldsEqual(t, orEmpty(s.recovering), recoveries)
+	assertBitfieldsEqual(t, orEmpty(s.terminations), terminations)
+	assertBitfieldsEqual(t, orEmpty(s.posts), dl.PostSubmissions)
 
 	require.Equal(t, len(s.partitionSectors), len(partitions))
 
@@ -550,11 +550,11 @@ func checkDeadlineInvariants(
 			var bf abi.BitField
 			found, err := expirationEpochs.Get(uint64(epoch), &bf)
 			require.NoError(t, err)
-			require.True(t, found)
+			require.True(t, found, "expected to find partitions with expirations at epoch %d", epoch)
 			for _, p := range partitions {
 				present, err := bf.IsSet(p)
 				require.NoError(t, err)
-				assert.True(t, present)
+				assert.True(t, present, "expected partition %d to be present in deadline expiration queue at epoch %d", p, epoch)
 			}
 		}
 	}

--- a/actors/builtin/miner/partition_state_test.go
+++ b/actors/builtin/miner/partition_state_test.go
@@ -299,8 +299,8 @@ func TestPartitions(t *testing.T) {
 		expset, err := partition.PopExpiredSectors(store, expireEpoch, quantSpec)
 		require.NoError(t, err)
 
-		assertBitfieldsEqual(t, expset.OnTimeSectors, bf(1, 2))
-		assertBitfieldsEqual(t, expset.EarlySectors, bf(4))
+		assertBitfieldEquals(t, expset.OnTimeSectors, 1, 2)
+		assertBitfieldEquals(t, expset.EarlySectors, 4)
 		assert.Equal(t, abi.NewTokenAmount(1000+1001), expset.OnTimePledge)
 
 		// active power only contains power from non-faulty sectors
@@ -406,7 +406,7 @@ func TestPartitions(t *testing.T) {
 		require.NoError(t, err)
 
 		// expect first sector to be in early terminations
-		assertBitfieldsEqual(t, bf(1), result.Sectors[terminationEpoch])
+		assertBitfieldEquals(t, result.Sectors[terminationEpoch], 1)
 
 		// expect more results
 		assert.True(t, hasMore)
@@ -425,7 +425,7 @@ func TestPartitions(t *testing.T) {
 		require.NoError(t, err)
 
 		// expect 3 and 5
-		assertBitfieldsEqual(t, bf(3, 5), result.Sectors[terminationEpoch])
+		assertBitfieldEquals(t, result.Sectors[terminationEpoch], 3, 5)
 
 		// expect no more results
 		assert.False(t, hasMore)
@@ -699,27 +699,6 @@ func emptyPartition(t *testing.T, rt *mock.Runtime) *miner.Partition {
 	require.NoError(t, err)
 
 	return miner.ConstructPartition(root)
-}
-
-func assertBitfieldsEqual(t *testing.T, bf1 *bitfield.BitField, bf2 *bitfield.BitField) {
-	count, err := bf2.Count()
-	require.NoError(t, err)
-
-	err = bf1.ForEach(func(v uint64) error {
-		other, err := bf2.First()
-		require.NoError(t, err)
-
-		assert.Equal(t, other, v)
-
-		bf2, err = bf2.Slice(1, count-1)
-		require.NoError(t, err)
-		count -= 1
-		return nil
-	})
-	require.NoError(t, err)
-
-	// assert no bits left in second bitfield.
-	assert.Equal(t, uint64(0), count)
 }
 
 func rescheduleSectors(t *testing.T, target abi.ChainEpoch, sectors []*miner.SectorOnChainInfo, filter *bitfield.BitField) []*miner.SectorOnChainInfo {


### PR DESCRIPTION
1. Skip processing posts for completely faulty sectors.
2. When we reschedule sector expirations due to faults, update the per-deadline
   bitfield.

Note: We're being a bit sloppy in step 2.

1. We're relying on faulty power to determine if we added any new faults. This works, but maybe we should return a boolean?
2. Technically, if the newly faulty sectors would have expired before the "max faulty" deadline, we won't reschedule their expiration. However, we'll still _record_ this expiration in the deadline's bitfield. Given the fact that this bitfield is best-effort anyways (e.g., we don't remove bits from it after recovering sectors), this should be fine. At worst, we'll try to pop expirations from a partition that has no expirations at that epoch.