### PR TITLE
Commit windowed post submissions to a particular chain.

### DIFF
--- a/actors/builtin/miner/cbor_gen.go
+++ b/actors/builtin/miner/cbor_gen.go
@@ -1951,7 +1951,7 @@ func (t *WorkerKeyChange) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
-var lengthBufSubmitWindowedPoStParams = []byte{131}
+var lengthBufSubmitWindowedPoStParams = []byte{133}
 
 func (t *SubmitWindowedPoStParams) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -2014,7 +2014,7 @@ func (t *SubmitWindowedPoStParams) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 3 {
+	if extra != 5 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -2090,6 +2090,40 @@ func (t *SubmitWindowedPoStParams) UnmarshalCBOR(r io.Reader) error {
 		t.Proofs[i] = v
 	}
 
+	// t.ChainCommitEpoch (abi.ChainEpoch) (int64)
+	{
+		maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+		var extraI int64
+		if err != nil {
+			return err
+		}
+		switch maj {
+		case cbg.MajUnsignedInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 positive overflow")
+			}
+		case cbg.MajNegativeInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 negative oveflow")
+			}
+			extraI = -1 - extraI
+		default:
+			return fmt.Errorf("wrong type for int64 field: %d", maj)
+		}
+
+		t.ChainCommitEpoch = abi.ChainEpoch(extraI)
+	}
+	// t.ChainCommitSig (crypto.Signature) (struct)
+
+	{
+
+		if err := t.ChainCommitSig.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.ChainCommitSig: %w", err)
+		}
+
+	}
 	return nil
 }
 
@@ -2118,6 +2152,22 @@ func (t *TerminateSectorsParams) MarshalCBOR(w io.Writer) error {
 		if err := v.MarshalCBOR(w); err != nil {
 			return err
 		}
+	}
+
+	// t.ChainCommitEpoch (abi.ChainEpoch) (int64)
+	if t.ChainCommitEpoch >= 0 {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.ChainCommitEpoch)); err != nil {
+			return err
+		}
+	} else {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.ChainCommitEpoch-1)); err != nil {
+			return err
+		}
+	}
+
+	// t.ChainCommitSig (crypto.Signature) (struct)
+	if err := t.ChainCommitSig.MarshalCBOR(w); err != nil {
+		return err
 	}
 	return nil
 }

--- a/actors/builtin/miner/cbor_gen.go
+++ b/actors/builtin/miner/cbor_gen.go
@@ -2115,14 +2115,26 @@ func (t *SubmitWindowedPoStParams) UnmarshalCBOR(r io.Reader) error {
 
 		t.ChainCommitEpoch = abi.ChainEpoch(extraI)
 	}
-	// t.ChainCommitSig (crypto.Signature) (struct)
+	// t.ChainCommitRand (abi.Randomness) (slice)
 
-	{
+	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
 
-		if err := t.ChainCommitSig.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.ChainCommitSig: %w", err)
-		}
+	if extra > cbg.ByteArrayMaxLen {
+		return fmt.Errorf("t.ChainCommitRand: byte array too large (%d)", extra)
+	}
+	if maj != cbg.MajByteString {
+		return fmt.Errorf("expected byte array")
+	}
 
+	if extra > 0 {
+		t.ChainCommitRand = make([]uint8, extra)
+	}
+
+	if _, err := io.ReadFull(br, t.ChainCommitRand[:]); err != nil {
+		return err
 	}
 	return nil
 }
@@ -2165,8 +2177,16 @@ func (t *TerminateSectorsParams) MarshalCBOR(w io.Writer) error {
 		}
 	}
 
-	// t.ChainCommitSig (crypto.Signature) (struct)
-	if err := t.ChainCommitSig.MarshalCBOR(w); err != nil {
+	// t.ChainCommitRand (abi.Randomness) (slice)
+	if len(t.ChainCommitRand) > cbg.ByteArrayMaxLen {
+		return xerrors.Errorf("Byte array in field t.ChainCommitRand was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajByteString, uint64(len(t.ChainCommitRand))); err != nil {
+		return err
+	}
+
+	if _, err := w.Write(t.ChainCommitRand[:]); err != nil {
 		return err
 	}
 	return nil

--- a/actors/builtin/miner/cbor_gen.go
+++ b/actors/builtin/miner/cbor_gen.go
@@ -1997,6 +1997,30 @@ func (t *SubmitWindowedPoStParams) MarshalCBOR(w io.Writer) error {
 			return err
 		}
 	}
+
+	// t.ChainCommitEpoch (abi.ChainEpoch) (int64)
+	if t.ChainCommitEpoch >= 0 {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.ChainCommitEpoch)); err != nil {
+			return err
+		}
+	} else {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.ChainCommitEpoch-1)); err != nil {
+			return err
+		}
+	}
+
+	// t.ChainCommitRand (abi.Randomness) (slice)
+	if len(t.ChainCommitRand) > cbg.ByteArrayMaxLen {
+		return xerrors.Errorf("Byte array in field t.ChainCommitRand was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajByteString, uint64(len(t.ChainCommitRand))); err != nil {
+		return err
+	}
+
+	if _, err := w.Write(t.ChainCommitRand[:]); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -2164,30 +2188,6 @@ func (t *TerminateSectorsParams) MarshalCBOR(w io.Writer) error {
 		if err := v.MarshalCBOR(w); err != nil {
 			return err
 		}
-	}
-
-	// t.ChainCommitEpoch (abi.ChainEpoch) (int64)
-	if t.ChainCommitEpoch >= 0 {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.ChainCommitEpoch)); err != nil {
-			return err
-		}
-	} else {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.ChainCommitEpoch-1)); err != nil {
-			return err
-		}
-	}
-
-	// t.ChainCommitRand (abi.Randomness) (slice)
-	if len(t.ChainCommitRand) > cbg.ByteArrayMaxLen {
-		return xerrors.Errorf("Byte array in field t.ChainCommitRand was too long")
-	}
-
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajByteString, uint64(len(t.ChainCommitRand))); err != nil {
-		return err
-	}
-
-	if _, err := w.Write(t.ChainCommitRand[:]); err != nil {
-		return err
 	}
 	return nil
 }

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -260,8 +260,8 @@ func (a Actor) SubmitWindowedPoSt(rt Runtime, params *SubmitWindowedPoStParams) 
 	if params.ChainCommitEpoch >= currEpoch {
 		rt.Abortf(exitcode.ErrIllegalArgument, "PoSt chain commitment %d must be in the past", params.ChainCommitEpoch)
 	}
-	if params.ChainCommitEpoch < currEpoch-MaxPoStChainCommitAge {
-		rt.Abortf(exitcode.ErrIllegalArgument, "PoSt chain commitment %d too far in the past, must exceed %d", params.ChainCommitEpoch, currEpoch-MaxPoStChainCommitAge)
+	if params.ChainCommitEpoch < currEpoch-WPoStMaxChainCommitAge {
+		rt.Abortf(exitcode.ErrIllegalArgument, "PoSt chain commitment %d too far in the past, must be after %d", params.ChainCommitEpoch, currEpoch-WPoStMaxChainCommitAge)
 	}
 	commRand := rt.GetRandomnessFromTickets(crypto.DomainSeparationTag_PoStChainCommit, params.ChainCommitEpoch, nil)
 	if !bytes.Equal(commRand, params.ChainCommitRand) {

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -257,18 +257,17 @@ func (a Actor) SubmitWindowedPoSt(rt Runtime, params *SubmitWindowedPoStParams) 
 	if params.Deadline >= WPoStPeriodDeadlines {
 		rt.Abortf(exitcode.ErrIllegalArgument, "invalid deadline %d of %d", params.Deadline, WPoStPeriodDeadlines)
 	}
-	// TODO: limit the length of proofs array https://github.com/filecoin-project/specs-actors/issues/416
-
 	if params.ChainCommitEpoch >= currEpoch {
 		rt.Abortf(exitcode.ErrIllegalArgument, "PoSt chain commitment %d must be in the past", params.ChainCommitEpoch)
 	}
-	if params.ChainCommitEpoch < currEpoch - MaxPoStChainCommitAge {
-		rt.Abortf(exitcode.ErrIllegalArgument, "PoSt chain commitment %d too far in the past, must exceed %d", params.ChainCommitEpoch, currEpoch - MaxPoStChainCommitAge)
+	if params.ChainCommitEpoch < currEpoch-MaxPoStChainCommitAge {
+		rt.Abortf(exitcode.ErrIllegalArgument, "PoSt chain commitment %d too far in the past, must exceed %d", params.ChainCommitEpoch, currEpoch-MaxPoStChainCommitAge)
 	}
 	commRand := rt.GetRandomnessFromTickets(crypto.DomainSeparationTag_PoStChainCommit, params.ChainCommitEpoch, nil)
 	if !bytes.Equal(commRand, params.ChainCommitRand) {
 		rt.Abortf(exitcode.ErrIllegalArgument, "post commit randomness mismatched")
 	}
+	// TODO: limit the length of proofs array https://github.com/filecoin-project/specs-actors/issues/416
 
 	// Get the total power/reward. We need these to compute penalties.
 	rewardStats := requestCurrentEpochBlockReward(rt)

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -242,6 +242,10 @@ type SubmitWindowedPoStParams struct {
 	// Array of proofs, one per distinct registered proof type present in the sectors being proven.
 	// In the usual case of a single proof type, this array will always have a single element (independent of number of partitions).
 	Proofs []abi.PoStProof
+	// The epoch at which these proofs is being committed to a particular chain.
+	ChainCommitEpoch abi.ChainEpoch
+	// A signature from the miner worker over the randomness at the chain commit epoch.
+	ChainCommitSig crypto.Signature
 }
 
 // Invoked by miner's worker address to submit their fallback post
@@ -254,6 +258,16 @@ func (a Actor) SubmitWindowedPoSt(rt Runtime, params *SubmitWindowedPoStParams) 
 		rt.Abortf(exitcode.ErrIllegalArgument, "invalid deadline %d of %d", params.Deadline, WPoStPeriodDeadlines)
 	}
 	// TODO: limit the length of proofs array https://github.com/filecoin-project/specs-actors/issues/416
+
+	if params.ChainCommitEpoch >= currEpoch {
+		rt.Abortf(exitcode.ErrIllegalArgument, "PoSt chain commitment %d must be in the past", params.ChainCommitEpoch)
+	}
+	if params.ChainCommitEpoch < currEpoch - MaxPoStChainCommitAge {
+		rt.Abortf(exitcode.ErrIllegalArgument, "PoSt chain commitment %d too far in the past, must exceed %d", params.ChainCommitEpoch, currEpoch - MaxPoStChainCommitAge)
+	}
+	commRand := rt.GetRandomnessFromTickets(crypto.DomainSeparationTag_PoStChainCommit, params.ChainCommitEpoch, nil)
+	err := rt.Syscalls().VerifySignature(params.ChainCommitSig, rt.Message().Caller(), commRand)
+	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalArgument, "chain commit signature invalid")
 
 	// Get the total power/reward. We need these to compute penalties.
 	rewardStats := requestCurrentEpochBlockReward(rt)

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -753,7 +753,7 @@ func TestWindowPost(t *testing.T) {
 
 		// Submit a duplicate proof for the same partition, which should be ignored.
 		// The skipped fault declared here has no effect.
-		commitEpoch := rt.Epoch() - 100
+		commitEpoch := rt.Epoch() - 1
 		commitRand := abi.Randomness("chaincommitment")
 		params := miner.SubmitWindowedPoStParams{
 			Deadline: dlIdx,
@@ -763,7 +763,7 @@ func TestWindowPost(t *testing.T) {
 			}},
 			Proofs:           makePoStProofs(actor.postProofType),
 			ChainCommitEpoch: commitEpoch,
-			ChainCommitRand:   commitRand,
+			ChainCommitRand:  commitRand,
 		}
 		expectQueryNetworkInfo(rt, actor)
 		rt.SetCaller(actor.worker, builtin.AccountActorCodeID)
@@ -2495,7 +2495,7 @@ type poStConfig struct {
 func (h *actorHarness) submitWindowPoSt(rt *mock.Runtime, deadline *miner.DeadlineInfo, partitions []miner.PoStPartition, infos []*miner.SectorOnChainInfo, poStCfg *poStConfig) {
 	rt.SetCaller(h.worker, builtin.AccountActorCodeID)
 	commitRand := abi.Randomness("chaincommitment")
-	commitEpoch := rt.Epoch() - 100
+	commitEpoch := rt.Epoch() - 4
 	rt.ExpectGetRandomnessTickets(crypto.DomainSeparationTag_PoStChainCommit, commitEpoch, nil, commitRand)
 
 	rt.ExpectValidateCallerAddr(h.worker)

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -753,17 +753,27 @@ func TestWindowPost(t *testing.T) {
 
 		// Submit a duplicate proof for the same partition, which should be ignored.
 		// The skipped fault declared here has no effect.
+		commitEpoch := rt.Epoch() - 100
+		commitRand := abi.Randomness("chaincommitment")
+		commitSig := crypto.Signature{
+			Type: crypto.SigTypeBLS,
+			Data: []byte("sig"),
+		}
 		params := miner.SubmitWindowedPoStParams{
 			Deadline: dlIdx,
 			Partitions: []miner.PoStPartition{{
 				Index:   pIdx,
 				Skipped: bf(uint64(sector.SectorNumber)),
 			}},
-			Proofs: makePoStProofs(actor.postProofType),
+			Proofs:           makePoStProofs(actor.postProofType),
+			ChainCommitEpoch: commitEpoch,
+			ChainCommitSig:   commitSig,
 		}
 		expectQueryNetworkInfo(rt, actor)
 		rt.SetCaller(actor.worker, builtin.AccountActorCodeID)
 		rt.ExpectValidateCallerAddr(actor.worker)
+		rt.ExpectGetRandomnessTickets(crypto.DomainSeparationTag_PoStChainCommit, commitEpoch, nil, commitRand)
+		rt.ExpectVerifySignature(commitSig, actor.worker, commitRand, nil)
 		rt.Call(actor.a.SubmitWindowedPoSt, &params)
 		rt.Verify()
 
@@ -2489,6 +2499,15 @@ type poStConfig struct {
 
 func (h *actorHarness) submitWindowPoSt(rt *mock.Runtime, deadline *miner.DeadlineInfo, partitions []miner.PoStPartition, infos []*miner.SectorOnChainInfo, poStCfg *poStConfig) {
 	rt.SetCaller(h.worker, builtin.AccountActorCodeID)
+	commitRand := abi.Randomness("chaincommitment")
+	commitEpoch := rt.Epoch() - 100
+	commitSig := crypto.Signature{
+		Type: crypto.SigTypeBLS,
+		Data: []byte("sig"),
+	}
+	rt.ExpectGetRandomnessTickets(crypto.DomainSeparationTag_PoStChainCommit, commitEpoch, nil, commitRand)
+	rt.ExpectVerifySignature(commitSig, h.worker, commitRand, nil)
+
 	rt.ExpectValidateCallerAddr(h.worker)
 
 	expectQueryNetworkInfo(rt, h)
@@ -2574,9 +2593,11 @@ func (h *actorHarness) submitWindowPoSt(rt *mock.Runtime, deadline *miner.Deadli
 	}
 
 	params := miner.SubmitWindowedPoStParams{
-		Deadline:   deadline.Index,
-		Partitions: partitions,
-		Proofs:     proofs,
+		Deadline:         deadline.Index,
+		Partitions:       partitions,
+		Proofs:           proofs,
+		ChainCommitEpoch: commitEpoch,
+		ChainCommitSig:   commitSig,
 	}
 
 	rt.Call(h.a.SubmitWindowedPoSt, &params)

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -755,10 +755,6 @@ func TestWindowPost(t *testing.T) {
 		// The skipped fault declared here has no effect.
 		commitEpoch := rt.Epoch() - 100
 		commitRand := abi.Randomness("chaincommitment")
-		commitSig := crypto.Signature{
-			Type: crypto.SigTypeBLS,
-			Data: []byte("sig"),
-		}
 		params := miner.SubmitWindowedPoStParams{
 			Deadline: dlIdx,
 			Partitions: []miner.PoStPartition{{
@@ -767,13 +763,12 @@ func TestWindowPost(t *testing.T) {
 			}},
 			Proofs:           makePoStProofs(actor.postProofType),
 			ChainCommitEpoch: commitEpoch,
-			ChainCommitSig:   commitSig,
+			ChainCommitRand:   commitRand,
 		}
 		expectQueryNetworkInfo(rt, actor)
 		rt.SetCaller(actor.worker, builtin.AccountActorCodeID)
 		rt.ExpectValidateCallerAddr(actor.worker)
 		rt.ExpectGetRandomnessTickets(crypto.DomainSeparationTag_PoStChainCommit, commitEpoch, nil, commitRand)
-		rt.ExpectVerifySignature(commitSig, actor.worker, commitRand, nil)
 		rt.Call(actor.a.SubmitWindowedPoSt, &params)
 		rt.Verify()
 
@@ -2501,12 +2496,7 @@ func (h *actorHarness) submitWindowPoSt(rt *mock.Runtime, deadline *miner.Deadli
 	rt.SetCaller(h.worker, builtin.AccountActorCodeID)
 	commitRand := abi.Randomness("chaincommitment")
 	commitEpoch := rt.Epoch() - 100
-	commitSig := crypto.Signature{
-		Type: crypto.SigTypeBLS,
-		Data: []byte("sig"),
-	}
 	rt.ExpectGetRandomnessTickets(crypto.DomainSeparationTag_PoStChainCommit, commitEpoch, nil, commitRand)
-	rt.ExpectVerifySignature(commitSig, h.worker, commitRand, nil)
 
 	rt.ExpectValidateCallerAddr(h.worker)
 
@@ -2597,7 +2587,7 @@ func (h *actorHarness) submitWindowPoSt(rt *mock.Runtime, deadline *miner.Deadli
 		Partitions:       partitions,
 		Proofs:           proofs,
 		ChainCommitEpoch: commitEpoch,
-		ChainCommitSig:   commitSig,
+		ChainCommitRand:  commitRand,
 	}
 
 	rt.Call(h.a.SubmitWindowedPoSt, &params)

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -117,6 +117,10 @@ const MinSectorExpiration = 180 * builtin.EpochsInDay
 // and sector.ActivationEpoch+sealProof.SectorMaximumLifetime()
 const MaxSectorExpirationExtension = 540 * builtin.EpochsInDay
 
+// MaxPoStChainCommitAge is the maximum distance back that a PoSt can commit to
+// a chain before being invalid
+const MaxPoStChainCommitAge = 5
+
 // Ratio of sector size to maximum deals per sector.
 // The maximum number of deals is the sector size divided by this number (2^27)
 // which limits 32GiB sectors to 256 deals and 64GiB sectors to 512

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -22,6 +22,9 @@ var WPoStChallengeWindow = abi.ChainEpoch(30 * 60 / builtin.EpochDurationSeconds
 // The number of non-overlapping PoSt deadlines in each proving period.
 const WPoStPeriodDeadlines = uint64(48)
 
+// WPoStMaxChainCommitAge is the maximum distance back that a valid Window PoSt must commit to the current chain.
+var WPoStMaxChainCommitAge = WPoStChallengeWindow
+
 func init() {
 	// Check that the challenge windows divide the proving period evenly.
 	if WPoStProvingPeriod%WPoStChallengeWindow != 0 {
@@ -116,10 +119,6 @@ const MinSectorExpiration = 180 * builtin.EpochsInDay
 // The actual maximum extension will be the minimum of CurrEpoch + MaximumSectorExpirationExtension
 // and sector.ActivationEpoch+sealProof.SectorMaximumLifetime()
 const MaxSectorExpirationExtension = 540 * builtin.EpochsInDay
-
-// MaxPoStChainCommitAge is the maximum distance back that a PoSt can commit to
-// a chain before being invalid
-const MaxPoStChainCommitAge = 5
 
 // Ratio of sector size to maximum deals per sector.
 // The maximum number of deals is the sector size divided by this number (2^27)

--- a/actors/crypto/randomness.go
+++ b/actors/crypto/randomness.go
@@ -11,4 +11,5 @@ const (
 	DomainSeparationTag_SealRandomness
 	DomainSeparationTag_InteractiveSealChallengeSeed
 	DomainSeparationTag_WindowedPoStDeadlineAssignment
+	DomainSeparationTag_PoStChainCommit
 )


### PR DESCRIPTION
This prevents posts from being replayed on distant forks and helps to protect filecoin against long range attacks.

Replaces #680, which I accidentally merged into the wrong branch.

cc @magik6k @whyrusleeping 