### PR TITLE
Miner: Allow owner key to act as miner

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -198,7 +198,7 @@ func (a Actor) ChangePeerID(rt Runtime, params *ChangePeerIDParams) *adt.EmptyVa
 	rt.State().Transaction(&st, func() {
 		info := getMinerInfo(rt, &st)
 
-		rt.ValidateImmediateCallerIs(info.Worker)
+		rt.ValidateImmediateCallerIs(info.Worker, info.Owner)
 		info.PeerId = params.NewID
 		err := st.SaveInfo(adt.AsStore(rt), info)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "could not save miner info")
@@ -216,7 +216,7 @@ func (a Actor) ChangeMultiaddrs(rt Runtime, params *ChangeMultiaddrsParams) *adt
 	var st State
 	rt.State().Transaction(&st, func() {
 		info := getMinerInfo(rt, &st)
-		rt.ValidateImmediateCallerIs(info.Worker)
+		rt.ValidateImmediateCallerIs(info.Worker, info.Owner)
 		info.Multiaddrs = params.NewMultiaddrs
 		err := st.SaveInfo(adt.AsStore(rt), info)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "could not save miner info")
@@ -282,7 +282,7 @@ func (a Actor) SubmitWindowedPoSt(rt Runtime, params *SubmitWindowedPoStParams) 
 	var info *MinerInfo
 	rt.State().Transaction(&st, func() {
 		info = getMinerInfo(rt, &st)
-		rt.ValidateImmediateCallerIs(info.Worker)
+		rt.ValidateImmediateCallerIs(info.Worker, info.Owner)
 
 		// Validate that the miner didn't try to prove too many partitions at once.
 		submissionPartitionLimit := loadPartitionsSectorsMax(info.WindowPoStPartitionSectors)
@@ -446,7 +446,7 @@ func (a Actor) PreCommitSector(rt Runtime, params *SectorPreCommitInfo) *adt.Emp
 	newlyVested := big.Zero()
 	rt.State().Transaction(&st, func() {
 		info := getMinerInfo(rt, &st)
-		rt.ValidateImmediateCallerIs(info.Worker)
+		rt.ValidateImmediateCallerIs(info.Worker, info.Owner)
 		if params.SealProof != info.SealProofType {
 			rt.Abortf(exitcode.ErrIllegalArgument, "sector seal proof %v must match miner seal proof type %d", params.SealProof, info.SealProofType)
 		}
@@ -809,7 +809,7 @@ func (a Actor) ExtendSectorExpiration(rt Runtime, params *ExtendSectorExpiration
 	var st State
 	rt.State().Transaction(&st, func() {
 		info := getMinerInfo(rt, &st)
-		rt.ValidateImmediateCallerIs(info.Worker)
+		rt.ValidateImmediateCallerIs(info.Worker, info.Owner)
 
 		deadlines, err := st.LoadDeadlines(adt.AsStore(rt))
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deadlines")
@@ -961,7 +961,7 @@ func (a Actor) TerminateSectors(rt Runtime, params *TerminateSectorsParams) *Ter
 		hadEarlyTerminations = havePendingEarlyTerminations(rt, &st)
 
 		info := getMinerInfo(rt, &st)
-		rt.ValidateImmediateCallerIs(info.Worker)
+		rt.ValidateImmediateCallerIs(info.Worker, info.Owner)
 
 		deadlines, err := st.LoadDeadlines(adt.AsStore(rt))
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deadlines")
@@ -1044,7 +1044,7 @@ func (a Actor) DeclareFaults(rt Runtime, params *DeclareFaultsParams) *adt.Empty
 	newFaultPowerTotal := NewPowerPairZero()
 	rt.State().Transaction(&st, func() {
 		info := getMinerInfo(rt, &st)
-		rt.ValidateImmediateCallerIs(info.Worker)
+		rt.ValidateImmediateCallerIs(info.Worker, info.Owner)
 
 		deadlines, err := st.LoadDeadlines(store)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deadlines")
@@ -1116,7 +1116,7 @@ func (a Actor) DeclareFaultsRecovered(rt Runtime, params *DeclareFaultsRecovered
 	var st State
 	rt.State().Transaction(&st, func() {
 		info := getMinerInfo(rt, &st)
-		rt.ValidateImmediateCallerIs(info.Worker)
+		rt.ValidateImmediateCallerIs(info.Worker, info.Owner)
 
 		deadlines, err := st.LoadDeadlines(adt.AsStore(rt))
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load deadlines")
@@ -1177,7 +1177,7 @@ func (a Actor) CompactPartitions(rt Runtime, params *CompactPartitionsParams) *a
 	var st State
 	rt.State().Transaction(&st, func() {
 		info := getMinerInfo(rt, &st)
-		rt.ValidateImmediateCallerIs(info.Worker)
+		rt.ValidateImmediateCallerIs(info.Worker, info.Owner)
 
 		if !deadlineIsMutable(st.ProvingPeriodStart, params.Deadline, rt.CurrEpoch()) {
 			rt.Abortf(exitcode.ErrForbidden,
@@ -1240,7 +1240,7 @@ func (a Actor) CompactSectorNumbers(rt Runtime, params *CompactSectorNumbersPara
 	var st State
 	rt.State().Transaction(&st, func() {
 		info := getMinerInfo(rt, &st)
-		rt.ValidateImmediateCallerIs(info.Worker)
+		rt.ValidateImmediateCallerIs(info.Worker, info.Owner)
 
 		err := st.MaskSectorNumbers(store, params.MaskSectorNumbers)
 

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -167,6 +167,9 @@ func (a Actor) ChangeWorkerAddress(rt Runtime, params *ChangeWorkerAddressParams
 	rt.State().Transaction(&st, func() {
 		info := getMinerInfo(rt, &st)
 
+		// Only the Owner is allowed to change the worker address.
+		// Allowing the worker to do this does not make sense because the owner would usually do it
+		// only if the worker keys are lost.
 		rt.ValidateImmediateCallerIs(info.Owner)
 
 		effectiveEpoch = rt.CurrEpoch() + WorkerKeyChangeDelay
@@ -1343,6 +1346,8 @@ func (a Actor) WithdrawBalance(rt Runtime, params *WithdrawBalanceParams) *adt.E
 	rt.State().Transaction(&st, func() {
 		var err error
 		info = getMinerInfo(rt, &st)
+		// Only the owner is allowed to withdraw the balance as it belongs to/is controlled by the owner
+		// and not the worker.
 		rt.ValidateImmediateCallerIs(info.Owner)
 		// Ensure we don't have any pending terminations.
 		if count, err := st.EarlyTerminations.Count(); err != nil {

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -766,7 +766,7 @@ func TestWindowPost(t *testing.T) {
 		}
 		expectQueryNetworkInfo(rt, actor)
 		rt.SetCaller(actor.worker, builtin.AccountActorCodeID)
-		rt.ExpectValidateCallerAddr(actor.worker)
+		rt.ExpectValidateCallerAddr(actor.worker, actor.owner)
 		rt.ExpectGetRandomnessTickets(crypto.DomainSeparationTag_PoStChainCommit, commitEpoch, nil, commitRand)
 		rt.Call(actor.a.SubmitWindowedPoSt, &params)
 		rt.Verify()
@@ -2273,7 +2273,7 @@ func (h *actorHarness) controlAddresses(rt *mock.Runtime) (owner, worker addr.Ad
 func (h *actorHarness) preCommitSector(rt *mock.Runtime, params *miner.SectorPreCommitInfo) *miner.SectorPreCommitOnChainInfo {
 
 	rt.SetCaller(h.worker, builtin.AccountActorCodeID)
-	rt.ExpectValidateCallerAddr(h.worker)
+	rt.ExpectValidateCallerAddr(h.worker, h.owner)
 
 	{
 		expectQueryNetworkInfo(rt, h)
@@ -2449,7 +2449,7 @@ func (h *actorHarness) commitAndProveSectors(rt *mock.Runtime, n int, lifetimePe
 
 func (h *actorHarness) compactSectorNumbers(rt *mock.Runtime, bf bitfield.BitField) {
 	rt.SetCaller(h.worker, builtin.AccountActorCodeID)
-	rt.ExpectValidateCallerAddr(h.worker)
+	rt.ExpectValidateCallerAddr(h.worker, h.owner)
 
 	rt.Call(h.a.CompactSectorNumbers, &miner.CompactSectorNumbersParams{
 		MaskSectorNumbers: bf,
@@ -2497,7 +2497,7 @@ func (h *actorHarness) submitWindowPoSt(rt *mock.Runtime, deadline *miner.Deadli
 	commitEpoch := rt.Epoch() - 4
 	rt.ExpectGetRandomnessTickets(crypto.DomainSeparationTag_PoStChainCommit, commitEpoch, nil, commitRand)
 
-	rt.ExpectValidateCallerAddr(h.worker)
+	rt.ExpectValidateCallerAddr(h.worker, h.owner)
 
 	expectQueryNetworkInfo(rt, h)
 
@@ -2595,7 +2595,7 @@ func (h *actorHarness) submitWindowPoSt(rt *mock.Runtime, deadline *miner.Deadli
 
 func (h *actorHarness) declareFaults(rt *mock.Runtime, faultSectorInfos ...*miner.SectorOnChainInfo) {
 	rt.SetCaller(h.worker, builtin.AccountActorCodeID)
-	rt.ExpectValidateCallerAddr(h.worker)
+	rt.ExpectValidateCallerAddr(h.worker, h.owner)
 
 	ss, err := faultSectorInfos[0].SealProof.SectorSize()
 	require.NoError(h.t, err)
@@ -2626,7 +2626,7 @@ func (h *actorHarness) declareFaults(rt *mock.Runtime, faultSectorInfos ...*mine
 
 func (h *actorHarness) declareRecoveries(rt *mock.Runtime, deadlineIdx uint64, partitionIdx uint64, recoverySectors bitfield.BitField) {
 	rt.SetCaller(h.worker, builtin.AccountActorCodeID)
-	rt.ExpectValidateCallerAddr(h.worker)
+	rt.ExpectValidateCallerAddr(h.worker, h.owner)
 
 	// Calculate params from faulted sector infos
 	params := &miner.DeclareFaultsRecoveredParams{Recoveries: []miner.RecoveryDeclaration{{
@@ -2641,7 +2641,7 @@ func (h *actorHarness) declareRecoveries(rt *mock.Runtime, deadlineIdx uint64, p
 
 func (h *actorHarness) extendSectors(rt *mock.Runtime, params *miner.ExtendSectorExpirationParams) {
 	rt.SetCaller(h.worker, builtin.AccountActorCodeID)
-	rt.ExpectValidateCallerAddr(h.worker)
+	rt.ExpectValidateCallerAddr(h.worker, h.owner)
 
 	qaDelta := big.Zero()
 	for _, extension := range params.Extensions {
@@ -2675,7 +2675,7 @@ func (h *actorHarness) extendSectors(rt *mock.Runtime, params *miner.ExtendSecto
 
 func (h *actorHarness) terminateSectors(rt *mock.Runtime, sectors bitfield.BitField, expectedFee abi.TokenAmount) {
 	rt.SetCaller(h.worker, builtin.AccountActorCodeID)
-	rt.ExpectValidateCallerAddr(h.worker)
+	rt.ExpectValidateCallerAddr(h.worker, h.owner)
 
 	dealIDs := []abi.DealID{}
 	sectorInfos := []*miner.SectorOnChainInfo{}

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -355,7 +355,7 @@ func TestCommitments(t *testing.T) {
 		})
 		rt.Reset()
 
-		// Seal randomness challenge too far in past 
+		// Seal randomness challenge too far in past
 		tooOldChallengeEpoch := precommitEpoch - miner.ChainFinality - miner.MaxSealDuration[actor.sealProofType] - 1
 		rt.ExpectAbortContainsMessage(exitcode.ErrIllegalArgument, "too old", func() {
 			actor.preCommitSector(rt, actor.makePreCommit(102, tooOldChallengeEpoch, expiration, nil))
@@ -2343,7 +2343,7 @@ func (h *actorHarness) changeWorkerAddress(rt *mock.Runtime, newWorker addr.Addr
 
 func (h *actorHarness) changePeerID(rt *mock.Runtime, newPID abi.PeerID) {
 	param := &miner.ChangePeerIDParams{NewID: newPID}
-	rt.ExpectValidateCallerAddr(h.worker)
+	rt.ExpectValidateCallerAddr(h.worker, h.owner)
 	rt.SetCaller(h.worker, builtin.AccountActorCodeID)
 
 	rt.Call(h.a.ChangePeerID, param)


### PR DESCRIPTION
Closes #547 .

@anorth Do we need to write a test for each of the functions we've touched by setting the caller as the owner and ensuring things work ? Looks like adding a lot of testing code to test a simple change. Let me know.