### PR TITLE
increase sector termination fee for replaced capacity sectors

### DIFF
--- a/actors/builtin/miner/cbor_gen.go
+++ b/actors/builtin/miner/cbor_gen.go
@@ -1610,7 +1610,7 @@ func (t *SectorPreCommitInfo) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
-var lengthBufSectorOnChainInfo = []byte{139}
+var lengthBufSectorOnChainInfo = []byte{141}
 
 func (t *SectorOnChainInfo) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -1706,6 +1706,22 @@ func (t *SectorOnChainInfo) MarshalCBOR(w io.Writer) error {
 	if err := t.ExpectedStoragePledge.MarshalCBOR(w); err != nil {
 		return err
 	}
+
+	// t.ReplacedSectorAge (abi.ChainEpoch) (int64)
+	if t.ReplacedSectorAge >= 0 {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.ReplacedSectorAge)); err != nil {
+			return err
+		}
+	} else {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.ReplacedSectorAge-1)); err != nil {
+			return err
+		}
+	}
+
+	// t.ReplacedDayReward (big.Int) (struct)
+	if err := t.ReplacedDayReward.MarshalCBOR(w); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -1723,7 +1739,7 @@ func (t *SectorOnChainInfo) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 11 {
+	if extra != 13 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -1903,6 +1919,40 @@ func (t *SectorOnChainInfo) UnmarshalCBOR(r io.Reader) error {
 
 		if err := t.ExpectedStoragePledge.UnmarshalCBOR(br); err != nil {
 			return xerrors.Errorf("unmarshaling t.ExpectedStoragePledge: %w", err)
+		}
+
+	}
+	// t.ReplacedSectorAge (abi.ChainEpoch) (int64)
+	{
+		maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+		var extraI int64
+		if err != nil {
+			return err
+		}
+		switch maj {
+		case cbg.MajUnsignedInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 positive overflow")
+			}
+		case cbg.MajNegativeInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 negative oveflow")
+			}
+			extraI = -1 - extraI
+		default:
+			return fmt.Errorf("wrong type for int64 field: %d", maj)
+		}
+
+		t.ReplacedSectorAge = abi.ChainEpoch(extraI)
+	}
+	// t.ReplacedDayReward (big.Int) (struct)
+
+	{
+
+		if err := t.ReplacedDayReward.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.ReplacedDayReward: %w", err)
 		}
 
 	}

--- a/actors/builtin/miner/deadline_state.go
+++ b/actors/builtin/miner/deadline_state.go
@@ -988,13 +988,14 @@ func (dl *Deadline) RescheduleSectorExpirations(
 	store adt.Store, sectors Sectors,
 	expiration abi.ChainEpoch, partitionSectors PartitionSectorMap,
 	ssize abi.SectorSize, quant QuantSpec,
-) error {
+) ([]*SectorOnChainInfo, error) {
 	partitions, err := dl.PartitionsArray(store)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var rescheduledPartitions []uint64 // track partitions with moved expirations.
+	var allReplaced []*SectorOnChainInfo
 	if err := partitionSectors.ForEach(func(partIdx uint64, sectorNos bitfield.BitField) error {
 		var partition Partition
 		if found, err := partitions.Get(partIdx, &partition); err != nil {
@@ -1006,7 +1007,7 @@ func (dl *Deadline) RescheduleSectorExpirations(
 			return nil
 		}
 
-		moved, err := partition.RescheduleExpirations(store, sectors, expiration, sectorNos, ssize, quant)
+		moved, replaced, err := partition.RescheduleExpirations(store, sectors, expiration, sectorNos, ssize, quant)
 		if err != nil {
 			return xerrors.Errorf("failed to reschedule expirations in partition %d: %w", partIdx, err)
 		}
@@ -1016,6 +1017,7 @@ func (dl *Deadline) RescheduleSectorExpirations(
 			// nothing moved.
 			return nil
 		}
+		allReplaced = append(allReplaced, replaced...)
 
 		rescheduledPartitions = append(rescheduledPartitions, partIdx)
 		if err = partitions.Set(partIdx, &partition); err != nil {
@@ -1023,19 +1025,19 @@ func (dl *Deadline) RescheduleSectorExpirations(
 		}
 		return nil
 	}); err != nil {
-		return err
+		return nil, err
 	}
 
 	if len(rescheduledPartitions) > 0 {
 		dl.Partitions, err = partitions.Root()
 		if err != nil {
-			return xerrors.Errorf("failed to save partitions: %w", err)
+			return nil, xerrors.Errorf("failed to save partitions: %w", err)
 		}
 		err := dl.AddExpirationPartitions(store, expiration, rescheduledPartitions, quant)
 		if err != nil {
-			return xerrors.Errorf("failed to reschedule partition expirations: %w", err)
+			return nil, xerrors.Errorf("failed to reschedule partition expirations: %w", err)
 		}
 	}
 
-	return nil
+	return allReplaced, nil
 }

--- a/actors/builtin/miner/deadline_state.go
+++ b/actors/builtin/miner/deadline_state.go
@@ -1007,13 +1007,11 @@ func (dl *Deadline) RescheduleSectorExpirations(
 			return nil
 		}
 
-		moved, replaced, err := partition.RescheduleExpirations(store, sectors, expiration, sectorNos, ssize, quant)
+		replaced, err := partition.RescheduleExpirations(store, sectors, expiration, sectorNos, ssize, quant)
 		if err != nil {
 			return xerrors.Errorf("failed to reschedule expirations in partition %d: %w", partIdx, err)
 		}
-		if empty, err := moved.IsEmpty(); err != nil {
-			return xerrors.Errorf("failed to parse bitfield of rescheduled expirations: %w", err)
-		} else if empty {
+		if len(replaced) == 0 {
 			// nothing moved.
 			return nil
 		}

--- a/actors/builtin/miner/deadline_state_test.go
+++ b/actors/builtin/miner/deadline_state_test.go
@@ -573,12 +573,14 @@ func TestDeadlines(t *testing.T) {
 		addThenMarkFaulty(t, store, dl)
 
 		// Try to reschedule two sectors, only the 7 (non faulty) should succeed.
-		err := dl.RescheduleSectorExpirations(store, sectorArr, 1, miner.PartitionSectorMap{
+		replaced, err := dl.RescheduleSectorExpirations(store, sectorArr, 1, miner.PartitionSectorMap{
 			1: bf(6, 7, 99), // 99 should be skipped, it doesn't exist.
 			5: bf(100),      // partition 5 doesn't exist.
 			2: bf(),         // empty bitfield should be fine.
 		}, sectorSize, quantSpec)
 		require.NoError(t, err)
+
+		assert.Len(t, replaced, 1)
 
 		exp, err := dl.PopExpiredSectors(store, 1, quantSpec)
 		require.NoError(t, err)

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -2155,6 +2155,8 @@ func replacedSectorParameters(rt Runtime, precommit *SectorPreCommitOnChainInfo,
 	if !ok {
 		rt.Abortf(exitcode.ErrNotFound, "no such sector %v to replace", precommit.Info.ReplaceSectorNumber)
 	}
+	// The sector will actually be active for the period between activation and its next proving deadline,
+	// but this covers the period for which we will be looking to the old sector for termination fees.
 	return maxEpoch(0, rt.CurrEpoch()-replaced.Activation), replaced.ExpectedDayReward
 }
 

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -697,7 +697,6 @@ func (a Actor) ConfirmSectorProofsValid(rt Runtime, params *builtin.ConfirmSecto
 				uint64(precommit.Info.ReplaceSectorNumber),
 			)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalArgument, "failed to record sectors for replacement")
-
 		}
 	}
 
@@ -738,6 +737,9 @@ func (a Actor) ConfirmSectorProofsValid(rt Runtime, params *builtin.ConfirmSecto
 
 			totalPrecommitDeposit = big.Add(totalPrecommitDeposit, precommit.PreCommitDeposit)
 			totalPledge = big.Add(totalPledge, initialPledge)
+
+			replacedAge, replacedDayReward := replacedSectorParameters(precommit, st, rt)
+
 			newSectorInfo := SectorOnChainInfo{
 				SectorNumber:          precommit.Info.SectorNumber,
 				SealProof:             precommit.Info.SealProof,
@@ -750,6 +752,8 @@ func (a Actor) ConfirmSectorProofsValid(rt Runtime, params *builtin.ConfirmSecto
 				InitialPledge:         initialPledge,
 				ExpectedDayReward:     dayReward,
 				ExpectedStoragePledge: storagePledge,
+				ReplacedSectorAge:     replacedAge,
+				ReplacedDayReward:     replacedDayReward,
 			}
 			newSectors = append(newSectors, &newSectorInfo)
 			newSectorNos = append(newSectorNos, newSectorInfo.SectorNumber)
@@ -787,6 +791,18 @@ func (a Actor) ConfirmSectorProofsValid(rt Runtime, params *builtin.ConfirmSecto
 	notifyPledgeChanged(rt, big.Sub(totalPledge, newlyVested))
 
 	return nil
+}
+
+func replacedSectorParameters(precommit *SectorPreCommitOnChainInfo, st State, rt Runtime) (abi.ChainEpoch, big.Int) {
+	if !precommit.Info.ReplaceCapacity {
+		return abi.ChainEpoch(0), big.Zero()
+	}
+	replaced, found, err := st.GetSector(adt.AsStore(rt), precommit.Info.ReplaceSectorNumber)
+	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load sector %v", precommit.Info.ReplaceSectorNumber)
+	if !found {
+		rt.Abortf(exitcode.ErrNotFound, "no such sector %v to replace", precommit.Info.ReplaceSectorNumber)
+	}
+	return minEpoch(0, rt.CurrEpoch()-replaced.Activation), replaced.ExpectedDayReward
 }
 
 type CheckSectorProvenParams struct {
@@ -2172,7 +2188,7 @@ func terminationPenalty(sectorSize abi.SectorSize, currEpoch abi.ChainEpoch, rew
 	totalFee := big.Zero()
 	for _, s := range sectors {
 		sectorPower := QAPowerForSector(sectorSize, s)
-		fee := PledgePenaltyForTermination(s.ExpectedDayReward, s.ExpectedStoragePledge, currEpoch-s.Activation, rewardEstimate, networkQAPowerEstimate, sectorPower)
+		fee := PledgePenaltyForTermination(s.ExpectedDayReward, s.ReplacedDayReward, s.ExpectedStoragePledge, currEpoch-s.Activation, s.ReplacedSectorAge, rewardEstimate, networkQAPowerEstimate, sectorPower)
 		totalFee = big.Add(fee, totalFee)
 	}
 	return totalFee

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -737,7 +737,6 @@ func (a Actor) ConfirmSectorProofsValid(rt Runtime, params *builtin.ConfirmSecto
 
 			totalPrecommitDeposit = big.Add(totalPrecommitDeposit, precommit.PreCommitDeposit)
 			totalPledge = big.Add(totalPledge, initialPledge)
-
 			replacedAge, replacedDayReward := replacedSectorParameters(precommit, st, rt)
 
 			newSectorInfo := SectorOnChainInfo{
@@ -802,7 +801,7 @@ func replacedSectorParameters(precommit *SectorPreCommitOnChainInfo, st State, r
 	if !found {
 		rt.Abortf(exitcode.ErrNotFound, "no such sector %v to replace", precommit.Info.ReplaceSectorNumber)
 	}
-	return minEpoch(0, rt.CurrEpoch()-replaced.Activation), replaced.ExpectedDayReward
+	return maxEpoch(0, rt.CurrEpoch()-replaced.Activation), replaced.ExpectedDayReward
 }
 
 type CheckSectorProvenParams struct {
@@ -2241,6 +2240,13 @@ func max64(a, b uint64) uint64 {
 
 func minEpoch(a, b abi.ChainEpoch) abi.ChainEpoch {
 	if a < b {
+		return a
+	}
+	return b
+}
+
+func maxEpoch(a, b abi.ChainEpoch) abi.ChainEpoch {
+	if a > b {
 		return a
 	}
 	return b

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -2195,7 +2195,7 @@ func terminationPenalty(sectorSize abi.SectorSize, currEpoch abi.ChainEpoch, rew
 	totalFee := big.Zero()
 	for _, s := range sectors {
 		sectorPower := QAPowerForSector(sectorSize, s)
-		fee := PledgePenaltyForTermination(s.ExpectedDayReward, s.ReplacedDayReward, s.ExpectedStoragePledge, currEpoch-s.Activation, s.ReplacedSectorAge, rewardEstimate, networkQAPowerEstimate, sectorPower)
+		fee := PledgePenaltyForTermination(s.ExpectedDayReward, currEpoch-s.Activation, s.ExpectedStoragePledge, networkQAPowerEstimate, sectorPower, rewardEstimate, s.ReplacedDayReward, s.ReplacedSectorAge)
 		totalFee = big.Add(fee, totalFee)
 	}
 	return totalFee

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -150,6 +150,8 @@ type SectorOnChainInfo struct {
 	InitialPledge         abi.TokenAmount // Pledge collected to commit this sector
 	ExpectedDayReward     abi.TokenAmount // Expected one day projection of reward for sector computed at activation time
 	ExpectedStoragePledge abi.TokenAmount // Expected twenty day projection of reward for sector computed at activation time
+	ReplacedSectorAge     abi.ChainEpoch  // Age of sector this sector replaced or zero
+	ReplacedDayReward     abi.TokenAmount // Day reward of sector this sector replace or zero
 }
 
 func ConstructState(infoCid cid.Cid, periodStart abi.ChainEpoch, emptyBitfieldCid, emptyArrayCid, emptyMapCid, emptyDeadlinesCid cid.Cid,

--- a/actors/builtin/miner/miner_state_test.go
+++ b/actors/builtin/miner/miner_state_test.go
@@ -922,6 +922,8 @@ func newSectorOnChainInfo(sectorNo abi.SectorNumber, sealed cid.Cid, weight big.
 		InitialPledge:         abi.NewTokenAmount(0),
 		ExpectedDayReward:     abi.NewTokenAmount(0),
 		ExpectedStoragePledge: abi.NewTokenAmount(0),
+		ReplacedSectorAge:     abi.ChainEpoch(0),
+		ReplacedDayReward:     big.Zero(),
 	}
 }
 

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -1786,17 +1786,12 @@ func TestTerminateSectors(t *testing.T) {
 	builder := builderForHarness(actor).
 		WithBalance(big.Mul(big.NewInt(1e18), big.NewInt(200000)), big.Zero())
 
-	commitSector := func(t *testing.T, rt *mock.Runtime) *miner.SectorOnChainInfo {
-		actor.constructAndVerify(rt)
-		precommitEpoch := abi.ChainEpoch(1)
-		rt.SetEpoch(precommitEpoch)
-		sectorInfo := actor.commitAndProveSectors(rt, 1, defaultSectorExpiration, nil)
-		return sectorInfo[0]
-	}
-
 	t.Run("removes sector with correct accounting", func(t *testing.T) {
 		rt := builder.Build(t)
-		sector := commitSector(t, rt)
+		actor.constructAndVerify(rt)
+		rt.SetEpoch(abi.ChainEpoch(1))
+		sectorInfo := actor.commitAndProveSectors(rt, 1, defaultSectorExpiration, nil)
+		sector := sectorInfo[0]
 		rt.SetEpoch(rt.Epoch() + 100)
 
 		// A miner will pay the minimum of termination fee and locked funds. Add some locked funds to ensure
@@ -1811,7 +1806,15 @@ func TestTerminateSectors(t *testing.T) {
 		dayReward := miner.ExpectedRewardForPower(actor.epochRewardSmooth, actor.epochQAPowerSmooth, sectorPower, builtin.EpochsInDay)
 		twentyDayReward := miner.ExpectedRewardForPower(actor.epochRewardSmooth, actor.epochQAPowerSmooth, sectorPower, miner.InitialPledgeProjectionPeriod)
 		sectorAge := rt.Epoch() - sector.Activation
-		expectedFee := miner.PledgePenaltyForTermination(dayReward, twentyDayReward, sectorAge, actor.epochRewardSmooth, actor.epochQAPowerSmooth, sectorPower)
+		expectedFee := miner.PledgePenaltyForTermination(
+			dayReward,
+			big.Zero(),
+			twentyDayReward,
+			sectorAge,
+			0,
+			actor.epochRewardSmooth,
+			actor.epochQAPowerSmooth,
+			sectorPower)
 
 		sectors := bf(uint64(sector.SectorNumber))
 		actor.terminateSectors(rt, sectors, expectedFee)
@@ -1834,6 +1837,67 @@ func TestTerminateSectors(t *testing.T) {
 			// expect pledge requirement to have been decremented
 			assert.Equal(t, big.Zero(), st.InitialPledgeRequirement)
 		}
+	})
+
+	t.Run("charges correct fee for young termination of committed capacity upgrade", func(t *testing.T) {
+		actor := newHarness(t, periodOffset)
+		rt := builderForHarness(actor).
+			WithBalance(bigBalance, big.Zero()).
+			Build(t)
+		actor.constructAndVerify(rt)
+
+		// A miner will pay the minimum of termination fee and locked funds. Add some locked funds to ensure
+		// correct fee calculation is used.
+		actor.addLockedFunds(rt, big.Mul(big.NewInt(1e18), big.NewInt(20000)))
+
+		// Move the current epoch forward so that the first deadline is a stable candidate for both sectors
+		rt.SetEpoch(periodOffset + miner.WPoStChallengeWindow)
+
+		// Commit a sector to upgrade
+		// Use the max sector number to make sure everything works.
+		oldSector := actor.commitAndProveSector(rt, abi.MaxSectorNumber, defaultSectorExpiration, nil)
+		st := getState(rt)
+		dlIdx, partIdx, err := st.FindSector(rt.AdtStore(), oldSector.SectorNumber)
+		require.NoError(t, err)
+
+		// Reduce the epoch reward so that a new sector's initial pledge would otherwise be lesser.
+		actor.epochReward = big.Div(actor.epochReward, big.NewInt(2))
+		actor.epochRewardSmooth = smoothing.TestingConstantEstimate(actor.epochReward)
+
+		challengeEpoch := rt.Epoch() - 1
+		upgradeParams := actor.makePreCommit(200, challengeEpoch, oldSector.Expiration, []abi.DealID{1})
+		upgradeParams.ReplaceCapacity = true
+		upgradeParams.ReplaceSectorDeadline = dlIdx
+		upgradeParams.ReplaceSectorPartition = partIdx
+		upgradeParams.ReplaceSectorNumber = oldSector.SectorNumber
+		upgrade := actor.preCommitSector(rt, upgradeParams)
+
+		// Prove new sector
+		rt.SetEpoch(upgrade.PreCommitEpoch + miner.PreCommitChallengeDelay + 1)
+		newSector := actor.proveCommitSectorAndConfirm(rt, &upgrade.Info, upgrade.PreCommitEpoch,
+			makeProveCommit(upgrade.Info.SectorNumber), proveCommitConf{})
+
+		// Expect replace parameters have been set
+		assert.Equal(t, oldSector.ExpectedDayReward, newSector.ReplacedDayReward)
+		assert.Equal(t, rt.Epoch()-oldSector.Activation, newSector.ReplacedSectorAge)
+
+		// advance clock a little and terminate new sector
+		rt.SetEpoch(rt.Epoch() + 100)
+		sectorPower := miner.QAPowerForSector(actor.sectorSize, newSector)
+		twentyDayReward := miner.ExpectedRewardForPower(actor.epochRewardSmooth, actor.epochQAPowerSmooth, sectorPower, miner.InitialPledgeProjectionPeriod)
+		sectorAge := rt.Epoch() - newSector.Activation
+		expectedFee := miner.PledgePenaltyForTermination(
+			newSector.ExpectedDayReward,
+			oldSector.ExpectedDayReward,
+			twentyDayReward,
+			sectorAge,
+			newSector.Activation-oldSector.Activation,
+			actor.epochRewardSmooth,
+			actor.epochQAPowerSmooth,
+			sectorPower)
+
+		sectors := bf(uint64(newSector.SectorNumber))
+		actor.terminateSectors(rt, sectors, expectedFee)
 	})
 }
 
@@ -3062,9 +3126,7 @@ func (h *actorHarness) terminateSectors(rt *mock.Runtime, sectors bitfield.BitFi
 	})
 	require.NoError(h.t, err)
 
-	{
-		expectQueryNetworkInfo(rt, h)
-	}
+	expectQueryNetworkInfo(rt, h)
 
 	pledgeDelta := big.Zero()
 	if big.Zero().LessThan(expectedFee) {
@@ -3079,6 +3141,17 @@ func (h *actorHarness) terminateSectors(rt *mock.Runtime, sectors bitfield.BitFi
 	}
 	if !pledgeDelta.Equals(big.Zero()) {
 		rt.ExpectSend(builtin.StoragePowerActorAddr, builtin.MethodsPower.UpdatePledgeTotal, &pledgeDelta, big.Zero(), nil, exitcode.Ok)
+	}
+	if len(dealIDs) > 0 {
+		size := len(dealIDs)
+		if size > cbg.MaxLength {
+			size = cbg.MaxLength
+		}
+		rt.ExpectSend(builtin.StorageMarketActorAddr, builtin.MethodsMarket.OnMinerSectorsTerminate, &market.OnMinerSectorsTerminateParams{
+			Epoch:   rt.Epoch(),
+			DealIDs: dealIDs[:size],
+		}, abi.NewTokenAmount(0), nil, exitcode.Ok)
+		dealIDs = dealIDs[size:]
 	}
 	{
 		sectorPower := miner.PowerForSectors(h.sectorSize, sectorInfos)

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -1806,15 +1806,7 @@ func TestTerminateSectors(t *testing.T) {
 		dayReward := miner.ExpectedRewardForPower(actor.epochRewardSmooth, actor.epochQAPowerSmooth, sectorPower, builtin.EpochsInDay)
 		twentyDayReward := miner.ExpectedRewardForPower(actor.epochRewardSmooth, actor.epochQAPowerSmooth, sectorPower, miner.InitialPledgeProjectionPeriod)
 		sectorAge := rt.Epoch() - sector.Activation
-		expectedFee := miner.PledgePenaltyForTermination(
-			dayReward,
-			big.Zero(),
-			twentyDayReward,
-			sectorAge,
-			0,
-			actor.epochRewardSmooth,
-			actor.epochQAPowerSmooth,
-			sectorPower)
+		expectedFee := miner.PledgePenaltyForTermination(dayReward, sectorAge, twentyDayReward, actor.epochQAPowerSmooth, sectorPower, actor.epochRewardSmooth, big.Zero(), 0)
 
 		sectors := bf(uint64(sector.SectorNumber))
 		actor.terminateSectors(rt, sectors, expectedFee)
@@ -1884,15 +1876,7 @@ func TestTerminateSectors(t *testing.T) {
 		twentyDayReward := miner.ExpectedRewardForPower(actor.epochRewardSmooth, actor.epochQAPowerSmooth, sectorPower, miner.InitialPledgeProjectionPeriod)
 		newSectorAge := rt.Epoch() - newSector.Activation
 		oldSectorAge := newSector.Activation - oldSector.Activation
-		expectedFee := miner.PledgePenaltyForTermination(
-			newSector.ExpectedDayReward,
-			oldSector.ExpectedDayReward,
-			twentyDayReward,
-			newSectorAge,
-			oldSectorAge,
-			actor.epochRewardSmooth,
-			actor.epochQAPowerSmooth,
-			sectorPower)
+		expectedFee := miner.PledgePenaltyForTermination(newSector.ExpectedDayReward, newSectorAge, twentyDayReward, actor.epochQAPowerSmooth, sectorPower, actor.epochRewardSmooth, oldSector.ExpectedDayReward, oldSectorAge)
 
 		sectors := bf(uint64(newSector.SectorNumber))
 		actor.terminateSectors(rt, sectors, expectedFee)

--- a/actors/builtin/miner/monies.go
+++ b/actors/builtin/miner/monies.go
@@ -61,6 +61,8 @@ func PledgePenaltyForUndeclaredFault(rewardEstimate, networkQAPowerEstimate *smo
 
 // Penalty to locked pledge collateral for the termination of a sector before scheduled expiry.
 // SectorAge is the time between the sector's activation and termination.
+// replacedDayReward and replacedSectorAge are the day reward and age of the replaced sector in a capacity upgrade.
+// They must be zero if no upgrade occurred.
 func PledgePenaltyForTermination(dayReward, replacedDayReward, twentyDayRewardAtActivation abi.TokenAmount, sectorAge, replacedSectorAge abi.ChainEpoch, rewardEstimate, networkQAPowerEstimate *smoothing.FilterEstimate, qaSectorPower abi.StoragePower) abi.TokenAmount {
 	// max(SP(t), BR(StartEpoch, 20d) + BR(StartEpoch, 1d)*min(SectorAgeInDays, 70))
 	// and sectorAgeInDays = sectorAge / EpochsInDay

--- a/actors/builtin/miner/monies.go
+++ b/actors/builtin/miner/monies.go
@@ -61,17 +61,24 @@ func PledgePenaltyForUndeclaredFault(rewardEstimate, networkQAPowerEstimate *smo
 
 // Penalty to locked pledge collateral for the termination of a sector before scheduled expiry.
 // SectorAge is the time between the sector's activation and termination.
-func PledgePenaltyForTermination(dayRewardAtActivation, twentyDayRewardAtActivation abi.TokenAmount, sectorAge abi.ChainEpoch, rewardEstimate, networkQAPowerEstimate *smoothing.FilterEstimate, qaSectorPower abi.StoragePower) abi.TokenAmount {
+func PledgePenaltyForTermination(dayReward, replacedDayReward, twentyDayRewardAtActivation abi.TokenAmount, sectorAge, replacedSectorAge abi.ChainEpoch, rewardEstimate, networkQAPowerEstimate *smoothing.FilterEstimate, qaSectorPower abi.StoragePower) abi.TokenAmount {
 	// max(SP(t), BR(StartEpoch, 20d) + BR(StartEpoch, 1d)*min(SectorAgeInDays, 70))
 	// and sectorAgeInDays = sectorAge / EpochsInDay
-	cappedSectorAge := big.NewInt(int64(minEpoch(sectorAge, TerminationLifetimeCap*builtin.EpochsInDay)))
+	lifetimeCap := TerminationLifetimeCap * builtin.EpochsInDay
+	cappedSectorAge := minEpoch(sectorAge, lifetimeCap)
+	// expected reward for lifetime of new sector (epochs*AttoFIL/day)
+	expectedReward := big.Mul(dayReward, big.NewInt(int64(cappedSectorAge)))
+	// if lifetime under cap and this sector replaced capacity, add expected reward for old sector's lifetime up to cap
+	relevantReplacedAge := minEpoch(replacedSectorAge, lifetimeCap-cappedSectorAge)
+	expectedReward = big.Add(expectedReward, big.Mul(replacedDayReward, big.NewInt(int64(relevantReplacedAge))))
+
 	return big.Max(
 		PledgePenaltyForUndeclaredFault(rewardEstimate, networkQAPowerEstimate, qaSectorPower),
 		big.Add(
 			twentyDayRewardAtActivation,
 			big.Div(
-				big.Mul(dayRewardAtActivation, cappedSectorAge),
-				big.NewInt(builtin.EpochsInDay))))
+				expectedReward,
+				big.NewInt(builtin.EpochsInDay)))) // (epochs*AttoFIL/day -> AttoFIL)
 }
 
 // Computes the PreCommit Deposit given sector qa weight and current network conditions.

--- a/actors/builtin/miner/monies.go
+++ b/actors/builtin/miner/monies.go
@@ -63,7 +63,11 @@ func PledgePenaltyForUndeclaredFault(rewardEstimate, networkQAPowerEstimate *smo
 // SectorAge is the time between the sector's activation and termination.
 // replacedDayReward and replacedSectorAge are the day reward and age of the replaced sector in a capacity upgrade.
 // They must be zero if no upgrade occurred.
-func PledgePenaltyForTermination(dayReward, replacedDayReward, twentyDayRewardAtActivation abi.TokenAmount, sectorAge, replacedSectorAge abi.ChainEpoch, rewardEstimate, networkQAPowerEstimate *smoothing.FilterEstimate, qaSectorPower abi.StoragePower) abi.TokenAmount {
+func PledgePenaltyForTermination(dayReward abi.TokenAmount, sectorAge abi.ChainEpoch,
+	twentyDayRewardAtActivation abi.TokenAmount, networkQAPowerEstimate *smoothing.FilterEstimate,
+	qaSectorPower abi.StoragePower, rewardEstimate *smoothing.FilterEstimate, replacedDayReward abi.TokenAmount,
+	replacedSectorAge abi.ChainEpoch,
+) abi.TokenAmount {
 	// max(SP(t), BR(StartEpoch, 20d) + BR(StartEpoch, 1d)*min(SectorAgeInDays, 70))
 	// and sectorAgeInDays = sectorAge / EpochsInDay
 	lifetimeCap := TerminationLifetimeCap * builtin.EpochsInDay

--- a/actors/builtin/miner/monies_test.go
+++ b/actors/builtin/miner/monies_test.go
@@ -107,28 +107,7 @@ func TestPledgePenaltyForTermination(t *testing.T) {
 		// use low power, so we don't test SP=SP
 		power := big.NewInt(1)
 
-		// fee for new sector with not replacement
-		noReplace := miner.PledgePenaltyForTermination(dayReward, replacementAge, twentyDayReward, powerEstimate, power, rewardEstimate, big.Zero(), 0)
-
-		// actual fee including replacement parameters
-		withReplace := miner.PledgePenaltyForTermination(dayReward, replacementAge, twentyDayReward, powerEstimate, power, rewardEstimate, dayReward, sectorAge)
-
-		assert.Equal(t, noReplace, withReplace)
-	})
-
-	t.Run("fee for replacement = fee for same sector without replacement after 70 days", func(t *testing.T) {
-		// initialPledge equal to undeclaredPenalty guarantees expected reward is greater
-		initialPledge := undeclaredPenalty
-		dayReward := big.Div(initialPledge, bigInitialPledgeFactor)
-		twentyDayReward := big.Mul(dayReward, bigInitialPledgeFactor)
-		sectorAgeInDays := int64(20)
-		sectorAge := abi.ChainEpoch(sectorAgeInDays * builtin.EpochsInDay)
-		replacementAge := abi.ChainEpoch(71 * builtin.EpochsInDay)
-
-		// use low power, so termination fee exceeds SP
-		power := big.NewInt(1)
-
-		// fee for new sector with not replacement
+		// fee for new sector with no replacement
 		noReplace := miner.PledgePenaltyForTermination(dayReward, replacementAge, twentyDayReward, powerEstimate, power, rewardEstimate, big.Zero(), 0)
 
 		// actual fee including replacement parameters

--- a/actors/builtin/miner/monies_test.go
+++ b/actors/builtin/miner/monies_test.go
@@ -32,7 +32,7 @@ func TestPledgePenaltyForTermination(t *testing.T) {
 		twentyDayReward := big.Mul(dayReward, big.NewInt(int64(miner.InitialPledgeFactor)))
 		sectorAge := 20 * abi.ChainEpoch(builtin.EpochsInDay)
 
-		fee := miner.PledgePenaltyForTermination(dayReward, big.Zero(), twentyDayReward, sectorAge, 0, rewardEstimate, powerEstimate, qaSectorPower)
+		fee := miner.PledgePenaltyForTermination(dayReward, sectorAge, twentyDayReward, powerEstimate, qaSectorPower, rewardEstimate, big.Zero(), 0)
 
 		assert.Equal(t, undeclaredPenalty, fee)
 	})
@@ -45,7 +45,7 @@ func TestPledgePenaltyForTermination(t *testing.T) {
 		sectorAgeInDays := int64(20)
 		sectorAge := abi.ChainEpoch(sectorAgeInDays * builtin.EpochsInDay)
 
-		fee := miner.PledgePenaltyForTermination(dayReward, big.Zero(), twentyDayReward, sectorAge, 0, rewardEstimate, powerEstimate, qaSectorPower)
+		fee := miner.PledgePenaltyForTermination(dayReward, sectorAge, twentyDayReward, powerEstimate, qaSectorPower, rewardEstimate, big.Zero(), 0)
 
 		// expect fee to be pledge * br * age where br = pledge/initialPledgeFactor
 		expectedFee := big.Add(
@@ -63,7 +63,7 @@ func TestPledgePenaltyForTermination(t *testing.T) {
 		sectorAgeInDays := 500
 		sectorAge := abi.ChainEpoch(sectorAgeInDays * builtin.EpochsInDay)
 
-		fee := miner.PledgePenaltyForTermination(dayReward, big.Zero(), twentyDayReward, sectorAge, 0, rewardEstimate, powerEstimate, qaSectorPower)
+		fee := miner.PledgePenaltyForTermination(dayReward, sectorAge, twentyDayReward, powerEstimate, qaSectorPower, rewardEstimate, big.Zero(), 0)
 
 		// expect fee to be pledge * br * age where br = pledge/initialPledgeFactor
 		expectedFee := big.Add(
@@ -87,22 +87,10 @@ func TestPledgePenaltyForTermination(t *testing.T) {
 		power := big.NewInt(1)
 
 		// fee for old sector if had terminated when it was replaced
-		unreplacedFee := miner.PledgePenaltyForTermination(
-			dayReward,
-			big.Zero(),
-			twentyDayReward,
-			sectorAge,
-			0,
-			rewardEstimate, powerEstimate, power)
+		unreplacedFee := miner.PledgePenaltyForTermination(dayReward, sectorAge, twentyDayReward, powerEstimate, power, rewardEstimate, big.Zero(), 0)
 
 		// actual fee including replacement parameters
-		actualFee := miner.PledgePenaltyForTermination(
-			dayReward,
-			dayReward,
-			twentyDayReward,
-			replacementAge,
-			sectorAge-replacementAge,
-			rewardEstimate, powerEstimate, power)
+		actualFee := miner.PledgePenaltyForTermination(dayReward, replacementAge, twentyDayReward, powerEstimate, power, rewardEstimate, dayReward, sectorAge-replacementAge)
 
 		// newFee + oldFee double counts the twentyDay reward so subtract it from expectation
 		assert.Equal(t, unreplacedFee, actualFee)

--- a/actors/builtin/miner/partition_state.go
+++ b/actors/builtin/miner/partition_state.go
@@ -327,43 +327,43 @@ func (p *Partition) RescheduleExpirations(
 	store adt.Store, sectors Sectors,
 	newExpiration abi.ChainEpoch, sectorNos bitfield.BitField,
 	ssize abi.SectorSize, quant QuantSpec,
-) (moved bitfield.BitField, replaced []*SectorOnChainInfo, err error) {
+) (replaced []*SectorOnChainInfo, err error) {
 	// Ensure these sectors actually belong to this partition.
 	present, err := bitfield.IntersectBitField(sectorNos, p.Sectors)
 	if err != nil {
-		return bitfield.BitField{}, nil, err
+		return nil, err
 	}
 
 	// Filter out terminated sectors.
 	live, err := bitfield.SubtractBitField(present, p.Terminated)
 	if err != nil {
-		return bitfield.BitField{}, nil, err
+		return nil, err
 	}
 
 	// Filter out faulty sectors.
 	active, err := bitfield.SubtractBitField(live, p.Faults)
 	if err != nil {
-		return bitfield.BitField{}, nil, err
+		return nil, err
 	}
 
 	sectorInfos, err := sectors.Load(active)
 	if err != nil {
-		return bitfield.BitField{}, nil, err
+		return nil, err
 	}
 
 	expirations, err := LoadExpirationQueue(store, p.ExpirationsEpochs, quant)
 	if err != nil {
-		return bitfield.BitField{}, nil, xerrors.Errorf("failed to load sector expirations: %w", err)
+		return nil, xerrors.Errorf("failed to load sector expirations: %w", err)
 	}
 	if err = expirations.RescheduleExpirations(newExpiration, sectorInfos, ssize); err != nil {
-		return bitfield.BitField{}, nil, err
+		return nil, err
 	}
 	p.ExpirationsEpochs, err = expirations.Root()
 	if err != nil {
-		return bitfield.BitField{}, nil, err
+		return nil, err
 	}
 
-	return active, sectorInfos, nil
+	return sectorInfos, nil
 }
 
 // Replaces a number of "old" sectors with new ones.

--- a/actors/builtin/miner/partition_state_test.go
+++ b/actors/builtin/miner/partition_state_test.go
@@ -241,11 +241,8 @@ func TestPartitions(t *testing.T) {
 		require.NoError(t, err)
 
 		// reschedule
-		moved, replaced, err := partition.RescheduleExpirations(store, sectorsArr(t, store, sectors), 18, bf(2, 4, 6), sectorSize, quantSpec)
+		replaced, err := partition.RescheduleExpirations(store, sectorsArr(t, store, sectors), 18, bf(2, 4, 6), sectorSize, quantSpec)
 		require.NoError(t, err)
-
-		// Make sure we moved the right ones.
-		assertBitfieldEquals(t, moved, 4, 6)
 
 		// Assert we returned the sector infos of the replaced sectors
 		assert.Len(t, replaced, 2)

--- a/actors/builtin/miner/partition_state_test.go
+++ b/actors/builtin/miner/partition_state_test.go
@@ -3,6 +3,7 @@ package miner_test
 import (
 	"bytes"
 	"context"
+	"sort"
 	"testing"
 
 	"github.com/filecoin-project/go-bitfield"
@@ -234,17 +235,25 @@ func TestPartitions(t *testing.T) {
 		store, partition := setup(t)
 		sectorArr := sectorsArr(t, store, sectors)
 
-		// Mark sector 2 faulty, we should skip it when rescheudling
+		// Mark sector 2 faulty, we should skip it when rescheduling
 		faultSet := bf(2)
 		_, _, err := partition.DeclareFaults(store, sectorArr, faultSet, abi.ChainEpoch(7), sectorSize, quantSpec)
 		require.NoError(t, err)
 
 		// reschedule
-		moved, err := partition.RescheduleExpirations(store, sectorsArr(t, store, sectors), 18, bf(2, 4, 6), sectorSize, quantSpec)
+		moved, replaced, err := partition.RescheduleExpirations(store, sectorsArr(t, store, sectors), 18, bf(2, 4, 6), sectorSize, quantSpec)
 		require.NoError(t, err)
 
 		// Make sure we moved the right ones.
 		assertBitfieldEquals(t, moved, 4, 6)
+
+		// Assert we returned the sector infos of the replaced sectors
+		assert.Len(t, replaced, 2)
+		sort.Slice(replaced, func(i, j int) bool {
+			return replaced[i].SectorNumber < replaced[j].SectorNumber
+		})
+		assert.Equal(t, abi.SectorNumber(4), replaced[0].SectorNumber)
+		assert.Equal(t, abi.SectorNumber(6), replaced[1].SectorNumber)
 
 		// We need to change the actual sector infos so our queue validation works.
 		rescheduled := rescheduleSectors(t, 18, sectors, bf(4, 6))


### PR DESCRIPTION
closes #532

### Motivation

Termination fees for a sector increase  with time (up to a limit), so a miner that needed to terminate a sector could replace with a younger sector and terminate for a smaller fee. This PR addresses that issue by taking the replacement into account when charging a termination fee.

### Proposed Changes

1. Add `ReplacedSectorAge` and `ReplacedDayReward` to `SectorOnChainInfo` to use in our termination fee calculation.
2. Set the parameters above in `ConfirmSectorProofsValid`.
3. Alter the `PledgePenaltyForTermination` to take the the parameters above as arguments and use them to charge for the old sector's lifetime at its expected day rate up to the 70 day limit.
4. Test.