### PR TITLE
Return Address by-pointer.

### DIFF
--- a/actors/builtin/account/account_actor.go
+++ b/actors/builtin/account/account_actor.go
@@ -42,9 +42,9 @@ func (a Actor) Constructor(rt vmr.Runtime, address *addr.Address) *adt.EmptyValu
 }
 
 // Fetches the pubkey-type address from this actor.
-func (a Actor) PubkeyAddress(rt vmr.Runtime, _ *adt.EmptyValue) addr.Address {
+func (a Actor) PubkeyAddress(rt vmr.Runtime, _ *adt.EmptyValue) *addr.Address {
 	rt.ValidateImmediateCallerAcceptAny()
 	var st State
 	rt.State().Readonly(&st)
-	return st.Address
+	return &st.Address
 }

--- a/actors/builtin/account/account_test.go
+++ b/actors/builtin/account/account_test.go
@@ -65,8 +65,8 @@ func TestAccountactor(t *testing.T) {
 				assert.Equal(t, tc.addr, st.Address)
 
 				rt.ExpectValidateCallerAny()
-				pubkeyAddress := rt.Call(actor.PubkeyAddress, nil).(address.Address)
-				assert.Equal(t, tc.addr, pubkeyAddress)
+				pubkeyAddress := rt.Call(actor.PubkeyAddress, nil).(*address.Address)
+				assert.Equal(t, &tc.addr, pubkeyAddress)
 			} else {
 				rt.ExpectAbort(tc.exitCode, func() {
 					rt.Call(actor.Constructor, &tc.addr)

--- a/support/mock/mockrt.go
+++ b/support/mock/mockrt.go
@@ -1043,12 +1043,7 @@ func (rt *Runtime) verifyExportedMethodType(meth reflect.Value) {
 	rt.require(t.In(1).Kind() == reflect.Ptr, "exported method second parameter must be pointer to params, got %v", t.In(1))
 	rt.require(t.In(1).Implements(typeOfCborUnmarshaler), "exported method second parameter must be CBOR-unmarshalable params, got %v", t.In(1))
 	rt.require(t.NumOut() == 1, "exported method must return a single value")
-	// Allow returning by-value.
-	retType := t.Out(0)
-	rt.require(
-		retType.Implements(typeOfCborMarshaler) || (retType.Kind() != reflect.Ptr && reflect.PtrTo(retType).Implements(typeOfCborMarshaler)),
-		"exported method must return CBOR-marshalable value",
-	)
+	rt.require(t.Out(0).Implements(typeOfCborMarshaler), "exported method must return CBOR-marshalable value")
 }
 
 func (rt *Runtime) requireInCall() {


### PR DESCRIPTION
`*Address` implements `CBORMarshaler` now, not `Address`. I was planning on handling this in the lotus runtime and just auto-referencing/dereferencing, but that's not worth the additional complexity.