### PR TITLE
recover skipped fault tests

### DIFF
--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -1221,7 +1221,7 @@ func TestProvingPeriodCron(t *testing.T) {
 		ongoingPenalty := miner.PledgePenaltyForDeclaredFault(actor.epochRewardSmooth, actor.epochQAPowerSmooth, pwr.QA)
 
 		actor.onDeadlineCron(rt, &cronConfig{
-			expectedEntrollment:      dlinfo.NextPeriodStart(),
+			expectedEnrollment:       dlinfo.NextPeriodStart(),
 			detectedFaultsPenalty:    undetectedPenalty,
 			detectedFaultsPowerDelta: &powerDeltaClaim,
 			ongoingFaultsPenalty:     ongoingPenalty,
@@ -1252,7 +1252,7 @@ func TestProvingPeriodCron(t *testing.T) {
 		ongoingPenalty = miner.PledgePenaltyForDeclaredFault(actor.epochRewardSmooth, actor.epochQAPowerSmooth, faultPwr.QA)
 
 		actor.onDeadlineCron(rt, &cronConfig{
-			expectedEntrollment:   dlinfo.Close,
+			expectedEnrollment:    dlinfo.Close,
 			detectedFaultsPenalty: retractedPenalty,
 			ongoingFaultsPenalty:  ongoingPenalty,
 		})
@@ -2066,7 +2066,7 @@ func (h *actorHarness) advancePastProvingPeriodWithCron(rt *mock.Runtime) {
 	rt.SetEpoch(deadline.PeriodEnd())
 	nextCron := deadline.NextPeriodStart() + miner.WPoStProvingPeriod - 1
 	h.onDeadlineCron(rt, &cronConfig{
-		expectedEntrollment: nextCron,
+		expectedEnrollment: nextCron,
 	})
 	rt.SetEpoch(deadline.NextPeriodStart())
 }
@@ -2354,7 +2354,7 @@ func (h *actorHarness) addLockedFunds(rt *mock.Runtime, amt abi.TokenAmount) {
 }
 
 type cronConfig struct {
-	expectedEntrollment       abi.ChainEpoch
+	expectedEnrollment        abi.ChainEpoch
 	vestingPledgeDelta        abi.TokenAmount // nolint:structcheck,unused
 	detectedFaultsPowerDelta  *miner.PowerPair
 	detectedFaultsPenalty     abi.TokenAmount
@@ -2421,7 +2421,7 @@ func (h *actorHarness) onDeadlineCron(rt *mock.Runtime, config *cronConfig) {
 
 	// Re-enrollment for next period.
 	rt.ExpectSend(builtin.StoragePowerActorAddr, builtin.MethodsPower.EnrollCronEvent,
-		makeDeadlineCronEventParams(h.t, config.expectedEntrollment), big.Zero(), nil, exitcode.Ok)
+		makeDeadlineCronEventParams(h.t, config.expectedEnrollment), big.Zero(), nil, exitcode.Ok)
 
 	rt.SetCaller(builtin.StoragePowerActorAddr, builtin.StoragePowerActorCodeID)
 	rt.Call(h.a.OnDeferredCronEvent, &miner.CronEventPayload{
@@ -2477,7 +2477,7 @@ func (h *actorHarness) makePreCommit(sectorNo abi.SectorNumber, challenge, expir
 func completeProvingPeriod(rt *mock.Runtime, h *actorHarness, config *cronConfig) {
 	deadline := h.deadline(rt)
 	rt.SetEpoch(deadline.PeriodEnd())
-	config.expectedEntrollment = deadline.NextPeriodStart() + miner.WPoStProvingPeriod - 1
+	config.expectedEnrollment = deadline.NextPeriodStart() + miner.WPoStProvingPeriod - 1
 	h.onDeadlineCron(rt, config)
 	rt.SetEpoch(deadline.NextPeriodStart())
 }
@@ -2487,7 +2487,7 @@ func completeProvingPeriod(rt *mock.Runtime, h *actorHarness, config *cronConfig
 func advanceDeadline(rt *mock.Runtime, h *actorHarness, config *cronConfig) *miner.DeadlineInfo {
 	deadline := h.deadline(rt)
 	rt.SetEpoch(deadline.Last())
-	config.expectedEntrollment = deadline.Last() + miner.WPoStChallengeWindow
+	config.expectedEnrollment = deadline.Last() + miner.WPoStChallengeWindow
 	h.onDeadlineCron(rt, config)
 	rt.SetEpoch(deadline.NextOpen())
 	return h.deadline(rt)

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -1086,47 +1086,6 @@ func TestWindowPost(t *testing.T) {
 			actor.submitWindowPoSt(rt, dlinfo, partitions, infos, cfg)
 		})
 	})
-
-	// TODO minerstate
-	//t.Run("detects faults from previous missed posts", func(t *testing.T) {
-	//	rt := builder.Build(t)
-	//
-	//	// skip two PoSts
-	//	_, infos1, _ := runTillFirstDeadline(rt)
-	//	_, infos2, _ := runTillNextDeadline(rt)
-	//	deadline, infos3, partitions := runTillNextDeadline(rt)
-	//
-	//	// assert we have sectors in each deadline
-	//	assert.Greater(t, len(infos1), 0)
-	//	assert.Greater(t, len(infos2), 0)
-	//	assert.Greater(t, len(infos3), 0)
-	//
-	//	// expect power to be deducted for all sectors in first two deadlines
-	//	pwr := miner.PowerForSectors(actor.sectorSize, append(infos1, infos2...))
-	//
-	//	// expected penalty is the late undeclared fault penalty for all faulted sectors including retracted recoveries..
-	//	expectedPenalty := miner.PledgePenaltyForLateUndeclaredFault(actor.epochReward, actor.networkQAPower, pwr.QA)
-	//
-	//	cfg := &poStConfig{
-	//		skipped:               abi.NewBitField(),
-	//		expectedRawPowerDelta: pwr.Raw.Neg(),
-	//		expectedQAPowerDelta:  pwr.QA.Neg(),
-	//		expectedPenalty:       expectedPenalty,
-	//	}
-	//
-	//	actor.submitWindowPoSt(rt, deadline, partitions, infos3, cfg)
-	//
-	//	// same size and every info is set in bitset implies info1+info2 and st.Faults represent the same sectors
-	//	st := getState(rt)
-	//	faultCount, err := st.Faults.Count()
-	//	require.NoError(t, err)
-	//	assert.Equal(t, uint64(len(infos1)+len(infos2)), faultCount)
-	//	for _, info := range append(infos1, infos2...) {
-	//		set, err := st.Faults.IsSet(uint64(info.SectorNumber))
-	//		require.NoError(t, err)
-	//		assert.True(t, set)
-	//	}
-	//})
 }
 
 func TestProveCommit(t *testing.T) {

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -1184,8 +1184,11 @@ func TestProvingPeriodCron(t *testing.T) {
 		st = getState(rt)
 		assert.Equal(t, periodOffset, st.ProvingPeriodStart)
 
-		// next cron moves proving period forward
-		advanceDeadline(rt, actor, &cronConfig{})
+		// next cron moves proving period forward and enrolls for next cron
+		rt.SetEpoch(dlinfo.Last())
+		actor.onDeadlineCron(rt, &cronConfig{
+			expectedEnrollment: rt.Epoch() + miner.WPoStChallengeWindow,
+		})
 		st = getState(rt)
 		assert.Equal(t, periodOffset+miner.WPoStProvingPeriod, st.ProvingPeriodStart)
 	})


### PR DESCRIPTION
work towards #829

### Motivation

We had skipped many miner tests to simplify the miner state refactor. This PR brings some of them back

### Proposed Changes

1. Modify to `actorHarness.submitPoSt` so that it chooses sectors for validation from sectors that are not skipped and not previously faulty.
2. Restore "skipped faults are penalized and adjust power adjusted"
3. Restore "skipped all sectors in a deadline may be skipped"
4. Restore "skipped recoveries are penalized and do not recover power"
5. Restore "skipping a fault from the wrong partition is an error"
6. Delete "detects faults from previous missed posts" from `TestSubmitPoSt` because that behavior now occurs in cron.