### PR TITLE
Sum pledge/power on sector extension and fix go gotcha

### DIFF
--- a/actors/builtin/miner/expiration_queue.go
+++ b/actors/builtin/miner/expiration_queue.go
@@ -670,10 +670,7 @@ func groupSectorsByExpiration(sectorSize abi.SectorSize, sectors []*SectorOnChai
 		totalPledge := big.Zero()
 		for i, sector := range epochSectors {
 			sectorNumbers[i] = uint64(sector.SectorNumber)
-			totalPower = totalPower.Add(PowerPair{
-				Raw: big.NewIntUnsigned(uint64(sectorSize)),
-				QA:  QAPowerForSector(sectorSize, sector),
-			})
+			totalPower = totalPower.Add(PowerForSector(sectorSize, sector))
 			totalPledge = big.Add(totalPledge, sector.InitialPledge)
 		}
 		sectorEpochSets = append(sectorEpochSets, sectorEpochSet{

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -814,7 +814,8 @@ func (a Actor) ExtendSectorExpiration(rt Runtime, params *ExtendSectorExpiration
 		var deadlinesToLoad []uint64
 		for i := range params.Extensions {
 			// Take a pointer to the value inside the slice, don't
-			// take a reference to the temporary loop variable.
+			// take a reference to the temporary loop variable as it
+			// will be overwritten every iteration.
 			decl := &params.Extensions[i]
 			if _, ok := declsByDeadline[decl.Deadline]; !ok {
 				deadlinesToLoad = append(deadlinesToLoad, decl.Deadline)

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -812,11 +812,14 @@ func (a Actor) ExtendSectorExpiration(rt Runtime, params *ExtendSectorExpiration
 		// Group declarations by deadline, and remember iteration order.
 		declsByDeadline := map[uint64][]*ExpirationExtension{}
 		var deadlinesToLoad []uint64
-		for _, decl := range params.Extensions {
+		for i := range params.Extensions {
+			// Take a pointer to the value inside the slice, don't
+			// take a reference to the temporary loop variable.
+			decl := &params.Extensions[i]
 			if _, ok := declsByDeadline[decl.Deadline]; !ok {
 				deadlinesToLoad = append(deadlinesToLoad, decl.Deadline)
 			}
-			declsByDeadline[decl.Deadline] = append(declsByDeadline[decl.Deadline], &decl)
+			declsByDeadline[decl.Deadline] = append(declsByDeadline[decl.Deadline], decl)
 		}
 
 		sectors, err := LoadSectors(store, st.Sectors)

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"math"
 
 	addr "github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-bitfield"
@@ -784,6 +785,9 @@ func (a Actor) ExtendSectorExpiration(rt Runtime, params *ExtendSectorExpiration
 			"failed to count sectors for deadline %d, partition %d",
 			decl.Deadline, decl.Partition,
 		)
+		if sectorCount > math.MaxUint64-count {
+			rt.Abortf(exitcode.ErrIllegalArgument, "sector bitfield integer overflow")
+		}
 		sectorCount += count
 	}
 	if sectorCount > AddressedSectorsMax {

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -1500,7 +1500,7 @@ func TestExtendSectorExpiration(t *testing.T) {
 			}))
 		}
 
-		// Make sure we're touching at least to sectors.
+		// Make sure we're touching at least two sectors.
 		require.GreaterOrEqual(t, len(params.Extensions), 2,
 			"test error: this test should touch more than one partition",
 		)


### PR DESCRIPTION
* Avoid taking a reference to the loop variable.
* Sum power/pledge on sector extension.
* Test extending sectors from multiple partitions. This test is unfortunately slow (5s), we can probably speed up the sector adding logic.

fixes #864, #865.