### PR TITLE
Enforce termination logic invariants in Partition object

### DIFF
--- a/actors/builtin/miner/expiration_queue.go
+++ b/actors/builtin/miner/expiration_queue.go
@@ -105,6 +105,21 @@ func (es *ExpirationSet) IsEmpty() (empty bool, err error) {
 	}
 }
 
+// Counts all sectors in the expiration set.
+func (es *ExpirationSet) Count() (count uint64, err error) {
+	onTime, err := es.OnTimeSectors.Count()
+	if err != nil {
+		return 0, err
+	}
+
+	early, err := es.EarlySectors.Count()
+	if err != nil {
+		return 0, err
+	}
+
+	return onTime + early, nil
+}
+
 // A queue of expiration sets by epoch, representing the on-time or early termination epoch for a collection of sectors.
 // Wraps an AMT[ChainEpoch]*ExpirationSet.
 // Keys in the queue are quantized (upwards), modulo some offset, to reduce the cardinality of keys.

--- a/actors/builtin/miner/expiration_queue_test.go
+++ b/actors/builtin/miner/expiration_queue_test.go
@@ -37,6 +37,10 @@ func TestExpirationSet(t *testing.T) {
 		assert.Equal(t, onTimePledge, set.OnTimePledge)
 		assert.True(t, activePower.Equals(set.ActivePower))
 		assert.True(t, faultyPower.Equals(set.FaultyPower))
+
+		count, err := set.Count()
+		require.NoError(t, err)
+		assert.EqualValues(t, 5, count)
 	})
 
 	t.Run("adds sectors and power to non-empty set", func(t *testing.T) {
@@ -156,6 +160,10 @@ func TestExpirationSet(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, empty)
 
+		count, err := set.Count()
+		require.NoError(t, err)
+		assert.Zero(t, count)
+
 		err = set.Add(onTimeSectors, earlySectors, onTimePledge, activePower, faultyPower)
 		require.NoError(t, err)
 
@@ -169,6 +177,10 @@ func TestExpirationSet(t *testing.T) {
 		empty, err = set.IsEmpty()
 		require.NoError(t, err)
 		assert.True(t, empty)
+
+		count, err = set.Count()
+		require.NoError(t, err)
+		assert.Zero(t, count)
 	})
 }
 

--- a/actors/builtin/miner/partition_state_test.go
+++ b/actors/builtin/miner/partition_state_test.go
@@ -254,6 +254,7 @@ func TestPartitions(t *testing.T) {
 
 	t.Run("terminate sectors", func(t *testing.T) {
 		rt, store, partition := setup(t)
+		sectorArr := sectorsArr(t, rt, sectors)
 
 		// fault sector 3, 4, 5 and 6
 		faultSet := bf(3, 4, 5, 6)
@@ -270,9 +271,8 @@ func TestPartitions(t *testing.T) {
 
 		// now terminate 1, 3 and 5
 		terminations := bf(1, 3, 5)
-		terminatedSectors := selectSectors(t, sectors, terminations)
 		terminationEpoch := abi.ChainEpoch(3)
-		removed, err := partition.TerminateSectors(store, terminationEpoch, terminatedSectors, sectorSize, quantSpec)
+		removed, err := partition.TerminateSectors(store, sectorArr, terminationEpoch, terminations, sectorSize, quantSpec)
 		require.NoError(t, err)
 
 		expectedActivePower := miner.PowerForSectors(sectorSize, selectSectors(t, sectors, bf(1)))
@@ -390,7 +390,8 @@ func TestPartitions(t *testing.T) {
 	})
 
 	t.Run("pops early terminations", func(t *testing.T) {
-		_, store, partition := setup(t)
+		rt, store, partition := setup(t)
+		sectorArr := sectorsArr(t, rt, sectors)
 
 		// fault sector 3, 4, 5 and 6
 		faultSet := bf(3, 4, 5, 6)
@@ -407,9 +408,8 @@ func TestPartitions(t *testing.T) {
 
 		// now terminate 1, 3 and 5
 		terminations := bf(1, 3, 5)
-		terminatedSectors := selectSectors(t, sectors, terminations)
 		terminationEpoch := abi.ChainEpoch(3)
-		_, err = partition.TerminateSectors(store, terminationEpoch, terminatedSectors, sectorSize, quantSpec)
+		_, err = partition.TerminateSectors(store, sectorArr, terminationEpoch, terminations, sectorSize, quantSpec)
 		require.NoError(t, err)
 
 		// pop first termination


### PR DESCRIPTION
This PR validates that terminated sectors belong to the appropriate partition. This is already technically validated by the expiration queue, but I'd prefer to make it implicit.