### PR TITLE
Multisig: State should ONLY have ID address -> create accounts if they do NOT exist

### DIFF
--- a/actors/builtin/multisig/multisig_test.go
+++ b/actors/builtin/multisig/multisig_test.go
@@ -637,6 +637,48 @@ func TestApprove(t *testing.T) {
 		})
 	})
 
+	t.Run("fail duplicate approval even if we pass non-ID address of param", func(t *testing.T) {
+		signers = []addr.Address{anne, bob, chuck}
+		builder := mock.NewBuilder(context.Background(), receiver).
+			WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID).
+			WithHasher(blake2b.Sum256)
+		rt := builder.Build(t)
+
+		numApprovals := uint64(3)
+		actor.constructAndVerify(rt, numApprovals, noUnlockDuration, signers...)
+
+		rt.SetCaller(anne, builtin.AccountActorCodeID)
+		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
+
+		// chuck proposes -> 1 approval
+		proposalHash := actor.proposeOK(rt, chuck, sendValue, fakeMethod, fakeParams, nil)
+		rt.Verify()
+
+		actor.assertTransactions(rt, multisig.Transaction{
+			To:       chuck,
+			Value:    sendValue,
+			Method:   fakeMethod,
+			Params:   fakeParams,
+			Approved: []addr.Address{anne},
+		})
+
+		// approve with bob's ID address -> 2 approvals
+		rt.SetBalance(sendValue)
+		rt.SetCaller(bob, builtin.AccountActorCodeID)
+		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
+		actor.approveOK(rt, txnID, proposalHash, nil)
+
+		// approve with bob's non-ID address -> should fail
+		bobNonId := tutil.NewBLSAddr(t, 555)
+		rt.AddIDAddress(bobNonId, bob)
+		rt.SetCaller(bobNonId, builtin.AccountActorCodeID)
+		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
+		rt.ExpectAbort(exitcode.ErrForbidden, func() {
+			actor.approveOK(rt, txnID, proposalHash, nil)
+		})
+		rt.Verify()
+	})
+
 	t.Run("fail to approve transaction by non-signer", func(t *testing.T) {
 		// non-signer address
 		richard := tutil.NewIDAddr(t, 105)

--- a/actors/builtin/shared.go
+++ b/actors/builtin/shared.go
@@ -69,7 +69,7 @@ func ResolveToIDAddr(rt runtime.Runtime, address addr.Address) (addr.Address, er
 	// send 0 balance to the account so an ID address for it is created and then try to resolve
 	_, code := rt.Send(address, MethodSend, nil, abi.NewTokenAmount(0))
 	if !code.IsSuccess() {
-		return address, fmt.Errorf("failed to send zero balance to account %v, got code %v", address, code)
+		return address, code.Wrapf("failed to send zero balance to address %v", address)
 	}
 
 	// now try to resolve it to an ID address -> fail if not possible


### PR DESCRIPTION
For #730.

@anorth We should move the `resolveToIdAddr` func to a common location so the `Verifreg` and `PaymentChannel` actors can use it too.