### PR TITLE
Add boolean found return value to init state address resolution

### DIFF
--- a/actors/builtin/init/init_actor_state.go
+++ b/actors/builtin/init/init_actor_state.go
@@ -3,7 +3,6 @@ package init
 import (
 	addr "github.com/filecoin-project/go-address"
 	cid "github.com/ipfs/go-cid"
-	errors "github.com/pkg/errors"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	xerrors "golang.org/x/xerrors"
 
@@ -12,8 +11,6 @@ import (
 	autil "github.com/filecoin-project/specs-actors/actors/util"
 	adt "github.com/filecoin-project/specs-actors/actors/util/adt"
 )
-
-var ErrAddressNotFound = errors.New("address not found")
 
 type AddrKey = adt.AddrKey
 
@@ -33,36 +30,37 @@ func ConstructState(addressMapRoot cid.Cid, networkName string) *State {
 
 // ResolveAddress resolves an address to an ID-address, if possible.
 // If the provided address is an ID address, it is returned as-is.
-// This means that ID-addresses (which should only appear as values, not keys) and singleton actor addresses
-// pass through unchanged.
+// This means that mapped ID-addresses (which should only appear as values, not keys) and
+// singleton actor addresses (which are not in the map) pass through unchanged.
 //
-// Post-condition: all addresses succesfully returned by this method satisfy `addr.Protocol() == addr.ID`.
-func (s *State) ResolveAddress(store adt.Store, address addr.Address) (addr.Address, error) {
+// Returns an ID-address and `true` if the address was already an ID-address or was resolved in the mapping.
+// Returns an undefined address and `false` if the address was not an ID-address and not found in the mapping.
+// Returns an error only if state was inconsistent.
+func (s *State) ResolveAddress(store adt.Store, address addr.Address) (addr.Address, bool, error) {
 	// Short-circuit ID address resolution.
 	if address.Protocol() == addr.ID {
-		return address, nil
+		return address, true, nil
 	}
 
 	// Lookup address.
 	m, err := adt.AsMap(store, s.AddressMap)
 	if err != nil {
-		return addr.Undef, xerrors.Errorf("failed to load address map: %w", err)
+		return addr.Undef, false, xerrors.Errorf("failed to load address map: %w", err)
 	}
 
 	var actorID cbg.CborInt
 	found, err := m.Get(AddrKey(address), &actorID)
 	if err != nil {
-		return addr.Undef, errors.Wrapf(err, "resolve address failed to look up map")
+		return addr.Undef, false, xerrors.Errorf("failed to get from address map: %w", err)
 	}
 	if found {
 		// Reconstruct address from the ActorID.
 		idAddr, err2 := addr.NewIDAddress(uint64(actorID))
 		autil.Assert(err2 == nil)
-		return idAddr, nil
+		return idAddr, true, nil
+	} else {
+		return addr.Undef, false, nil
 	}
-
-	// Not found.
-	return addr.Undef, ErrAddressNotFound
 }
 
 // Allocates a new ID address and stores a mapping of the argument address to it.

--- a/actors/builtin/init/init_test.go
+++ b/actors/builtin/init/init_test.go
@@ -84,8 +84,9 @@ func TestExec(t *testing.T) {
 
 		var st init_.State
 		rt.GetState(&st)
-		actualIdAddr, err := st.ResolveAddress(adt.AsStore(rt), uniqueAddr1)
+		actualIdAddr, found, err := st.ResolveAddress(adt.AsStore(rt), uniqueAddr1)
 		assert.NoError(t, err)
+		assert.True(t, found)
 		assert.Equal(t, expectedIdAddr1, actualIdAddr)
 
 		// creating another actor should get a different address, the below logic is a repeat of the above to insure
@@ -106,8 +107,9 @@ func TestExec(t *testing.T) {
 
 		var st2 init_.State
 		rt.GetState(&st2)
-		actualIdAddr2, err := st2.ResolveAddress(adt.AsStore(rt), uniqueAddr2)
+		actualIdAddr2, found, err := st2.ResolveAddress(adt.AsStore(rt), uniqueAddr2)
 		assert.NoError(t, err)
+		assert.True(t, found)
 		assert.Equal(t, expectedIdAddr2, actualIdAddr2)
 	})
 
@@ -135,14 +137,16 @@ func TestExec(t *testing.T) {
 
 		var st init_.State
 		rt.GetState(&st)
-		actualIdAddr, err := st.ResolveAddress(adt.AsStore(rt), uniqueAddr)
+		actualIdAddr, found, err := st.ResolveAddress(adt.AsStore(rt), uniqueAddr)
 		assert.NoError(t, err)
+		assert.True(t, found)
 		assert.Equal(t, expectedIdAddr, actualIdAddr)
 
-		// returns error if not able to resolve
+		// returns false if not able to resolve
 		expUnknowAddr := tutil.NewActorAddr(t, "flurbo")
-		actualUnknownAddr, err := st.ResolveAddress(adt.AsStore(rt), expUnknowAddr)
-		assert.Error(t, err)
+		actualUnknownAddr, found, err := st.ResolveAddress(adt.AsStore(rt), expUnknowAddr)
+		assert.NoError(t, err)
+		assert.False(t, found)
 		assert.Equal(t, addr.Undef, actualUnknownAddr)
 	})
 
@@ -196,8 +200,9 @@ func TestExec(t *testing.T) {
 		// since the send failed the uniqueAddr not resolve
 		var st init_.State
 		rt.GetState(&st)
-		noResoAddr, err := st.ResolveAddress(adt.AsStore(rt), uniqueAddr)
-		assert.Error(t, err)
+		noResoAddr, found, err := st.ResolveAddress(adt.AsStore(rt), uniqueAddr)
+		assert.NoError(t, err)
+		assert.False(t, found)
 		assert.Equal(t, addr.Undef, noResoAddr)
 
 	})


### PR DESCRIPTION
The init actor's `State.ResolveAddress` returns a sentinel `ErrAddressNotFound` if the resolution fails. This is a more fragile pattern than distinguishing between an actual state error and a negative lookup statically.

Lotus appears to have six instances of testing for `ErrAddressNotFound`. Hopefully that corresponds to all the cases where the behaviour should differ, but after this we'll have to be explicit about any cases where it doesn't.

This is a proposal, I won't merge it unless Lotus team are in favour. FYI @magik6k .