### PR TITLE
Feat/update ip debt restrictions

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -549,11 +549,6 @@ func (a Actor) ProveCommitSector(rt Runtime, params *ProveCommitSectorParams) *a
 	var st State
 	rt.State().Readonly(&st)
 
-	// Verify locked funds are are at least the sum of sector initial pledges.
-	// Note that this call does not actually compute recent vesting, so the reported locked funds may be
-	// slightly higher than the true amount (i.e. slightly in the miner's favour).
-	// Computing vesting here would be almost always redundant since vesting is quantized to ~daily units.
-	// Vesting will be at most one proving period old if computed in the cron callback.
 	verifyPledgeMeetsInitialRequirements(rt, &st)
 
 	sectorNo := params.SectorNumber

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -1972,7 +1972,11 @@ func requestCurrentTotalPower(rt Runtime) *power.CurrentTotalPowerReturn {
 	return &pwr
 }
 
-// Verifies that the total locked balance exceeds the sum of sector initial pledges.
+// Verifies that the total unlocked balance exceeds the sum of sector initial pledges.
+// Note that this call does not compute recent vesting so reported unlocked balance
+// may be slightly lower than the true amount.
+// Computing vesting here would be almost always redundant since vesting is quantized to ~daily units.
+// Vesting will be at most one proving period old if computed in the cron callback.
 func verifyPledgeMeetsInitialRequirements(rt Runtime, st *State) {
 	if !st.MeetsInitialPledgeCondition(rt.CurrentBalance()) {
 		rt.Abortf(exitcode.ErrInsufficientFunds,

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -1366,6 +1366,37 @@ func TestDeclareFaults(t *testing.T) {
 	})
 }
 
+func TestDeclareRecoveries(t *testing.T) {
+	periodOffset := abi.ChainEpoch(100)
+	actor := newHarness(t, periodOffset)
+	builder := builderForHarness(actor).
+		WithBalance(bigBalance, big.Zero())
+
+	t.Run("recovery fails when in IP debt", func(t *testing.T) {
+		rt := builder.Build(t)
+		actor.constructAndVerify(rt)
+		oneSector := actor.commitAndProveSectors(rt, 1, defaultSectorExpiration, nil)
+
+		// advance to first proving period and submit so we'll have time to declare the fault next cycle
+		advanceAndSubmitPoSts(rt, actor, oneSector...)
+
+		// Declare the sector as faulted
+		actor.declareFaults(rt, oneSector...)
+
+		// Get into IP debt
+		st := getState(rt)
+		st.InitialPledgeRequirement = big.Add(rt.Balance(), abi.NewTokenAmount(1e18))
+		rt.ReplaceState(st)
+
+		// Attempt to recover
+		dlIdx, pIdx, err := st.FindSector(rt.AdtStore(), oneSector[0].SectorNumber)
+		require.NoError(t, err)
+		rt.ExpectAbortContainsMessage(exitcode.ErrInsufficientFunds, "does not cover pledge requirements", func () {
+			actor.declareRecoveries(rt, dlIdx, pIdx, bf(uint64(oneSector[0].SectorNumber)))
+		})
+	})
+}
+
 func TestExtendSectorExpiration(t *testing.T) {
 	periodOffset := abi.ChainEpoch(100)
 	actor := newHarness(t, periodOffset)


### PR DESCRIPTION
Closes #886 

In preparation for #888 I'm moving the requirements check within a transaction because we will soon be doing a state mutation to pay off debt every time we do the verification check.
