### PR TITLE
more miner tests restored

### DIFF
--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -1241,7 +1241,7 @@ func TestProvingPeriodCron(t *testing.T) {
 		// Retracted recovery is penalized as an undetected fault, but power is unchanged
 		retractedPwr := miner.PowerForSectors(actor.sectorSize, allSectors[1:])
 		retractedPenalty := miner.PledgePenaltyForUndeclaredFault(actor.epochRewardSmooth, actor.epochQAPowerSmooth, retractedPwr.QA)
-		// subtract ongoing penalty, because it's chareged below (this prevents round-off mismatches)
+		// subtract ongoing penalty, because it's charged below (this prevents round-off mismatches)
 		retractedPenalty = big.Sub(retractedPenalty, miner.PledgePenaltyForDeclaredFault(actor.epochRewardSmooth, actor.epochQAPowerSmooth, retractedPwr.QA))
 
 		// Un-recovered faults are charged as ongoing faults

--- a/actors/builtin/power/power_test.go
+++ b/actors/builtin/power/power_test.go
@@ -682,7 +682,7 @@ func TestCron(t *testing.T) {
 		actor.constructAndVerify(rt)
 
 		// enroll a cron task at epoch 2 (which is in the past)
-		rt.ExpectAbortConstainsMessage(exitcode.ErrIllegalArgument, "epoch -2 cannot be less than zero", func() {
+		rt.ExpectAbortContainsMessage(exitcode.ErrIllegalArgument, "epoch -2 cannot be less than zero", func() {
 			actor.enrollCronEvent(rt, miner1, -2, []byte{0x1, 0x3})
 		})
 	})


### PR DESCRIPTION
work towards #829

### Motivation

The miner state refactor broke a lot of tests. This PR brings some of them back.

### Proposed Changes

1. Restore `handleProvingPeriod` cron tests that detected faults.
2. Restore `DeclareFaults` tests.
3. Restore `ExtendSectorExpiration` tests.
4. Fix surprisingly ubiquitous misspelling of `ExpectAbortContainsMessage`
5. Fix problem in `MockRT` where effectively equal messages and message expectations would appear unequal.