### PR TITLE
Move fault handling logic into partition methods

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -9,6 +9,7 @@ import (
 	"github.com/filecoin-project/go-bitfield"
 	cid "github.com/ipfs/go-cid"
 	cbg "github.com/whyrusleeping/cbor-gen"
+	"golang.org/x/xerrors"
 
 	abi "github.com/filecoin-project/specs-actors/actors/abi"
 	big "github.com/filecoin-project/specs-actors/actors/abi/big"
@@ -2112,15 +2113,15 @@ func validateFRDeclarationDeadline(deadline *DeadlineInfo) error {
 	return nil
 }
 
-// Validates that a fault or recovery declaration for a partition is valid.
-func validateFRDeclarationPartition(partition *Partition, sectors *abi.BitField) error {
+// Validates that a partition contains the given sectors.
+func validatePartitionContainsSectors(partition *Partition, sectors *abi.BitField) error {
 	// Check that the declared sectors are actually assigned to the partition.
 	contains, err := abi.BitFieldContainsAll(partition.Sectors, sectors)
 	if err != nil {
-		return fmt.Errorf("failed to check sectors: %w", err)
+		return xerrors.Errorf("failed to check sectors: %w", err)
 	}
 	if !contains {
-		return fmt.Errorf("sectors not all due")
+		return xerrors.Errorf("not all sectors are assigned to the partition")
 	}
 	return nil
 }

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -533,9 +533,12 @@ func TestCommitments(t *testing.T) {
 			found, err := partitions.Get(partIdx, &partition)
 			require.True(t, found)
 			require.NoError(t, err)
-			_, err = partition.AddFaults(rt.AdtStore(), bf(uint64(oldSectors[0].SectorNumber)), oldSectors[0:1], 100000,
+			sectorArr, err := miner.LoadSectors(rt.AdtStore(), st.Sectors)
+			require.NoError(t, err)
+			newFaults, _, err := partition.DeclareFaults(rt.AdtStore(), sectorArr, bf(uint64(oldSectors[0].SectorNumber)), 100000,
 				actor.sectorSize, st.QuantEndOfDeadline())
 			require.NoError(t, err)
+			assertBitfieldEquals(t, newFaults, uint64(oldSectors[0].SectorNumber))
 			require.NoError(t, partitions.Set(partIdx, &partition))
 			deadline.Partitions, err = partitions.Root()
 			require.NoError(t, err)

--- a/actors/builtin/miner/partition_state.go
+++ b/actors/builtin/miner/partition_state.go
@@ -107,6 +107,12 @@ func (p *Partition) AddSectors(store adt.Store, sectors []*SectorOnChainInfo, ss
 		return NewPowerPairZero(), xerrors.Errorf("failed to store sector expirations: %w", err)
 	}
 
+	if contains, err := abi.BitFieldContainsAny(p.Sectors, snos); err != nil {
+		return NewPowerPairZero(), xerrors.Errorf("failed to check if any new sector was already in the partition: %w", err)
+	} else if contains {
+		return NewPowerPairZero(), xerrors.Errorf("not all added sectors are new")
+	}
+
 	// Update other metadata using the calculated totals.
 	if p.Sectors, err = bitfield.MergeBitFields(p.Sectors, snos); err != nil {
 		return NewPowerPairZero(), xerrors.Errorf("failed to record new sector numbers: %w", err)
@@ -117,18 +123,11 @@ func (p *Partition) AddSectors(store adt.Store, sectors []*SectorOnChainInfo, ss
 	return power, nil
 }
 
-// Records a set of sectors as faulty.
-// The sectors are added to the Faults bitfield and the FaultyPower is increased.
-// The sectors' expirations are rescheduled to the fault expiration epoch, as "early" (if not expiring earlier).
-// The sectors must not be already faulty.
-// Returns the power of the now-faulty sectors.
-func (p *Partition) AddFaults(store adt.Store, sectorNos *abi.BitField, sectors []*SectorOnChainInfo, faultExpiration abi.ChainEpoch,
-	ssize abi.SectorSize, quant QuantSpec) (PowerPair, error) {
-	if len(sectors) == 0 {
-		return NewPowerPairZero(), nil
-	}
-
-	var err error
+// marks a set of sectors faulty
+func (p *Partition) addFaults(
+	store adt.Store, sectorNos *abi.BitField, sectors []*SectorOnChainInfo, faultExpiration abi.ChainEpoch,
+	ssize abi.SectorSize, quant QuantSpec,
+) (PowerPair, error) {
 	// Load expiration queue
 	queue, err := LoadExpirationQueue(store, p.ExpirationsEpochs, quant)
 	if err != nil {
@@ -158,20 +157,83 @@ func (p *Partition) AddFaults(store adt.Store, sectorNos *abi.BitField, sectors 
 	return power, nil
 }
 
-// Removes sector numbers from faults and thus from recoveries.
-// The sectors are removed from the Faults and Recovering bitfields, and FaultyPower and RecoveringPower reduced.
-// The sectors are re-scheduled for expiration shortly after their target expiration epoch.
-// Consistency between the partition totals and queue depend on the reported sectors actually being faulty and recovering.
-// Returns the power of the now-recovered sectors.
-func (p *Partition) RecoverFaults(store adt.Store, recovered *abi.BitField, sectors []*SectorOnChainInfo,
-	ssize abi.SectorSize, quant QuantSpec) (PowerPair, error) {
+// Declares a set of sectors faulty. Already faulty sectors are ignored,
+// terminated sectors are skipped, and recovering sectors are reverted to
+// faulty.
+//
+// - New faults are added to the Faults bitfield and the FaultyPower is increased.
+// - The sectors' expirations are rescheduled to the fault expiration epoch, as "early" (if not expiring earlier).
+//
+// Returns the power of the now-faulty sectors.
+func (p *Partition) DeclareFaults(
+	store adt.Store, sectors Sectors, sectorNos *abi.BitField, faultExpirationEpoch abi.ChainEpoch,
+	ssize abi.SectorSize, quant QuantSpec,
+) (newFaults *bitfield.BitField, newFaultyPower PowerPair, err error) {
+	err = validateFRDeclarationPartition(p, sectorNos)
+	if err != nil {
+		return nil, NewPowerPairZero(), xc.ErrIllegalArgument.Wrapf("failed fault declaration: %w", err)
+	}
+
+	// Split declarations into declarations of new faults, and retraction of declared recoveries.
+	retractedRecoveries, err := bitfield.IntersectBitField(p.Recoveries, sectorNos)
+	if err != nil {
+		return nil, NewPowerPairZero(), xerrors.Errorf("failed to intersect sectors with recoveries: %w", err)
+	}
+
+	newFaults, err = bitfield.SubtractBitField(sectorNos, retractedRecoveries)
+	if err != nil {
+		return nil, NewPowerPairZero(), xerrors.Errorf("failed to subtract recoveries from sectors: %w", err)
+	}
+
+	// Ignore any terminated sectors and previously declared or detected faults
+	newFaults, err = bitfield.SubtractBitField(newFaults, p.Terminated)
+	if err != nil {
+		return nil, NewPowerPairZero(), xerrors.Errorf("failed to subtract terminations from faults: %w", err)
+	}
+	newFaults, err = bitfield.SubtractBitField(newFaults, p.Faults)
+	if err != nil {
+		return nil, NewPowerPairZero(), xerrors.Errorf("failed to subtract existing faults from faults: %w", err)
+	}
+
+	// Add new faults to state.
+	newFaultyPower = NewPowerPairZero()
+	if newFaultSectors, err := sectors.Load(newFaults); err != nil {
+		return nil, NewPowerPairZero(), xerrors.Errorf("failed to load fault sectors: %w", err)
+	} else if len(newFaultSectors) > 0 {
+		newFaultyPower, err = p.addFaults(store, newFaults, newFaultSectors, faultExpirationEpoch, ssize, quant)
+		if err != nil {
+			return nil, NewPowerPairZero(), xerrors.Errorf("failed to add faults: %w", err)
+		}
+	}
+
+	// Remove faulty recoveries from state.
+	if retractedRecoverySectors, err := sectors.Load(retractedRecoveries); err != nil {
+		return nil, NewPowerPairZero(), xerrors.Errorf("failed to load recovery sectors: %w", err)
+	} else if len(retractedRecoverySectors) > 0 {
+		retractedRecoveryPower := PowerForSectors(ssize, retractedRecoverySectors)
+		err = p.removeRecoveries(retractedRecoveries, retractedRecoveryPower)
+		if err != nil {
+			return nil, NewPowerPairZero(), xerrors.Errorf("failed to remove recoveries: %w", err)
+		}
+	}
+	return newFaults, newFaultyPower, nil
+}
+
+// Recovers all faulty sectors marked recovering.
+func (p *Partition) RecoverFaults(store adt.Store, sectors Sectors, ssize abi.SectorSize, quant QuantSpec) (PowerPair, error) {
+	// Process recoveries, assuming the proof will be successful.
+	// This similarly updates state.
+	recoveredSectors, err := sectors.Load(p.Recoveries)
+	if err != nil {
+		return NewPowerPairZero(), xerrors.Errorf("failed to load recovered sectors: %w", err)
+	}
 	// Load expiration queue
 	queue, err := LoadExpirationQueue(store, p.ExpirationsEpochs, quant)
 	if err != nil {
 		return NewPowerPairZero(), xerrors.Errorf("failed to load partition queue: %w", err)
 	}
 	// Reschedule recovered
-	power, err := queue.RescheduleRecovered(sectors, ssize)
+	power, err := queue.RescheduleRecovered(recoveredSectors, ssize)
 	if err != nil {
 		return NewPowerPairZero(), xerrors.Errorf("failed to reschedule faults in partition queue: %w", err)
 	}
@@ -181,16 +243,13 @@ func (p *Partition) RecoverFaults(store adt.Store, recovered *abi.BitField, sect
 	}
 
 	// Update partition metadata
-	if newFaults, err := bitfield.SubtractBitField(p.Faults, recovered); err != nil {
+	if newFaults, err := bitfield.SubtractBitField(p.Faults, p.Recoveries); err != nil {
 		return NewPowerPairZero(), err
 	} else {
 		p.Faults = newFaults
 	}
-	if newRecoveries, err := bitfield.SubtractBitField(p.Recoveries, recovered); err != nil {
-		return NewPowerPairZero(), err
-	} else {
-		p.Recoveries = newRecoveries
-	}
+	p.Recoveries = abi.NewBitField()
+
 	// No change to live power.
 	p.FaultyPower = p.FaultyPower.Sub(power)
 	p.RecoveringPower = p.RecoveringPower.Sub(power)
@@ -198,19 +257,36 @@ func (p *Partition) RecoverFaults(store adt.Store, recovered *abi.BitField, sect
 	return power, err
 }
 
-// Adds sectors to recoveries and recovering power. Assumes sectors are faulty but not already present in recoveries.
-func (p *Partition) AddRecoveries(sectorNos *abi.BitField, power PowerPair) (err error) {
-	empty, err := sectorNos.IsEmpty()
+// Declares sectors as recovering. Non-faulty and already recovering sectors will be skipped.
+func (p *Partition) DeclareFaultsRecovered(sectors Sectors, ssize abi.SectorSize, sectorNos *abi.BitField) (err error) {
+	// Check that the declared sectors are actually assigned to the partition.
+	err = validateFRDeclarationPartition(p, sectorNos)
+	if err != nil {
+		return xc.ErrIllegalArgument.Wrapf("failed fault declaration: %w", err)
+	}
+
+	// Ignore sectors not faulty or already declared recovered
+	recoveries, err := bitfield.IntersectBitField(sectorNos, p.Faults)
+	if err != nil {
+		return xerrors.Errorf("failed to intersect recoveries with faults: %w", err)
+	}
+	recoveries, err = bitfield.SubtractBitField(recoveries, p.Recoveries)
+	if err != nil {
+		return xerrors.Errorf("failed to subtract existing recoveries: %w", err)
+	}
+
+	// Record the new recoveries for processing at Window PoSt or deadline cron.
+	recoverySectors, err := sectors.Load(recoveries)
+	if err != nil {
+		return xerrors.Errorf("failed to load recovery sectors: %w", err)
+	}
+
+	p.Recoveries, err = bitfield.MergeBitFields(p.Recoveries, recoveries)
 	if err != nil {
 		return err
 	}
-	if empty {
-		return nil
-	}
-	p.Recoveries, err = bitfield.MergeBitFields(p.Recoveries, sectorNos)
-	if err != nil {
-		return err
-	}
+
+	power := PowerForSectors(ssize, recoverySectors)
 	p.RecoveringPower = p.RecoveringPower.Add(power)
 	// No change to faults, or terminations.
 	// No change to faulty power.
@@ -218,7 +294,7 @@ func (p *Partition) AddRecoveries(sectorNos *abi.BitField, power PowerPair) (err
 }
 
 // Removes sectors from recoveries and recovering power. Assumes sectors are currently faulty and recovering..
-func (p *Partition) RemoveRecoveries(sectorNos *abi.BitField, power PowerPair) (err error) {
+func (p *Partition) removeRecoveries(sectorNos *abi.BitField, power PowerPair) (err error) {
 	empty, err := sectorNos.IsEmpty()
 	if err != nil {
 		return err
@@ -631,13 +707,13 @@ func (p *Partition) RecordSkippedFaults(
 	}
 
 	// Record new faults
-	newFaultPower, err = p.AddFaults(store, newFaults, newFaultSectors, faultExpiration, ssize, quant)
+	newFaultPower, err = p.addFaults(store, newFaults, newFaultSectors, faultExpiration, ssize, quant)
 	if err != nil {
 		return NewPowerPairZero(), NewPowerPairZero(), xc.ErrIllegalState.Wrapf("failed to add skipped faults: %w", err)
 	}
 
 	// Remove faulty recoveries
-	err = p.RemoveRecoveries(retractedRecoveries, retractedRecoveryPower)
+	err = p.removeRecoveries(retractedRecoveries, retractedRecoveryPower)
 	if err != nil {
 		return NewPowerPairZero(), NewPowerPairZero(), xc.ErrIllegalState.Wrapf("failed to remove recoveries: %w", err)
 	}


### PR DESCRIPTION
Move fault handling logic into partition methods. This way, partition invariants can be enforced and tested on partition objects themselves.

Based on #875.
fixes #773.