### PR TITLE
Don't pay all fees every deadline and fix termination faulty power

### DIFF
--- a/actors/builtin/miner/cbor_gen.go
+++ b/actors/builtin/miner/cbor_gen.go
@@ -15,7 +15,7 @@ import (
 
 var _ = xerrors.Errorf
 
-var lengthBufState = []byte{141}
+var lengthBufState = []byte{140}
 
 func (t *State) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -100,11 +100,6 @@ func (t *State) MarshalCBOR(w io.Writer) error {
 	if err := t.EarlyTerminations.MarshalCBOR(w); err != nil {
 		return err
 	}
-
-	// t.FaultyPower (miner.PowerPair) (struct)
-	if err := t.FaultyPower.MarshalCBOR(w); err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -122,7 +117,7 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 13 {
+	if extra != 12 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -282,15 +277,6 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 			if err := t.EarlyTerminations.UnmarshalCBOR(br); err != nil {
 				return xerrors.Errorf("unmarshaling t.EarlyTerminations pointer: %w", err)
 			}
-		}
-
-	}
-	// t.FaultyPower (miner.PowerPair) (struct)
-
-	{
-
-		if err := t.FaultyPower.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.FaultyPower: %w", err)
 		}
 
 	}
@@ -639,7 +625,7 @@ func (t *Deadlines) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
-var lengthBufDeadline = []byte{134}
+var lengthBufDeadline = []byte{135}
 
 func (t *Deadline) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -686,6 +672,10 @@ func (t *Deadline) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
+	// t.FaultyPower (miner.PowerPair) (struct)
+	if err := t.FaultyPower.MarshalCBOR(w); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -703,7 +693,7 @@ func (t *Deadline) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 6 {
+	if extra != 7 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -799,6 +789,15 @@ func (t *Deadline) UnmarshalCBOR(r io.Reader) error {
 			return fmt.Errorf("wrong type for uint64 field")
 		}
 		t.TotalSectors = uint64(extra)
+
+	}
+	// t.FaultyPower (miner.PowerPair) (struct)
+
+	{
+
+		if err := t.FaultyPower.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.FaultyPower: %w", err)
+		}
 
 	}
 	return nil

--- a/actors/builtin/miner/deadline_state.go
+++ b/actors/builtin/miner/deadline_state.go
@@ -53,6 +53,9 @@ type Deadline struct {
 
 	// The total number of sectors in this deadline (incl dead).
 	TotalSectors uint64
+
+	// Memoized sum of faulty power in partitions.
+	FaultyPower PowerPair
 }
 
 //
@@ -116,6 +119,8 @@ func ConstructDeadline(emptyArrayCid cid.Cid) *Deadline {
 		PostSubmissions:   abi.NewBitField(),
 		EarlyTerminations: abi.NewBitField(),
 		LiveSectors:       0,
+		TotalSectors:      0,
+		FaultyPower:       NewPowerPairZero(),
 	}
 }
 
@@ -240,12 +245,15 @@ func (dl *Deadline) PopExpiredSectors(store adt.Store, until abi.ChainEpoch, qua
 	}
 	dl.LiveSectors -= onTimeCount + earlyCount
 
+	dl.FaultyPower = dl.FaultyPower.Sub(allFaultyPower)
+
 	return NewExpirationSet(allOnTimeSectors, allEarlySectors, allOnTimePledge, allActivePower, allFaultyPower), nil
 }
 
 // Adds sectors to a deadline. It's the caller's responsibility to make sure
 // that this deadline isn't currently "open" (i.e., being proved at this point
 // in time).
+// The sectors are assumed to be non-faulty.
 func (dl *Deadline) AddSectors(store adt.Store, partitionSize uint64, sectors []*SectorOnChainInfo,
 	ssize abi.SectorSize, quant QuantSpec) (PowerPair, error) {
 	if len(sectors) == 0 {
@@ -454,7 +462,7 @@ func (dl *Deadline) TerminateSectors(
 	partitionSectors map[uint64][]*SectorOnChainInfo,
 	ssize abi.SectorSize,
 	quant QuantSpec,
-) (removedPower PowerPair, err error) {
+) (powerLost PowerPair, err error) {
 
 	partitions, err := dl.PartitionsArray(store)
 	if err != nil {
@@ -467,7 +475,7 @@ func (dl *Deadline) TerminateSectors(
 	}
 	sort.Slice(partitionIdxs, func(i, j int) bool { return i < j })
 
-	removedPower = NewPowerPairZero()
+	powerLost = NewPowerPairZero()
 
 	var partition Partition
 	for _, partIdx := range partitionIdxs {
@@ -477,7 +485,7 @@ func (dl *Deadline) TerminateSectors(
 		} else if !found {
 			return NewPowerPairZero(), xerrors.Errorf("failed to find partition %d", partIdx)
 		}
-		pwr, err := partition.TerminateSectors(store, epoch, partSectors, ssize, quant)
+		removed, err := partition.TerminateSectors(store, epoch, partSectors, ssize, quant)
 		if err != nil {
 			return NewPowerPairZero(), xerrors.Errorf("failed to terminate sectors in partition %d: %w", partIdx, err)
 		}
@@ -489,11 +497,12 @@ func (dl *Deadline) TerminateSectors(
 
 		// Record that partition now has pending early terminations.
 		dl.EarlyTerminations.Set(partIdx)
-		// Record live sector change
+		// Record change to sectors and power
 		dl.LiveSectors -= uint64(len(partSectors))
+		dl.FaultyPower = dl.FaultyPower.Sub(removed.FaultyPower)
 
-		// update power
-		removedPower = removedPower.Add(pwr)
+		// Aggregate power lost from active sectors
+		powerLost = powerLost.Add(removed.ActivePower)
 	}
 
 	// save partitions back
@@ -502,7 +511,7 @@ func (dl *Deadline) TerminateSectors(
 		return NewPowerPairZero(), xerrors.Errorf("failed to persist partitions: %w", err)
 	}
 
-	return removedPower, nil
+	return powerLost, nil
 }
 
 // RemovePartitions removes the specified partitions, shifting the remaining
@@ -753,6 +762,9 @@ func (dl *Deadline) DeclareFaults(
 	if err != nil {
 		return NewPowerPairZero(), xc.ErrIllegalState.Wrapf("failed to update expirations for partitions with faults: %w", err)
 	}
+
+	dl.FaultyPower = dl.FaultyPower.Add(newFaultyPower)
+
 	return newFaultyPower, nil
 }
 
@@ -815,6 +827,8 @@ func (dl *Deadline) DeclareFaultsRecovered(
 			return xc.ErrIllegalState.Wrapf("failed to update partition %d: %w", partIdx, err)
 		}
 	}
+
+	// Power is not regained until the deadline end, when the recovery is confirmed.
 
 	dl.Partitions, err = partitions.Root()
 	if err != nil {
@@ -900,6 +914,8 @@ func (dl *Deadline) ProcessDeadlineEnd(store adt.Store, quant QuantSpec, faultEx
 	if err != nil {
 		return newFaultyPower, failedRecoveryPower, xc.ErrIllegalState.Wrapf("failed to update deadline expiration queue: %w", err)
 	}
+
+	dl.FaultyPower = dl.FaultyPower.Add(newFaultyPower)
 
 	// Reset PoSt submissions.
 	dl.PostSubmissions = abi.NewBitField()
@@ -1033,17 +1049,20 @@ func (dl *Deadline) RecordProvenSectors(
 		return nil, xc.ErrIllegalState.Wrapf("failed to merge ignored sectors bitfields: %w", err)
 	}
 
+	result := &PoStResult{
+		Sectors:                allSectorNos,
+		IgnoredSectors:         allIgnoredSectorNos,
+		NewFaultyPower:         newFaultyPowerTotal,
+		RecoveredPower:         recoveredPowerTotal,
+		RetractedRecoveryPower: retractedRecoveryPowerTotal,
+	}
+
 	// Save everything back.
 	dl.Partitions, err = partitions.Root()
 	if err != nil {
 		return nil, xc.ErrIllegalState.Wrapf("failed to persist partitions: %w", err)
 	}
 
-	return &PoStResult{
-		Sectors:                allSectorNos,
-		IgnoredSectors:         allIgnoredSectorNos,
-		NewFaultyPower:         newFaultyPowerTotal,
-		RecoveredPower:         recoveredPowerTotal,
-		RetractedRecoveryPower: retractedRecoveryPowerTotal,
-	}, nil
+	dl.FaultyPower = dl.FaultyPower.Sub(result.PowerDelta())
+	return result, nil
 }

--- a/actors/builtin/miner/deadline_state_test.go
+++ b/actors/builtin/miner/deadline_state_test.go
@@ -304,7 +304,7 @@ func TestDeadlines(t *testing.T) {
 		rt := builder.Build(t)
 		dl := emptyDeadline(t, rt)
 
-		addThenMarkFaulty(t, rt, dl) // 5, 6 faulty
+		addThenMarkFaulty(t, rt, dl) // 1, 5, 6 faulty
 
 		store := adt.AsStore(rt)
 		removedPower, err := dl.TerminateSectors(store, 15, map[uint64][]*miner.SectorOnChainInfo{
@@ -313,8 +313,8 @@ func TestDeadlines(t *testing.T) {
 		}, sectorSize, quantSpec)
 		require.NoError(t, err)
 
-		// Sector 1, 3 were active, 6 faulty
-		expectedPowerLoss := miner.PowerForSectors(sectorSize, selectSectors(t, sectors, bf(1, 3)))
+		// Sector 3 active, 1, 6 faulty
+		expectedPowerLoss := miner.PowerForSectors(sectorSize, selectSectors(t, sectors, bf(3)))
 		require.True(t, expectedPowerLoss.Equals(removedPower), "dlState to remove power for terminated sectors")
 
 		dlState.withTerminations(1, 3, 6).

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -66,9 +66,6 @@ type State struct {
 
 	// Deadlines with outstanding fees for early sector termination.
 	EarlyTerminations *bitfield.BitField
-
-	// Memoized power information
-	FaultyPower PowerPair
 }
 
 type MinerInfo struct {
@@ -166,7 +163,6 @@ func ConstructState(infoCid cid.Cid, periodStart abi.ChainEpoch, emptyBitfieldCi
 		CurrentDeadline:     0,
 		Deadlines:           emptyDeadlinesCid,
 
-		FaultyPower:       NewPowerPairZero(),
 		EarlyTerminations: abi.NewBitField(),
 	}, nil
 }

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -122,7 +122,6 @@ func TestConstruction(t *testing.T) {
 		}
 
 		assertEmptyBitfield(t, st.EarlyTerminations)
-		assert.Equal(t, miner.NewPowerPairZero(), st.FaultyPower)
 	})
 }
 
@@ -579,20 +578,11 @@ func TestCommitments(t *testing.T) {
 		upgrade := actor.preCommitSector(rt, upgradeParams)
 
 		// Declare the old sector faulty
-		_, qaPower := powerForSectors(actor.sectorSize, []*miner.SectorOnChainInfo{oldSector})
-		fee := miner.PledgePenaltyForDeclaredFault(actor.epochRewardSmooth, actor.epochQAPowerSmooth, qaPower)
-		actor.declareFaults(rt, fee, oldSector)
+		actor.declareFaults(rt, oldSector)
 
 		rt.SetEpoch(upgrade.PreCommitEpoch + miner.PreCommitChallengeDelay + 1)
-		// Proof is initially denied because the fault fee has reduced locked funds.
-		rt.ExpectAbort(exitcode.ErrInsufficientFunds, func() {
-			actor.proveCommitSectorAndConfirm(rt, &upgrade.Info, upgrade.PreCommitEpoch,
-				makeProveCommit(upgrade.Info.SectorNumber), proveCommitConf{})
-		})
-		rt.Reset()
 
 		// Prove the new sector
-		actor.addLockedFunds(rt, fee)
 		newSector := actor.proveCommitSectorAndConfirm(rt, &upgrade.Info, upgrade.PreCommitEpoch,
 			makeProveCommit(upgrade.Info.SectorNumber), proveCommitConf{})
 
@@ -838,7 +828,8 @@ func TestWindowPost(t *testing.T) {
 		pwr := miner.PowerForSectors(actor.sectorSize, infos)
 
 		// add lots of funds so we can pay penalties without going into debt
-		actor.addLockedFunds(rt, big.Mul(big.NewInt(200), big.NewInt(1e18)))
+		initialLocked := big.Mul(big.NewInt(200), big.NewInt(1e18))
+		actor.addLockedFunds(rt, initialLocked)
 
 		// Submit first PoSt to ensure we are sufficiently early to add a fault
 		// advance to next proving period
@@ -846,11 +837,10 @@ func TestWindowPost(t *testing.T) {
 
 		// advance deadline and declare fault
 		advanceDeadline(rt, actor, &cronConfig{})
-		actor.declareFaults(rt, actor.declaredFaultPenalty(infos), infos...)
+		actor.declareFaults(rt, infos...)
 
 		// advance a deadline and declare recovery
-		ongoingFee := actor.declaredFaultPenalty(infos)
-		advanceDeadline(rt, actor, &cronConfig{ongoingFaultsPenalty: ongoingFee})
+		advanceDeadline(rt, actor, &cronConfig{})
 
 		// declare recovery
 		st := getState(rt)
@@ -861,35 +851,36 @@ func TestWindowPost(t *testing.T) {
 		// advance to epoch when submitPoSt is due
 		dlinfo := actor.deadline(rt)
 		for dlinfo.Index != dlIdx {
-			advanceDeadline(rt, actor, &cronConfig{ongoingFaultsPenalty: ongoingFee})
+			advanceDeadline(rt, actor, &cronConfig{})
 			dlinfo = actor.deadline(rt)
 		}
 
 		// Now submit PoSt
 		// Power should return for recovered sector.
-		// Recovery should be charged ongoing fee one more time.
+		// Recovery should be charged ongoing fee.
+		recoveryFee := actor.declaredFaultPenalty(infos)
 		cfg := &poStConfig{
 			expectedRawPowerDelta: pwr.Raw,
 			expectedQAPowerDelta:  pwr.QA,
-			expectedPenalty:       ongoingFee,
+			expectedPenalty:       recoveryFee,
 		}
 		partitions := []miner.PoStPartition{
 			{Index: pIdx, Skipped: abi.NewBitField()},
 		}
 		actor.submitWindowPoSt(rt, dlinfo, partitions, infos, cfg)
 
-		// faulty power has been removed
-		st = getState(rt)
-		assert.Equal(t, miner.NewPowerPairZero(), st.FaultyPower)
-
-		// partition containing sector no longer has faults or recoveries
-		partition := loadParitionForSector(t, st, rt.AdtStore(), infos[0])
+		// faulty power has been removed, partition no longer has faults or recoveries
+		deadline, partition := actor.findSector(rt, infos[0].SectorNumber)
+		assert.Equal(t, miner.NewPowerPairZero(), deadline.FaultyPower)
 		assert.Equal(t, miner.NewPowerPairZero(), partition.FaultyPower)
 		assertBitfieldEmpty(t, partition.Faults)
 		assertBitfieldEmpty(t, partition.Recoveries)
 
 		// Next deadline cron does not charge for the fault
 		advanceDeadline(rt, actor, &cronConfig{})
+
+		expectedBalance := big.Sub(initialLocked, recoveryFee)
+		assert.Equal(t, expectedBalance, actor.getLockedFunds(rt))
 	})
 
 	t.Run("skipped faults are penalized and adjust power adjusted", func(t *testing.T) {
@@ -1112,7 +1103,7 @@ func TestProveCommit(t *testing.T) {
 				sectorNoA: exitcode.ErrIllegalArgument,
 			},
 		}
-		actor.confirmSectorProofsValid(rt, conf, precommitEpoch, precommitA, precommitB)
+		actor.confirmSectorProofsValid(rt, conf, precommitA, precommitB)
 	})
 }
 
@@ -1275,7 +1266,7 @@ func TestDeclareFaults(t *testing.T) {
 	builder := builderForHarness(actor).
 		WithBalance(bigBalance, big.Zero())
 
-	t.Run("declare fault pays fee", func(t *testing.T) {
+	t.Run("declare fault pays fee at window post", func(t *testing.T) {
 		// Get sector into proving state
 		rt := builder.Build(t)
 		actor.constructAndVerify(rt)
@@ -1286,12 +1277,14 @@ func TestDeclareFaults(t *testing.T) {
 		info := actor.getSector(rt, precommits[0].SectorNumber)
 
 		// Declare the sector as faulted
-		ss, err := info.SealProof.SectorSize()
-		require.NoError(t, err)
-		sectorQAPower := miner.QAPowerForSector(ss, info)
-		fee := miner.PledgePenaltyForDeclaredFault(actor.epochRewardSmooth, actor.epochQAPowerSmooth, sectorQAPower)
+		actor.declareFaults(rt, info)
 
-		actor.declareFaults(rt, fee, info)
+		// TODO: advance to window post and observe fee
+		//
+		//ss, err := info.SealProof.SectorSize()
+		//require.NoError(t, err)
+		//sectorQAPower := miner.QAPowerForSector(ss, info)
+		//fee := miner.PledgePenaltyForDeclaredFault(actor.epochRewardSmooth, actor.epochQAPowerSmooth, sectorQAPower)
 	})
 }
 
@@ -1465,7 +1458,7 @@ func TestTerminateSectors(t *testing.T) {
 			st := getState(rt)
 
 			// expect sector to be marked as terminated and the early termination queue to be empty (having been fully processed)
-			partition := loadParitionForSector(t, st, rt.AdtStore(), sector)
+			_, partition := actor.findSector(rt, sector.SectorNumber)
 			terminated, err := partition.Terminated.IsSet(uint64(sector.SectorNumber))
 			require.NoError(t, err)
 			assert.True(t, terminated)
@@ -1779,6 +1772,21 @@ func (h *actorHarness) getDeadlineAndPartition(rt *mock.Runtime, dlIdx, pIdx uin
 	return deadline, partition
 }
 
+func (h *actorHarness) findSector(rt *mock.Runtime, sno abi.SectorNumber) (*miner.Deadline, *miner.Partition) {
+	var st miner.State
+	rt.GetState(&st)
+	deadlines, err := st.LoadDeadlines(rt.AdtStore())
+	require.NoError(h.t, err)
+	dlIdx, pIdx, err := miner.FindSector(rt.AdtStore(), deadlines, sno)
+	require.NoError(h.t, err)
+
+	deadline, err := deadlines.LoadDeadline(rt.AdtStore(), dlIdx)
+	require.NoError(h.t, err)
+	partition, err := deadline.LoadPartition(rt.AdtStore(), pIdx)
+	require.NoError(h.t, err)
+	return deadline, partition
+}
+
 // Collects all sector infos into a map.
 func (h *actorHarness) collectSectors(rt *mock.Runtime) map[abi.SectorNumber]*miner.SectorOnChainInfo {
 	sectors := map[abi.SectorNumber]*miner.SectorOnChainInfo{}
@@ -1818,6 +1826,11 @@ func (h *actorHarness) collectPartitionExpirations(rt *mock.Runtime, partition *
 		return nil
 	})
 	return expirations
+}
+
+func (h *actorHarness) getLockedFunds(rt *mock.Runtime) abi.TokenAmount {
+	st := getState(rt)
+	return st.LockedFunds
 }
 
 //
@@ -1928,7 +1941,7 @@ func (h *actorHarness) proveCommitSector(rt *mock.Runtime, precommit *miner.Sect
 	rt.Verify()
 }
 
-func (h *actorHarness) confirmSectorProofsValid(rt *mock.Runtime, conf proveCommitConf, precommitEpoch abi.ChainEpoch, precommits ...*miner.SectorPreCommitInfo) {
+func (h *actorHarness) confirmSectorProofsValid(rt *mock.Runtime, conf proveCommitConf, precommits ...*miner.SectorPreCommitInfo) {
 	// expect calls to get network stats
 	expectQueryNetworkInfo(rt, h)
 
@@ -1984,7 +1997,7 @@ func (h *actorHarness) confirmSectorProofsValid(rt *mock.Runtime, conf proveComm
 func (h *actorHarness) proveCommitSectorAndConfirm(rt *mock.Runtime, precommit *miner.SectorPreCommitInfo, precommitEpoch abi.ChainEpoch,
 	params *miner.ProveCommitSectorParams, conf proveCommitConf) *miner.SectorOnChainInfo {
 	h.proveCommitSector(rt, precommit, precommitEpoch, params)
-	h.confirmSectorProofsValid(rt, conf, precommitEpoch, precommit)
+	h.confirmSectorProofsValid(rt, conf, precommit)
 
 	newSector := h.getSector(rt, params.SectorNumber)
 	return newSector
@@ -2135,7 +2148,6 @@ func (h *actorHarness) submitWindowPoSt(rt *mock.Runtime, deadline *miner.Deadli
 			rt.ExpectSend(builtin.StoragePowerActorAddr, builtin.MethodsPower.UpdatePledgeTotal, &pledgeDelta,
 				abi.NewTokenAmount(0), nil, exitcode.Ok)
 		}
-		//skipped = *poStCfg.skipped
 	}
 
 	params := miner.SubmitWindowedPoStParams{
@@ -2148,34 +2160,7 @@ func (h *actorHarness) submitWindowPoSt(rt *mock.Runtime, deadline *miner.Deadli
 	rt.Verify()
 }
 
-func (h *actorHarness) computePartitions(rt *mock.Runtime, deadlines *miner.Deadlines, deadlineIdx uint64) ([]*miner.SectorOnChainInfo, []uint64) {
-	panic("todo")
-	// TODO minerstate
-	//st := getState(rt)
-	//firstPartIdx, sectorCount, err := miner.PartitionsForDeadline(deadlines, h.partitionSize, deadlineIdx)
-	//require.NoError(h.t, err)
-	//if sectorCount == 0 {
-	//	return nil, nil
-	//}
-	//partitionCount, _, err := miner.DeadlineCount(deadlines, h.partitionSize, deadlineIdx)
-	//require.NoError(h.t, err)
-	//
-	//partitions := make([]uint64, partitionCount)
-	//for i := uint64(0); i < partitionCount; i++ {
-	//	partitions[i] = firstPartIdx + i
-	//}
-	//
-	//partitionsSectors, err := miner.ComputePartitionsSectors(deadlines, h.partitionSize, deadlineIdx, partitions)
-	//require.NoError(h.t, err)
-	//provenSectors, err := bitfield.MultiMerge(partitionsSectors...)
-	//require.NoError(h.t, err)
-	//infos, _, err := st.LoadSectorInfosForProof(rt.AdtStore(), provenSectors)
-	//require.NoError(h.t, err)
-	//
-	//return infos, partitions
-}
-
-func (h *actorHarness) declareFaults(rt *mock.Runtime, fee abi.TokenAmount, faultSectorInfos ...*miner.SectorOnChainInfo) {
+func (h *actorHarness) declareFaults(rt *mock.Runtime, faultSectorInfos ...*miner.SectorOnChainInfo) {
 	rt.SetCaller(h.worker, builtin.AccountActorCodeID)
 	rt.ExpectValidateCallerAddr(h.worker)
 
@@ -2360,8 +2345,8 @@ func (h *actorHarness) reportConsensusFault(rt *mock.Runtime, from addr.Address,
 	}, nil)
 
 	// slash reward
-	reward := miner.RewardForConsensusSlashReport(1, rt.Balance())
-	rt.ExpectSend(from, builtin.MethodSend, nil, reward, nil, exitcode.Ok)
+	rwd := miner.RewardForConsensusSlashReport(1, rt.Balance())
+	rt.ExpectSend(from, builtin.MethodSend, nil, rwd, nil, exitcode.Ok)
 
 	// power termination
 	lockedFunds := getState(rt).LockedFunds
@@ -2410,12 +2395,12 @@ func (h *actorHarness) onDeadlineCron(rt *mock.Runtime, config *cronConfig) {
 	rt.ExpectValidateCallerAddr(builtin.StoragePowerActorAddr)
 
 	// Preamble
-	reward := reward.ThisEpochRewardReturn{
+	rwd := reward.ThisEpochRewardReturn{
 		ThisEpochReward:         h.epochReward,
 		ThisEpochBaselinePower:  h.baselinePower,
 		ThisEpochRewardSmoothed: h.epochRewardSmooth,
 	}
-	rt.ExpectSend(builtin.RewardActorAddr, builtin.MethodsReward.ThisEpochReward, nil, big.Zero(), &reward, exitcode.Ok)
+	rt.ExpectSend(builtin.RewardActorAddr, builtin.MethodsReward.ThisEpochReward, nil, big.Zero(), &rwd, exitcode.Ok)
 	networkPower := big.NewIntUnsigned(1 << 50)
 	rt.ExpectSend(builtin.StoragePowerActorAddr, builtin.MethodsPower.CurrentTotalPower, nil, big.Zero(),
 		&power.CurrentTotalPowerReturn{
@@ -2670,19 +2655,6 @@ func fixedHasher(target uint64) func([]byte) [32]byte {
 		copy(digest[:], buf.Bytes())
 		return digest
 	}
-}
-
-func loadParitionForSector(t *testing.T, st *miner.State, store adt.Store, sector *miner.SectorOnChainInfo) *miner.Partition {
-	deadlines, err := st.LoadDeadlines(store)
-	require.NoError(t, err)
-	dlIdx, pIdx, err := miner.FindSector(store, deadlines, sector.SectorNumber)
-	require.NoError(t, err)
-
-	deadline, err := deadlines.LoadDeadline(store, dlIdx)
-	require.NoError(t, err)
-	partition, err := deadline.LoadPartition(store, pIdx)
-	require.NoError(t, err)
-	return partition
 }
 
 func expectQueryNetworkInfo(rt *mock.Runtime, h *actorHarness) {

--- a/actors/builtin/miner/partition_state.go
+++ b/actors/builtin/miner/partition_state.go
@@ -314,47 +314,46 @@ func (p *Partition) recordEarlyTermination(store adt.Store, epoch abi.ChainEpoch
 // The sectors are removed from Faults and Recoveries.
 // The epoch of termination is recorded for future termination fee calculation.
 func (p *Partition) TerminateSectors(store adt.Store, epoch abi.ChainEpoch, sectors []*SectorOnChainInfo,
-	ssize abi.SectorSize, quant QuantSpec) (PowerPair, error) {
+	ssize abi.SectorSize, quant QuantSpec) (*ExpirationSet, error) {
 	expirations, err := LoadExpirationQueue(store, p.ExpirationsEpochs, quant)
 	if err != nil {
-		return NewPowerPairZero(), xerrors.Errorf("failed to load sector expirations: %w", err)
+		return nil, xerrors.Errorf("failed to load sector expirations: %w", err)
 	}
 	removed, removedRecovering, err := expirations.RemoveSectors(sectors, p.Faults, p.Recoveries, ssize)
 	if err != nil {
-		return NewPowerPairZero(), xerrors.Errorf("failed to remove sector expirations: %w", err)
+		return nil, xerrors.Errorf("failed to remove sector expirations: %w", err)
 	}
 	if p.ExpirationsEpochs, err = expirations.Root(); err != nil {
-		return NewPowerPairZero(), xerrors.Errorf("failed to save sector expirations: %w", err)
+		return nil, xerrors.Errorf("failed to save sector expirations: %w", err)
 	}
 
 	removedSectors, err := bitfield.MergeBitFields(removed.OnTimeSectors, removed.EarlySectors)
 	if err != nil {
-		return NewPowerPairZero(), err
+		return nil, err
 	}
 
 	// Record early termination.
 	err = p.recordEarlyTermination(store, epoch, removedSectors)
 	if err != nil {
-		return NewPowerPairZero(), xerrors.Errorf("failed to record early sector termination: %w", err)
+		return nil, xerrors.Errorf("failed to record early sector termination: %w", err)
 	}
 
 	// Update partition metadata.
 	if p.Faults, err = bitfield.SubtractBitField(p.Faults, removedSectors); err != nil {
-		return NewPowerPairZero(), xerrors.Errorf("failed to remove terminated sectors from faults: %w", err)
+		return nil, xerrors.Errorf("failed to remove terminated sectors from faults: %w", err)
 	}
 	if p.Recoveries, err = bitfield.SubtractBitField(p.Recoveries, removedSectors); err != nil {
-		return NewPowerPairZero(), xerrors.Errorf("failed to remove terminated sectors from recoveries: %w", err)
+		return nil, xerrors.Errorf("failed to remove terminated sectors from recoveries: %w", err)
 	}
 	if p.Terminated, err = bitfield.MergeBitFields(p.Terminated, removedSectors); err != nil {
-		return NewPowerPairZero(), xerrors.Errorf("failed to add terminated sectors: %w", err)
+		return nil, xerrors.Errorf("failed to add terminated sectors: %w", err)
 	}
 
-	powerRemoved := removed.ActivePower.Add(removed.FaultyPower)
-	p.LivePower = p.LivePower.Sub(powerRemoved)
+	p.LivePower = p.LivePower.Sub(removed.ActivePower).Sub(removed.FaultyPower)
 	p.FaultyPower = p.FaultyPower.Sub(removed.FaultyPower)
 	p.RecoveringPower = p.RecoveringPower.Sub(removedRecovering)
 
-	return powerRemoved, nil
+	return removed, nil
 }
 
 // PopExpiredSectors traverses the expiration queue up to and including some epoch, and marks all expiring

--- a/actors/builtin/miner/partition_state_test.go
+++ b/actors/builtin/miner/partition_state_test.go
@@ -263,11 +263,13 @@ func TestPartitions(t *testing.T) {
 		terminations := bf(1, 3, 5)
 		terminatedSectors := selectSectors(t, sectors, terminations)
 		terminationEpoch := abi.ChainEpoch(3)
-		powerDelta, err := partition.TerminateSectors(store, terminationEpoch, terminatedSectors, sectorSize, quantSpec)
+		removed, err := partition.TerminateSectors(store, terminationEpoch, terminatedSectors, sectorSize, quantSpec)
 		require.NoError(t, err)
 
-		expectedPowerDelta := miner.PowerForSectors(sectorSize, terminatedSectors)
-		assert.True(t, expectedPowerDelta.Equals(powerDelta))
+		expectedActivePower := miner.PowerForSectors(sectorSize, selectSectors(t, sectors, bf(1)))
+		assert.True(t, expectedActivePower.Equals(removed.ActivePower))
+		expectedFaultyPower := miner.PowerForSectors(sectorSize, selectSectors(t, sectors, bf(3, 5)))
+		assert.True(t, expectedFaultyPower.Equals(removed.FaultyPower))
 
 		// expect partition state to no longer reflect power and pledge from terminated sectors and terminations to contain new sectors
 		assertPartitionState(t, store, partition, quantSpec, sectorSize, sectors, bf(1, 2, 3, 4, 5, 6), bf(4, 6), bf(4), terminations)


### PR DESCRIPTION
The tests in #844 revealed that we're charging the ongoing fault fee for _all_ faulty power every deadline, rather than charging for the faulty power for that deadline. Moving the `FaultyPower` memo from miner to deadline state prompted me to check that we're maintaining it on each relevant operation, and realise that sector termination was ignoring the faulty state of some power, incorrectly subtracting it again.