### PR TITLE
Remove WalkSectors abstraction

### DIFF
--- a/actors/builtin/miner/deadline_state.go
+++ b/actors/builtin/miner/deadline_state.go
@@ -3,7 +3,6 @@ package miner
 import (
 	"bytes"
 	"errors"
-	"sort"
 
 	"github.com/filecoin-project/go-bitfield"
 	"github.com/ipfs/go-cid"
@@ -458,8 +457,9 @@ func (dl *Deadline) popExpiredPartitions(store adt.Store, until abi.ChainEpoch, 
 
 func (dl *Deadline) TerminateSectors(
 	store adt.Store,
+	sectors Sectors,
 	epoch abi.ChainEpoch,
-	partitionSectors map[uint64][]*SectorOnChainInfo,
+	partitionSectors PartitionSectorMap,
 	ssize abi.SectorSize,
 	quant QuantSpec,
 ) (powerLost PowerPair, err error) {
@@ -469,40 +469,40 @@ func (dl *Deadline) TerminateSectors(
 		return NewPowerPairZero(), err
 	}
 
-	partitionIdxs := make([]uint64, 0, len(partitionSectors))
-	for partIdx := range partitionSectors { //nolint:nomaprange
-		partitionIdxs = append(partitionIdxs, partIdx)
-	}
-	sort.Slice(partitionIdxs, func(i, j int) bool { return i < j })
-
 	powerLost = NewPowerPairZero()
-
 	var partition Partition
-	for _, partIdx := range partitionIdxs {
-		partSectors := partitionSectors[partIdx]
+	if err := partitionSectors.ForEach(func(partIdx uint64, sectorNos *abi.BitField) error {
 		if found, err := partitions.Get(partIdx, &partition); err != nil {
-			return NewPowerPairZero(), xerrors.Errorf("failed to load partition %d: %w", partIdx, err)
+			return xerrors.Errorf("failed to load partition %d: %w", partIdx, err)
 		} else if !found {
-			return NewPowerPairZero(), xerrors.Errorf("failed to find partition %d", partIdx)
+			return xerrors.Errorf("failed to find partition %d", partIdx)
 		}
-		removed, err := partition.TerminateSectors(store, epoch, partSectors, ssize, quant)
+
+		sectorInfos, err := sectors.Load(sectorNos)
 		if err != nil {
-			return NewPowerPairZero(), xerrors.Errorf("failed to terminate sectors in partition %d: %w", partIdx, err)
+			return xerrors.Errorf("failed to load sectors for termination for partition %d: %w", partIdx, err)
+		}
+		removed, err := partition.TerminateSectors(store, epoch, sectorInfos, ssize, quant)
+		if err != nil {
+			return xerrors.Errorf("failed to terminate sectors in partition %d: %w", partIdx, err)
 		}
 
 		err = partitions.Set(partIdx, &partition)
 		if err != nil {
-			return NewPowerPairZero(), xerrors.Errorf("failed to store updated partition %d: %w", partIdx, err)
+			return xerrors.Errorf("failed to store updated partition %d: %w", partIdx, err)
 		}
 
 		// Record that partition now has pending early terminations.
 		dl.EarlyTerminations.Set(partIdx)
 		// Record change to sectors and power
-		dl.LiveSectors -= uint64(len(partSectors))
+		dl.LiveSectors -= uint64(len(sectorInfos))
 		dl.FaultyPower = dl.FaultyPower.Sub(removed.FaultyPower)
 
 		// Aggregate power lost from active sectors
 		powerLost = powerLost.Add(removed.ActivePower)
+		return nil
+	}); err != nil {
+		return NewPowerPairZero(), err
 	}
 
 	// save partitions back
@@ -654,7 +654,7 @@ func (dl *Deadline) RemovePartitions(store adt.Store, toRemove *bitfield.BitFiel
 
 func (dl *Deadline) DeclareFaults(
 	store adt.Store, sectors Sectors, ssize abi.SectorSize, quant QuantSpec,
-	faultExpirationEpoch abi.ChainEpoch, partitionSectors map[uint64]*abi.BitField,
+	faultExpirationEpoch abi.ChainEpoch, partitionSectors PartitionSectorMap,
 ) (newFaultyPower PowerPair, err error) {
 	partitions, err := dl.PartitionsArray(store)
 	if err != nil {
@@ -664,66 +664,56 @@ func (dl *Deadline) DeclareFaults(
 	// Record partitions with some fault, for subsequently indexing in the deadline.
 	// Duplicate entries don't matter, they'll be stored in a bitfield (a set).
 	partitionsWithFault := make([]uint64, 0, len(partitionSectors))
-
-	partitionIdxs := make([]uint64, 0, len(partitionSectors))
-	for partIdx := range partitionSectors { //nolint:nomaprange
-		partitionIdxs = append(partitionIdxs, partIdx)
-	}
-	sort.Slice(partitionIdxs, func(i, j int) bool { return i < j })
-
 	newFaultyPower = NewPowerPairZero()
-
-	for _, partIdx := range partitionIdxs {
-		sectorNos := partitionSectors[partIdx]
-
+	if err := partitionSectors.ForEach(func(partIdx uint64, sectorNos *abi.BitField) error {
 		var partition Partition
 		found, err := partitions.Get(partIdx, &partition)
 		if err != nil {
-			return NewPowerPairZero(), xc.ErrIllegalState.Wrapf("failed to load partition %d: %w", partIdx, err)
+			return xc.ErrIllegalState.Wrapf("failed to load partition %d: %w", partIdx, err)
 		}
 		if !found {
-			return NewPowerPairZero(), xc.ErrNotFound.Wrapf("no such partition %d", partIdx)
+			return xc.ErrNotFound.Wrapf("no such partition %d", partIdx)
 		}
 
 		err = validateFRDeclarationPartition(&partition, sectorNos)
 		if err != nil {
-			return NewPowerPairZero(), exitcode.ErrIllegalArgument.Wrapf("failed fault declaration for %d: %w", partIdx, err)
+			return exitcode.ErrIllegalArgument.Wrapf("failed fault declaration for %d: %w", partIdx, err)
 		}
 
 		// Split declarations into declarations of new faults, and retraction of declared recoveries.
 		retractedRecoveries, err := bitfield.IntersectBitField(partition.Recoveries, sectorNos)
 		if err != nil {
-			return NewPowerPairZero(), xc.ErrIllegalState.Wrapf("failed to intersect sectors with recoveries: %w", err)
+			return xc.ErrIllegalState.Wrapf("failed to intersect sectors with recoveries: %w", err)
 		}
 
 		newFaults, err := bitfield.SubtractBitField(sectorNos, retractedRecoveries)
 		if err != nil {
-			return NewPowerPairZero(), xc.ErrIllegalState.Wrapf("failed to subtract recoveries from sectors: %w", err)
+			return xc.ErrIllegalState.Wrapf("failed to subtract recoveries from sectors: %w", err)
 		}
 		// Ignore any terminated sectors and previously declared or detected faults
 		newFaults, err = bitfield.SubtractBitField(newFaults, partition.Terminated)
 		if err != nil {
-			return NewPowerPairZero(), xc.ErrIllegalState.Wrapf("failed to subtract terminations from faults: %w", err)
+			return xc.ErrIllegalState.Wrapf("failed to subtract terminations from faults: %w", err)
 		}
 		newFaults, err = bitfield.SubtractBitField(newFaults, partition.Faults)
 		if err != nil {
-			return NewPowerPairZero(), xc.ErrIllegalState.Wrapf("failed to subtract existing faults from faults: %w", err)
+			return xc.ErrIllegalState.Wrapf("failed to subtract existing faults from faults: %w", err)
 		}
 
 		// Add new faults to state.
 		empty, err := newFaults.IsEmpty()
 		if err != nil {
-			return NewPowerPairZero(), xc.ErrIllegalState.Wrapf("failed to check if bitfield was empty: %w", err)
+			return xc.ErrIllegalState.Wrapf("failed to check if bitfield was empty: %w", err)
 		}
 		if !empty {
 			newFaultSectors, err := sectors.Load(newFaults)
 			if err != nil {
-				return NewPowerPairZero(), xc.ErrIllegalState.Wrapf("failed to load fault sectors: %w", err)
+				return xc.ErrIllegalState.Wrapf("failed to load fault sectors: %w", err)
 			}
 
 			newPartitionFaultyPower, err := partition.AddFaults(store, newFaults, newFaultSectors, faultExpirationEpoch, ssize, quant)
 			if err != nil {
-				return NewPowerPairZero(), xc.ErrIllegalState.Wrapf("failed to add faults: %w", err)
+				return xc.ErrIllegalState.Wrapf("failed to add faults: %w", err)
 			}
 
 			newFaultyPower = newFaultyPower.Add(newPartitionFaultyPower)
@@ -733,26 +723,31 @@ func (dl *Deadline) DeclareFaults(
 		// Remove faulty recoveries from state.
 		empty, err = retractedRecoveries.IsEmpty()
 		if err != nil {
-			return NewPowerPairZero(), xc.ErrIllegalState.Wrapf("failed to check if bitfield was empty: %w", err)
+			return xc.ErrIllegalState.Wrapf("failed to check if bitfield was empty: %w", err)
 		}
 		if !empty {
 			retractedRecoverySectors, err := sectors.Load(retractedRecoveries)
 			if err != nil {
-				return NewPowerPairZero(), xc.ErrIllegalState.Wrapf("failed to load recovery sectors: %w", err)
+				return xc.ErrIllegalState.Wrapf("failed to load recovery sectors: %w", err)
 			}
 			retractedRecoveryPower := PowerForSectors(ssize, retractedRecoverySectors)
 
 			err = partition.RemoveRecoveries(retractedRecoveries, retractedRecoveryPower)
 			if err != nil {
-				return NewPowerPairZero(), xc.ErrIllegalState.Wrapf("failed to remove recoveries: %w", err)
+				return xc.ErrIllegalState.Wrapf("failed to remove recoveries: %w", err)
 			}
 		}
 
 		err = partitions.Set(partIdx, &partition)
 		if err != nil {
-			return NewPowerPairZero(), xc.ErrIllegalState.Wrapf("failed to store partition %d: %w", partIdx, err)
+			return xc.ErrIllegalState.Wrapf("failed to store partition %d: %w", partIdx, err)
 		}
+
+		return nil
+	}); err != nil {
+		return NewPowerPairZero(), err
 	}
+
 	dl.Partitions, err = partitions.Root()
 	if err != nil {
 		return NewPowerPairZero(), xc.ErrIllegalState.Wrapf("failed to store partitions root: %w", err)
@@ -770,22 +765,14 @@ func (dl *Deadline) DeclareFaults(
 
 func (dl *Deadline) DeclareFaultsRecovered(
 	store adt.Store, sectors Sectors, ssize abi.SectorSize,
-	partitionSectors map[uint64]*abi.BitField,
+	partitionSectors PartitionSectorMap,
 ) (err error) {
 	partitions, err := dl.PartitionsArray(store)
 	if err != nil {
 		return err
 	}
 
-	partitionIdxs := make([]uint64, 0, len(partitionSectors))
-	for partIdx := range partitionSectors { //nolint:nomaprange
-		partitionIdxs = append(partitionIdxs, partIdx)
-	}
-	sort.Slice(partitionIdxs, func(i, j int) bool { return i < j })
-
-	for _, partIdx := range partitionIdxs {
-		sectorNos := partitionSectors[partIdx]
-
+	if err := partitionSectors.ForEach(func(partIdx uint64, sectorNos *abi.BitField) error {
 		var partition Partition
 		found, err := partitions.Get(partIdx, &partition)
 		if err != nil {
@@ -826,6 +813,9 @@ func (dl *Deadline) DeclareFaultsRecovered(
 		if err != nil {
 			return xc.ErrIllegalState.Wrapf("failed to update partition %d: %w", partIdx, err)
 		}
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	// Power is not regained until the deadline end, when the recovery is confirmed.

--- a/actors/builtin/miner/deadline_state_test.go
+++ b/actors/builtin/miner/deadline_state_test.go
@@ -77,9 +77,9 @@ func TestDeadlines(t *testing.T) {
 		addSectors(t, rt, dl)
 
 		store := adt.AsStore(rt)
-		removedPower, err := dl.TerminateSectors(store, 15, map[uint64][]*miner.SectorOnChainInfo{
-			0: selectSectors(t, sectors, bf(1, 3)),
-			1: selectSectors(t, sectors, bf(6)),
+		removedPower, err := dl.TerminateSectors(store, sectorsArr(t, rt, sectors), 15, miner.PartitionSectorMap{
+			0: bf(1, 3),
+			1: bf(6),
 		}, sectorSize, quantSpec)
 		require.NoError(t, err)
 
@@ -307,9 +307,10 @@ func TestDeadlines(t *testing.T) {
 		addThenMarkFaulty(t, rt, dl) // 1, 5, 6 faulty
 
 		store := adt.AsStore(rt)
-		removedPower, err := dl.TerminateSectors(store, 15, map[uint64][]*miner.SectorOnChainInfo{
-			0: selectSectors(t, sectors, bf(1, 3)),
-			1: selectSectors(t, sectors, bf(6)),
+		sectorArr := sectorsArr(t, rt, sectors)
+		removedPower, err := dl.TerminateSectors(store, sectorArr, 15, miner.PartitionSectorMap{
+			0: bf(1, 3),
+			1: bf(6),
 		}, sectorSize, quantSpec)
 		require.NoError(t, err)
 

--- a/actors/builtin/miner/deadline_state_test.go
+++ b/actors/builtin/miner/deadline_state_test.go
@@ -584,12 +584,6 @@ func TestDeadlines(t *testing.T) {
 	})
 }
 
-func sectorsArr(t *testing.T, rt *mock.Runtime, sectors []*miner.SectorOnChainInfo) miner.Sectors {
-	sectorArr := miner.Sectors{adt.MakeEmptyArray(adt.AsStore(rt))}
-	require.NoError(t, sectorArr.Store(sectors...))
-	return sectorArr
-}
-
 func emptyDeadline(t *testing.T, rt *mock.Runtime) *miner.Deadline {
 	store := adt.AsStore(rt)
 	root, err := adt.MakeEmptyArray(store).Root()

--- a/actors/builtin/miner/deadline_state_test.go
+++ b/actors/builtin/miner/deadline_state_test.go
@@ -582,6 +582,43 @@ func TestDeadlines(t *testing.T) {
 				bf(9),
 			).assert(t, rt, dl)
 	})
+
+	t.Run("reschedule expirations", func(t *testing.T) {
+		rt := builder.Build(t)
+		dl := emptyDeadline(t, rt)
+
+		store := adt.AsStore(rt)
+		sectorArr := sectorsArr(t, rt, sectors)
+
+		// Marks sectors 1 (partition 0), 5 & 6 (partition 1) as faulty.
+		addThenMarkFaulty(t, rt, dl)
+
+		// Try to reschedule two sectors, only the 7 (non faulty) should succeed.
+		err := dl.RescheduleSectorExpirations(store, sectorArr, sectorSize, quantSpec, 1, miner.PartitionSectorMap{
+			1: bf(6, 7, 99), // 99 should be skipped, it doesn't exist.
+			5: bf(100),      // partition 5 doesn't exist.
+			2: bf(),         // empty bitfield should be fine.
+		})
+		require.NoError(t, err)
+
+		exp, err := dl.PopExpiredSectors(store, 1, quantSpec)
+		require.NoError(t, err)
+
+		sector7 := selectSectors(t, sectors, bf(7))[0]
+
+		dlState.withFaults(1, 5, 6).
+			withTerminations(7).
+			withPartitions(
+				bf(1, 2, 3, 4),
+				bf(5, 6, 7, 8),
+				bf(9),
+			).assert(t, rt, dl)
+		assertBitfieldEmpty(t, exp.EarlySectors)
+		assertBitfieldEquals(t, exp.OnTimeSectors, 7)
+		assert.True(t, exp.ActivePower.Equals(miner.PowerForSector(sectorSize, sector7)))
+		assert.True(t, exp.FaultyPower.IsZero())
+		assert.True(t, exp.OnTimePledge.Equals(sector7.InitialPledge))
+	})
 }
 
 func emptyDeadline(t *testing.T, rt *mock.Runtime) *miner.Deadline {

--- a/actors/builtin/miner/deadline_state_test.go
+++ b/actors/builtin/miner/deadline_state_test.go
@@ -594,11 +594,11 @@ func TestDeadlines(t *testing.T) {
 		addThenMarkFaulty(t, rt, dl)
 
 		// Try to reschedule two sectors, only the 7 (non faulty) should succeed.
-		err := dl.RescheduleSectorExpirations(store, sectorArr, sectorSize, quantSpec, 1, miner.PartitionSectorMap{
+		err := dl.RescheduleSectorExpirations(store, sectorArr, 1, miner.PartitionSectorMap{
 			1: bf(6, 7, 99), // 99 should be skipped, it doesn't exist.
 			5: bf(100),      // partition 5 doesn't exist.
 			2: bf(),         // empty bitfield should be fine.
-		})
+		}, sectorSize, quantSpec)
 		require.NoError(t, err)
 
 		exp, err := dl.PopExpiredSectors(store, 1, quantSpec)

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -923,32 +923,15 @@ func (a Actor) TerminateSectors(rt Runtime, params *TerminateSectorsParams) *Ter
 	// Note: this cannot terminate pre-committed but un-proven sectors.
 	// They must be allowed to expire (and deposit burnt).
 
-	// Enforce partition/sector maximums.
-	// https://github.com/filecoin-project/specs-actors/issues/416
-	if uint64(len(params.Terminations)) > AddressedPartitionsMax {
-		rt.Abortf(exitcode.ErrIllegalArgument,
-			"too many partitions for declarations %d, max %d",
-			len(params.Terminations), AddressedPartitionsMax,
-		)
-	}
-	var sectorCount uint64
+	toProcess := make(DeadlineSectorMap)
 	for _, term := range params.Terminations {
-		if term.Deadline >= WPoStPeriodDeadlines {
-			rt.Abortf(exitcode.ErrIllegalArgument, "deadline %d not in range 0..%d", term.Deadline, WPoStPeriodDeadlines)
-		}
-		count, err := term.Sectors.Count()
+		err := toProcess.Add(term.Deadline, term.Partition, term.Sectors)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalArgument,
-			"failed to count sectors for deadline %d, partition %d",
-			term.Deadline, term.Partition,
-		)
-		sectorCount += count
-	}
-	if sectorCount > AddressedSectorsMax {
-		rt.Abortf(exitcode.ErrIllegalArgument,
-			"too many sectors for declaration %d, max %d",
-			sectorCount, AddressedSectorsMax,
+			"failed to process deadline %d, partition %d", term.Deadline, term.Partition,
 		)
 	}
+	err := toProcess.Check(AddressedPartitionsMax, AddressedSectorsMax)
+	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalArgument, "cannot process requested parameters")
 
 	var hadEarlyTerminations bool
 	var st State
@@ -965,35 +948,16 @@ func (a Actor) TerminateSectors(rt Runtime, params *TerminateSectorsParams) *Ter
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deadlines")
 		quant := st.QuantEndOfDeadline()
 
-		// Group declarations by deadline, and remember iteration order.
-		declsByDeadline := map[uint64][]*TerminationDeclaration{}
-		var deadlinesToLoad []uint64
-		for _, decl := range params.Terminations {
-			if _, ok := declsByDeadline[decl.Deadline]; !ok {
-				deadlinesToLoad = append(deadlinesToLoad, decl.Deadline)
-			}
-			declsByDeadline[decl.Deadline] = append(declsByDeadline[decl.Deadline], &decl)
-		}
-
 		// We're only reading the sectors, so there's no need to save this back.
 		// However, we still want to avoid re-loading this array per-partition.
 		sectors, err := LoadSectors(store, st.Sectors)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load sectors")
 
-		for _, dlIdx := range deadlinesToLoad {
-			decls := declsByDeadline[dlIdx]
-
+		err = toProcess.ForEach(func(dlIdx uint64, partitionSectors PartitionSectorMap) error {
 			deadline, err := deadlines.LoadDeadline(store, dlIdx)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deadline %d", dlIdx)
 
-			byPartition := make(map[uint64][]*SectorOnChainInfo, len(decls))
-			for _, decl := range decls {
-				sectors, err := sectors.Load(decl.Sectors)
-				builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deadline %d", dlIdx)
-				byPartition[decl.Partition] = append(byPartition[decl.Partition], sectors...)
-			}
-
-			removedPower, err := deadline.TerminateSectors(store, currEpoch, byPartition, info.SectorSize, quant)
+			removedPower, err := deadline.TerminateSectors(store, sectors, currEpoch, partitionSectors, info.SectorSize, quant)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to terminate sectors in deadline %d", dlIdx)
 
 			st.EarlyTerminations.Set(dlIdx)
@@ -1002,7 +966,10 @@ func (a Actor) TerminateSectors(rt Runtime, params *TerminateSectorsParams) *Ter
 
 			err = deadlines.UpdateDeadline(store, dlIdx, deadline)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to update deadline %d", dlIdx)
-		}
+
+			return nil
+		})
+		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to walk sectors")
 
 		err = st.SaveDeadlines(store, deadlines)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to save deadlines")
@@ -1042,27 +1009,15 @@ type FaultDeclaration struct {
 }
 
 func (a Actor) DeclareFaults(rt Runtime, params *DeclareFaultsParams) *adt.EmptyValue {
-	if uint64(len(params.Faults)) > AddressedPartitionsMax {
-		rt.Abortf(exitcode.ErrIllegalArgument, "too many declarations %d, max %d", len(params.Faults), AddressedPartitionsMax)
-	}
-	var sectorCount uint64
-	for _, decl := range params.Faults {
-		if decl.Deadline >= WPoStPeriodDeadlines {
-			rt.Abortf(exitcode.ErrIllegalArgument, "deadline %d not in range 0..%d", decl.Deadline, WPoStPeriodDeadlines)
-		}
-		count, err := decl.Sectors.Count()
+	toProcess := make(DeadlineSectorMap)
+	for _, term := range params.Faults {
+		err := toProcess.Add(term.Deadline, term.Partition, term.Sectors)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalArgument,
-			"failed to count sectors for deadline %d, partition %d",
-			decl.Deadline, decl.Partition,
-		)
-		sectorCount += count
-	}
-	if sectorCount > AddressedSectorsMax {
-		rt.Abortf(exitcode.ErrIllegalArgument,
-			"too many sectors for declaration %d, max %d",
-			sectorCount, AddressedSectorsMax,
+			"failed to process deadline %d, partition %d", term.Deadline, term.Partition,
 		)
 	}
+	err := toProcess.Check(AddressedPartitionsMax, AddressedSectorsMax)
+	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalArgument, "cannot process requested parameters")
 
 	store := adt.AsStore(rt)
 	var st State
@@ -1075,31 +1030,10 @@ func (a Actor) DeclareFaults(rt Runtime, params *DeclareFaultsParams) *adt.Empty
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deadlines")
 		quant := st.QuantEndOfDeadline()
 
-		// Convert declarations to sectors grouped by deadline, then partition.
-		//
-		// Deadlines are processed in declaration order, partitions are
-		// processed in order of ascending partition index.
-		partitionsByDeadline := make(map[uint64]map[uint64]*bitfield.BitField, len(params.Faults))
-		var deadlinesToLoad []uint64
-		for _, decl := range params.Faults {
-			forDl, ok := partitionsByDeadline[decl.Deadline]
-			if !ok {
-				forDl = make(map[uint64]*bitfield.BitField, 1)
-				partitionsByDeadline[decl.Deadline] = forDl
-				deadlinesToLoad = append(deadlinesToLoad, decl.Deadline)
-			}
-			sectors := decl.Sectors
-			if old, ok := forDl[decl.Partition]; ok {
-				sectors, err = bitfield.MergeBitFields(old, sectors)
-				builtin.RequireNoErr(rt, err, exitcode.ErrIllegalArgument, "failed to merge sector bitfields")
-			}
-			forDl[decl.Partition] = sectors
-		}
-
 		sectors, err := LoadSectors(store, st.Sectors)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load sectors array")
 
-		for _, dlIdx := range deadlinesToLoad {
+		err = toProcess.ForEach(func(dlIdx uint64, pm PartitionSectorMap) error {
 			targetDeadline, err := declarationDeadlineInfo(st.ProvingPeriodStart, dlIdx, rt.CurrEpoch())
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalArgument, "invalid fault declaration deadline %d", dlIdx)
 
@@ -1110,14 +1044,16 @@ func (a Actor) DeclareFaults(rt Runtime, params *DeclareFaultsParams) *adt.Empty
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deadline %d", dlIdx)
 
 			faultExpirationEpoch := targetDeadline.Last() + FaultMaxAge
-			newFaultyPower, err := deadline.DeclareFaults(store, sectors, info.SectorSize, quant, faultExpirationEpoch, partitionsByDeadline[dlIdx])
+			newFaultyPower, err := deadline.DeclareFaults(store, sectors, info.SectorSize, quant, faultExpirationEpoch, pm)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to declare faults for deadline %d", dlIdx)
 
 			err = deadlines.UpdateDeadline(store, dlIdx, deadline)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to store deadline %d partitions", dlIdx)
 
 			newFaultPowerTotal = newFaultPowerTotal.Add(newFaultyPower)
-		}
+			return nil
+		})
+		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to iterate deadlines")
 
 		err = st.SaveDeadlines(store, deadlines)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to save deadlines")
@@ -1147,28 +1083,15 @@ type RecoveryDeclaration struct {
 }
 
 func (a Actor) DeclareFaultsRecovered(rt Runtime, params *DeclareFaultsRecoveredParams) *adt.EmptyValue {
-	if uint64(len(params.Recoveries)) > AddressedPartitionsMax {
-		rt.Abortf(exitcode.ErrIllegalArgument, "too many declarations %d, max %d", len(params.Recoveries), AddressedPartitionsMax)
-	}
-
-	var sectorCount uint64
-	for _, decl := range params.Recoveries {
-		if decl.Deadline >= WPoStPeriodDeadlines {
-			rt.Abortf(exitcode.ErrIllegalArgument, "deadline %d not in range 0..%d", decl.Deadline, WPoStPeriodDeadlines)
-		}
-		count, err := decl.Sectors.Count()
+	toProcess := make(DeadlineSectorMap)
+	for _, term := range params.Recoveries {
+		err := toProcess.Add(term.Deadline, term.Partition, term.Sectors)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalArgument,
-			"failed to count sectors for deadline %d, partition %d",
-			decl.Deadline, decl.Partition,
-		)
-		sectorCount += count
-	}
-	if sectorCount > AddressedSectorsMax {
-		rt.Abortf(exitcode.ErrIllegalArgument,
-			"too many sectors for declaration %d, max %d",
-			sectorCount, AddressedSectorsMax,
+			"failed to process deadline %d, partition %d", term.Deadline, term.Partition,
 		)
 	}
+	err := toProcess.Check(AddressedPartitionsMax, AddressedSectorsMax)
+	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalArgument, "cannot process requested parameters")
 
 	store := adt.AsStore(rt)
 	var st State
@@ -1179,31 +1102,10 @@ func (a Actor) DeclareFaultsRecovered(rt Runtime, params *DeclareFaultsRecovered
 		deadlines, err := st.LoadDeadlines(adt.AsStore(rt))
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deadlines")
 
-		// Convert declarations to sectors grouped by deadline, then partition.
-		//
-		// Deadlines are processed in declaration order, partitions are
-		// processed in order of ascending partition index.
-		partitionsByDeadline := make(map[uint64]map[uint64]*bitfield.BitField, len(params.Recoveries))
-		var deadlinesToLoad []uint64
-		for _, decl := range params.Recoveries {
-			forDl, ok := partitionsByDeadline[decl.Deadline]
-			if !ok {
-				forDl = make(map[uint64]*bitfield.BitField, 1)
-				partitionsByDeadline[decl.Deadline] = forDl
-				deadlinesToLoad = append(deadlinesToLoad, decl.Deadline)
-			}
-			sectors := decl.Sectors
-			if old, ok := forDl[decl.Partition]; ok {
-				sectors, err = bitfield.MergeBitFields(old, sectors)
-				builtin.RequireNoErr(rt, err, exitcode.ErrIllegalArgument, "failed to merge sector bitfields")
-			}
-			forDl[decl.Partition] = sectors
-		}
-
 		sectors, err := LoadSectors(store, st.Sectors)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load sectors array")
 
-		for _, dlIdx := range deadlinesToLoad {
+		err = toProcess.ForEach(func(dlIdx uint64, pm PartitionSectorMap) error {
 			targetDeadline, err := declarationDeadlineInfo(st.ProvingPeriodStart, dlIdx, rt.CurrEpoch())
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalArgument, "invalid recovery declaration deadline %d", dlIdx)
 			err = validateFRDeclarationDeadline(targetDeadline)
@@ -1212,12 +1114,14 @@ func (a Actor) DeclareFaultsRecovered(rt Runtime, params *DeclareFaultsRecovered
 			deadline, err := deadlines.LoadDeadline(store, dlIdx)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deadline %d", dlIdx)
 
-			err = deadline.DeclareFaultsRecovered(store, sectors, info.SectorSize, partitionsByDeadline[dlIdx])
+			err = deadline.DeclareFaultsRecovered(store, sectors, info.SectorSize, pm)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to declare recoveries for deadline %d", dlIdx)
 
 			err = deadlines.UpdateDeadline(store, dlIdx, deadline)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to store deadline %d", dlIdx)
-		}
+			return nil
+		})
+		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to walk sectors")
 
 		err = st.SaveDeadlines(store, deadlines)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to save deadlines")

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -143,11 +143,6 @@ type SectorOnChainInfo struct {
 }
 
 // Location of a specific sector
-type SectorLocation struct {
-	Deadline, Partition uint64
-	SectorNumber        abi.SectorNumber
-}
-
 func ConstructState(infoCid cid.Cid, periodStart abi.ChainEpoch, emptyBitfieldCid, emptyArrayCid, emptyMapCid, emptyDeadlinesCid cid.Cid) (*State, error) {
 	return &State{
 		Info: infoCid,
@@ -418,190 +413,47 @@ func (st *State) FindSector(store adt.Store, sno abi.SectorNumber) (uint64, uint
 	return FindSector(store, deadlines, sno)
 }
 
-// Walks the given sectors, deadline by deadline, partition by partition,
-// skipping missing partitions/sectors.
-func (st *State) WalkSectors(
-	store adt.Store,
-	locations []SectorLocation,
-	beforeDeadlineCb func(dlIdx uint64, dl *Deadline) (update bool, err error),
-	partitionCb func(dl *Deadline, partition *Partition, dlIdx, partIdx uint64, sectors *bitfield.BitField) (update bool, err error),
-	afterDeadlineCb func(dlIdx uint64, dl *Deadline) (update bool, err error),
-) error {
-	deadlines, err := st.LoadDeadlines(store)
-	if err != nil {
-		return err
-	}
-
-	var toVisit [WPoStPeriodDeadlines]map[uint64][]uint64
-	for _, loc := range locations {
-		if loc.Deadline >= WPoStPeriodDeadlines {
-			return xc.ErrIllegalArgument.Wrapf("deadline %d out of range", loc.Deadline)
-		}
-		dl := toVisit[loc.Deadline]
-		if dl == nil {
-			dl = make(map[uint64][]uint64, 1)
-			toVisit[loc.Deadline] = dl
-		}
-		dl[loc.Partition] = append(dl[loc.Partition], uint64(loc.SectorNumber))
-	}
-
-	var deadlinesUpdated bool
-	for dlIdx, partitions := range toVisit {
-		if partitions == nil {
-			continue
-		}
-
-		var deadlineUpdated bool
-		dl, err := deadlines.LoadDeadline(store, uint64(dlIdx))
-		if err != nil {
-			return err
-		}
-
-		deadlineUpdated, err = beforeDeadlineCb(uint64(dlIdx), dl)
-		if err != nil {
-			return err
-		}
-
-		partitionsArr, err := dl.PartitionsArray(store)
-		if err != nil {
-			return err
-		}
-
-		partitionNumbers := make([]uint64, 0, len(partitions))
-		for partIdx := range partitions { // nolint:nomaprange // subsequently sorted
-			partitionNumbers = append(partitionNumbers, partIdx)
-		}
-		sort.Slice(partitionNumbers, func(i, j int) bool {
-			return partitionNumbers[i] < partitionNumbers[j]
-		})
-
-		for _, partIdx := range partitionNumbers {
-			var partition Partition
-			found, err := partitionsArr.Get(partIdx, &partition)
-			if err != nil {
-				return err
-			}
-			if !found {
-				continue
-			}
-
-			sectorNos := partitions[partIdx]
-			foundSectors, err := bitfield.IntersectBitField(bitfield.NewFromSet(sectorNos), partition.Sectors)
-			if err != nil {
-				return err
-			}
-
-			// Anything to update?
-			if empty, err := foundSectors.IsEmpty(); err != nil {
-				return err
-			} else if empty {
-				// no.
-				continue
-			}
-
-			if updated, err := partitionCb(dl, &partition, uint64(dlIdx), partIdx, foundSectors); err != nil {
-				return err
-			} else if updated {
-				err = partitionsArr.Set(partIdx, &partition)
-				if err != nil {
-					return err
-				}
-
-				deadlineUpdated = true
-			}
-		}
-		if deadlineUpdated {
-			dl.Partitions, err = partitionsArr.Root()
-			if err != nil {
-				return err
-			}
-		}
-		if updated, err := afterDeadlineCb(uint64(dlIdx), dl); err != nil {
-			return err
-		} else if updated || deadlineUpdated {
-			if err := deadlines.UpdateDeadline(store, uint64(dlIdx), dl); err != nil {
-				return err
-			}
-			deadlinesUpdated = true
-		}
-	}
-	if deadlinesUpdated {
-		if err := st.SaveDeadlines(store, deadlines); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // Schedule's each sector to expire at its next deadline end.
 //
 // If it can't find any given sector, it skips it.
 //
 // This method assumes that each sector's power has not changed, despite the rescheduling.
-func (st *State) RescheduleSectorExpirations(store adt.Store, currEpoch abi.ChainEpoch, sectors []SectorLocation,
-	ssize abi.SectorSize, quant QuantSpec) error {
-	var (
-		newEpoch              abi.ChainEpoch
-		rescheduledPartitions []uint64 // track partitions with moved expirations.
-	)
-	return st.WalkSectors(store, sectors,
-		// Prepare to process deadline.
-		func(dlIdx uint64, dl *Deadline) (bool, error) {
-			rescheduledPartitions = nil
+func (st *State) RescheduleSectorExpirations(
+	store adt.Store, currEpoch abi.ChainEpoch, ssize abi.SectorSize,
+	deadlineSectors DeadlineSectorMap,
+) error {
+	quant := st.QuantEndOfDeadline()
+	deadlines, err := st.LoadDeadlines(store)
+	if err != nil {
+		return err
+	}
+	sectors, err := LoadSectors(store, st.Sectors)
+	if err != nil {
+		return err
+	}
 
-			// Figure out the sector's next deadline end.
-			dlInfo := NewDeadlineInfo(st.ProvingPeriodStart, dlIdx, currEpoch).NextNotElapsed()
-			newEpoch = dlInfo.Last()
-			return false, nil
-		},
-		// Process partitions in deadline.
-		func(dl *Deadline, partition *Partition, dlIdx, partIdx uint64, sectors *bitfield.BitField) (bool, error) {
-			// Sectors are uniquified by being represented in a bitfield.
-			// This is an important property for the reschedule logic to be correct.
-			live, err := bitfield.SubtractBitField(sectors, partition.Terminated)
-			if err != nil {
-				return false, err
-			}
+	if err = deadlineSectors.ForEach(func(dlIdx uint64, pm PartitionSectorMap) error {
+		dlInfo := NewDeadlineInfo(st.ProvingPeriodStart, dlIdx, currEpoch).NextNotElapsed()
+		newExpiration := dlInfo.Last()
 
-			active, err := bitfield.SubtractBitField(live, partition.Faults)
-			if err != nil {
-				return false, err
-			}
+		dl, err := deadlines.LoadDeadline(store, dlIdx)
+		if err != nil {
+			return err
+		}
 
-			sectorInfos, err := st.LoadSectorInfos(store, active)
-			if err != nil {
-				return false, err
-			}
+		if err := dl.RescheduleSectorExpirations(store, sectors, ssize, quant, newExpiration, pm); err != nil {
+			return err
+		}
 
-			if len(sectorInfos) == 0 {
-				// Nothing to do
-				return false, nil
-			}
+		if err := deadlines.UpdateDeadline(store, dlIdx, dl); err != nil {
+			return err
+		}
 
-			// Note: The expiration stored in the sector info is not altered, but remains the initially-scheduled epoch.
-			err = partition.RescheduleExpirations(store, newEpoch, sectorInfos, ssize, quant)
-			if err != nil {
-				return false, err
-			}
-
-			// Make sure we update the deadline's queue as well.
-			rescheduledPartitions = append(rescheduledPartitions, partIdx)
-			return true, nil
-		},
-		// Update deadline.
-		func(dlIdx uint64, dl *Deadline) (bool, error) {
-			if len(rescheduledPartitions) == 0 {
-				return false, nil
-			}
-
-			// Record partitions that now expire at the new epoch.
-			// Don't _remove_ anything from this queue, that's not safe.
-			if err := dl.AddExpirationPartitions(store, newEpoch, rescheduledPartitions, quant); err != nil {
-				return false, xerrors.Errorf("failed to add partition expirations: %w", err)
-			}
-			return true, nil
-		},
-	)
+		return nil
+	}); err != nil {
+		return err
+	}
+	return st.SaveDeadlines(store, deadlines)
 }
 
 // Assign new sectors to deadlines.
@@ -611,12 +463,13 @@ func (st *State) AssignSectorsToDeadlines(
 	sectors []*SectorOnChainInfo,
 	partitionSize uint64,
 	sectorSize abi.SectorSize,
-	quant QuantSpec,
 ) (PowerPair, error) {
 	deadlines, err := st.LoadDeadlines(store)
 	if err != nil {
 		return NewPowerPairZero(), err
 	}
+
+	quant := st.QuantEndOfDeadline()
 
 	// Sort sectors by number to get better runs in partition bitfields.
 	sort.Slice(sectors, func(i, j int) bool {

--- a/actors/builtin/miner/partition_state_test.go
+++ b/actors/builtin/miner/partition_state_test.go
@@ -172,7 +172,7 @@ func TestPartitions(t *testing.T) {
 		require.NoError(t, err)
 
 		// reschedule
-		moved, err := partition.RescheduleExpirations(store, sectorsArr(t, rt, sectors), sectorSize, quantSpec, 18, bf(2, 4, 6))
+		moved, err := partition.RescheduleExpirations(store, sectorsArr(t, rt, sectors), 18, bf(2, 4, 6), sectorSize, quantSpec)
 		require.NoError(t, err)
 
 		// Make sure we moved the right ones.

--- a/actors/builtin/miner/partition_state_test.go
+++ b/actors/builtin/miner/partition_state_test.go
@@ -165,9 +165,11 @@ func TestPartitions(t *testing.T) {
 	t.Run("reschedules expirations", func(t *testing.T) {
 		rt, store, partition := setup(t)
 
-		sectorsToMove := selectSectors(t, sectors, bf(2, 4, 6))
-		err := partition.RescheduleExpirations(store, 18, sectorsToMove, sectorSize, quantSpec)
+		moved, err := partition.RescheduleExpirations(store, sectorsArr(t, rt, sectors), sectorSize, quantSpec, 18, bf(2, 4, 6))
 		require.NoError(t, err)
+
+		// Make sure we moved them.
+		assertBitfieldEquals(t, moved, 2, 4, 6)
 
 		// We need to change the actual sector infos so our queue validation works.
 		rescheduled := rescheduleSectors(t, 18, sectors, bf(2, 4, 6))

--- a/actors/builtin/miner/sector_map.go
+++ b/actors/builtin/miner/sector_map.go
@@ -1,0 +1,151 @@
+package miner
+
+import (
+	"math"
+	"sort"
+
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/go-bitfield"
+)
+
+// Maps deadlines to partition maps.
+type DeadlineSectorMap map[uint64]PartitionSectorMap
+
+// Maps partitions to sector bitfields.
+type PartitionSectorMap map[uint64]*bitfield.BitField
+
+// Check validates all bitfields and counts the number of partitions & sectors
+// contained within the map, and returns an error if they exceed the given
+// maximums.
+func (dm DeadlineSectorMap) Check(maxPartitions, maxSectors uint64) error {
+	partitionCount, sectorCount, err := dm.Count()
+	if err != nil {
+		return xerrors.Errorf("failed to count sectors: %w", err)
+	}
+	if partitionCount > maxPartitions {
+		return xerrors.Errorf("too many partitions %d, max %d", partitionCount, maxPartitions)
+	}
+
+	if sectorCount > maxSectors {
+		return xerrors.Errorf("too many sectors %d, max %d", sectorCount, maxSectors)
+	}
+
+	return nil
+}
+
+// Count counts the number of partitions & sectors within the map.
+func (dm DeadlineSectorMap) Count() (partitions, sectors uint64, err error) {
+	for dlIdx, pm := range dm { //nolint:nomaprange
+		partCount, sectorCount, err := pm.Count()
+		if err != nil {
+			return 0, 0, xerrors.Errorf("when counting deadline %d: %w", dlIdx, err)
+		}
+		if partCount > math.MaxUint64-partitions {
+			return 0, 0, xerrors.Errorf("uint64 overflow when counting partitions")
+		}
+
+		if sectorCount > math.MaxUint64-sectors {
+			return 0, 0, xerrors.Errorf("uint64 overflow when counting sectors")
+		}
+		sectors += sectorCount
+		partitions += partCount
+	}
+	return partitions, sectors, nil
+}
+
+// Add records the given sector bitfield at the given deadline/partition index.
+func (dm DeadlineSectorMap) Add(dlIdx, partIdx uint64, sectorNos *bitfield.BitField) error {
+	if dlIdx >= WPoStPeriodDeadlines {
+		return xerrors.Errorf("invalid deadline %d", dlIdx)
+	}
+	dl, ok := dm[dlIdx]
+	if !ok {
+		dl = make(PartitionSectorMap, 1)
+		dm[dlIdx] = dl
+	}
+	return dl.Add(partIdx, sectorNos)
+}
+
+// AddValues records the given sectors at the given deadline/partition index.
+func (dm DeadlineSectorMap) AddValues(dlIdx, partIdx uint64, sectorNos ...uint64) error {
+	return dm.Add(dlIdx, partIdx, bitfield.NewFromSet(sectorNos))
+}
+
+// Deadlines returns a sorted slice of deadlines in the map.
+func (dm DeadlineSectorMap) Deadlines() []uint64 {
+	deadlines := make([]uint64, 0, len(dm))
+	for dlIdx := range dm { //nolint:nomaprange
+		deadlines = append(deadlines, dlIdx)
+	}
+	sort.Slice(deadlines, func(i, j int) bool {
+		return i < j
+	})
+	return deadlines
+}
+
+// ForEach walks the deadlines in deadline order.
+func (dm DeadlineSectorMap) ForEach(cb func(dlIdx uint64, pm PartitionSectorMap) error) error {
+	for _, dlIdx := range dm.Deadlines() {
+		if err := cb(dlIdx, dm[dlIdx]); err != nil {
+			return xerrors.Errorf("while processing deadline %d: %w", dlIdx, err)
+		}
+	}
+	return nil
+}
+
+// AddValues records the given sectors at the given partition.
+func (pm PartitionSectorMap) AddValues(partIdx uint64, sectorNos ...uint64) error {
+	return pm.Add(partIdx, bitfield.NewFromSet(sectorNos))
+}
+
+// Add records the given sector bitfield at the given partition index, merging
+// it with any existing bitfields if necessary.
+func (pm PartitionSectorMap) Add(partIdx uint64, sectorNos *bitfield.BitField) error {
+	if oldSectorNos, ok := pm[partIdx]; ok {
+		var err error
+		sectorNos, err = bitfield.MergeBitFields(sectorNos, oldSectorNos)
+		if err != nil {
+			return xerrors.Errorf("failed to merge sector bitfields: %w", err)
+		}
+	}
+	pm[partIdx] = sectorNos
+	return nil
+}
+
+// Count counts the number of partitions & sectors within the map.
+func (pm PartitionSectorMap) Count() (partitions, sectors uint64, err error) {
+	for partIdx, bf := range pm { //nolint:nomaprange
+		count, err := bf.Count()
+		if err != nil {
+			return 0, 0, xerrors.Errorf("failed to parse bitmap for partition %d: %w", partIdx, err)
+		}
+		if count > math.MaxUint64-sectors {
+			return 0, 0, xerrors.Errorf("uint64 overflow when counting sectors")
+		}
+		sectors += count
+	}
+	return uint64(len(pm)), sectors, nil
+}
+
+// Partitions returns a sorted slice of partitions in the map.
+func (pm PartitionSectorMap) Partitions() []uint64 {
+	partitions := make([]uint64, 0, len(pm))
+	for partIdx := range pm { //nolint:nomaprange
+		partitions = append(partitions, partIdx)
+	}
+	sort.Slice(partitions, func(i, j int) bool {
+		return i < j
+	})
+	return partitions
+}
+
+// ForEach walks the partitions in the map, in order of increasing index.
+func (pm PartitionSectorMap) ForEach(cb func(partIdx uint64, sectorNos *bitfield.BitField) error) error {
+	for _, partIdx := range pm.Partitions() {
+		if err := cb(partIdx, pm[partIdx]); err != nil {
+			return xerrors.Errorf("while processing partition %d: %w", partIdx, err)
+		}
+	}
+	return nil
+}

--- a/actors/builtin/miner/sector_map.go
+++ b/actors/builtin/miner/sector_map.go
@@ -88,7 +88,7 @@ func (dm DeadlineSectorMap) Deadlines() []uint64 {
 func (dm DeadlineSectorMap) ForEach(cb func(dlIdx uint64, pm PartitionSectorMap) error) error {
 	for _, dlIdx := range dm.Deadlines() {
 		if err := cb(dlIdx, dm[dlIdx]); err != nil {
-			return xerrors.Errorf("while processing deadline %d: %w", dlIdx, err)
+			return err
 		}
 	}
 	return nil
@@ -144,7 +144,7 @@ func (pm PartitionSectorMap) Partitions() []uint64 {
 func (pm PartitionSectorMap) ForEach(cb func(partIdx uint64, sectorNos *bitfield.BitField) error) error {
 	for _, partIdx := range pm.Partitions() {
 		if err := cb(partIdx, pm[partIdx]); err != nil {
-			return xerrors.Errorf("while processing partition %d: %w", partIdx, err)
+			return err
 		}
 	}
 	return nil

--- a/actors/builtin/miner/sector_map_test.go
+++ b/actors/builtin/miner/sector_map_test.go
@@ -1,0 +1,61 @@
+package miner_test
+
+import (
+	"testing"
+
+	"github.com/filecoin-project/go-bitfield"
+	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeadlineSectorMap(t *testing.T) {
+	dm := make(miner.DeadlineSectorMap)
+	dlCount := uint64(10)
+	partCount := uint64(5)
+	for dlIdx := uint64(0); dlIdx < dlCount; dlIdx++ {
+		for partIdx := uint64(0); partIdx < partCount; partIdx++ {
+			assert.NoError(t, dm.Add(dlIdx, partIdx, bf(dlIdx*partCount+partIdx)))
+		}
+	}
+
+	dm.ForEach(func(dlIdx uint64, partitions miner.PartitionSectorMap) error {
+		assert.Equal(t, dm[dlIdx], partitions)
+		partitions.ForEach(func(partIdx uint64, sectorNos *bitfield.BitField) error {
+			assert.Equal(t, partitions[partIdx], sectorNos)
+			assertBitfieldEquals(t, sectorNos, dlIdx*partCount+partIdx)
+			return nil
+		})
+		return nil
+	})
+
+	// check all counts.
+	parts, sectors, err := dm.Count()
+	require.NoError(t, err)
+	assert.Equal(t, parts, partCount*dlCount)
+	assert.Equal(t, sectors, partCount*dlCount)
+	assert.Error(t, dm.Check(1, 1))
+	assert.Error(t, dm.Check(100, 1))
+	assert.Error(t, dm.Check(1, 100))
+	assert.NoError(t, dm.Check(partCount*dlCount, partCount*dlCount))
+
+	// Merge a sector in.
+	require.NoError(t, dm.Add(0, 0, bf(1000)))
+	assertBitfieldEquals(t, dm[0][0], 0, 1000)
+	assert.Error(t, dm.Check(partCount*dlCount, partCount*dlCount))
+	assert.NoError(t, dm.Check(partCount*dlCount, partCount*dlCount+1))
+}
+
+func TestDeadlineSectorMapValues(t *testing.T) {
+	dm := make(miner.DeadlineSectorMap)
+	assert.NoError(t, dm.AddValues(0, 1, 0, 1, 2, 3))
+
+	assertBitfieldEquals(t, dm[0][1], 0, 1, 2, 3)
+}
+
+func TestPartitionSectorMapValues(t *testing.T) {
+	pm := make(miner.PartitionSectorMap)
+	assert.NoError(t, pm.AddValues(0, 0, 1, 2, 3))
+
+	assertBitfieldEquals(t, pm[0], 0, 1, 2, 3)
+}

--- a/actors/builtin/miner/sector_map_test.go
+++ b/actors/builtin/miner/sector_map_test.go
@@ -111,3 +111,32 @@ func TestPartitionSectorMapOverflow(t *testing.T) {
 	_, _, err = pm.Count()
 	require.Error(t, err)
 }
+
+func TestDeadlineSectorMapEmpty(t *testing.T) {
+	var dm miner.DeadlineSectorMap
+	partitions, sectors, err := dm.Count()
+	require.NoError(t, err)
+	require.Zero(t, partitions)
+	require.Zero(t, sectors)
+
+	dm.ForEach(func(dlIdx uint64, pm miner.PartitionSectorMap) error {
+		require.Fail(t, "should not iterate over an empty map")
+		return nil
+	})
+	require.Empty(t, dm.Deadlines())
+}
+
+func TestPartitionSectorMapEmpty(t *testing.T) {
+	var pm miner.PartitionSectorMap
+
+	partitions, sectors, err := pm.Count()
+	require.NoError(t, err)
+	require.Zero(t, partitions)
+	require.Zero(t, sectors)
+
+	pm.ForEach(func(dlIdx uint64, sectorNos *bitfield.BitField) error {
+		require.Fail(t, "should not iterate over an empty map")
+		return nil
+	})
+	require.Empty(t, pm.Partitions())
+}

--- a/actors/builtin/miner/sector_map_test.go
+++ b/actors/builtin/miner/sector_map_test.go
@@ -1,6 +1,7 @@
 package miner_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/filecoin-project/go-bitfield"
@@ -19,15 +20,15 @@ func TestDeadlineSectorMap(t *testing.T) {
 		}
 	}
 
-	dm.ForEach(func(dlIdx uint64, partitions miner.PartitionSectorMap) error {
+	err := dm.ForEach(func(dlIdx uint64, partitions miner.PartitionSectorMap) error {
 		assert.Equal(t, dm[dlIdx], partitions)
-		partitions.ForEach(func(partIdx uint64, sectorNos *bitfield.BitField) error {
+		return partitions.ForEach(func(partIdx uint64, sectorNos *bitfield.BitField) error {
 			assert.Equal(t, partitions[partIdx], sectorNos)
 			assertBitfieldEquals(t, sectorNos, dlIdx*partCount+partIdx)
 			return nil
 		})
-		return nil
 	})
+	require.NoError(t, err)
 
 	// check all counts.
 	parts, sectors, err := dm.Count()
@@ -44,6 +45,26 @@ func TestDeadlineSectorMap(t *testing.T) {
 	assertBitfieldEquals(t, dm[0][0], 0, 1000)
 	assert.Error(t, dm.Check(partCount*dlCount, partCount*dlCount))
 	assert.NoError(t, dm.Check(partCount*dlCount, partCount*dlCount+1))
+}
+
+func TestDeadlineSectorMapError(t *testing.T) {
+	dm := make(miner.DeadlineSectorMap)
+	dlCount := uint64(10)
+	partCount := uint64(5)
+	for dlIdx := uint64(0); dlIdx < dlCount; dlIdx++ {
+		for partIdx := uint64(0); partIdx < partCount; partIdx++ {
+			assert.NoError(t, dm.Add(dlIdx, partIdx, bf(dlIdx*partCount+partIdx)))
+		}
+	}
+
+	expErr := errors.New("foobar")
+
+	err := dm.ForEach(func(dlIdx uint64, partitions miner.PartitionSectorMap) error {
+		return partitions.ForEach(func(partIdx uint64, sectorNos *bitfield.BitField) error {
+			return expErr
+		})
+	})
+	require.Equal(t, expErr, err)
 }
 
 func TestDeadlineSectorMapValues(t *testing.T) {

--- a/actors/builtin/miner/sector_map_test.go
+++ b/actors/builtin/miner/sector_map_test.go
@@ -119,10 +119,10 @@ func TestDeadlineSectorMapEmpty(t *testing.T) {
 	require.Zero(t, partitions)
 	require.Zero(t, sectors)
 
-	dm.ForEach(func(dlIdx uint64, pm miner.PartitionSectorMap) error {
+	require.NoError(t, dm.ForEach(func(dlIdx uint64, pm miner.PartitionSectorMap) error {
 		require.Fail(t, "should not iterate over an empty map")
 		return nil
-	})
+	}))
 	require.Empty(t, dm.Deadlines())
 }
 
@@ -134,9 +134,9 @@ func TestPartitionSectorMapEmpty(t *testing.T) {
 	require.Zero(t, partitions)
 	require.Zero(t, sectors)
 
-	pm.ForEach(func(dlIdx uint64, sectorNos *bitfield.BitField) error {
+	require.NoError(t, pm.ForEach(func(dlIdx uint64, sectorNos *bitfield.BitField) error {
 		require.Fail(t, "should not iterate over an empty map")
 		return nil
-	})
+	}))
 	require.Empty(t, pm.Partitions())
 }

--- a/actors/builtin/miner/sectors.go
+++ b/actors/builtin/miner/sectors.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/filecoin-project/specs-actors/actors/abi"
+	xc "github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
 	"golang.org/x/xerrors"
 
@@ -30,14 +31,17 @@ func (sa Sectors) Load(sectorNos *abi.BitField) ([]*SectorOnChainInfo, error) {
 		var sectorOnChain SectorOnChainInfo
 		found, err := sa.Array.Get(i, &sectorOnChain)
 		if err != nil {
-			return xerrors.Errorf("failed to load sector %v: %w", abi.SectorNumber(i), err)
+			return xc.ErrIllegalState.Wrapf("failed to load sector %v: %w", abi.SectorNumber(i), err)
 		} else if !found {
-			return xerrors.Errorf("can't find sector %d", i)
+			return xc.ErrNotFound.Wrapf("can't find sector %d", i)
 		}
 		sectorInfos = append(sectorInfos, &sectorOnChain)
 		return nil
 	}); err != nil {
-		return nil, err
+		// Keep the underlying error code, unless the error was from
+		// traversing the bitfield. In that case, it's an illegal
+		// argument error.
+		return nil, xc.Unwrap(err, xc.ErrIllegalArgument).Wrapf("failed to load sectors: %w", err)
 	}
 	return sectorInfos, nil
 }

--- a/actors/builtin/miner/sectors_test.go
+++ b/actors/builtin/miner/sectors_test.go
@@ -1,0 +1,16 @@
+package miner_test
+
+import (
+	"testing"
+
+	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
+	"github.com/filecoin-project/specs-actors/actors/util/adt"
+	"github.com/filecoin-project/specs-actors/support/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func sectorsArr(t *testing.T, rt *mock.Runtime, sectors []*miner.SectorOnChainInfo) miner.Sectors {
+	sectorArr := miner.Sectors{adt.MakeEmptyArray(adt.AsStore(rt))}
+	require.NoError(t, sectorArr.Store(sectors...))
+	return sectorArr
+}


### PR DESCRIPTION
This patch introduces a new abstraction for walking sectors, but this one is
much simpler and reusable.

This patch also splits up sector expiration rescheduling into a state and a
deadline function (and pushes the partition invariants down into the partition
itself).

fixes #686