### PR TITLE
Quantize sector expiration queues per-deadline

### DIFF
--- a/actors/builtin/miner/bitfield_test.go
+++ b/actors/builtin/miner/bitfield_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/filecoin-project/go-bitfield"
+	rlepluslazy "github.com/filecoin-project/go-bitfield/rle"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -33,4 +34,16 @@ func assertBitfieldEmpty(t *testing.T, bf *bitfield.BitField) {
 	empty, err := bf.IsEmpty()
 	require.NoError(t, err)
 	assert.True(t, empty)
+}
+
+// Create a bitfield with count bits set, starting at "start".
+func seq(t *testing.T, start, count uint64) *bitfield.BitField {
+	var runs []rlepluslazy.Run
+	if start > 0 {
+		runs = append(runs, rlepluslazy.Run{Val: false, Len: start})
+	}
+	runs = append(runs, rlepluslazy.Run{Val: true, Len: count})
+	bf, err := bitfield.NewFromIter(&rlepluslazy.RunSliceIterator{Runs: runs})
+	require.NoError(t, err)
+	return bf
 }

--- a/actors/builtin/miner/deadlines.go
+++ b/actors/builtin/miner/deadlines.go
@@ -78,6 +78,10 @@ func (d *DeadlineInfo) NextNotElapsed() *DeadlineInfo {
 	return next
 }
 
+func (d *DeadlineInfo) QuantSpec() QuantSpec {
+	return NewQuantSpec(WPoStProvingPeriod, d.Last())
+}
+
 // Returns deadline-related calculations for a deadline in some proving period and the current epoch.
 func NewDeadlineInfo(periodStart abi.ChainEpoch, deadlineIdx uint64, currEpoch abi.ChainEpoch) *DeadlineInfo {
 	if deadlineIdx < WPoStPeriodDeadlines {

--- a/actors/builtin/miner/deadlines_test.go
+++ b/actors/builtin/miner/deadlines_test.go
@@ -181,4 +181,12 @@ func TestProvingPeriodDeadlines(t *testing.T) {
 		assert.Equal(t, miner.WPoStProvingPeriod-1, d.PeriodEnd())
 		assert.Equal(t, miner.WPoStProvingPeriod, d.NextPeriodStart())
 	})
+
+	t.Run("quantization spec rounds to the next deadline", func(t *testing.T) {
+		periodStart := abi.ChainEpoch(2)
+		curr := periodStart + miner.WPoStProvingPeriod
+		d := miner.NewDeadlineInfo(periodStart, 10, curr)
+		quant := d.QuantSpec()
+		assert.Equal(t, d.NextNotElapsed().Last(), quant.QuantizeUp(curr))
+	})
 }

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -832,7 +832,7 @@ func (a Actor) ExtendSectorExpiration(rt Runtime, params *ExtendSectorExpiration
 			partitions, err := deadline.PartitionsArray(store)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load partitions for deadline %d", dlIdx)
 
-			quant := NewDeadlineInfo(st.ProvingPeriodStart, dlIdx, rt.CurrEpoch()).QuantSpec()
+			quant := st.QuantSpecForDeadline(dlIdx)
 
 			for _, decl := range declsByDeadline[dlIdx] {
 				key := PartitionKey{dlIdx, decl.Partition}
@@ -966,7 +966,7 @@ func (a Actor) TerminateSectors(rt Runtime, params *TerminateSectorsParams) *Ter
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load sectors")
 
 		err = toProcess.ForEach(func(dlIdx uint64, partitionSectors PartitionSectorMap) error {
-			quant := NewDeadlineInfo(st.ProvingPeriodStart, dlIdx, rt.CurrEpoch()).QuantSpec()
+			quant := st.QuantSpecForDeadline(dlIdx)
 
 			deadline, err := deadlines.LoadDeadline(store, dlIdx)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deadline %d", dlIdx)
@@ -1183,7 +1183,7 @@ func (a Actor) CompactPartitions(rt Runtime, params *CompactPartitionsParams) *a
 			rt.Abortf(exitcode.ErrIllegalArgument, "too many partitions %d, limit %d", partitionCount, submissionPartitionLimit)
 		}
 
-		quant := NewDeadlineInfo(st.ProvingPeriodStart, params.Deadline, rt.CurrEpoch()).QuantSpec()
+		quant := st.QuantSpecForDeadline(params.Deadline)
 
 		deadlines, err := st.LoadDeadlines(store)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deadlines")

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -310,7 +310,7 @@ func (a Actor) SubmitWindowedPoSt(rt Runtime, params *SubmitWindowedPoStParams) 
 		// If proof verification fails, the this deadline MUST NOT be saved and this function should
 		// be aborted.
 		faultExpiration := currDeadline.Last() + FaultMaxAge
-		postResult, err = deadline.RecordProvenSectors(store, sectors, info.SectorSize, st.QuantEndOfDeadline(), faultExpiration, params.Partitions)
+		postResult, err = deadline.RecordProvenSectors(store, sectors, info.SectorSize, currDeadline.QuantSpec(), faultExpiration, params.Partitions)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to process post submission for deadline %d", params.Deadline)
 
 		// Validate proofs
@@ -807,7 +807,6 @@ func (a Actor) ExtendSectorExpiration(rt Runtime, params *ExtendSectorExpiration
 
 		deadlines, err := st.LoadDeadlines(adt.AsStore(rt))
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deadlines")
-		quant := st.QuantEndOfDeadline()
 
 		// Group declarations by deadline, and remember iteration order.
 		declsByDeadline := map[uint64][]*ExpirationExtension{}
@@ -832,6 +831,8 @@ func (a Actor) ExtendSectorExpiration(rt Runtime, params *ExtendSectorExpiration
 
 			partitions, err := deadline.PartitionsArray(store)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load partitions for deadline %d", dlIdx)
+
+			quant := NewDeadlineInfo(st.ProvingPeriodStart, dlIdx, rt.CurrEpoch()).QuantSpec()
 
 			for _, decl := range declsByDeadline[dlIdx] {
 				key := PartitionKey{dlIdx, decl.Partition}
@@ -958,7 +959,6 @@ func (a Actor) TerminateSectors(rt Runtime, params *TerminateSectorsParams) *Ter
 
 		deadlines, err := st.LoadDeadlines(adt.AsStore(rt))
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deadlines")
-		quant := st.QuantEndOfDeadline()
 
 		// We're only reading the sectors, so there's no need to save this back.
 		// However, we still want to avoid re-loading this array per-partition.
@@ -966,6 +966,8 @@ func (a Actor) TerminateSectors(rt Runtime, params *TerminateSectorsParams) *Ter
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load sectors")
 
 		err = toProcess.ForEach(func(dlIdx uint64, partitionSectors PartitionSectorMap) error {
+			quant := NewDeadlineInfo(st.ProvingPeriodStart, dlIdx, rt.CurrEpoch()).QuantSpec()
+
 			deadline, err := deadlines.LoadDeadline(store, dlIdx)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deadline %d", dlIdx)
 
@@ -1040,7 +1042,6 @@ func (a Actor) DeclareFaults(rt Runtime, params *DeclareFaultsParams) *adt.Empty
 
 		deadlines, err := st.LoadDeadlines(store)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deadlines")
-		quant := st.QuantEndOfDeadline()
 
 		sectors, err := LoadSectors(store, st.Sectors)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load sectors array")
@@ -1056,7 +1057,7 @@ func (a Actor) DeclareFaults(rt Runtime, params *DeclareFaultsParams) *adt.Empty
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deadline %d", dlIdx)
 
 			faultExpirationEpoch := targetDeadline.Last() + FaultMaxAge
-			newFaultyPower, err := deadline.DeclareFaults(store, sectors, info.SectorSize, quant, faultExpirationEpoch, pm)
+			newFaultyPower, err := deadline.DeclareFaults(store, sectors, info.SectorSize, targetDeadline.QuantSpec(), faultExpirationEpoch, pm)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to declare faults for deadline %d", dlIdx)
 
 			err = deadlines.UpdateDeadline(store, dlIdx, deadline)
@@ -1182,7 +1183,7 @@ func (a Actor) CompactPartitions(rt Runtime, params *CompactPartitionsParams) *a
 			rt.Abortf(exitcode.ErrIllegalArgument, "too many partitions %d, limit %d", partitionCount, submissionPartitionLimit)
 		}
 
-		quant := st.QuantEndOfDeadline()
+		quant := NewDeadlineInfo(st.ProvingPeriodStart, params.Deadline, rt.CurrEpoch()).QuantSpec()
 
 		deadlines, err := st.LoadDeadlines(store)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deadlines")
@@ -1540,7 +1541,7 @@ func handleProvingDeadline(rt Runtime) {
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deadlines")
 		deadline, err := deadlines.LoadDeadline(store, dlInfo.Index)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deadline %d", dlInfo.Index)
-		quant := st.QuantEndOfDeadline()
+		quant := dlInfo.QuantSpec()
 		unlockedBalance := st.GetUnlockedBalance(rt.CurrentBalance())
 
 		{

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -207,6 +207,11 @@ func (st *State) DeadlineInfo(currEpoch abi.ChainEpoch) *DeadlineInfo {
 	return NewDeadlineInfo(st.ProvingPeriodStart, st.CurrentDeadline, currEpoch)
 }
 
+// Returns deadline calculations for the current (according to state) proving period.
+func (st *State) QuantSpecForDeadline(dlIdx uint64) QuantSpec {
+	return NewDeadlineInfo(st.ProvingPeriodStart, dlIdx, 0).QuantSpec()
+}
+
 func (st *State) AllocateSectorNumber(store adt.Store, sectorNo abi.SectorNumber) error {
 	// This will likely already have been checked, but this is a good place
 	// to catch any mistakes.
@@ -494,7 +499,7 @@ func (st *State) AssignSectorsToDeadlines(
 			continue
 		}
 
-		quant := NewDeadlineInfo(st.ProvingPeriodStart, uint64(dlIdx), currentEpoch).QuantSpec()
+		quant := st.QuantSpecForDeadline(uint64(dlIdx))
 		dl := deadlineArr[dlIdx]
 
 		deadlineNewPower, err := dl.AddSectors(store, partitionSize, newPartitions, sectorSize, quant)

--- a/actors/builtin/miner/miner_state_test.go
+++ b/actors/builtin/miner/miner_state_test.go
@@ -579,10 +579,10 @@ func TestSectorAssignment(t *testing.T) {
 		dls, err := harness.s.LoadDeadlines(harness.store)
 		require.NoError(t, err)
 		require.NoError(t, dls.ForEach(harness.store, func(dlIdx uint64, dl *miner.Deadline) error {
-			dlInfo := miner.NewDeadlineInfo(harness.s.ProvingPeriodStart, dlIdx, 0)
+			quantSpec := harness.s.QuantSpecForDeadline(dlIdx)
 			// deadlines 0 & 1 are closed for assignment right now.
 			if dlIdx < 2 {
-				dlState.withQuantSpec(dlInfo.QuantSpec()).
+				dlState.withQuantSpec(quantSpec).
 					assert(t, harness.store, dl)
 				return nil
 			}
@@ -599,7 +599,7 @@ func TestSectorAssignment(t *testing.T) {
 				require.NoError(t, err)
 				partitions = append(partitions, bf)
 			}
-			dlState.withQuantSpec(dlInfo.QuantSpec()).
+			dlState.withQuantSpec(quantSpec).
 				withPartitions(partitions...).
 				assert(t, harness.store, dl)
 

--- a/actors/builtin/miner/miner_state_test.go
+++ b/actors/builtin/miner/miner_state_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/filecoin-project/go-bitfield"
-	rlepluslazy "github.com/filecoin-project/go-bitfield/rle"
 	cid "github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -589,14 +588,8 @@ func TestSectorAssignment(t *testing.T) {
 
 			var partitions []*bitfield.BitField
 			for i := uint64(0); i < uint64(partitionsPerDeadline); i++ {
-				var runs []rlepluslazy.Run
 				start := ((i * openDeadlines) + (dlIdx - 2)) * partitionSectors
-				if start > 0 {
-					runs = append(runs, rlepluslazy.Run{Val: false, Len: start})
-				}
-				runs = append(runs, rlepluslazy.Run{Val: true, Len: partitionSectors})
-				bf, err := bitfield.NewFromIter(&rlepluslazy.RunSliceIterator{Runs: runs})
-				require.NoError(t, err)
+				bf := seq(t, start, partitionSectors)
 				partitions = append(partitions, bf)
 			}
 			dlState.withQuantSpec(quantSpec).
@@ -654,8 +647,7 @@ func TestSectorNumberAllocation(t *testing.T) {
 				assert.Equal(t, code, exitcode.ErrIllegalArgument)
 
 				// mask half the sector ranges.
-				mask, err := bitfield.NewFromIter(&rlepluslazy.RunSliceIterator{Runs: []rlepluslazy.Run{{Val: true, Len: uint64(no) / 2}}})
-				require.NoError(t, err)
+				mask := seq(t, 0, uint64(no)/2)
 				require.NoError(t, harness.s.MaskSectorNumbers(harness.store, mask))
 
 				// try again

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -236,7 +236,7 @@ func TestCommitments(t *testing.T) {
 		assertEmptyBitfield(t, deadline.PostSubmissions)
 		assertEmptyBitfield(t, deadline.EarlyTerminations)
 
-		quant := miner.NewDeadlineInfo(st.ProvingPeriodStart, dlIdx, rt.Epoch()).QuantSpec()
+		quant := st.QuantSpecForDeadline(dlIdx)
 		quantizedExpiration := quant.QuantizeUp(precommit.Expiration)
 
 		dQueue := actor.collectDeadlineExpirations(rt, deadline)
@@ -527,7 +527,7 @@ func TestCommitments(t *testing.T) {
 			params := *upgradeParams
 			st := getState(rt)
 			prevState := *st
-			quant := miner.NewDeadlineInfo(st.ProvingPeriodStart, dlIdx, 0).QuantSpec()
+			quant := st.QuantSpecForDeadline(dlIdx)
 			deadlines, err := st.LoadDeadlines(rt.AdtStore())
 			require.NoError(t, err)
 			deadline, err := deadlines.LoadDeadline(rt.AdtStore(), dlIdx)

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -1210,7 +1210,7 @@ func TestDeadlineCron(t *testing.T) {
 		// recorded faulty power is unchanged
 		deadline = actor.getDeadline(rt, dlIdx)
 		assert.True(t, pwr.Equals(deadline.FaultyPower))
-		checkDeadlineInvariants(t, rt.AdtStore(), deadline, st.QuantEndOfDeadline(), actor.sectorSize, uint64(4), allSectors)
+		checkDeadlineInvariants(t, rt.AdtStore(), deadline, st.QuantSpecForDeadline(dlIdx), actor.sectorSize, uint64(4), allSectors)
 	})
 
 	t.Run("test cron run late", func(t *testing.T) {
@@ -1446,13 +1446,13 @@ func TestExtendSectorExpiration(t *testing.T) {
 		// assert that new expiration exists
 		st = getState(rt)
 		_, partition := actor.getDeadlineAndPartition(rt, dlIdx, pIdx)
-		expirationSet, err := partition.PopExpiredSectors(rt.AdtStore(), newExpiration-1, st.QuantEndOfDeadline())
+		expirationSet, err := partition.PopExpiredSectors(rt.AdtStore(), newExpiration-1, st.QuantSpecForDeadline(dlIdx))
 		require.NoError(t, err)
 		empty, err := expirationSet.IsEmpty()
 		require.NoError(t, err)
 		assert.True(t, empty)
 
-		expirationSet, err = partition.PopExpiredSectors(rt.AdtStore(), newExpiration, st.QuantEndOfDeadline())
+		expirationSet, err = partition.PopExpiredSectors(rt.AdtStore(), newExpiration, st.QuantSpecForDeadline(dlIdx))
 		require.NoError(t, err)
 		empty, err = expirationSet.IsEmpty()
 		require.NoError(t, err)

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -1521,7 +1521,7 @@ func TestExtendSectorExpiration(t *testing.T) {
 			// Half the sectors should expire on-time.
 			var onTimeTotal uint64
 			require.NoError(t, deadlines.ForEach(rt.AdtStore(), func(dlIdx uint64, dl *miner.Deadline) error {
-				expirationSet, err := dl.PopExpiredSectors(rt.AdtStore(), newExpiration-1, st.QuantEndOfDeadline())
+				expirationSet, err := dl.PopExpiredSectors(rt.AdtStore(), newExpiration-1, st.QuantSpecForDeadline(dlIdx))
 				require.NoError(t, err)
 
 				count, err := expirationSet.Count()
@@ -1534,7 +1534,7 @@ func TestExtendSectorExpiration(t *testing.T) {
 			// Half the sectors should expire late.
 			var extendedTotal uint64
 			require.NoError(t, deadlines.ForEach(rt.AdtStore(), func(dlIdx uint64, dl *miner.Deadline) error {
-				expirationSet, err := dl.PopExpiredSectors(rt.AdtStore(), newExpiration-1, st.QuantEndOfDeadline())
+				expirationSet, err := dl.PopExpiredSectors(rt.AdtStore(), newExpiration-1, st.QuantSpecForDeadline(dlIdx))
 				require.NoError(t, err)
 
 				count, err := expirationSet.Count()

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -1443,16 +1443,18 @@ func TestExtendSectorExpiration(t *testing.T) {
 		newSector := actor.getSector(rt, oldSector.SectorNumber)
 		assert.Equal(t, newExpiration, newSector.Expiration)
 
+		quant := st.QuantSpecForDeadline(dlIdx)
+
 		// assert that new expiration exists
 		st = getState(rt)
 		_, partition := actor.getDeadlineAndPartition(rt, dlIdx, pIdx)
-		expirationSet, err := partition.PopExpiredSectors(rt.AdtStore(), newExpiration-1, st.QuantSpecForDeadline(dlIdx))
+		expirationSet, err := partition.PopExpiredSectors(rt.AdtStore(), newExpiration-1, quant)
 		require.NoError(t, err)
 		empty, err := expirationSet.IsEmpty()
 		require.NoError(t, err)
 		assert.True(t, empty)
 
-		expirationSet, err = partition.PopExpiredSectors(rt.AdtStore(), newExpiration, st.QuantSpecForDeadline(dlIdx))
+		expirationSet, err = partition.PopExpiredSectors(rt.AdtStore(), quant.QuantizeUp(newExpiration), quant)
 		require.NoError(t, err)
 		empty, err = expirationSet.IsEmpty()
 		require.NoError(t, err)

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -1446,7 +1446,6 @@ func TestExtendSectorExpiration(t *testing.T) {
 		quant := st.QuantSpecForDeadline(dlIdx)
 
 		// assert that new expiration exists
-		st = getState(rt)
 		_, partition := actor.getDeadlineAndPartition(rt, dlIdx, pIdx)
 		expirationSet, err := partition.PopExpiredSectors(rt.AdtStore(), newExpiration-1, quant)
 		require.NoError(t, err)

--- a/actors/builtin/miner/sector_map_test.go
+++ b/actors/builtin/miner/sector_map_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/filecoin-project/go-bitfield"
-	rlepluslazy "github.com/filecoin-project/go-bitfield/rle"
 	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -86,13 +85,12 @@ func TestPartitionSectorMapValues(t *testing.T) {
 func TestDeadlineSectorMapOverflow(t *testing.T) {
 	dm := make(miner.DeadlineSectorMap)
 	dlCount := uint64(10)
-	bf, err := bitfield.NewFromIter(&rlepluslazy.RunSliceIterator{Runs: []rlepluslazy.Run{{Val: true, Len: math.MaxUint64}}})
-	require.NoError(t, err)
+	bf := seq(t, 0, math.MaxUint64)
 	for dlIdx := uint64(0); dlIdx < dlCount; dlIdx++ {
 		assert.NoError(t, dm.Add(dlIdx, 0, bf))
 	}
 
-	_, _, err = dm[0].Count()
+	_, _, err := dm[0].Count()
 	require.NoError(t, err)
 
 	_, _, err = dm.Count()
@@ -102,13 +100,12 @@ func TestDeadlineSectorMapOverflow(t *testing.T) {
 func TestPartitionSectorMapOverflow(t *testing.T) {
 	pm := make(miner.PartitionSectorMap)
 	partCount := uint64(2)
-	bf, err := bitfield.NewFromIter(&rlepluslazy.RunSliceIterator{Runs: []rlepluslazy.Run{{Val: true, Len: math.MaxUint64}}})
-	require.NoError(t, err)
+	bf := seq(t, 0, math.MaxUint64)
 	for partIdx := uint64(0); partIdx < partCount; partIdx++ {
 		assert.NoError(t, pm.Add(partIdx, bf))
 	}
 
-	_, _, err = pm.Count()
+	_, _, err := pm.Count()
 	require.Error(t, err)
 }
 


### PR DESCRIPTION
This also adds a test for sector assignment which should test this quantization.

fixes #739 