### PR TITLE
Check parameters

### DIFF
--- a/actors/builtin/market/deal.go
+++ b/actors/builtin/market/deal.go
@@ -35,6 +35,7 @@ type DealProposal struct {
 	Provider     addr.Address
 
 	// Label is an arbitrary client chosen label to apply to the deal
+	// TODO: Limit the size of this: https://github.com/filecoin-project/specs-actors/issues/897
 	Label string
 
 	// Nominal start epoch. Deal payment is linear between StartEpoch and EndEpoch,

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -86,6 +86,8 @@ type ConstructorParams = power.MinerConstructorParams
 func (a Actor) Constructor(rt Runtime, params *ConstructorParams) *adt.EmptyValue {
 	rt.ValidateImmediateCallerIs(builtin.InitActorAddr)
 
+	checkPeerInfo(rt, params.PeerId, params.Multiaddrs)
+
 	_, ok := SupportedProofTypes[params.SealProofType]
 	if !ok {
 		rt.Abortf(exitcode.ErrIllegalArgument, "proof type %d not allowed for new miner actors", params.SealProofType)
@@ -230,8 +232,8 @@ type ChangePeerIDParams struct {
 }
 
 func (a Actor) ChangePeerID(rt Runtime, params *ChangePeerIDParams) *adt.EmptyValue {
-	// TODO: Consider limiting the maximum number of bytes used by the peer ID on-chain.
-	// https://github.com/filecoin-project/specs-actors/issues/712
+	checkPeerInfo(rt, params.NewID, nil)
+
 	var st State
 	rt.State().Transaction(&st, func() {
 		info := getMinerInfo(rt, &st)
@@ -250,8 +252,8 @@ type ChangeMultiaddrsParams struct {
 }
 
 func (a Actor) ChangeMultiaddrs(rt Runtime, params *ChangeMultiaddrsParams) *adt.EmptyValue {
-	// TODO: Consider limiting the maximum number of bytes used by multiaddrs on-chain.
-	// https://github.com/filecoin-project/specs-actors/issues/712
+	checkPeerInfo(rt, nil, params.NewMultiaddrs)
+
 	var st State
 	rt.State().Transaction(&st, func() {
 		info := getMinerInfo(rt, &st)
@@ -310,7 +312,6 @@ func (a Actor) SubmitWindowedPoSt(rt Runtime, params *SubmitWindowedPoStParams) 
 	if !bytes.Equal(commRand, params.ChainCommitRand) {
 		rt.Abortf(exitcode.ErrIllegalArgument, "post commit randomness mismatched")
 	}
-	// TODO: limit the length of proofs array https://github.com/filecoin-project/specs-actors/issues/416
 
 	// Get the total power/reward. We need these to compute penalties.
 	rewardStats := requestCurrentEpochBlockReward(rt)
@@ -326,17 +327,26 @@ func (a Actor) SubmitWindowedPoSt(rt Runtime, params *SubmitWindowedPoStParams) 
 
 		rt.ValidateImmediateCallerIs(append(info.ControlAddresses, info.Owner, info.Worker)...)
 
+		// Verify that the miner has passed 0 or 1 proofs. If they've
+		// passed 1, verify that it's a good proof.
+		//
+		// This can be 0 if the miner isn't actually proving anything,
+		// just skipping all sectors.
+		windowPoStProofType, err := info.SealProofType.RegisteredWindowPoStProof()
+		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to determine window PoSt type")
+		if len(params.Proofs) > 1 {
+			rt.Abortf(exitcode.ErrIllegalArgument, "expected at most one proof, got %d", len(params.Proofs))
+		} else if len(params.Proofs) == 1 && params.Proofs[0].PoStProof != windowPoStProofType {
+			rt.Abortf(exitcode.ErrIllegalArgument, "expected proof of type %s, got proof of type %s", params.Proofs[0], windowPoStProofType)
+		}
+
 		// Validate that the miner didn't try to prove too many partitions at once.
 		submissionPartitionLimit := loadPartitionsSectorsMax(info.WindowPoStPartitionSectors)
 		if uint64(len(params.Partitions)) > submissionPartitionLimit {
 			rt.Abortf(exitcode.ErrIllegalArgument, "too many partitions %d, limit %d", len(params.Partitions), submissionPartitionLimit)
 		}
 
-		// Load and check deadline.
 		currDeadline := st.DeadlineInfo(currEpoch)
-		deadlines, err := st.LoadDeadlines(adt.AsStore(rt))
-		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deadlines")
-
 		// Check that the miner state indicates that the current proving deadline has started.
 		// This should only fail if the cron actor wasn't invoked, and matters only in case that it hasn't been
 		// invoked for a whole proving period, and hence the missed PoSt submissions from the prior occurrence
@@ -353,6 +363,9 @@ func (a Actor) SubmitWindowedPoSt(rt Runtime, params *SubmitWindowedPoStParams) 
 
 		sectors, err := LoadSectors(store, st.Sectors)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load sectors")
+
+		deadlines, err := st.LoadDeadlines(adt.AsStore(rt))
+		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deadlines")
 
 		deadline, err := deadlines.LoadDeadline(store, params.Deadline)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deadline %d", params.Deadline)
@@ -380,6 +393,10 @@ func (a Actor) SubmitWindowedPoSt(rt Runtime, params *SubmitWindowedPoStParams) 
 		// Skip verification if all sectors are faults.
 		// We still need to allow this call to succeed so the miner can declare a whole partition as skipped.
 		if len(sectorInfos) > 0 {
+			if len(params.Proofs) == 0 {
+				// The miner _was_ supposed to prove something, but didn't.
+				rt.Abortf(exitcode.ErrIllegalArgument, "no proofs submitted in window PoSt for %d sectors", len(sectorInfos))
+			}
 			// Verify the proof.
 			// A failed verification doesn't immediately cause a penalty; the miner can try again.
 			//
@@ -464,9 +481,11 @@ func (a Actor) PreCommitSector(rt Runtime, params *SectorPreCommitInfo) *adt.Emp
 		rt.Abortf(exitcode.ErrIllegalArgument, "seal challenge epoch %v too old, must be after %v", params.SealRandEpoch, challengeEarliest)
 	}
 
-	if params.Expiration <= rt.CurrEpoch() {
-		rt.Abortf(exitcode.ErrIllegalArgument, "sector expiration %v must be after now (%v)", params.Expiration, rt.CurrEpoch())
-	}
+	// Require sector lifetime meets minimum by assuming activation happens at last epoch permitted for seal proof.
+	// This could make sector maximum lifetime validation more lenient if the maximum sector limit isn't hit first.
+	maxActivation := rt.CurrEpoch() + MaxSealDuration[params.SealProof]
+	validateExpiration(rt, maxActivation, params.Expiration, params.SealProof)
+
 	if params.ReplaceCapacity && len(params.DealIDs) == 0 {
 		rt.Abortf(exitcode.ErrIllegalArgument, "cannot replace sector without committing deals")
 	}
@@ -520,13 +539,11 @@ func (a Actor) PreCommitSector(rt Runtime, params *SectorPreCommitInfo) *adt.Emp
 			rt.Abortf(exitcode.ErrIllegalState, "sector %v already committed", params.SectorNumber)
 		}
 
-		// Require sector lifetime meets minimum by assuming activation happens at last epoch permitted for seal proof.
-		// This could make sector maximum lifetime validation more lenient if the maximum sector limit isn't hit first.
-		maxActivation := rt.CurrEpoch() + MaxSealDuration[params.SealProof]
-		validateExpiration(rt, maxActivation, params.Expiration, params.SealProof)
-
 		depositMinimum := big.Zero()
 		if params.ReplaceCapacity {
+			// NOTE: we don't validate that the replacement sector
+			// lives at the target deadline/partition. If it
+			// doesn't, sealing may still succeed but replacement will fail.
 			replaceSector := validateReplaceSector(rt, &st, store, params)
 			// Note the replaced sector's initial pledge as a lower bound for the new sector's deposit
 			depositMinimum = replaceSector.InitialPledge
@@ -588,6 +605,14 @@ type ProveCommitSectorParams struct {
 func (a Actor) ProveCommitSector(rt Runtime, params *ProveCommitSectorParams) *adt.EmptyValue {
 	rt.ValidateImmediateCallerAcceptAny()
 
+	if params.SectorNumber > abi.MaxSectorNumber {
+		rt.Abortf(exitcode.ErrIllegalArgument, "sector number greater than maximum")
+	}
+
+	if len(params.Proof) > MaxProveCommitSize {
+		rt.Abortf(exitcode.ErrIllegalArgument, "sector prove-commit proof of size %d exceeds max size of %d", len(params.Proof), MaxProveCommitSize)
+	}
+
 	store := adt.AsStore(rt)
 	var st State
 	var precommit *SectorPreCommitOnChainInfo
@@ -634,6 +659,14 @@ func (a Actor) ProveCommitSector(rt Runtime, params *ProveCommitSectorParams) *a
 
 func (a Actor) ConfirmSectorProofsValid(rt Runtime, params *builtin.ConfirmSectorProofsParams) *adt.EmptyValue {
 	rt.ValidateImmediateCallerIs(builtin.StoragePowerActorAddr)
+
+	// This should be enforced by the power actor. We log here just in case
+	// something goes wrong.
+	if len(params.Sectors) > power.MaxMinerProveCommitsPerEpoch {
+		rt.Log(vmr.WARN, "confirmed more prove commits in an epoch than permitted: %d > %d",
+			len(params.Sectors), power.MaxMinerProveCommitsPerEpoch,
+		)
+	}
 
 	// get network stats from other actors
 	rewardStats := requestCurrentEpochBlockReward(rt)
@@ -800,6 +833,10 @@ type CheckSectorProvenParams struct {
 func (a Actor) CheckSectorProven(rt Runtime, params *CheckSectorProvenParams) *adt.EmptyValue {
 	rt.ValidateImmediateCallerAcceptAny()
 
+	if params.SectorNumber > abi.MaxSectorNumber {
+		rt.Abortf(exitcode.ErrIllegalArgument, "sector number out of range")
+	}
+
 	var st State
 	rt.State().Readonly(&st)
 	store := adt.AsStore(rt)
@@ -860,6 +897,8 @@ func (a Actor) ExtendSectorExpiration(rt Runtime, params *ExtendSectorExpiration
 		)
 	}
 
+	currEpoch := rt.CurrEpoch()
+
 	powerDelta := NewPowerPairZero()
 	pledgeDelta := big.Zero()
 	store := adt.AsStore(rt)
@@ -908,12 +947,21 @@ func (a Actor) ExtendSectorExpiration(rt Runtime, params *ExtendSectorExpiration
 				}
 
 				oldSectors, err := sectors.Load(decl.Sectors)
-				builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load sectors")
+				builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load sectors in partition %v", key)
 				newSectors := make([]*SectorOnChainInfo, len(oldSectors))
 				for i, sector := range oldSectors {
+					// This can happen if the sector should have already expired, but hasn't
+					// because the end of its deadline hasn't passed yet.
+					if sector.Expiration < currEpoch {
+						rt.Abortf(exitcode.ErrForbidden, "cannot extend expiration for expired sector %v, expired at %d, now %d",
+							sector.SectorNumber,
+							sector.Expiration,
+							currEpoch,
+						)
+					}
 					if decl.NewExpiration < sector.Expiration {
-						rt.Abortf(exitcode.ErrIllegalArgument, "cannot reduce sector expiration to %d from %d",
-							decl.NewExpiration, sector.Expiration)
+						rt.Abortf(exitcode.ErrIllegalArgument, "cannot reduce sector %v's expiration to %d from %d",
+							sector.SectorNumber, decl.NewExpiration, sector.Expiration)
 					}
 					validateExpiration(rt, sector.Activation, decl.NewExpiration, sector.SealProof)
 
@@ -1726,6 +1774,10 @@ func handleProvingDeadline(rt Runtime) {
 
 // Check expiry is exactly *the epoch before* the start of a proving period.
 func validateExpiration(rt Runtime, activation, expiration abi.ChainEpoch, sealProof abi.RegisteredSealProof) {
+	// Expiration must be after activation. Check this explicitly to avoid an underflow below.
+	if expiration <= activation {
+		rt.Abortf(exitcode.ErrIllegalArgument, "sector expiration %v must be after activation (%v)", expiration, activation)
+	}
 	// expiration cannot be less than minimum after activation
 	if expiration-activation < MinSectorExpiration {
 		rt.Abortf(exitcode.ErrIllegalArgument, "invalid expiration %d, total sector lifetime (%d) must exceed %d after activation %d",
@@ -2260,4 +2312,21 @@ func maxEpoch(a, b abi.ChainEpoch) abi.ChainEpoch {
 		return a
 	}
 	return b
+}
+
+func checkPeerInfo(rt Runtime, peerID abi.PeerID, multiaddrs []abi.Multiaddrs) {
+	if len(peerID) > MaxPeerIDLength {
+		rt.Abortf(exitcode.ErrIllegalArgument, "peer ID size of %d exceeds maximum size of %d", peerID, MaxPeerIDLength)
+	}
+
+	totalSize := 0
+	for _, ma := range multiaddrs {
+		if len(ma) == 0 {
+			rt.Abortf(exitcode.ErrIllegalArgument, "invalid empty multiaddr")
+		}
+		totalSize += len(ma)
+	}
+	if totalSize > MaxMultiaddrData {
+		rt.Abortf(exitcode.ErrIllegalArgument, "multiaddr size of %d exceeds maximum of %d", totalSize, MaxMultiaddrData)
+	}
 }

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -45,8 +45,8 @@ func init() {
 	testPid = abi.PeerID("peerID")
 
 	testMultiaddrs = []abi.Multiaddrs{
-		{1},
-		{2},
+		[]byte("foobar"),
+		[]byte("imafilminer"),
 	}
 
 	// permit 2KiB sectors in tests
@@ -187,6 +187,140 @@ func TestConstruction(t *testing.T) {
 			rt.Call(actor.Constructor, &params)
 		})
 		rt.Verify()
+	})
+
+	t.Run("test construct with invalid peer ID", func(t *testing.T) {
+		rt := builder.Build(t)
+		pid := [miner.MaxPeerIDLength + 1]byte{1, 2, 3, 4}
+		params := miner.ConstructorParams{
+			OwnerAddr:     owner,
+			WorkerAddr:    worker,
+			SealProofType: abi.RegisteredSealProof_StackedDrg32GiBV1,
+			PeerId:        abi.PeerID(pid[:]),
+			Multiaddrs:    testMultiaddrs,
+		}
+
+		rt.ExpectValidateCallerAddr(builtin.InitActorAddr)
+
+		rt.ExpectAbortContainsMessage(exitcode.ErrIllegalArgument, "peer ID size", func() {
+			rt.Call(actor.Constructor, &params)
+		})
+	})
+
+	t.Run("test construct with large multiaddr", func(t *testing.T) {
+		rt := builder.Build(t)
+		maddrs := make([]abi.Multiaddrs, 100)
+		for i := range maddrs {
+			maddrs[i] = []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}
+		}
+		params := miner.ConstructorParams{
+			OwnerAddr:     owner,
+			WorkerAddr:    worker,
+			SealProofType: abi.RegisteredSealProof_StackedDrg32GiBV1,
+			PeerId:        testPid,
+			Multiaddrs:    maddrs,
+		}
+
+		rt.ExpectValidateCallerAddr(builtin.InitActorAddr)
+
+		rt.ExpectAbortContainsMessage(exitcode.ErrIllegalArgument, "multiaddr size", func() {
+			rt.Call(actor.Constructor, &params)
+		})
+	})
+
+	t.Run("test construct with empty multiaddr", func(t *testing.T) {
+		rt := builder.Build(t)
+		maddrs := []abi.Multiaddrs{
+			[]byte{},
+			[]byte{1},
+		}
+		params := miner.ConstructorParams{
+			OwnerAddr:     owner,
+			WorkerAddr:    worker,
+			SealProofType: abi.RegisteredSealProof_StackedDrg32GiBV1,
+			PeerId:        testPid,
+			Multiaddrs:    maddrs,
+		}
+
+		rt.ExpectValidateCallerAddr(builtin.InitActorAddr)
+
+		rt.ExpectAbortContainsMessage(exitcode.ErrIllegalArgument, "invalid empty multiaddr", func() {
+			rt.Call(actor.Constructor, &params)
+		})
+	})
+}
+
+// Test operations related to peer info (peer ID/multiaddrs)
+func TestPeerInfo(t *testing.T) {
+	h := newHarness(t, 0)
+	builder := builderForHarness(h)
+
+	t.Run("can set peer id", func(t *testing.T) {
+		rt := builder.Build(t)
+		h.constructAndVerify(rt)
+
+		h.setPeerID(rt, abi.PeerID("new peer id"))
+	})
+
+	t.Run("can clear peer id", func(t *testing.T) {
+		rt := builder.Build(t)
+		h.constructAndVerify(rt)
+
+		h.setPeerID(rt, nil)
+	})
+
+	t.Run("can't set large peer id", func(t *testing.T) {
+		rt := builder.Build(t)
+		h.constructAndVerify(rt)
+
+		largePid := [miner.MaxPeerIDLength + 1]byte{1, 2, 3}
+		rt.ExpectAbortContainsMessage(exitcode.ErrIllegalArgument, "peer ID size", func() {
+			h.setPeerID(rt, largePid[:])
+		})
+	})
+
+	t.Run("can set multiaddrs", func(t *testing.T) {
+		rt := builder.Build(t)
+		h.constructAndVerify(rt)
+
+		h.setMultiaddrs(rt, abi.Multiaddrs("imanewminer"))
+	})
+
+	t.Run("can set multiple multiaddrs", func(t *testing.T) {
+		rt := builder.Build(t)
+		h.constructAndVerify(rt)
+
+		h.setMultiaddrs(rt, abi.Multiaddrs("imanewminer"), abi.Multiaddrs("ihavemany"))
+	})
+
+	t.Run("can set clear the multiaddr", func(t *testing.T) {
+		rt := builder.Build(t)
+		h.constructAndVerify(rt)
+
+		h.setMultiaddrs(rt)
+	})
+
+	t.Run("can't set empty multiaddrs", func(t *testing.T) {
+		rt := builder.Build(t)
+		h.constructAndVerify(rt)
+
+		rt.ExpectAbortContainsMessage(exitcode.ErrIllegalArgument, "invalid empty multiaddr", func() {
+			h.setMultiaddrs(rt, nil)
+		})
+	})
+
+	t.Run("can't set large multiaddrs", func(t *testing.T) {
+		rt := builder.Build(t)
+		h.constructAndVerify(rt)
+
+		maddrs := make([]abi.Multiaddrs, 100)
+		for i := range maddrs {
+			maddrs[i] = []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}
+		}
+
+		rt.ExpectAbortContainsMessage(exitcode.ErrIllegalArgument, "multiaddr size", func() {
+			h.setMultiaddrs(rt, maddrs...)
+		})
 	})
 }
 
@@ -382,13 +516,13 @@ func TestCommitments(t *testing.T) {
 		rt.Reset()
 
 		// Expires at current epoch
-		rt.ExpectAbortContainsMessage(exitcode.ErrIllegalArgument, "must be after now", func() {
+		rt.ExpectAbortContainsMessage(exitcode.ErrIllegalArgument, "must be after activation", func() {
 			actor.preCommitSector(rt, actor.makePreCommit(102, challengeEpoch, rt.Epoch(), nil))
 		})
 		rt.Reset()
 
 		// Expires before current epoch
-		rt.ExpectAbortContainsMessage(exitcode.ErrIllegalArgument, "must be after now", func() {
+		rt.ExpectAbortContainsMessage(exitcode.ErrIllegalArgument, "must be after activation", func() {
 			actor.preCommitSector(rt, actor.makePreCommit(102, challengeEpoch, rt.Epoch()-1, nil))
 		})
 		rt.Reset()
@@ -432,7 +566,7 @@ func TestCommitments(t *testing.T) {
 		oldIPReqs := st.InitialPledgeRequirement
 		st.InitialPledgeRequirement = big.Add(rt.Balance(), abi.NewTokenAmount(1e18))
 		rt.ReplaceState(st)
-		rt.ExpectAbortContainsMessage(exitcode.ErrInsufficientFunds, "does not cover pledge requirements", func () {
+		rt.ExpectAbortContainsMessage(exitcode.ErrInsufficientFunds, "does not cover pledge requirements", func() {
 			actor.preCommitSector(rt, actor.makePreCommit(102, challengeEpoch, expiration, nil))
 		})
 		// reset state back to normal
@@ -1479,7 +1613,7 @@ func TestDeclareRecoveries(t *testing.T) {
 		// Attempt to recover
 		dlIdx, pIdx, err := st.FindSector(rt.AdtStore(), oneSector[0].SectorNumber)
 		require.NoError(t, err)
-		rt.ExpectAbortContainsMessage(exitcode.ErrInsufficientFunds, "does not cover pledge requirements", func () {
+		rt.ExpectAbortContainsMessage(exitcode.ErrInsufficientFunds, "does not cover pledge requirements", func() {
 			actor.declareRecoveries(rt, dlIdx, pIdx, bf(uint64(oneSector[0].SectorNumber)))
 		})
 	})
@@ -1520,7 +1654,7 @@ func TestExtendSectorExpiration(t *testing.T) {
 			}},
 		}
 
-		rt.ExpectAbortContainsMessage(exitcode.ErrIllegalArgument, "cannot reduce sector expiration", func() {
+		rt.ExpectAbortContainsMessage(exitcode.ErrIllegalArgument, fmt.Sprintf("cannot reduce sector %d's expiration", sector.SectorNumber), func() {
 			actor.extendSectors(rt, params)
 		})
 	})
@@ -3335,6 +3469,42 @@ func (h *actorHarness) makePreCommit(sectorNo abi.SectorNumber, challenge, expir
 		DealIDs:       dealIDs,
 		Expiration:    expiration,
 	}
+}
+
+func (h *actorHarness) setPeerID(rt *mock.Runtime, newID abi.PeerID) {
+	params := miner.ChangePeerIDParams{NewID: newID}
+
+	rt.SetCaller(h.worker, builtin.AccountActorCodeID)
+	rt.ExpectValidateCallerAddr(append(h.controlAddrs, h.owner, h.worker)...)
+
+	ret := rt.Call(h.a.ChangePeerID, &params)
+	assert.Nil(h.t, ret)
+	rt.Verify()
+
+	var st miner.State
+	rt.GetState(&st)
+	info, err := st.GetInfo(adt.AsStore(rt))
+	require.NoError(h.t, err)
+
+	assert.Equal(h.t, newID, info.PeerId)
+}
+
+func (h *actorHarness) setMultiaddrs(rt *mock.Runtime, newMultiaddrs ...abi.Multiaddrs) {
+	params := miner.ChangeMultiaddrsParams{NewMultiaddrs: newMultiaddrs}
+
+	rt.SetCaller(h.worker, builtin.AccountActorCodeID)
+	rt.ExpectValidateCallerAddr(append(h.controlAddrs, h.owner, h.worker)...)
+
+	ret := rt.Call(h.a.ChangeMultiaddrs, &params)
+	assert.Nil(h.t, ret)
+	rt.Verify()
+
+	var st miner.State
+	rt.GetState(&st)
+	info, err := st.GetInfo(adt.AsStore(rt))
+	require.NoError(h.t, err)
+
+	assert.Equal(h.t, newMultiaddrs, info.Multiaddrs)
 }
 
 //

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -10,7 +10,6 @@ import (
 	big "github.com/filecoin-project/specs-actors/actors/abi/big"
 	builtin "github.com/filecoin-project/specs-actors/actors/builtin"
 	. "github.com/filecoin-project/specs-actors/actors/util"
-
 )
 
 // The period over which all a miner's active sectors will be challenged.
@@ -49,6 +48,20 @@ const AddressedPartitionsMax = 200
 
 // The maximum number of sector infos that may be required to be loaded in a single invocation.
 const AddressedSectorsMax = 10_000
+
+// Libp2p peer info limits.
+const (
+	// MaxPeerIDLength is the maximum length allowed for any on-chain peer ID. Most
+	// Peer IDs should be less than 50 bytes.
+	MaxPeerIDLength = 128
+
+	// MaxMultiaddrData is the maximum amount of data that can be stored in
+	// multiaddrs.
+	MaxMultiaddrData = 1024
+)
+
+// Maximum bytes in a single prove-commit proof.
+const MaxProveCommitSize = 1024
 
 // The maximum number of partitions that may be required to be loaded in a single invocation,
 // when all the sector infos for the partitions will be loaded.

--- a/actors/builtin/multisig/multisig_state.go
+++ b/actors/builtin/multisig/multisig_state.go
@@ -16,6 +16,8 @@ type State struct {
 	// for a public key that has not yet received a message on chain.
 	// If any signer address is a public-key address, it will be resolved to an ID address and persisted
 	// in this state when the address is used.
+	// TODO: consider limiting the number of signers
+	// https://github.com/filecoin-project/specs-actors/issues/897
 	Signers               []address.Address
 	NumApprovalsThreshold uint64
 	NextTxnID             TxnID

--- a/actors/builtin/paych/paych_actor.go
+++ b/actors/builtin/paych/paych_actor.go
@@ -2,7 +2,6 @@ package paych
 
 import (
 	"bytes"
-	"math"
 
 	addr "github.com/filecoin-project/go-address"
 
@@ -14,11 +13,6 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 	adt "github.com/filecoin-project/specs-actors/actors/util/adt"
 )
-
-// Maximum number of lanes in a channel.
-const MaxLane = math.MaxInt64
-
-const SettleDelay = builtin.EpochsInHour * 12
 
 type Actor struct{}
 
@@ -147,6 +141,10 @@ func (pca Actor) UpdateChannelState(rt vmr.Runtime, params *UpdateChannelStatePa
 
 	if sv.Signature == nil {
 		rt.Abortf(exitcode.ErrIllegalArgument, "voucher has no signature")
+	}
+
+	if len(params.Secret) > MaxSecretSize {
+		rt.Abortf(exitcode.ErrIllegalArgument, "secret must be at most 256 bytes long")
 	}
 
 	vb, err := sv.SigningBytes()

--- a/actors/builtin/paych/policy.go
+++ b/actors/builtin/paych/policy.go
@@ -1,0 +1,15 @@
+package paych
+
+import (
+	"math"
+
+	"github.com/filecoin-project/specs-actors/actors/builtin"
+)
+
+// Maximum number of lanes in a channel.
+const MaxLane = math.MaxInt64
+
+const SettleDelay = builtin.EpochsInHour * 12
+
+// Maximum size of a secret that can be submitted with a payment channel update (in bytes).
+const MaxSecretSize = 256

--- a/actors/builtin/verifreg/verified_registry_actor.go
+++ b/actors/builtin/verifreg/verified_registry_actor.go
@@ -120,6 +120,7 @@ type AddVerifiedClientParams struct {
 }
 
 func (a Actor) AddVerifiedClient(rt vmr.Runtime, params *AddVerifiedClientParams) *adt.EmptyValue {
+	// The caller will be verified by checking the verifiers table below.
 	rt.ValidateImmediateCallerAcceptAny()
 
 	if params.Allowance.LessThan(MinVerifiedDealSize) {
@@ -229,6 +230,9 @@ func (a Actor) UseBytes(rt vmr.Runtime, params *UseBytesParams) *adt.EmptyValue 
 		if newVcCap.LessThan(MinVerifiedDealSize) {
 			// Delete entry if remaining DataCap is less than MinVerifiedDealSize.
 			// Will be restored later if the deal did not get activated with a ProvenSector.
+			//
+			// NOTE: Technically, client could lose up to MinVerifiedDealSize worth of DataCap.
+			// See: https://github.com/filecoin-project/specs-actors/issues/727
 			err = verifiedClients.Delete(AddrKey(client))
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to delete verified client %v", client)
 		} else {


### PR DESCRIPTION
* Limit the size of the peer ID to 128 bytes.
* Limit the total size of all multiaddrs combined to 1024 bytes, and forbid empty multiaddrs.
* Require at most one window post and require that it (if present) match the miner's declared proof type. This should be fine (?) given that we don't currently support changing proof types at runtime anyways.
* Cleanup expiration validation.
* Validate "max sector number" in a couple of places. Honestly, this isn't strictly speaking necessary, but it's nice to do.
* Log if we somehow end up trying to confirm more sector proofs than we should.
* Verify that we don't allow extending sector expirations after their expiration.
* Limit payment channel secrets to 256 bytes. Really, they shouldn't ever be more than 32.
* Limit seal proofs to 1KiB.