### PR TITLE
Switch to by-value bitfields

### DIFF
--- a/actors/abi/bitfield.go
+++ b/actors/abi/bitfield.go
@@ -1,21 +1,11 @@
 package abi
 
 import (
-	"fmt"
-
 	"github.com/filecoin-project/go-bitfield"
 	"github.com/filecoin-project/go-bitfield/rle"
 )
 
 type BitField = bitfield.BitField
-
-func NewBitField() *BitField {
-	bf, err := bitfield.NewFromBytes([]byte{})
-	if err != nil {
-		panic(fmt.Sprintf("creating empty rle: %+v", err))
-	}
-	return &bf
-}
 
 func isEmpty(iter rlepluslazy.RunIterator) (bool, error) {
 	// Look for the first non-zero bit.
@@ -32,7 +22,7 @@ func isEmpty(iter rlepluslazy.RunIterator) (bool, error) {
 }
 
 // Checks whether bitfield `a` contains any bit that is set in bitfield `b`.
-func BitFieldContainsAny(a, b *BitField) (bool, error) {
+func BitFieldContainsAny(a, b BitField) (bool, error) {
 	aruns, err := a.RunIterator()
 	if err != nil {
 		return false, err
@@ -58,7 +48,7 @@ func BitFieldContainsAny(a, b *BitField) (bool, error) {
 }
 
 // Checks whether bitfield `a` contains all bits set in bitfield `b`.
-func BitFieldContainsAll(a, b *BitField) (bool, error) {
+func BitFieldContainsAll(a, b BitField) (bool, error) {
 	aruns, err := a.RunIterator()
 	if err != nil {
 		return false, err

--- a/actors/abi/bitfield_test.go
+++ b/actors/abi/bitfield_test.go
@@ -6,11 +6,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/filecoin-project/go-bitfield"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 )
 
 func TestBitFieldUnset(t *testing.T) {
-	bf := abi.NewBitField()
+	bf := bitfield.New()
 	bf.Set(1)
 	bf.Set(2)
 	bf.Set(3)
@@ -40,39 +41,39 @@ func TestBitFieldUnset(t *testing.T) {
 	assert.False(t, found)
 }
 
-func roundtripMarshal(t *testing.T, in *abi.BitField) *abi.BitField {
+func roundtripMarshal(t *testing.T, in bitfield.BitField) bitfield.BitField {
 	buf := new(bytes.Buffer)
 	err := in.MarshalCBOR(buf)
 	assert.NoError(t, err)
 
-	bf2 := abi.NewBitField()
+	bf2 := bitfield.New()
 	err = bf2.UnmarshalCBOR(buf)
 	assert.NoError(t, err)
 	return bf2
 }
 
 func TestBitFieldContains(t *testing.T) {
-	a := abi.NewBitField()
+	a := bitfield.New()
 	a.Set(2)
 	a.Set(4)
 	a.Set(5)
 
-	b := abi.NewBitField()
+	b := bitfield.New()
 	b.Set(3)
 	b.Set(4)
 
-	c := abi.NewBitField()
+	c := bitfield.New()
 	c.Set(2)
 	c.Set(5)
 
-	assertContainsAny := func(a, b *abi.BitField, expected bool) {
+	assertContainsAny := func(a, b bitfield.BitField, expected bool) {
 		t.Helper()
 		actual, err := abi.BitFieldContainsAny(a, b)
 		assert.NoError(t, err)
 		assert.Equal(t, expected, actual)
 	}
 
-	assertContainsAll := func(a, b *abi.BitField, expected bool) {
+	assertContainsAll := func(a, b bitfield.BitField, expected bool) {
 		t.Helper()
 		actual, err := abi.BitFieldContainsAll(a, b)
 		assert.NoError(t, err)

--- a/actors/builtin/miner/bitfield_queue_test.go
+++ b/actors/builtin/miner/bitfield_queue_test.go
@@ -258,7 +258,7 @@ func (bqe *bqExpectation) Equals(t *testing.T, q miner.BitfieldQueue) {
 
 	assert.Equal(t, uint64(len(bqe.expected)), q.Length())
 
-	err = q.ForEach(func(epoch abi.ChainEpoch, bf *bitfield.BitField) error {
+	err = q.ForEach(func(epoch abi.ChainEpoch, bf bitfield.BitField) error {
 		values, ok := bqe.expected[epoch]
 		require.True(t, ok)
 

--- a/actors/builtin/miner/bitfield_test.go
+++ b/actors/builtin/miner/bitfield_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func assertBitfieldsEqual(t *testing.T, expected *bitfield.BitField, actual *bitfield.BitField) {
+func assertBitfieldsEqual(t *testing.T, expected bitfield.BitField, actual bitfield.BitField) {
 	const maxDiff = 100
 
 	missing, err := bitfield.SubtractBitField(expected, actual)
@@ -26,18 +26,18 @@ func assertBitfieldsEqual(t *testing.T, expected *bitfield.BitField, actual *bit
 	assert.Empty(t, unexpectedSet, "unexpected bits set")
 }
 
-func assertBitfieldEquals(t *testing.T, actual *bitfield.BitField, expected ...uint64) {
+func assertBitfieldEquals(t *testing.T, actual bitfield.BitField, expected ...uint64) {
 	assertBitfieldsEqual(t, actual, bf(expected...))
 }
 
-func assertBitfieldEmpty(t *testing.T, bf *bitfield.BitField) {
+func assertBitfieldEmpty(t *testing.T, bf bitfield.BitField) {
 	empty, err := bf.IsEmpty()
 	require.NoError(t, err)
 	assert.True(t, empty)
 }
 
 // Create a bitfield with count bits set, starting at "start".
-func seq(t *testing.T, start, count uint64) *bitfield.BitField {
+func seq(t *testing.T, start, count uint64) bitfield.BitField {
 	var runs []rlepluslazy.Run
 	if start > 0 {
 		runs = append(runs, rlepluslazy.Run{Val: false, Len: start})

--- a/actors/builtin/miner/cbor_gen.go
+++ b/actors/builtin/miner/cbor_gen.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/filecoin-project/go-bitfield"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/ipfs/go-cid"
 	cbg "github.com/whyrusleeping/cbor-gen"
@@ -263,20 +262,8 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 
 	{
 
-		pb, err := br.PeekByte()
-		if err != nil {
-			return err
-		}
-		if pb == cbg.CborNull[0] {
-			var nbuf [1]byte
-			if _, err := br.Read(nbuf[:]); err != nil {
-				return err
-			}
-		} else {
-			t.EarlyTerminations = new(bitfield.BitField)
-			if err := t.EarlyTerminations.UnmarshalCBOR(br); err != nil {
-				return xerrors.Errorf("unmarshaling t.EarlyTerminations pointer: %w", err)
-			}
+		if err := t.EarlyTerminations.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.EarlyTerminations: %w", err)
 		}
 
 	}
@@ -733,20 +720,8 @@ func (t *Deadline) UnmarshalCBOR(r io.Reader) error {
 
 	{
 
-		pb, err := br.PeekByte()
-		if err != nil {
-			return err
-		}
-		if pb == cbg.CborNull[0] {
-			var nbuf [1]byte
-			if _, err := br.Read(nbuf[:]); err != nil {
-				return err
-			}
-		} else {
-			t.PostSubmissions = new(bitfield.BitField)
-			if err := t.PostSubmissions.UnmarshalCBOR(br); err != nil {
-				return xerrors.Errorf("unmarshaling t.PostSubmissions pointer: %w", err)
-			}
+		if err := t.PostSubmissions.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.PostSubmissions: %w", err)
 		}
 
 	}
@@ -754,20 +729,8 @@ func (t *Deadline) UnmarshalCBOR(r io.Reader) error {
 
 	{
 
-		pb, err := br.PeekByte()
-		if err != nil {
-			return err
-		}
-		if pb == cbg.CborNull[0] {
-			var nbuf [1]byte
-			if _, err := br.Read(nbuf[:]); err != nil {
-				return err
-			}
-		} else {
-			t.EarlyTerminations = new(bitfield.BitField)
-			if err := t.EarlyTerminations.UnmarshalCBOR(br); err != nil {
-				return xerrors.Errorf("unmarshaling t.EarlyTerminations pointer: %w", err)
-			}
+		if err := t.EarlyTerminations.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.EarlyTerminations: %w", err)
 		}
 
 	}
@@ -895,20 +858,8 @@ func (t *Partition) UnmarshalCBOR(r io.Reader) error {
 
 	{
 
-		pb, err := br.PeekByte()
-		if err != nil {
-			return err
-		}
-		if pb == cbg.CborNull[0] {
-			var nbuf [1]byte
-			if _, err := br.Read(nbuf[:]); err != nil {
-				return err
-			}
-		} else {
-			t.Sectors = new(bitfield.BitField)
-			if err := t.Sectors.UnmarshalCBOR(br); err != nil {
-				return xerrors.Errorf("unmarshaling t.Sectors pointer: %w", err)
-			}
+		if err := t.Sectors.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.Sectors: %w", err)
 		}
 
 	}
@@ -916,20 +867,8 @@ func (t *Partition) UnmarshalCBOR(r io.Reader) error {
 
 	{
 
-		pb, err := br.PeekByte()
-		if err != nil {
-			return err
-		}
-		if pb == cbg.CborNull[0] {
-			var nbuf [1]byte
-			if _, err := br.Read(nbuf[:]); err != nil {
-				return err
-			}
-		} else {
-			t.Faults = new(bitfield.BitField)
-			if err := t.Faults.UnmarshalCBOR(br); err != nil {
-				return xerrors.Errorf("unmarshaling t.Faults pointer: %w", err)
-			}
+		if err := t.Faults.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.Faults: %w", err)
 		}
 
 	}
@@ -937,20 +876,8 @@ func (t *Partition) UnmarshalCBOR(r io.Reader) error {
 
 	{
 
-		pb, err := br.PeekByte()
-		if err != nil {
-			return err
-		}
-		if pb == cbg.CborNull[0] {
-			var nbuf [1]byte
-			if _, err := br.Read(nbuf[:]); err != nil {
-				return err
-			}
-		} else {
-			t.Recoveries = new(bitfield.BitField)
-			if err := t.Recoveries.UnmarshalCBOR(br); err != nil {
-				return xerrors.Errorf("unmarshaling t.Recoveries pointer: %w", err)
-			}
+		if err := t.Recoveries.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.Recoveries: %w", err)
 		}
 
 	}
@@ -958,20 +885,8 @@ func (t *Partition) UnmarshalCBOR(r io.Reader) error {
 
 	{
 
-		pb, err := br.PeekByte()
-		if err != nil {
-			return err
-		}
-		if pb == cbg.CborNull[0] {
-			var nbuf [1]byte
-			if _, err := br.Read(nbuf[:]); err != nil {
-				return err
-			}
-		} else {
-			t.Terminated = new(bitfield.BitField)
-			if err := t.Terminated.UnmarshalCBOR(br); err != nil {
-				return xerrors.Errorf("unmarshaling t.Terminated pointer: %w", err)
-			}
+		if err := t.Terminated.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.Terminated: %w", err)
 		}
 
 	}
@@ -1089,20 +1004,8 @@ func (t *ExpirationSet) UnmarshalCBOR(r io.Reader) error {
 
 	{
 
-		pb, err := br.PeekByte()
-		if err != nil {
-			return err
-		}
-		if pb == cbg.CborNull[0] {
-			var nbuf [1]byte
-			if _, err := br.Read(nbuf[:]); err != nil {
-				return err
-			}
-		} else {
-			t.OnTimeSectors = new(bitfield.BitField)
-			if err := t.OnTimeSectors.UnmarshalCBOR(br); err != nil {
-				return xerrors.Errorf("unmarshaling t.OnTimeSectors pointer: %w", err)
-			}
+		if err := t.OnTimeSectors.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.OnTimeSectors: %w", err)
 		}
 
 	}
@@ -1110,20 +1013,8 @@ func (t *ExpirationSet) UnmarshalCBOR(r io.Reader) error {
 
 	{
 
-		pb, err := br.PeekByte()
-		if err != nil {
-			return err
-		}
-		if pb == cbg.CborNull[0] {
-			var nbuf [1]byte
-			if _, err := br.Read(nbuf[:]); err != nil {
-				return err
-			}
-		} else {
-			t.EarlySectors = new(bitfield.BitField)
-			if err := t.EarlySectors.UnmarshalCBOR(br); err != nil {
-				return xerrors.Errorf("unmarshaling t.EarlySectors pointer: %w", err)
-			}
+		if err := t.EarlySectors.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.EarlySectors: %w", err)
 		}
 
 	}
@@ -3238,20 +3129,8 @@ func (t *CompactPartitionsParams) UnmarshalCBOR(r io.Reader) error {
 
 	{
 
-		pb, err := br.PeekByte()
-		if err != nil {
-			return err
-		}
-		if pb == cbg.CborNull[0] {
-			var nbuf [1]byte
-			if _, err := br.Read(nbuf[:]); err != nil {
-				return err
-			}
-		} else {
-			t.Partitions = new(bitfield.BitField)
-			if err := t.Partitions.UnmarshalCBOR(br); err != nil {
-				return xerrors.Errorf("unmarshaling t.Partitions pointer: %w", err)
-			}
+		if err := t.Partitions.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.Partitions: %w", err)
 		}
 
 	}
@@ -3336,20 +3215,8 @@ func (t *CronEventPayload) UnmarshalCBOR(r io.Reader) error {
 
 	{
 
-		pb, err := br.PeekByte()
-		if err != nil {
-			return err
-		}
-		if pb == cbg.CborNull[0] {
-			var nbuf [1]byte
-			if _, err := br.Read(nbuf[:]); err != nil {
-				return err
-			}
-		} else {
-			t.Sectors = new(bitfield.BitField)
-			if err := t.Sectors.UnmarshalCBOR(br); err != nil {
-				return xerrors.Errorf("unmarshaling t.Sectors pointer: %w", err)
-			}
+		if err := t.Sectors.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.Sectors: %w", err)
 		}
 
 	}
@@ -3438,20 +3305,8 @@ func (t *FaultDeclaration) UnmarshalCBOR(r io.Reader) error {
 
 	{
 
-		pb, err := br.PeekByte()
-		if err != nil {
-			return err
-		}
-		if pb == cbg.CborNull[0] {
-			var nbuf [1]byte
-			if _, err := br.Read(nbuf[:]); err != nil {
-				return err
-			}
-		} else {
-			t.Sectors = new(bitfield.BitField)
-			if err := t.Sectors.UnmarshalCBOR(br); err != nil {
-				return xerrors.Errorf("unmarshaling t.Sectors pointer: %w", err)
-			}
+		if err := t.Sectors.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.Sectors: %w", err)
 		}
 
 	}
@@ -3540,20 +3395,8 @@ func (t *RecoveryDeclaration) UnmarshalCBOR(r io.Reader) error {
 
 	{
 
-		pb, err := br.PeekByte()
-		if err != nil {
-			return err
-		}
-		if pb == cbg.CborNull[0] {
-			var nbuf [1]byte
-			if _, err := br.Read(nbuf[:]); err != nil {
-				return err
-			}
-		} else {
-			t.Sectors = new(bitfield.BitField)
-			if err := t.Sectors.UnmarshalCBOR(br); err != nil {
-				return xerrors.Errorf("unmarshaling t.Sectors pointer: %w", err)
-			}
+		if err := t.Sectors.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.Sectors: %w", err)
 		}
 
 	}
@@ -3653,20 +3496,8 @@ func (t *ExpirationExtension) UnmarshalCBOR(r io.Reader) error {
 
 	{
 
-		pb, err := br.PeekByte()
-		if err != nil {
-			return err
-		}
-		if pb == cbg.CborNull[0] {
-			var nbuf [1]byte
-			if _, err := br.Read(nbuf[:]); err != nil {
-				return err
-			}
-		} else {
-			t.Sectors = new(bitfield.BitField)
-			if err := t.Sectors.UnmarshalCBOR(br); err != nil {
-				return xerrors.Errorf("unmarshaling t.Sectors pointer: %w", err)
-			}
+		if err := t.Sectors.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.Sectors: %w", err)
 		}
 
 	}
@@ -3780,20 +3611,8 @@ func (t *TerminationDeclaration) UnmarshalCBOR(r io.Reader) error {
 
 	{
 
-		pb, err := br.PeekByte()
-		if err != nil {
-			return err
-		}
-		if pb == cbg.CborNull[0] {
-			var nbuf [1]byte
-			if _, err := br.Read(nbuf[:]); err != nil {
-				return err
-			}
-		} else {
-			t.Sectors = new(bitfield.BitField)
-			if err := t.Sectors.UnmarshalCBOR(br); err != nil {
-				return xerrors.Errorf("unmarshaling t.Sectors pointer: %w", err)
-			}
+		if err := t.Sectors.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.Sectors: %w", err)
 		}
 
 	}
@@ -3862,20 +3681,8 @@ func (t *PoStPartition) UnmarshalCBOR(r io.Reader) error {
 
 	{
 
-		pb, err := br.PeekByte()
-		if err != nil {
-			return err
-		}
-		if pb == cbg.CborNull[0] {
-			var nbuf [1]byte
-			if _, err := br.Read(nbuf[:]); err != nil {
-				return err
-			}
-		} else {
-			t.Skipped = new(bitfield.BitField)
-			if err := t.Skipped.UnmarshalCBOR(br); err != nil {
-				return xerrors.Errorf("unmarshaling t.Skipped pointer: %w", err)
-			}
+		if err := t.Skipped.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.Skipped: %w", err)
 		}
 
 	}

--- a/actors/builtin/miner/miner_state_test.go
+++ b/actors/builtin/miner/miner_state_test.go
@@ -76,7 +76,7 @@ func TestSectorsStore(t *testing.T) {
 		harness := constructStateHarness(t, abi.ChainEpoch(0))
 
 		sectorNo := abi.SectorNumber(1)
-		bf := abi.NewBitField()
+		bf := bitfield.New()
 		bf.Set(uint64(sectorNo))
 
 		assert.Error(t, harness.s.DeleteSectors(harness.store, bf))
@@ -586,7 +586,7 @@ func TestSectorAssignment(t *testing.T) {
 				return nil
 			}
 
-			var partitions []*bitfield.BitField
+			var partitions []bitfield.BitField
 			for i := uint64(0); i < uint64(partitionsPerDeadline); i++ {
 				start := ((i * openDeadlines) + (dlIdx - 2)) * partitionSectors
 				bf := seq(t, start, partitionSectors)

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -717,7 +717,7 @@ func TestWindowPost(t *testing.T) {
 
 		// Submit PoSt
 		partitions := []miner.PoStPartition{
-			{Index: pIdx, Skipped: abi.NewBitField()},
+			{Index: pIdx, Skipped: bitfield.New()},
 		}
 		actor.submitWindowPoSt(rt, dlinfo, partitions, []*miner.SectorOnChainInfo{sector}, nil)
 
@@ -747,7 +747,7 @@ func TestWindowPost(t *testing.T) {
 
 		// Submit PoSt
 		partitions := []miner.PoStPartition{
-			{Index: pIdx, Skipped: abi.NewBitField()},
+			{Index: pIdx, Skipped: bitfield.New()},
 		}
 		actor.submitWindowPoSt(rt, dlinfo, partitions, []*miner.SectorOnChainInfo{sector}, nil)
 
@@ -819,7 +819,7 @@ func TestWindowPost(t *testing.T) {
 			expectedPenalty:       recoveryFee,
 		}
 		partitions := []miner.PoStPartition{
-			{Index: pIdx, Skipped: abi.NewBitField()},
+			{Index: pIdx, Skipped: bitfield.New()},
 		}
 		actor.submitWindowPoSt(rt, dlinfo, partitions, infos, cfg)
 
@@ -1586,7 +1586,7 @@ func TestExtendSectorExpiration(t *testing.T) {
 			dlinfo = advanceDeadline(rt, actor, &cronConfig{})
 		}
 		partitions := []miner.PoStPartition{
-			{Index: pIdx, Skipped: abi.NewBitField()},
+			{Index: pIdx, Skipped: bitfield.New()},
 		}
 		actor.submitWindowPoSt(rt, dlinfo, partitions, []*miner.SectorOnChainInfo{newSector}, nil)
 
@@ -2134,7 +2134,7 @@ func (h *actorHarness) collectDeadlineExpirations(rt *mock.Runtime, deadline *mi
 	queue, err := miner.LoadBitfieldQueue(rt.AdtStore(), deadline.ExpirationsEpochs, miner.NoQuantization)
 	require.NoError(h.t, err)
 	expirations := map[abi.ChainEpoch][]uint64{}
-	_ = queue.ForEach(func(epoch abi.ChainEpoch, bf *bitfield.BitField) error {
+	_ = queue.ForEach(func(epoch abi.ChainEpoch, bf bitfield.BitField) error {
 		expanded, err := bf.All(miner.SectorsMax)
 		require.NoError(h.t, err)
 		expirations[epoch] = expanded
@@ -2574,7 +2574,7 @@ func (h *actorHarness) declareFaults(rt *mock.Runtime, faultSectorInfos ...*mine
 	rt.Verify()
 }
 
-func (h *actorHarness) declareRecoveries(rt *mock.Runtime, deadlineIdx uint64, partitionIdx uint64, recoverySectors *bitfield.BitField) {
+func (h *actorHarness) declareRecoveries(rt *mock.Runtime, deadlineIdx uint64, partitionIdx uint64, recoverySectors bitfield.BitField) {
 	rt.SetCaller(h.worker, builtin.AccountActorCodeID)
 	rt.ExpectValidateCallerAddr(h.worker)
 
@@ -2623,7 +2623,7 @@ func (h *actorHarness) extendSectors(rt *mock.Runtime, params *miner.ExtendSecto
 	rt.Verify()
 }
 
-func (h *actorHarness) terminateSectors(rt *mock.Runtime, sectors *abi.BitField, expectedFee abi.TokenAmount) {
+func (h *actorHarness) terminateSectors(rt *mock.Runtime, sectors bitfield.BitField, expectedFee abi.TokenAmount) {
 	rt.SetCaller(h.worker, builtin.AccountActorCodeID)
 	rt.ExpectValidateCallerAddr(h.worker)
 
@@ -2900,7 +2900,7 @@ func advanceAndSubmitPoSts(rt *mock.Runtime, h *actorHarness, sectors ...*miner.
 			for _, sector := range dlSectors {
 				_, pIdx, err := st.FindSector(rt.AdtStore(), sector.SectorNumber)
 				require.NoError(h.t, err)
-				partitions = append(partitions, miner.PoStPartition{Index: pIdx, Skipped: abi.NewBitField()})
+				partitions = append(partitions, miner.PoStPartition{Index: pIdx, Skipped: bitfield.New()})
 			}
 			h.submitWindowPoSt(rt, dlinfo, partitions, dlSectors, nil)
 			delete(deadlines, dlinfo.Index)
@@ -2985,12 +2985,12 @@ func makeFaultParamsFromFaultingSectors(t testing.TB, st *miner.State, store adt
 	return &miner.DeclareFaultsParams{Faults: declarations}
 }
 
-func sectorInfoAsBitfield(infos []*miner.SectorOnChainInfo) *bitfield.BitField {
+func sectorInfoAsBitfield(infos []*miner.SectorOnChainInfo) bitfield.BitField {
 	bf := bitfield.New()
 	for _, info := range infos {
 		bf.Set(uint64(info.SectorNumber))
 	}
-	return &bf
+	return bf
 }
 
 func powerForSectors(sectorSize abi.SectorSize, sectors []*miner.SectorOnChainInfo) (rawBytePower, qaPower big.Int) {
@@ -3002,7 +3002,7 @@ func powerForSectors(sectorSize abi.SectorSize, sectors []*miner.SectorOnChainIn
 	return rawBytePower, qaPower
 }
 
-func assertEmptyBitfield(t *testing.T, b *abi.BitField) {
+func assertEmptyBitfield(t *testing.T, b bitfield.BitField) {
 	empty, err := b.IsEmpty()
 	require.NoError(t, err)
 	assert.True(t, empty)

--- a/actors/builtin/miner/partition_state_test.go
+++ b/actors/builtin/miner/partition_state_test.go
@@ -615,7 +615,7 @@ func TestPartitions(t *testing.T) {
 
 type expectExpirationGroup struct {
 	expiration abi.ChainEpoch
-	sectors    *bitfield.BitField
+	sectors    bitfield.BitField
 }
 
 func assertPartitionExpirationQueue(t *testing.T, store adt.Store, partition *miner.Partition, quant miner.QuantSpec, groups []expectExpirationGroup) {
@@ -763,7 +763,7 @@ func checkPartitionInvariants(t *testing.T,
 		earlyQ, err := miner.LoadBitfieldQueue(store, partition.EarlyTerminated, miner.NoQuantization)
 		require.NoError(t, err)
 
-		err = earlyQ.ForEach(func(epoch abi.ChainEpoch, bf *bitfield.BitField) error {
+		err = earlyQ.ForEach(func(epoch abi.ChainEpoch, bf bitfield.BitField) error {
 			return bf.ForEach(func(i uint64) error {
 				assert.False(t, seenSectors[i], "sector already seen")
 				seenSectors[i] = true
@@ -789,10 +789,10 @@ func assertPartitionState(t *testing.T,
 	quant miner.QuantSpec,
 	sectorSize abi.SectorSize,
 	sectors []*miner.SectorOnChainInfo,
-	allSectorIds *bitfield.BitField,
-	faults *bitfield.BitField,
-	recovering *bitfield.BitField,
-	terminations *bitfield.BitField) {
+	allSectorIds bitfield.BitField,
+	faults bitfield.BitField,
+	recovering bitfield.BitField,
+	terminations bitfield.BitField) {
 
 	assertBitfieldsEqual(t, faults, partition.Faults)
 	assertBitfieldsEqual(t, recovering, partition.Recoveries)
@@ -802,11 +802,11 @@ func assertPartitionState(t *testing.T,
 	checkPartitionInvariants(t, store, partition, quant, sectorSize, sectors)
 }
 
-func bf(secNos ...uint64) *bitfield.BitField {
+func bf(secNos ...uint64) bitfield.BitField {
 	return bitfield.NewFromSet(secNos)
 }
 
-func selectSectors(t *testing.T, sectors []*miner.SectorOnChainInfo, field *bitfield.BitField) []*miner.SectorOnChainInfo {
+func selectSectors(t *testing.T, sectors []*miner.SectorOnChainInfo, field bitfield.BitField) []*miner.SectorOnChainInfo {
 	toInclude, err := field.AllMap(miner.SectorsMax)
 	require.NoError(t, err)
 
@@ -829,7 +829,7 @@ func emptyPartition(t *testing.T, store adt.Store) *miner.Partition {
 	return miner.ConstructPartition(root)
 }
 
-func rescheduleSectors(t *testing.T, target abi.ChainEpoch, sectors []*miner.SectorOnChainInfo, filter *bitfield.BitField) []*miner.SectorOnChainInfo {
+func rescheduleSectors(t *testing.T, target abi.ChainEpoch, sectors []*miner.SectorOnChainInfo, filter bitfield.BitField) []*miner.SectorOnChainInfo {
 	toReschedule, err := filter.AllMap(miner.SectorsMax)
 	require.NoError(t, err)
 	output := make([]*miner.SectorOnChainInfo, len(sectors))

--- a/actors/builtin/miner/sector_map.go
+++ b/actors/builtin/miner/sector_map.go
@@ -13,7 +13,7 @@ import (
 type DeadlineSectorMap map[uint64]PartitionSectorMap
 
 // Maps partitions to sector bitfields.
-type PartitionSectorMap map[uint64]*bitfield.BitField
+type PartitionSectorMap map[uint64]bitfield.BitField
 
 // Check validates all bitfields and counts the number of partitions & sectors
 // contained within the map, and returns an error if they exceed the given
@@ -55,7 +55,7 @@ func (dm DeadlineSectorMap) Count() (partitions, sectors uint64, err error) {
 }
 
 // Add records the given sector bitfield at the given deadline/partition index.
-func (dm DeadlineSectorMap) Add(dlIdx, partIdx uint64, sectorNos *bitfield.BitField) error {
+func (dm DeadlineSectorMap) Add(dlIdx, partIdx uint64, sectorNos bitfield.BitField) error {
 	if dlIdx >= WPoStPeriodDeadlines {
 		return xerrors.Errorf("invalid deadline %d", dlIdx)
 	}
@@ -101,7 +101,7 @@ func (pm PartitionSectorMap) AddValues(partIdx uint64, sectorNos ...uint64) erro
 
 // Add records the given sector bitfield at the given partition index, merging
 // it with any existing bitfields if necessary.
-func (pm PartitionSectorMap) Add(partIdx uint64, sectorNos *bitfield.BitField) error {
+func (pm PartitionSectorMap) Add(partIdx uint64, sectorNos bitfield.BitField) error {
 	if oldSectorNos, ok := pm[partIdx]; ok {
 		var err error
 		sectorNos, err = bitfield.MergeBitFields(sectorNos, oldSectorNos)
@@ -141,7 +141,7 @@ func (pm PartitionSectorMap) Partitions() []uint64 {
 }
 
 // ForEach walks the partitions in the map, in order of increasing index.
-func (pm PartitionSectorMap) ForEach(cb func(partIdx uint64, sectorNos *bitfield.BitField) error) error {
+func (pm PartitionSectorMap) ForEach(cb func(partIdx uint64, sectorNos bitfield.BitField) error) error {
 	for _, partIdx := range pm.Partitions() {
 		if err := cb(partIdx, pm[partIdx]); err != nil {
 			return err

--- a/actors/builtin/miner/sector_map_test.go
+++ b/actors/builtin/miner/sector_map_test.go
@@ -23,7 +23,7 @@ func TestDeadlineSectorMap(t *testing.T) {
 
 	err := dm.ForEach(func(dlIdx uint64, partitions miner.PartitionSectorMap) error {
 		assert.Equal(t, dm[dlIdx], partitions)
-		return partitions.ForEach(func(partIdx uint64, sectorNos *bitfield.BitField) error {
+		return partitions.ForEach(func(partIdx uint64, sectorNos bitfield.BitField) error {
 			assert.Equal(t, partitions[partIdx], sectorNos)
 			assertBitfieldEquals(t, sectorNos, dlIdx*partCount+partIdx)
 			return nil
@@ -61,7 +61,7 @@ func TestDeadlineSectorMapError(t *testing.T) {
 	expErr := errors.New("foobar")
 
 	err := dm.ForEach(func(dlIdx uint64, partitions miner.PartitionSectorMap) error {
-		return partitions.ForEach(func(partIdx uint64, sectorNos *bitfield.BitField) error {
+		return partitions.ForEach(func(partIdx uint64, sectorNos bitfield.BitField) error {
 			return expErr
 		})
 	})
@@ -131,7 +131,7 @@ func TestPartitionSectorMapEmpty(t *testing.T) {
 	require.Zero(t, partitions)
 	require.Zero(t, sectors)
 
-	require.NoError(t, pm.ForEach(func(dlIdx uint64, sectorNos *bitfield.BitField) error {
+	require.NoError(t, pm.ForEach(func(dlIdx uint64, sectorNos bitfield.BitField) error {
 		require.Fail(t, "should not iterate over an empty map")
 		return nil
 	}))

--- a/actors/builtin/miner/sectors.go
+++ b/actors/builtin/miner/sectors.go
@@ -3,6 +3,7 @@ package miner
 import (
 	"fmt"
 
+	"github.com/filecoin-project/go-bitfield"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	xc "github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
@@ -25,7 +26,7 @@ type Sectors struct {
 	*adt.Array
 }
 
-func (sa Sectors) Load(sectorNos *abi.BitField) ([]*SectorOnChainInfo, error) {
+func (sa Sectors) Load(sectorNos bitfield.BitField) ([]*SectorOnChainInfo, error) {
 	var sectorInfos []*SectorOnChainInfo
 	if err := sectorNos.ForEach(func(i uint64) error {
 		var sectorOnChain SectorOnChainInfo

--- a/actors/builtin/miner/termination.go
+++ b/actors/builtin/miner/termination.go
@@ -10,14 +10,14 @@ import (
 type TerminationResult struct {
 	// Sectors maps epochs at which sectors expired, to bitfields of sector
 	// numbers.
-	Sectors map[abi.ChainEpoch]*abi.BitField
+	Sectors map[abi.ChainEpoch]bitfield.BitField
 	// Counts the number of partitions & sectors processed.
 	PartitionsProcessed, SectorsProcessed uint64
 }
 
 func (t *TerminationResult) Add(newResult TerminationResult) error {
 	if t.Sectors == nil {
-		t.Sectors = make(map[abi.ChainEpoch]*abi.BitField, len(newResult.Sectors))
+		t.Sectors = make(map[abi.ChainEpoch]bitfield.BitField, len(newResult.Sectors))
 	}
 	t.PartitionsProcessed += newResult.PartitionsProcessed
 	t.SectorsProcessed += newResult.SectorsProcessed
@@ -45,7 +45,7 @@ func (t *TerminationResult) IsEmpty() bool {
 	return t.SectorsProcessed == 0
 }
 
-func (t *TerminationResult) ForEach(cb func(epoch abi.ChainEpoch, sectors *abi.BitField) error) error {
+func (t *TerminationResult) ForEach(cb func(epoch abi.ChainEpoch, sectors bitfield.BitField) error) error {
 	// We're sorting here, so iterating over the map is fine.
 	epochs := make([]abi.ChainEpoch, 0, len(t.Sectors))
 	for epoch := range t.Sectors { //nolint:nomaprange

--- a/actors/builtin/miner/termination_test.go
+++ b/actors/builtin/miner/termination_test.go
@@ -12,14 +12,14 @@ import (
 func TestTerminationResult(t *testing.T) {
 	var result miner.TerminationResult
 	require.True(t, result.IsEmpty())
-	err := result.ForEach(func(epoch abi.ChainEpoch, sectors *abi.BitField) error {
+	err := result.ForEach(func(epoch abi.ChainEpoch, sectors bitfield.BitField) error {
 		require.FailNow(t, "unreachable")
 		return nil
 	})
 	require.NoError(t, err)
 
 	resultA := miner.TerminationResult{
-		Sectors: map[abi.ChainEpoch]*abi.BitField{
+		Sectors: map[abi.ChainEpoch]bitfield.BitField{
 			3: bitfield.NewFromSet([]uint64{9}),
 			0: bitfield.NewFromSet([]uint64{1, 2, 4}),
 			2: bitfield.NewFromSet([]uint64{3, 5, 7}),
@@ -29,7 +29,7 @@ func TestTerminationResult(t *testing.T) {
 	}
 	require.False(t, resultA.IsEmpty())
 	resultB := miner.TerminationResult{
-		Sectors: map[abi.ChainEpoch]*abi.BitField{
+		Sectors: map[abi.ChainEpoch]bitfield.BitField{
 			1: bitfield.NewFromSet([]uint64{12}),
 			0: bitfield.NewFromSet([]uint64{10}),
 		},
@@ -41,7 +41,7 @@ func TestTerminationResult(t *testing.T) {
 	require.NoError(t, result.Add(resultB))
 	require.False(t, result.IsEmpty())
 	expected := miner.TerminationResult{
-		Sectors: map[abi.ChainEpoch]*abi.BitField{
+		Sectors: map[abi.ChainEpoch]bitfield.BitField{
 			2: bitfield.NewFromSet([]uint64{3, 5, 7}),
 			0: bitfield.NewFromSet([]uint64{1, 2, 4, 10}),
 			1: bitfield.NewFromSet([]uint64{12}),
@@ -55,7 +55,7 @@ func TestTerminationResult(t *testing.T) {
 	require.Equal(t, len(expected.Sectors), len(result.Sectors))
 
 	expectedEpoch := abi.ChainEpoch(0)
-	err = result.ForEach(func(epoch abi.ChainEpoch, actualBf *abi.BitField) error {
+	err = result.ForEach(func(epoch abi.ChainEpoch, actualBf bitfield.BitField) error {
 		require.Equal(t, expectedEpoch, epoch)
 		expectedEpoch++
 		expectedBf, ok := expected.Sectors[epoch]

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/filecoin-project/go-address v0.0.2-0.20200218010043-eb9bb40ed5be
 	github.com/filecoin-project/go-amt-ipld/v2 v2.1.0
-	github.com/filecoin-project/go-bitfield v0.1.2
+	github.com/filecoin-project/go-bitfield v0.2.0
 	github.com/gopherjs/gopherjs v0.0.0-20190812055157-5d271430af9f // indirect
 	github.com/ipfs/go-block-format v0.0.2
 	github.com/ipfs/go-cid v0.0.6

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/filecoin-project/go-address v0.0.2-0.20200218010043-eb9bb40ed5be h1:T
 github.com/filecoin-project/go-address v0.0.2-0.20200218010043-eb9bb40ed5be/go.mod h1:SAOwJoakQ8EPjwNIsiakIQKsoKdkcbx8U3IapgCg9R0=
 github.com/filecoin-project/go-amt-ipld/v2 v2.1.0 h1:t6qDiuGYYngDqaLc2ZUvdtAg4UNxPeOYaXhBWSNsVaM=
 github.com/filecoin-project/go-amt-ipld/v2 v2.1.0/go.mod h1:nfFPoGyX0CU9SkXX8EoCcSuHN1XcbN0c6KBh7yvP5fs=
-github.com/filecoin-project/go-bitfield v0.1.2 h1:TjLregCoyP1/5lm7WCM0axyV1myIHwbjGa21skuu5tk=
-github.com/filecoin-project/go-bitfield v0.1.2/go.mod h1:CNl9WG8hgR5mttCnUErjcQjGvuiZjRqK9rHVBsQF4oM=
+github.com/filecoin-project/go-bitfield v0.2.0 h1:gCtLcjskIPtdg4NfN7gQZSQF9yrBQ7mkT0qCJxzGI2Q=
+github.com/filecoin-project/go-bitfield v0.2.0/go.mod h1:CNl9WG8hgR5mttCnUErjcQjGvuiZjRqK9rHVBsQF4oM=
 github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03 h1:2pMXdBnCiXjfCYx/hLqFxccPoqsSveQFxVLvNxy9bus=
 github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03/go.mod h1:+viYnvGtUTgJRdy6oaeF4MTFKAfatX071MPDPBL11EQ=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=


### PR DESCRIPTION
Unfortunately, by-pointer bitfields meant we needed to check for nil bitfields in function parameters. Given the fact that we rarely do this, it's safer to just use bitfields by-value.

Note: "zero"/uninitialized bitfields are still valid for reading. However, updating a zero-value/uninitialized bitfield will cause a panic.

Part of https://github.com/filecoin-project/specs-actors/issues/895
Depends on https://github.com/filecoin-project/go-bitfield/pull/44