### PR TITLE
avoid prove commit aborts when sector lifetime <= 0

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -475,6 +475,7 @@ func (a Actor) PreCommitSector(rt Runtime, params *SectorPreCommitInfo) *adt.Emp
 		}
 
 		// Require sector lifetime meets minimum by assuming activation happens at last epoch permitted for seal proof.
+		// This could make sector maximum lifetime validation more lenient if the maximum sector limit isn't hit first.
 		maxActivation := rt.CurrEpoch() + MaxSealDuration[params.SealProof]
 		validateExpiration(rt, maxActivation, params.Expiration, params.SealProof)
 

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -676,6 +676,13 @@ func (a Actor) ConfirmSectorProofsValid(rt Runtime, params *builtin.ConfirmSecto
 			// compute initial pledge
 			activation := rt.CurrEpoch()
 			duration := precommit.Info.Expiration - activation
+
+			// Avoid math errors if duration is too low somehow.
+			if duration <= 0 {
+				rt.Log(vmr.WARN, "precommit %d has non-positive lifetime %d. ignoring", precommit.Info.SectorNumber, duration)
+				continue
+			}
+
 			power := QAPowerForWeight(info.SectorSize, duration, precommit.DealWeight, precommit.VerifiedDealWeight)
 			dayReward := ExpectedRewardForPower(rewardStats.ThisEpochRewardSmoothed, pwrTotal.QualityAdjPowerSmoothed, power, builtin.EpochsInDay)
 			storagePledge := ExpectedRewardForPower(rewardStats.ThisEpochRewardSmoothed, pwrTotal.QualityAdjPowerSmoothed, power, InitialPledgeProjectionPeriod)

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -474,7 +474,9 @@ func (a Actor) PreCommitSector(rt Runtime, params *SectorPreCommitInfo) *adt.Emp
 			rt.Abortf(exitcode.ErrIllegalState, "sector %v already committed", params.SectorNumber)
 		}
 
-		validateExpiration(rt, rt.CurrEpoch(), params.Expiration, params.SealProof)
+		// Require sector lifetime meets minimum by assuming activation happens at last epoch permitted for seal proof.
+		maxActivation := rt.CurrEpoch() + MaxSealDuration[params.SealProof]
+		validateExpiration(rt, maxActivation, params.Expiration, params.SealProof)
 
 		depositMinimum := big.Zero()
 		if params.ReplaceCapacity {

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -679,9 +679,9 @@ func (a Actor) ConfirmSectorProofsValid(rt Runtime, params *builtin.ConfirmSecto
 			activation := rt.CurrEpoch()
 			duration := precommit.Info.Expiration - activation
 
-			// Avoid math errors if duration is too low somehow.
-			if duration <= 0 {
-				rt.Log(vmr.WARN, "precommit %d has non-positive lifetime %d. ignoring", precommit.Info.SectorNumber, duration)
+			// This should have been caught in precommit, but don't let other sectors fail because of it.
+			if duration < MinSectorExpiration {
+				rt.Log(vmr.WARN, "precommit %d has lifetime %d less than minimum. ignoring", precommit.Info.SectorNumber, duration, MinSectorExpiration)
 				continue
 			}
 

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -39,7 +39,7 @@ var testMultiaddrs []abi.Multiaddrs
 var bigBalance = big.Mul(big.NewInt(1000000), big.NewInt(1e18))
 
 // an expriration 1 greater than min expiration
-const defaultSectorExpiration = 181
+const defaultSectorExpiration = 190
 
 func init() {
 	testPid = abi.PeerID("peerID")
@@ -279,13 +279,13 @@ func TestCommitments(t *testing.T) {
 		actor.preCommitSector(rt, actor.makePreCommit(101, challengeEpoch, expiration, nil))
 
 		// Duplicate pre-commit sector ID
-		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
+		rt.ExpectAbortContainsMessage(exitcode.ErrIllegalArgument, "already been allocated", func() {
 			actor.preCommitSector(rt, actor.makePreCommit(101, challengeEpoch, expiration, nil))
 		})
 		rt.Reset()
 
 		// Sector ID already committed
-		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
+		rt.ExpectAbortContainsMessage(exitcode.ErrIllegalArgument, "already been allocated", func() {
 			actor.preCommitSector(rt, actor.makePreCommit(oldSector.SectorNumber, challengeEpoch, expiration, nil))
 		})
 		rt.Reset()
@@ -299,7 +299,7 @@ func TestCommitments(t *testing.T) {
 		rt.Reset()
 
 		// Bad seal proof type
-		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
+		rt.ExpectAbortContainsMessage(exitcode.ErrIllegalArgument, "unsupported seal proof type", func() {
 			pc := actor.makePreCommit(102, challengeEpoch, deadline.PeriodEnd(), nil)
 			pc.SealProof = abi.RegisteredSealProof_StackedDrg8MiBV1
 			actor.preCommitSector(rt, pc)
@@ -307,22 +307,14 @@ func TestCommitments(t *testing.T) {
 		rt.Reset()
 
 		// Expires at current epoch
-		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
+		rt.ExpectAbortContainsMessage(exitcode.ErrIllegalArgument, "must be after now", func() {
 			actor.preCommitSector(rt, actor.makePreCommit(102, challengeEpoch, rt.Epoch(), nil))
 		})
 		rt.Reset()
 
 		// Expires before current epoch
-		rt.SetEpoch(expiration + 1)
-		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
-			actor.preCommitSector(rt, actor.makePreCommit(102, challengeEpoch, expiration, nil))
-		})
-		rt.Reset()
-
-		// Expires not on period end
-		rt.SetEpoch(precommitEpoch)
-		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
-			actor.preCommitSector(rt, actor.makePreCommit(102, challengeEpoch, deadline.PeriodEnd()-1, nil))
+		rt.ExpectAbortContainsMessage(exitcode.ErrIllegalArgument, "must be after now", func() {
+			actor.preCommitSector(rt, actor.makePreCommit(102, challengeEpoch, rt.Epoch()-1, nil))
 		})
 		rt.Reset()
 
@@ -332,15 +324,23 @@ func TestCommitments(t *testing.T) {
 		})
 		rt.Reset()
 
+		// Expires before min duration + max seal duration
+		rt.ExpectAbortContainsMessage(exitcode.ErrIllegalArgument, "must exceed", func() {
+			expiration := rt.Epoch() + miner.MinSectorExpiration + miner.MaxSealDuration[actor.sealProofType]-1
+			actor.preCommitSector(rt, actor.makePreCommit(102, challengeEpoch, expiration, nil))
+		})
+		rt.Reset()
+
 		// Errors when expiry too far in the future
 		rt.SetEpoch(precommitEpoch)
-		expiration = deadline.PeriodEnd() + miner.WPoStProvingPeriod*(miner.MaxSectorExpirationExtension/miner.WPoStProvingPeriod+1)
 		rt.ExpectAbortContainsMessage(exitcode.ErrIllegalArgument, "invalid expiration", func() {
-			actor.preCommitSector(rt, actor.makePreCommit(102, challengeEpoch, deadline.PeriodEnd()-1, nil))
+			expiration := deadline.PeriodEnd() + miner.WPoStProvingPeriod*(miner.MaxSectorExpirationExtension/miner.WPoStProvingPeriod+1)
+			actor.preCommitSector(rt, actor.makePreCommit(102, challengeEpoch, expiration, nil))
 		})
+		rt.Reset()
 
 		// Sector ID out of range
-		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
+		rt.ExpectAbortContainsMessage(exitcode.ErrIllegalArgument, "out of range", func() {
 			actor.preCommitSector(rt, actor.makePreCommit(abi.MaxSectorNumber+1, challengeEpoch, expiration, nil))
 		})
 		rt.Reset()

--- a/support/mock/mockrt.go
+++ b/support/mock/mockrt.go
@@ -1005,6 +1005,10 @@ func (rt *Runtime) ExpectLogsContain(substr string) {
 	rt.failTest("logs contain %d message(s) and do not contain \"%s\"", len(rt.logs), substr)
 }
 
+func (rt *Runtime) ClearLogs() {
+	rt.logs = []string{}
+}
+
 func (rt *Runtime) ExpectGasCharged(gas int64) {
 	if gas != rt.gasCharged {
 		rt.failTest("expected gas charged: %d, actual gas charged: %d", gas, rt.gasCharged)


### PR DESCRIPTION
closes #795

### Motivation

It's probably not possible for prove commit to occur past a valid sector's lifetime, but if it does, it will trigger panics in the power math, causing all the other sectors to fail. This PR check that the sector lifetime is less than equal to zero and skips the sector if so.

### Proposed Changes

1. Use current epoch + MaxSealDuration for activation time when validating in precommit.
2. Add check that sector duration meets or exceeds minimum in prove commit, and skip sector if not.
3. Test