### PR TITLE
Split seal delays into randomness lookback and max porep duration

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -474,9 +474,6 @@ func (a Actor) PreCommitSector(rt Runtime, params *SectorPreCommitInfo) *adt.Emp
 
 	challengeEarliest := sealChallengeEarliest(rt.CurrEpoch(), params.SealProof)
 	if params.SealRandEpoch < challengeEarliest {
-		// The subsequent commitment proof can't possibly be accepted because the seal challenge will be deemed
-		// too old. Note that passing this check doesn't guarantee the proof will be soon enough, depending on
-		// when it arrives.
 		rt.Abortf(exitcode.ErrIllegalArgument, "seal challenge epoch %v too old, must be after %v", params.SealRandEpoch, challengeEarliest)
 	}
 

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -472,7 +472,7 @@ func (a Actor) PreCommitSector(rt Runtime, params *SectorPreCommitInfo) *adt.Emp
 		rt.Abortf(exitcode.ErrIllegalArgument, "seal challenge epoch %v must be before now %v", params.SealRandEpoch, rt.CurrEpoch())
 	}
 
-	challengeEarliest := rt.CurrEpoch() - ChainFinality - MaxPreCommitRandomnessLookback
+	challengeEarliest := rt.CurrEpoch() - MaxPreCommitRandomnessLookback
 	if params.SealRandEpoch < challengeEarliest {
 		rt.Abortf(exitcode.ErrIllegalArgument, "seal challenge epoch %v too old, must be after %v", params.SealRandEpoch, challengeEarliest)
 	}

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -482,7 +482,7 @@ func (a Actor) PreCommitSector(rt Runtime, params *SectorPreCommitInfo) *adt.Emp
 
 	// Require sector lifetime meets minimum by assuming activation happens at last epoch permitted for seal proof.
 	// This could make sector maximum lifetime validation more lenient if the maximum sector limit isn't hit first.
-	maxActivation := rt.CurrEpoch() + MaxSealDuration[params.SealProof]
+	maxActivation := rt.CurrEpoch() + MaxProveCommitDuration[params.SealProof]
 	validateExpiration(rt, maxActivation, params.Expiration, params.SealProof)
 
 	if params.ReplaceCapacity && len(params.DealIDs) == 0 {
@@ -579,7 +579,7 @@ func (a Actor) PreCommitSector(rt Runtime, params *SectorPreCommitInfo) *adt.Emp
 			rt.Abortf(exitcode.ErrIllegalState, "failed to write pre-committed sector %v: %v", params.SectorNumber, err)
 		}
 		// add precommit expiry to the queue
-		msd, ok := MaxSealDuration[params.SealProof]
+		msd, ok := MaxProveCommitDuration[params.SealProof]
 		if !ok {
 			rt.Abortf(exitcode.ErrIllegalArgument, "no max seal duration set for proof type: %d", params.SealProof)
 		}
@@ -632,7 +632,7 @@ func (a Actor) ProveCommitSector(rt Runtime, params *ProveCommitSectorParams) *a
 		}
 	})
 
-	msd, ok := MaxSealDuration[precommit.Info.SealProof]
+	msd, ok := MaxProveCommitDuration[precommit.Info.SealProof]
 	if !ok {
 		rt.Abortf(exitcode.ErrIllegalState, "no max seal duration for proof type: %d", precommit.Info.SealProof)
 	}
@@ -2278,7 +2278,7 @@ func PowerForSectors(ssize abi.SectorSize, sectors []*SectorOnChainInfo) PowerPa
 
 // The oldest seal challenge epoch that will be accepted in the current epoch.
 func sealChallengeEarliest(currEpoch abi.ChainEpoch, proof abi.RegisteredSealProof) abi.ChainEpoch {
-	return currEpoch - ChainFinality - MaxSealDuration[proof]
+	return currEpoch - ChainFinality - MaxPreCommitRandomnessLookback
 }
 
 func getMinerInfo(rt Runtime, st *State) *MinerInfo {

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -581,7 +581,7 @@ func TestCommitments(t *testing.T) {
 
 		// Expires before min duration + max seal duration
 		rt.ExpectAbortContainsMessage(exitcode.ErrIllegalArgument, "must exceed", func() {
-			expiration := rt.Epoch() + miner.MinSectorExpiration + miner.MaxSealDuration[actor.sealProofType] - 1
+			expiration := rt.Epoch() + miner.MinSectorExpiration + miner.MaxProveCommitDuration[actor.sealProofType] - 1
 			actor.preCommitSector(rt, actor.makePreCommit(102, challengeEpoch, expiration, nil))
 		})
 		rt.Reset()
@@ -601,7 +601,7 @@ func TestCommitments(t *testing.T) {
 		rt.Reset()
 
 		// Seal randomness challenge too far in past
-		tooOldChallengeEpoch := precommitEpoch - miner.ChainFinality - miner.MaxSealDuration[actor.sealProofType] - 1
+		tooOldChallengeEpoch := precommitEpoch - miner.ChainFinality - miner.MaxProveCommitDuration[actor.sealProofType] - 1
 		rt.ExpectAbortContainsMessage(exitcode.ErrIllegalArgument, "too old", func() {
 			actor.preCommitSector(rt, actor.makePreCommit(102, tooOldChallengeEpoch, expiration, nil))
 		})
@@ -877,7 +877,7 @@ func TestCommitments(t *testing.T) {
 		rt.Reset()
 
 		// Too late.
-		rt.SetEpoch(precommitEpoch + miner.MaxSealDuration[precommit.SealProof] + 1)
+		rt.SetEpoch(precommitEpoch + miner.MaxProveCommitDuration[precommit.SealProof] + 1)
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			actor.proveCommitSectorAndConfirm(rt, precommit, precommitEpoch, makeProveCommit(sectorNo), proveCommitConf{})
 		})
@@ -1395,7 +1395,7 @@ func TestProveCommit(t *testing.T) {
 		rt.SetBalance(big.Add(st.PreCommitDeposits, st.LockedFunds))
 		info := actor.getInfo(rt)
 
-		rt.SetEpoch(precommitEpoch + miner.MaxSealDuration[info.SealProofType] - 1)
+		rt.SetEpoch(precommitEpoch + miner.MaxProveCommitDuration[info.SealProofType] - 1)
 		rt.ExpectAbort(exitcode.ErrInsufficientFunds, func() {
 			actor.proveCommitSectorAndConfirm(rt, precommit, precommitEpoch, makeProveCommit(actor.nextSectorNo), proveCommitConf{})
 		})
@@ -1424,7 +1424,7 @@ func TestProveCommit(t *testing.T) {
 
 		// handle both prove commits in the same epoch
 		info := actor.getInfo(rt)
-		rt.SetEpoch(precommitEpoch + miner.MaxSealDuration[info.SealProofType] - 1)
+		rt.SetEpoch(precommitEpoch + miner.MaxProveCommitDuration[info.SealProofType] - 1)
 
 		actor.proveCommitSector(rt, precommitA, precommitEpoch, makeProveCommit(sectorNoA))
 		actor.proveCommitSector(rt, precommitB, precommitEpoch, makeProveCommit(sectorNoB))

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -88,15 +88,18 @@ var SupportedProofTypes = map[abi.RegisteredSealProof]struct{}{
 	abi.RegisteredSealProof_StackedDrg64GiBV1: {},
 }
 
-// Maximum duration to allow for the sealing process for seal algorithms.
+// Maximum delay to allow between precommit and provecommit
 // Dependent on algorithm and sector size
-var MaxSealDuration = map[abi.RegisteredSealProof]abi.ChainEpoch{
+var MaxProveCommitDuration = map[abi.RegisteredSealProof]abi.ChainEpoch{
 	abi.RegisteredSealProof_StackedDrg32GiBV1:  abi.ChainEpoch(10000), // PARAM_FINISH
 	abi.RegisteredSealProof_StackedDrg2KiBV1:   abi.ChainEpoch(10000),
 	abi.RegisteredSealProof_StackedDrg8MiBV1:   abi.ChainEpoch(10000),
 	abi.RegisteredSealProof_StackedDrg512MiBV1: abi.ChainEpoch(10000),
 	abi.RegisteredSealProof_StackedDrg64GiBV1:  abi.ChainEpoch(10000),
 }
+
+// Maximum delay between challenge and precommit
+var MaxPreCommitRandomnessLookback = abi.ChainEpoch(10000)
 
 // Number of epochs between publishing the precommit and when the challenge for interactive PoRep is drawn
 // used to ensure it is not predictable by miner.


### PR DESCRIPTION
Closes #672

fyi @nicola not changing any numbers yet but splitting out so we can.  Should we be changing either of these from 10,000?  If so this PR would be a natural place.