### PR TITLE
Remove return value plumbing from runtime state transaction

### DIFF
--- a/actors/builtin/init/init_actor.go
+++ b/actors/builtin/init/init_actor.go
@@ -66,11 +66,12 @@ func (a Actor) Exec(rt runtime.Runtime, params *ExecParams) *ExecReturn {
 	// Allocate an ID for this actor.
 	// Store mapping of pubkey or actor address to actor ID
 	var st State
-	idAddr := rt.State().Transaction(&st, func() interface{} {
-		idAddr, err := st.MapAddressToNewID(adt.AsStore(rt), uniqueAddress)
+	var idAddr addr.Address
+	rt.State().Transaction(&st, func() {
+		var err error
+		idAddr, err = st.MapAddressToNewID(adt.AsStore(rt), uniqueAddress)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to allocate ID address")
-		return idAddr
-	}).(addr.Address)
+	})
 
 	// Create an empty actor.
 	rt.CreateActor(params.CodeCID, idAddr)

--- a/actors/builtin/market/market_actor.go
+++ b/actors/builtin/market/market_actor.go
@@ -81,7 +81,7 @@ func (a Actor) WithdrawBalance(rt Runtime, params *WithdrawBalanceParams) *adt.E
 
 	amountExtracted := abi.NewTokenAmount(0)
 	var st State
-	rt.State().Transaction(&st, func() interface{} {
+	rt.State().Transaction(&st, func() {
 		msm, err := st.mutator(adt.AsStore(rt)).withEscrowTable(WritePermission).
 			withLockedTable(WritePermission).build()
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load state")
@@ -99,7 +99,6 @@ func (a Actor) WithdrawBalance(rt Runtime, params *WithdrawBalanceParams) *adt.E
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to flush state")
 
 		amountExtracted = ex
-		return nil
 	})
 
 	_, code := rt.Send(recipient, builtin.MethodSend, nil, amountExtracted)
@@ -118,7 +117,7 @@ func (a Actor) AddBalance(rt Runtime, providerOrClientAddress *addr.Address) *ad
 	nominal, _, _ := escrowAddress(rt, *providerOrClientAddress)
 
 	var st State
-	rt.State().Transaction(&st, func() interface{} {
+	rt.State().Transaction(&st, func() {
 		msm, err := st.mutator(adt.AsStore(rt)).withEscrowTable(WritePermission).
 			withLockedTable(WritePermission).build()
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load state")
@@ -128,8 +127,6 @@ func (a Actor) AddBalance(rt Runtime, providerOrClientAddress *addr.Address) *ad
 
 		err = msm.commitState()
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to flush state")
-
-		return nil
 	})
 	return nil
 }
@@ -176,7 +173,7 @@ func (a Actor) PublishStorageDeals(rt Runtime, params *PublishStorageDealsParams
 
 	var newDealIds []abi.DealID
 	var st State
-	rt.State().Transaction(&st, func() interface{} {
+	rt.State().Transaction(&st, func() {
 		msm, err := st.mutator(adt.AsStore(rt)).withPendingProposals(WritePermission).
 			withDealProposals(WritePermission).withDealsByEpoch(WritePermission).withEscrowTable(WritePermission).
 			withLockedTable(WritePermission).build()
@@ -227,8 +224,6 @@ func (a Actor) PublishStorageDeals(rt Runtime, params *PublishStorageDealsParams
 
 		err = msm.commitState()
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to flush state")
-
-		return nil
 	})
 
 	for _, deal := range params.Deals {
@@ -302,7 +297,7 @@ func (a Actor) ActivateDeals(rt Runtime, params *ActivateDealsParams) *adt.Empty
 	store := adt.AsStore(rt)
 
 	// Update deal dealStates.
-	rt.State().Transaction(&st, func() interface{} {
+	rt.State().Transaction(&st, func() {
 		_, _, err := ValidateDealsForActivation(&st, store, params.DealIDs, minerAddr, params.SectorExpiry, currEpoch)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to validate dealProposals for activation")
 
@@ -342,7 +337,6 @@ func (a Actor) ActivateDeals(rt Runtime, params *ActivateDealsParams) *adt.Empty
 
 		err = msm.commitState()
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to flush state")
-		return nil
 	})
 
 	return nil
@@ -393,7 +387,7 @@ func (a Actor) OnMinerSectorsTerminate(rt Runtime, params *OnMinerSectorsTermina
 	minerAddr := rt.Message().Caller()
 
 	var st State
-	rt.State().Transaction(&st, func() interface{} {
+	rt.State().Transaction(&st, func() {
 		msm, err := st.mutator(adt.AsStore(rt)).withDealStates(WritePermission).
 			withDealProposals(ReadOnlyPermission).build()
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deal state")
@@ -435,8 +429,6 @@ func (a Actor) OnMinerSectorsTerminate(rt Runtime, params *OnMinerSectorsTermina
 
 		err = msm.commitState()
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to flush state")
-
-		return nil
 	})
 	return nil
 }
@@ -448,7 +440,7 @@ func (a Actor) CronTick(rt Runtime, _ *adt.EmptyValue) *adt.EmptyValue {
 	var timedOutVerifiedDeals []*DealProposal
 
 	var st State
-	rt.State().Transaction(&st, func() interface{} {
+	rt.State().Transaction(&st, func() {
 		updatesNeeded := make(map[abi.ChainEpoch][]abi.DealID)
 
 		msm, err := st.mutator(adt.AsStore(rt)).withDealStates(WritePermission).
@@ -544,8 +536,6 @@ func (a Actor) CronTick(rt Runtime, _ *adt.EmptyValue) *adt.EmptyValue {
 
 		err = msm.commitState()
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to flush state")
-
-		return nil
 	})
 
 	for _, d := range timedOutVerifiedDeals {

--- a/actors/builtin/market/market_test.go
+++ b/actors/builtin/market/market_test.go
@@ -2754,8 +2754,7 @@ func (h *marketActorTestHarness) publishAndActivateDeal(rt *mock.Runtime, client
 
 func (h *marketActorTestHarness) updateLastUpdated(rt *mock.Runtime, dealId abi.DealID, newLastUpdated abi.ChainEpoch) {
 	var st market.State
-
-	rt.Transaction(&st, func() interface{} {
+	rt.Transaction(&st, func() {
 		states, err := market.AsDealStateArray(adt.AsStore(rt), st.States)
 		require.NoError(h.t, err)
 		s, found, err := states.Get(dealId)
@@ -2766,20 +2765,18 @@ func (h *marketActorTestHarness) updateLastUpdated(rt *mock.Runtime, dealId abi.
 		require.NoError(h.t, states.Set(dealId, &market.DealState{s.SectorStartEpoch, newLastUpdated, s.SlashEpoch}))
 		st.States, err = states.Root()
 		require.NoError(h.t, err)
-		return nil
 	})
 }
 
 func (h *marketActorTestHarness) deleteDealProposal(rt *mock.Runtime, dealId abi.DealID) {
 	var st market.State
 
-	rt.Transaction(&st, func() interface{} {
+	rt.Transaction(&st, func() {
 		deals, err := market.AsDealProposalArray(adt.AsStore(rt), st.Proposals)
 		require.NoError(h.t, err)
 		require.NoError(h.t, deals.Delete(uint64(dealId)))
 		st.Proposals, err = deals.Root()
 		require.NoError(h.t, err)
-		return nil
 	})
 }
 

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -160,7 +160,7 @@ type ChangeWorkerAddressParams struct {
 func (a Actor) ChangeWorkerAddress(rt Runtime, params *ChangeWorkerAddressParams) *adt.EmptyValue {
 	var effectiveEpoch abi.ChainEpoch
 	var st State
-	rt.State().Transaction(&st, func() interface{} {
+	rt.State().Transaction(&st, func() {
 		info := getMinerInfo(rt, &st)
 
 		rt.ValidateImmediateCallerIs(info.Owner)
@@ -176,7 +176,6 @@ func (a Actor) ChangeWorkerAddress(rt Runtime, params *ChangeWorkerAddressParams
 		}
 		err := st.SaveInfo(adt.AsStore(rt), info)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "could not save miner info")
-		return nil
 	})
 
 	cronPayload := CronEventPayload{
@@ -194,14 +193,13 @@ func (a Actor) ChangePeerID(rt Runtime, params *ChangePeerIDParams) *adt.EmptyVa
 	// TODO: Consider limiting the maximum number of bytes used by the peer ID on-chain.
 	// https://github.com/filecoin-project/specs-actors/issues/712
 	var st State
-	rt.State().Transaction(&st, func() interface{} {
+	rt.State().Transaction(&st, func() {
 		info := getMinerInfo(rt, &st)
 
 		rt.ValidateImmediateCallerIs(info.Worker)
 		info.PeerId = params.NewID
 		err := st.SaveInfo(adt.AsStore(rt), info)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "could not save miner info")
-		return nil
 	})
 	return nil
 }
@@ -214,13 +212,12 @@ func (a Actor) ChangeMultiaddrs(rt Runtime, params *ChangeMultiaddrsParams) *adt
 	// TODO: Consider limiting the maximum number of bytes used by multiaddrs on-chain.
 	// https://github.com/filecoin-project/specs-actors/issues/712
 	var st State
-	rt.State().Transaction(&st, func() interface{} {
+	rt.State().Transaction(&st, func() {
 		info := getMinerInfo(rt, &st)
 		rt.ValidateImmediateCallerIs(info.Worker)
 		info.Multiaddrs = params.NewMultiaddrs
 		err := st.SaveInfo(adt.AsStore(rt), info)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "could not save miner info")
-		return nil
 	})
 	return nil
 }
@@ -267,7 +264,7 @@ func (a Actor) SubmitWindowedPoSt(rt Runtime, params *SubmitWindowedPoStParams) 
 	var postResult *PoStResult
 
 	var info *MinerInfo
-	rt.State().Transaction(&st, func() interface{} {
+	rt.State().Transaction(&st, func() {
 		info = getMinerInfo(rt, &st)
 		rt.ValidateImmediateCallerIs(info.Worker)
 
@@ -365,8 +362,6 @@ func (a Actor) SubmitWindowedPoSt(rt Runtime, params *SubmitWindowedPoStParams) 
 
 		err = st.SaveDeadlines(store, deadlines)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to save deadlines")
-
-		return nil
 	})
 
 	// Restore power for recovered sectors. Remove power for new faults.
@@ -432,7 +427,8 @@ func (a Actor) PreCommitSector(rt Runtime, params *SectorPreCommitInfo) *adt.Emp
 
 	store := adt.AsStore(rt)
 	var st State
-	newlyVestedAmount := rt.State().Transaction(&st, func() interface{} {
+	newlyVested := big.Zero()
+	rt.State().Transaction(&st, func() {
 		info := getMinerInfo(rt, &st)
 		rt.ValidateImmediateCallerIs(info.Worker)
 		if params.SealProof != info.SealProofType {
@@ -471,7 +467,7 @@ func (a Actor) PreCommitSector(rt Runtime, params *SectorPreCommitInfo) *adt.Emp
 			depositMinimum = replaceSector.InitialPledge
 		}
 
-		newlyVestedFund, err := st.UnlockVestedFunds(store, rt.CurrEpoch())
+		newlyVested, err = st.UnlockVestedFunds(store, rt.CurrEpoch())
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to vest funds")
 		availableBalance := st.GetAvailableBalance(rt.CurrentBalance())
 		duration := params.Expiration - rt.CurrEpoch()
@@ -497,11 +493,9 @@ func (a Actor) PreCommitSector(rt Runtime, params *SectorPreCommitInfo) *adt.Emp
 		}); err != nil {
 			rt.Abortf(exitcode.ErrIllegalState, "failed to write pre-committed sector %v: %v", params.SectorNumber, err)
 		}
+	})
 
-		return newlyVestedFund
-	}).(abi.TokenAmount)
-
-	notifyPledgeChanged(rt, newlyVestedAmount.Neg())
+	notifyPledgeChanged(rt, newlyVested.Neg())
 
 	bf := abi.NewBitField()
 	bf.Set(uint64(params.SectorNumber))
@@ -660,7 +654,8 @@ func (a Actor) ConfirmSectorProofsValid(rt Runtime, params *builtin.ConfirmSecto
 	totalPledge := big.Zero()
 	totalPrecommitDeposit := big.Zero()
 	newSectors := make([]*SectorOnChainInfo, 0)
-	newlyVestedAmount := rt.State().Transaction(&st, func() interface{} {
+	newlyVested := big.Zero()
+	rt.State().Transaction(&st, func() {
 		quant := st.QuantEndOfDeadline()
 		// Schedule expiration for replaced sectors to the end of their next deadline window.
 		// They can't be removed right now because we want to challenge them immediately before termination.
@@ -708,7 +703,7 @@ func (a Actor) ConfirmSectorProofsValid(rt Runtime, params *builtin.ConfirmSecto
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to assign new sectors to deadlines")
 
 		// Add sector and pledge lock-up to miner state
-		newlyVestedFund, err := st.UnlockVestedFunds(store, rt.CurrEpoch())
+		newlyVested, err = st.UnlockVestedFunds(store, rt.CurrEpoch())
 		if err != nil {
 			rt.Abortf(exitcode.ErrIllegalState, "failed to vest new funds: %s", err)
 		}
@@ -723,13 +718,11 @@ func (a Actor) ConfirmSectorProofsValid(rt Runtime, params *builtin.ConfirmSecto
 
 		st.AddInitialPledgeRequirement(totalPledge)
 		st.AssertBalanceInvariants(rt.CurrentBalance())
-
-		return newlyVestedFund
-	}).(abi.TokenAmount)
+	})
 
 	// Request power and pledge update for activated sector.
 	requestUpdatePower(rt, newPower)
-	notifyPledgeChanged(rt, big.Sub(totalPledge, newlyVestedAmount))
+	notifyPledgeChanged(rt, big.Sub(totalPledge, newlyVested))
 
 	return nil
 }
@@ -802,7 +795,7 @@ func (a Actor) ExtendSectorExpiration(rt Runtime, params *ExtendSectorExpiration
 	pledgeDelta := big.Zero()
 	store := adt.AsStore(rt)
 	var st State
-	rt.State().Transaction(&st, func() interface{} {
+	rt.State().Transaction(&st, func() {
 		info := getMinerInfo(rt, &st)
 		rt.ValidateImmediateCallerIs(info.Worker)
 
@@ -880,8 +873,6 @@ func (a Actor) ExtendSectorExpiration(rt Runtime, params *ExtendSectorExpiration
 
 		err = st.SaveDeadlines(store, deadlines)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to save deadlines")
-
-		return nil
 	})
 
 	requestUpdatePower(rt, powerDelta)
@@ -964,7 +955,7 @@ func (a Actor) TerminateSectors(rt Runtime, params *TerminateSectorsParams) *Ter
 	store := adt.AsStore(rt)
 	currEpoch := rt.CurrEpoch()
 	powerDelta := NewPowerPairZero()
-	rt.State().Transaction(&st, func() interface{} {
+	rt.State().Transaction(&st, func() {
 		hadEarlyTerminations = havePendingEarlyTerminations(rt, &st)
 
 		info := getMinerInfo(rt, &st)
@@ -1015,8 +1006,6 @@ func (a Actor) TerminateSectors(rt Runtime, params *TerminateSectorsParams) *Ter
 
 		err = st.SaveDeadlines(store, deadlines)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to save deadlines")
-
-		return nil
 	})
 
 	// Now, try to process these sectors.
@@ -1078,7 +1067,7 @@ func (a Actor) DeclareFaults(rt Runtime, params *DeclareFaultsParams) *adt.Empty
 	store := adt.AsStore(rt)
 	var st State
 	newFaultPowerTotal := NewPowerPairZero()
-	rt.State().Transaction(&st, func() interface{} {
+	rt.State().Transaction(&st, func() {
 		info := getMinerInfo(rt, &st)
 		rt.ValidateImmediateCallerIs(info.Worker)
 
@@ -1132,8 +1121,6 @@ func (a Actor) DeclareFaults(rt Runtime, params *DeclareFaultsParams) *adt.Empty
 
 		err = st.SaveDeadlines(store, deadlines)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to save deadlines")
-
-		return nil
 	})
 
 	// Remove power for new faulty sectors.
@@ -1185,7 +1172,7 @@ func (a Actor) DeclareFaultsRecovered(rt Runtime, params *DeclareFaultsRecovered
 
 	store := adt.AsStore(rt)
 	var st State
-	rt.State().Transaction(&st, func() interface{} {
+	rt.State().Transaction(&st, func() {
 		info := getMinerInfo(rt, &st)
 		rt.ValidateImmediateCallerIs(info.Worker)
 
@@ -1234,8 +1221,6 @@ func (a Actor) DeclareFaultsRecovered(rt Runtime, params *DeclareFaultsRecovered
 
 		err = st.SaveDeadlines(store, deadlines)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to save deadlines")
-
-		return nil
 	})
 
 	// Power is not restored yet, but when the recovered sectors are successfully PoSted.
@@ -1267,7 +1252,7 @@ func (a Actor) CompactPartitions(rt Runtime, params *CompactPartitionsParams) *a
 
 	store := adt.AsStore(rt)
 	var st State
-	rt.State().Transaction(&st, func() interface{} {
+	rt.State().Transaction(&st, func() {
 		info := getMinerInfo(rt, &st)
 		rt.ValidateImmediateCallerIs(info.Worker)
 
@@ -1304,8 +1289,6 @@ func (a Actor) CompactPartitions(rt Runtime, params *CompactPartitionsParams) *a
 		if !removedPower.Equals(newPower) {
 			rt.Abortf(exitcode.ErrIllegalState, "power changed when compacting partitions: was %v, is now %v", removedPower, newPower)
 		}
-
-		return nil
 	})
 	return nil
 }
@@ -1336,14 +1319,13 @@ func (a Actor) CompactSectorNumbers(rt Runtime, params *CompactSectorNumbersPara
 
 	store := adt.AsStore(rt)
 	var st State
-	rt.State().Transaction(&st, func() interface{} {
+	rt.State().Transaction(&st, func() {
 		info := getMinerInfo(rt, &st)
 		rt.ValidateImmediateCallerIs(info.Worker)
 
 		err := st.MaskSectorNumbers(store, params.MaskSectorNumbers)
 
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to mask sector numbers")
-		return nil
 	})
 	return nil
 }
@@ -1360,12 +1342,13 @@ func (a Actor) AddLockedFund(rt Runtime, amountToLock *abi.TokenAmount) *adt.Emp
 
 	store := adt.AsStore(rt)
 	var st State
-
-	newlyVested := rt.State().Transaction(&st, func() interface{} {
+	newlyVested := big.Zero()
+	rt.State().Transaction(&st, func() {
+		var err error
 		info := getMinerInfo(rt, &st)
 		rt.ValidateImmediateCallerIs(info.Worker, info.Owner, builtin.RewardActorAddr)
 
-		newlyVestedFund, err := st.UnlockVestedFunds(store, rt.CurrEpoch())
+		newlyVested, err = st.UnlockVestedFunds(store, rt.CurrEpoch())
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to vest funds")
 
 		// This may lock up unlocked balance that was covering InitialPledgeRequirements
@@ -1379,8 +1362,7 @@ func (a Actor) AddLockedFund(rt Runtime, amountToLock *abi.TokenAmount) *adt.Emp
 		if err := st.AddLockedFunds(store, rt.CurrEpoch(), *amountToLock, &RewardVestingSpec); err != nil {
 			rt.Abortf(exitcode.ErrIllegalState, "failed to lock funds in vesting table: %v", err)
 		}
-		return newlyVestedFund
-	}).(abi.TokenAmount)
+	})
 
 	notifyPledgeChanged(rt, big.Sub(*amountToLock, newlyVested))
 
@@ -1443,7 +1425,9 @@ func (a Actor) WithdrawBalance(rt Runtime, params *WithdrawBalanceParams) *adt.E
 		rt.Abortf(exitcode.ErrIllegalArgument, "negative fund requested for withdrawal: %s", params.AmountRequested)
 	}
 	var info *MinerInfo
-	newlyVestedAmount := rt.State().Transaction(&st, func() interface{} {
+	newlyVested := big.Zero()
+	rt.State().Transaction(&st, func() {
+		var err error
 		info = getMinerInfo(rt, &st)
 		rt.ValidateImmediateCallerIs(info.Owner)
 		// Ensure we don't have any pending terminations.
@@ -1457,16 +1441,14 @@ func (a Actor) WithdrawBalance(rt Runtime, params *WithdrawBalanceParams) *adt.E
 		}
 
 		// Unlock vested funds so we can spend them.
-		newlyVestedFund, err := st.UnlockVestedFunds(adt.AsStore(rt), rt.CurrEpoch())
+		newlyVested, err = st.UnlockVestedFunds(adt.AsStore(rt), rt.CurrEpoch())
 		if err != nil {
 			rt.Abortf(exitcode.ErrIllegalState, "failed to vest fund: %v", err)
 		}
 
 		// Verify InitialPledgeRequirement does not exceed unlocked funds
 		verifyPledgeMeetsInitialRequirements(rt, &st)
-
-		return newlyVestedFund
-	}).(abi.TokenAmount)
+	})
 
 	currBalance := rt.CurrentBalance()
 	amountWithdrawn := big.Min(st.GetAvailableBalance(currBalance), params.AmountRequested)
@@ -1476,7 +1458,7 @@ func (a Actor) WithdrawBalance(rt Runtime, params *WithdrawBalanceParams) *adt.E
 	_, code := rt.Send(info.Owner, builtin.MethodSend, nil, amountWithdrawn)
 	builtin.RequireSuccess(rt, code, "failed to withdraw balance")
 
-	pledgeDelta := newlyVestedAmount.Neg()
+	pledgeDelta := newlyVested.Neg()
 	notifyPledgeChanged(rt, pledgeDelta)
 
 	st.AssertBalanceInvariants(rt.CurrentBalance())
@@ -1529,7 +1511,7 @@ func processEarlyTerminations(rt Runtime) (more bool) {
 	)
 
 	var st State
-	rt.State().Transaction(&st, func() interface{} {
+	rt.State().Transaction(&st, func() {
 		var err error
 		result, more, err = st.PopEarlyTerminations(store, AddressedPartitionsMax, AddressedSectorsMax)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to pop early terminations")
@@ -1538,7 +1520,7 @@ func processEarlyTerminations(rt Runtime) (more bool) {
 		// This can happen if we end up processing early terminations
 		// before the cron callback fires.
 		if result.IsEmpty() {
-			return nil
+			return
 		}
 
 		info := getMinerInfo(rt, &st)
@@ -1577,8 +1559,6 @@ func processEarlyTerminations(rt Runtime) (more bool) {
 		// Remove pledge requirement.
 		st.AddInitialPledgeRequirement(totalInitialPledge.Neg())
 		pledgeDelta = big.Add(totalInitialPledge.Neg(), penaltyFromVesting.Neg())
-
-		return nil
 	})
 
 	// We didn't do anything, abort.
@@ -1616,8 +1596,7 @@ func handleProvingDeadline(rt Runtime) {
 	pledgeDelta := abi.NewTokenAmount(0)
 
 	var st State
-	rt.State().Transaction(&st, func() interface{} {
-
+	rt.State().Transaction(&st, func() {
 		var err error
 		{
 			// Vest locked funds.
@@ -1639,7 +1618,7 @@ func handleProvingDeadline(rt Runtime) {
 		// Use dlInfo.PeriodEnd() rather than rt.CurrEpoch unless certain of the desired semantics.
 		dlInfo := st.DeadlineInfo(currEpoch)
 		if !dlInfo.PeriodStarted() {
-			return nil // Skip checking faults on the first, incomplete period.
+			return // Skip checking faults on the first, incomplete period.
 		}
 		deadlines, err := st.LoadDeadlines(store)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deadlines")
@@ -1725,8 +1704,6 @@ func handleProvingDeadline(rt Runtime) {
 				st.ProvingPeriodStart = st.ProvingPeriodStart + WPoStProvingPeriod
 			}
 		}
-
-		return nil
 	})
 
 	// Remove power for new faults, and burn penalties.
@@ -1809,7 +1786,7 @@ func checkPrecommitExpiry(rt Runtime, sectors *abi.BitField) {
 
 	// initialize here to add together for all sectors and minimize calls across actors
 	depositToBurn := abi.NewTokenAmount(0)
-	rt.State().Transaction(&st, func() interface{} {
+	rt.State().Transaction(&st, func() {
 		var sectorNos []abi.SectorNumber
 		err := sectors.ForEach(func(i uint64) error {
 			sectorNo := abi.SectorNumber(i)
@@ -1839,7 +1816,6 @@ func checkPrecommitExpiry(rt Runtime, sectors *abi.BitField) {
 
 		st.PreCommitDeposits = big.Sub(st.PreCommitDeposits, depositToBurn)
 		Assert(st.PreCommitDeposits.GreaterThanEqual(big.Zero()))
-		return nil
 	})
 
 	// This deposit was locked separately to pledge collateral so there's no pledge change here.
@@ -2057,7 +2033,7 @@ func requestDealWeight(rt Runtime, dealIDs []abi.DealID, sectorStart, sectorExpi
 
 func commitWorkerKeyChange(rt Runtime) *adt.EmptyValue {
 	var st State
-	rt.State().Transaction(&st, func() interface{} {
+	rt.State().Transaction(&st, func() {
 		info := getMinerInfo(rt, &st)
 		if info.PendingWorkerKey == nil {
 			rt.Abortf(exitcode.ErrIllegalState, "No pending key change.")
@@ -2071,8 +2047,6 @@ func commitWorkerKeyChange(rt Runtime) *adt.EmptyValue {
 		info.PendingWorkerKey = nil
 		err := st.SaveInfo(adt.AsStore(rt), info)
 		builtin.RequireNoErr(rt, err, exitcode.ErrSerialization, "failed to save miner info")
-
-		return nil
 	})
 	return nil
 }

--- a/actors/builtin/paych/paych_actor.go
+++ b/actors/builtin/paych/paych_actor.go
@@ -197,7 +197,7 @@ func (pca Actor) UpdateChannelState(rt vmr.Runtime, params *UpdateChannelStatePa
 		builtin.RequireSuccess(rt, code, "spend voucher verification failed")
 	}
 
-	rt.State().Transaction(&st, func() interface{} {
+	rt.State().Transaction(&st, func() {
 		laneFound := true
 		// Find the voucher lane, create and insert it in sorted order if necessary.
 		laneIdx, ls := findLane(st.LaneStates, sv.Lane)
@@ -271,15 +271,13 @@ func (pca Actor) UpdateChannelState(rt vmr.Runtime, params *UpdateChannelStatePa
 				st.MinSettleHeight = sv.MinSettleHeight
 			}
 		}
-		return nil
 	})
 	return nil
 }
 
 func (pca Actor) Settle(rt vmr.Runtime, _ *adt.EmptyValue) *adt.EmptyValue {
 	var st State
-	rt.State().Transaction(&st, func() interface{} {
-
+	rt.State().Transaction(&st, func() {
 		rt.ValidateImmediateCallerIs(st.From, st.To)
 
 		if st.SettlingAt != 0 {
@@ -290,8 +288,6 @@ func (pca Actor) Settle(rt vmr.Runtime, _ *adt.EmptyValue) *adt.EmptyValue {
 		if st.SettlingAt < st.MinSettleHeight {
 			st.SettlingAt = st.MinSettleHeight
 		}
-
-		return nil
 	})
 	return nil
 }

--- a/actors/builtin/reward/reward_actor.go
+++ b/actors/builtin/reward/reward_actor.go
@@ -69,7 +69,7 @@ func (a Actor) AwardBlockReward(rt vmr.Runtime, params *AwardBlockRewardParams) 
 	penalty := abi.NewTokenAmount(0)
 	totalReward := big.Zero()
 	var st State
-	rt.State().Transaction(&st, func() interface{} {
+	rt.State().Transaction(&st, func() {
 		blockReward := big.Mul(st.ThisEpochReward, big.NewInt(params.WinCount))
 		blockReward = big.Div(blockReward, big.NewInt(builtin.ExpectedLeadersPerEpoch))
 		totalReward = big.Add(blockReward, params.GasReward)
@@ -82,7 +82,6 @@ func (a Actor) AwardBlockReward(rt vmr.Runtime, params *AwardBlockRewardParams) 
 			AssertMsg(blockReward.GreaterThanEqual(big.Zero()), "programming error, block reward is %v below zero", blockReward)
 		}
 		st.TotalMined = big.Add(st.TotalMined, blockReward)
-		return nil
 	})
 
 	// Cap the penalty at the total reward value.
@@ -137,7 +136,7 @@ func (a Actor) UpdateNetworkKPI(rt vmr.Runtime, currRealizedPower *abi.StoragePo
 	}
 
 	var st State
-	rt.State().Transaction(&st, func() interface{} {
+	rt.State().Transaction(&st, func() {
 		prev := st.Epoch
 		// if there were null runs catch up the computation until
 		// st.Epoch == rt.CurrEpoch()
@@ -149,7 +148,6 @@ func (a Actor) UpdateNetworkKPI(rt vmr.Runtime, currRealizedPower *abi.StoragePo
 		st.updateToNextEpochWithReward(*currRealizedPower)
 		// only update smoothed estimates after updating reward and epoch
 		st.updateSmoothedEstimates(st.Epoch - prev)
-		return nil
 	})
 	return nil
 }

--- a/actors/builtin/verifreg/verified_registry_actor.go
+++ b/actors/builtin/verifreg/verified_registry_actor.go
@@ -65,7 +65,7 @@ func (a Actor) AddVerifier(rt vmr.Runtime, params *AddVerifierParams) *adt.Empty
 	if params.Address == st.RootKey {
 		rt.Abortf(exitcode.ErrIllegalArgument, "Rootkey cannot be added as verifier")
 	}
-	rt.State().Transaction(&st, func() interface{} {
+	rt.State().Transaction(&st, func() {
 		verifiers, err := adt.AsMap(adt.AsStore(rt), st.Verifiers)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load verifiers")
 
@@ -84,8 +84,6 @@ func (a Actor) AddVerifier(rt vmr.Runtime, params *AddVerifierParams) *adt.Empty
 
 		st.Verifiers, err = verifiers.Root()
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to flush verifiers")
-
-		return nil
 	})
 
 	return nil
@@ -96,7 +94,7 @@ func (a Actor) RemoveVerifier(rt vmr.Runtime, verifierAddr *addr.Address) *adt.E
 	rt.State().Readonly(&st)
 	rt.ValidateImmediateCallerIs(st.RootKey)
 
-	rt.State().Transaction(&st, func() interface{} {
+	rt.State().Transaction(&st, func() {
 		verifiers, err := adt.AsMap(adt.AsStore(rt), st.Verifiers)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load verifiers")
 
@@ -105,7 +103,6 @@ func (a Actor) RemoveVerifier(rt vmr.Runtime, verifierAddr *addr.Address) *adt.E
 
 		st.Verifiers, err = verifiers.Root()
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to flush verifiers")
-		return nil
 	})
 
 	return nil
@@ -130,7 +127,7 @@ func (a Actor) AddVerifiedClient(rt vmr.Runtime, params *AddVerifiedClientParams
 		rt.Abortf(exitcode.ErrIllegalArgument, "Rootkey cannot be added as a verified client")
 	}
 
-	rt.State().Transaction(&st, func() interface{} {
+	rt.State().Transaction(&st, func() {
 		verifiers, err := adt.AsMap(adt.AsStore(rt), st.Verifiers)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load verifiers")
 
@@ -180,7 +177,6 @@ func (a Actor) AddVerifiedClient(rt vmr.Runtime, params *AddVerifiedClientParams
 
 		st.VerifiedClients, err = verifiedClients.Root()
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to flush verified clients")
-		return nil
 	})
 
 	return nil
@@ -202,7 +198,7 @@ func (a Actor) UseBytes(rt vmr.Runtime, params *UseBytesParams) *adt.EmptyValue 
 	}
 
 	var st State
-	rt.State().Transaction(&st, func() interface{} {
+	rt.State().Transaction(&st, func() {
 		verifiedClients, err := adt.AsMap(adt.AsStore(rt), st.VerifiedClients)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load verified clients")
 
@@ -231,8 +227,6 @@ func (a Actor) UseBytes(rt vmr.Runtime, params *UseBytesParams) *adt.EmptyValue 
 
 		st.VerifiedClients, err = verifiedClients.Root()
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to flush verified clients")
-
-		return nil
 	})
 
 	return nil
@@ -260,7 +254,7 @@ func (a Actor) RestoreBytes(rt vmr.Runtime, params *RestoreBytesParams) *adt.Emp
 		rt.Abortf(exitcode.ErrIllegalArgument, "Cannot restore allowance for Rootkey")
 	}
 
-	rt.State().Transaction(&st, func() interface{} {
+	rt.State().Transaction(&st, func() {
 		verifiedClients, err := adt.AsMap(adt.AsStore(rt), st.VerifiedClients)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load verified clients")
 
@@ -287,8 +281,6 @@ func (a Actor) RestoreBytes(rt vmr.Runtime, params *RestoreBytesParams) *adt.Emp
 
 		st.VerifiedClients, err = verifiedClients.Root()
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load verifiers")
-
-		return nil
 	})
 
 	return nil

--- a/actors/puppet/puppet.go
+++ b/actors/puppet/puppet.go
@@ -97,9 +97,8 @@ func (a Actor) RuntimeTransactionMarshalCBORFailure(rt runtime.Runtime, _ *adt.E
 
 	var st State
 
-	rt.State().Transaction(&st, func() interface{} {
+	rt.State().Transaction(&st, func() {
 		st.OptFailToMarshalCBOR = []*FailToMarshalCBOR{{}}
-		return nil
 	})
 
 	return nil

--- a/actors/runtime/runtime.go
+++ b/actors/runtime/runtime.go
@@ -200,7 +200,6 @@ type StateHandle interface {
 	// the execution from side effects (including message send).
 	//
 	// The second argument is a function which allows the caller to mutate the state.
-	// The return value from that function will be returned from the call to Transaction().
 	//
 	// If the state is modified after this function returns, execution will abort.
 	//
@@ -218,7 +217,7 @@ type StateHandle interface {
 	// })
 	// // state.ImLoaded = False // BAD!! state is readonly outside the lambda, it will panic
 	// ```
-	Transaction(obj CBORer, f func() interface{}) interface{}
+	Transaction(obj CBORer, f func())
 }
 
 // Result of checking two headers for a consensus fault.

--- a/support/mock/mockrt.go
+++ b/support/mock/mockrt.go
@@ -471,16 +471,15 @@ func (rt *Runtime) Readonly(st runtime.CBORUnmarshaler) {
 	}
 }
 
-func (rt *Runtime) Transaction(st runtime.CBORer, f func() interface{}) interface{} {
+func (rt *Runtime) Transaction(st runtime.CBORer, f func()) {
 	if rt.inTransaction {
 		rt.Abortf(exitcode.SysErrorIllegalActor, "nested transaction")
 	}
 	rt.Readonly(st)
 	rt.inTransaction = true
 	defer func() { rt.inTransaction = false }()
-	ret := f()
+	f()
 	rt.state = rt.Put(st)
-	return ret
 }
 
 ///// Syscalls implementation /////


### PR DESCRIPTION
This return value was a source of a couple of prior bugs, masked by Go's type checking semantics. I didn't find any more while making this change, so this is to prevent future ones.

Closes #616 

FYI @arajasek for integration, but I'll hold of landing this until after incentivized testnet starts.