### PR TITLE
Avoid pre-allocating with inaccurate hints

### DIFF
--- a/actors/builtin/miner/sector_map.go
+++ b/actors/builtin/miner/sector_map.go
@@ -61,7 +61,7 @@ func (dm DeadlineSectorMap) Add(dlIdx, partIdx uint64, sectorNos *bitfield.BitFi
 	}
 	dl, ok := dm[dlIdx]
 	if !ok {
-		dl = make(PartitionSectorMap, 1)
+		dl = make(PartitionSectorMap)
 		dm[dlIdx] = dl
 	}
 	return dl.Add(partIdx, sectorNos)


### PR DESCRIPTION
This hint shouldn't actually make a difference in practice, but @anorth pointed out that it's inaccurate and could, in theory, cause the compiler to allocate fewer buckets than it otherwise would, causing more allocations.

In the interest of simplicity and clarity (1 was a lower bound, not a true hint), I'm removing it.

see https://github.com/filecoin-project/specs-actors/pull/861#discussion_r464137297