### PR TITLE
Remove duplicate miner constructor params and serialization

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -91,8 +91,8 @@ func (a Actor) Constructor(rt Runtime, params *ConstructorParams) *adt.EmptyValu
 		rt.Abortf(exitcode.ErrIllegalArgument, "proof type %d not allowed for new miner actors", params.SealProofType)
 	}
 
-	owner := resolveOwnerAddress(rt, params.OwnerAddr)
-	worker := resolveWorkerAddress(rt, params.WorkerAddr)
+	owner := resolveOwnerAddress(rt, params.Owner)
+	worker := resolveWorkerAddress(rt, params.Worker)
 
 	emptyMap, err := adt.MakeEmptyMap(adt.AsStore(rt)).Root()
 	if err != nil {
@@ -121,7 +121,7 @@ func (a Actor) Constructor(rt Runtime, params *ConstructorParams) *adt.EmptyValu
 	periodStart := nextProvingPeriodStart(currEpoch, offset)
 	Assert(periodStart > currEpoch)
 
-	info, err := ConstructMinerInfo(owner, worker, params.PeerId, params.Multiaddrs, params.SealProofType)
+	info, err := ConstructMinerInfo(owner, worker, params.Peer, params.Multiaddrs, params.SealProofType)
 	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalArgument, "failed to construct initial miner info")
 	infoCid := rt.Store().Put(info)
 

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -72,10 +72,10 @@ func TestConstruction(t *testing.T) {
 	t.Run("simple construction", func(t *testing.T) {
 		rt := builder.Build(t)
 		params := miner.ConstructorParams{
-			OwnerAddr:     owner,
-			WorkerAddr:    worker,
+			Owner:         owner,
+			Worker:        worker,
 			SealProofType: abi.RegisteredSealProof_StackedDrg32GiBV1,
-			PeerId:        testPid,
+			Peer:          testPid,
 			Multiaddrs:    testMultiaddrs,
 		}
 
@@ -95,9 +95,9 @@ func TestConstruction(t *testing.T) {
 		rt.GetState(&st)
 		info, err := st.GetInfo(adt.AsStore(rt))
 		require.NoError(t, err)
-		assert.Equal(t, params.OwnerAddr, info.Owner)
-		assert.Equal(t, params.WorkerAddr, info.Worker)
-		assert.Equal(t, params.PeerId, info.PeerId)
+		assert.Equal(t, params.Owner, info.Owner)
+		assert.Equal(t, params.Worker, info.Worker)
+		assert.Equal(t, params.Peer, info.PeerId)
 		assert.Equal(t, params.Multiaddrs, info.Multiaddrs)
 		assert.Equal(t, abi.RegisteredSealProof_StackedDrg32GiBV1, info.SealProofType)
 		assert.Equal(t, abi.SectorSize(1<<35), info.SectorSize)
@@ -367,7 +367,7 @@ func TestCommitments(t *testing.T) {
 		oldIPReqs := st.InitialPledgeRequirement
 		st.InitialPledgeRequirement = big.Add(rt.Balance(), abi.NewTokenAmount(1e18))
 		rt.ReplaceState(st)
-		rt.ExpectAbortContainsMessage(exitcode.ErrInsufficientFunds, "does not cover pledge requirements", func () {
+		rt.ExpectAbortContainsMessage(exitcode.ErrInsufficientFunds, "does not cover pledge requirements", func() {
 			actor.preCommitSector(rt, actor.makePreCommit(102, challengeEpoch, expiration, nil))
 		})
 		// reset state back to normal
@@ -1414,7 +1414,7 @@ func TestDeclareRecoveries(t *testing.T) {
 		// Attempt to recover
 		dlIdx, pIdx, err := st.FindSector(rt.AdtStore(), oneSector[0].SectorNumber)
 		require.NoError(t, err)
-		rt.ExpectAbortContainsMessage(exitcode.ErrInsufficientFunds, "does not cover pledge requirements", func () {
+		rt.ExpectAbortContainsMessage(exitcode.ErrInsufficientFunds, "does not cover pledge requirements", func() {
 			actor.declareRecoveries(rt, dlIdx, pIdx, bf(uint64(oneSector[0].SectorNumber)))
 		})
 	})
@@ -2233,10 +2233,10 @@ func (h *actorHarness) setProofType(proof abi.RegisteredSealProof) {
 
 func (h *actorHarness) constructAndVerify(rt *mock.Runtime) {
 	params := miner.ConstructorParams{
-		OwnerAddr:     h.owner,
-		WorkerAddr:    h.worker,
+		Owner:         h.owner,
+		Worker:        h.worker,
 		SealProofType: h.sealProofType,
-		PeerId:        testPid,
+		Peer:          testPid,
 	}
 
 	rt.ExpectValidateCallerAddr(builtin.InitActorAddr)

--- a/actors/builtin/power/cbor_gen.go
+++ b/actors/builtin/power/cbor_gen.go
@@ -547,209 +547,6 @@ func (t *CronEvent) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
-var lengthBufCreateMinerParams = []byte{133}
-
-func (t *CreateMinerParams) MarshalCBOR(w io.Writer) error {
-	if t == nil {
-		_, err := w.Write(cbg.CborNull)
-		return err
-	}
-	if _, err := w.Write(lengthBufCreateMinerParams); err != nil {
-		return err
-	}
-
-	scratch := make([]byte, 9)
-
-	// t.Owner (address.Address) (struct)
-	if err := t.Owner.MarshalCBOR(w); err != nil {
-		return err
-	}
-
-	// t.Worker (address.Address) (struct)
-	if err := t.Worker.MarshalCBOR(w); err != nil {
-		return err
-	}
-
-	// t.SealProofType (abi.RegisteredSealProof) (int64)
-	if t.SealProofType >= 0 {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.SealProofType)); err != nil {
-			return err
-		}
-	} else {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.SealProofType-1)); err != nil {
-			return err
-		}
-	}
-
-	// t.Peer ([]uint8) (slice)
-	if len(t.Peer) > cbg.ByteArrayMaxLen {
-		return xerrors.Errorf("Byte array in field t.Peer was too long")
-	}
-
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajByteString, uint64(len(t.Peer))); err != nil {
-		return err
-	}
-
-	if _, err := w.Write(t.Peer[:]); err != nil {
-		return err
-	}
-
-	// t.Multiaddrs ([][]uint8) (slice)
-	if len(t.Multiaddrs) > cbg.MaxLength {
-		return xerrors.Errorf("Slice value in field t.Multiaddrs was too long")
-	}
-
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.Multiaddrs))); err != nil {
-		return err
-	}
-	for _, v := range t.Multiaddrs {
-		if len(v) > cbg.ByteArrayMaxLen {
-			return xerrors.Errorf("Byte array in field v was too long")
-		}
-
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajByteString, uint64(len(v))); err != nil {
-			return err
-		}
-
-		if _, err := w.Write(v[:]); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (t *CreateMinerParams) UnmarshalCBOR(r io.Reader) error {
-	*t = CreateMinerParams{}
-
-	br := cbg.GetPeeker(r)
-	scratch := make([]byte, 8)
-
-	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
-	if err != nil {
-		return err
-	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
-	}
-
-	if extra != 5 {
-		return fmt.Errorf("cbor input had wrong number of fields")
-	}
-
-	// t.Owner (address.Address) (struct)
-
-	{
-
-		if err := t.Owner.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.Owner: %w", err)
-		}
-
-	}
-	// t.Worker (address.Address) (struct)
-
-	{
-
-		if err := t.Worker.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.Worker: %w", err)
-		}
-
-	}
-	// t.SealProofType (abi.RegisteredSealProof) (int64)
-	{
-		maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
-		var extraI int64
-		if err != nil {
-			return err
-		}
-		switch maj {
-		case cbg.MajUnsignedInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 positive overflow")
-			}
-		case cbg.MajNegativeInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 negative oveflow")
-			}
-			extraI = -1 - extraI
-		default:
-			return fmt.Errorf("wrong type for int64 field: %d", maj)
-		}
-
-		t.SealProofType = abi.RegisteredSealProof(extraI)
-	}
-	// t.Peer ([]uint8) (slice)
-
-	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-	if err != nil {
-		return err
-	}
-
-	if extra > cbg.ByteArrayMaxLen {
-		return fmt.Errorf("t.Peer: byte array too large (%d)", extra)
-	}
-	if maj != cbg.MajByteString {
-		return fmt.Errorf("expected byte array")
-	}
-
-	if extra > 0 {
-		t.Peer = make([]uint8, extra)
-	}
-
-	if _, err := io.ReadFull(br, t.Peer[:]); err != nil {
-		return err
-	}
-	// t.Multiaddrs ([][]uint8) (slice)
-
-	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-	if err != nil {
-		return err
-	}
-
-	if extra > cbg.MaxLength {
-		return fmt.Errorf("t.Multiaddrs: array too large (%d)", extra)
-	}
-
-	if maj != cbg.MajArray {
-		return fmt.Errorf("expected cbor array")
-	}
-
-	if extra > 0 {
-		t.Multiaddrs = make([][]uint8, extra)
-	}
-
-	for i := 0; i < int(extra); i++ {
-		{
-			var maj byte
-			var extra uint64
-			var err error
-
-			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-			if err != nil {
-				return err
-			}
-
-			if extra > cbg.ByteArrayMaxLen {
-				return fmt.Errorf("t.Multiaddrs[i]: byte array too large (%d)", extra)
-			}
-			if maj != cbg.MajByteString {
-				return fmt.Errorf("expected byte array")
-			}
-
-			if extra > 0 {
-				t.Multiaddrs[i] = make([]uint8, extra)
-			}
-
-			if _, err := io.ReadFull(br, t.Multiaddrs[i][:]); err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
-}
-
 var lengthBufEnrollCronEventParams = []byte{130}
 
 func (t *EnrollCronEventParams) MarshalCBOR(w io.Writer) error {
@@ -1094,12 +891,12 @@ func (t *MinerConstructorParams) MarshalCBOR(w io.Writer) error {
 	scratch := make([]byte, 9)
 
 	// t.OwnerAddr (address.Address) (struct)
-	if err := t.OwnerAddr.MarshalCBOR(w); err != nil {
+	if err := t.Owner.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.WorkerAddr (address.Address) (struct)
-	if err := t.WorkerAddr.MarshalCBOR(w); err != nil {
+	if err := t.Worker.MarshalCBOR(w); err != nil {
 		return err
 	}
 
@@ -1115,15 +912,15 @@ func (t *MinerConstructorParams) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.PeerId ([]uint8) (slice)
-	if len(t.PeerId) > cbg.ByteArrayMaxLen {
+	if len(t.Peer) > cbg.ByteArrayMaxLen {
 		return xerrors.Errorf("Byte array in field t.PeerId was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajByteString, uint64(len(t.PeerId))); err != nil {
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajByteString, uint64(len(t.Peer))); err != nil {
 		return err
 	}
 
-	if _, err := w.Write(t.PeerId[:]); err != nil {
+	if _, err := w.Write(t.Peer[:]); err != nil {
 		return err
 	}
 
@@ -1173,7 +970,7 @@ func (t *MinerConstructorParams) UnmarshalCBOR(r io.Reader) error {
 
 	{
 
-		if err := t.OwnerAddr.UnmarshalCBOR(br); err != nil {
+		if err := t.Owner.UnmarshalCBOR(br); err != nil {
 			return xerrors.Errorf("unmarshaling t.OwnerAddr: %w", err)
 		}
 
@@ -1182,7 +979,7 @@ func (t *MinerConstructorParams) UnmarshalCBOR(r io.Reader) error {
 
 	{
 
-		if err := t.WorkerAddr.UnmarshalCBOR(br); err != nil {
+		if err := t.Worker.UnmarshalCBOR(br); err != nil {
 			return xerrors.Errorf("unmarshaling t.WorkerAddr: %w", err)
 		}
 
@@ -1227,10 +1024,10 @@ func (t *MinerConstructorParams) UnmarshalCBOR(r io.Reader) error {
 	}
 
 	if extra > 0 {
-		t.PeerId = make([]uint8, extra)
+		t.Peer = make([]uint8, extra)
 	}
 
-	if _, err := io.ReadFull(br, t.PeerId[:]); err != nil {
+	if _, err := io.ReadFull(br, t.Peer[:]); err != nil {
 		return err
 	}
 	// t.Multiaddrs ([][]uint8) (slice)

--- a/actors/builtin/power/cbor_gen.go
+++ b/actors/builtin/power/cbor_gen.go
@@ -890,12 +890,12 @@ func (t *MinerConstructorParams) MarshalCBOR(w io.Writer) error {
 
 	scratch := make([]byte, 9)
 
-	// t.OwnerAddr (address.Address) (struct)
+	// t.Owner (address.Address) (struct)
 	if err := t.Owner.MarshalCBOR(w); err != nil {
 		return err
 	}
 
-	// t.WorkerAddr (address.Address) (struct)
+	// t.Worker (address.Address) (struct)
 	if err := t.Worker.MarshalCBOR(w); err != nil {
 		return err
 	}
@@ -911,9 +911,9 @@ func (t *MinerConstructorParams) MarshalCBOR(w io.Writer) error {
 		}
 	}
 
-	// t.PeerId ([]uint8) (slice)
+	// t.Peer ([]uint8) (slice)
 	if len(t.Peer) > cbg.ByteArrayMaxLen {
-		return xerrors.Errorf("Byte array in field t.PeerId was too long")
+		return xerrors.Errorf("Byte array in field t.Peer was too long")
 	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajByteString, uint64(len(t.Peer))); err != nil {
@@ -966,21 +966,21 @@ func (t *MinerConstructorParams) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
-	// t.OwnerAddr (address.Address) (struct)
+	// t.Owner (address.Address) (struct)
 
 	{
 
 		if err := t.Owner.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.OwnerAddr: %w", err)
+			return xerrors.Errorf("unmarshaling t.Owner: %w", err)
 		}
 
 	}
-	// t.WorkerAddr (address.Address) (struct)
+	// t.Worker (address.Address) (struct)
 
 	{
 
 		if err := t.Worker.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.WorkerAddr: %w", err)
+			return xerrors.Errorf("unmarshaling t.Worker: %w", err)
 		}
 
 	}
@@ -1009,7 +1009,7 @@ func (t *MinerConstructorParams) UnmarshalCBOR(r io.Reader) error {
 
 		t.SealProofType = abi.RegisteredSealProof(extraI)
 	}
-	// t.PeerId ([]uint8) (slice)
+	// t.Peer ([]uint8) (slice)
 
 	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
 	if err != nil {
@@ -1017,7 +1017,7 @@ func (t *MinerConstructorParams) UnmarshalCBOR(r io.Reader) error {
 	}
 
 	if extra > cbg.ByteArrayMaxLen {
-		return fmt.Errorf("t.PeerId: byte array too large (%d)", extra)
+		return fmt.Errorf("t.Peer: byte array too large (%d)", extra)
 	}
 	if maj != cbg.MajByteString {
 		return fmt.Errorf("expected byte array")

--- a/actors/builtin/power/power_test.go
+++ b/actors/builtin/power/power_test.go
@@ -1232,10 +1232,10 @@ func (h *spActorHarness) expectTotalPledgeEager(rt *mock.Runtime, expectedPledge
 
 func initCreateMinerBytes(t testing.TB, owner, worker addr.Address, peer abi.PeerID, multiaddrs []abi.Multiaddrs, sealProofType abi.RegisteredSealProof) []byte {
 	params := &power.MinerConstructorParams{
-		OwnerAddr:     owner,
-		WorkerAddr:    worker,
+		Owner:         owner,
+		Worker:        worker,
 		SealProofType: sealProofType,
-		PeerId:        peer,
+		Peer:          peer,
 		Multiaddrs:    multiaddrs,
 	}
 

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -130,7 +130,6 @@ func main() {
 		power.Claim{},
 		power.CronEvent{},
 		// method params
-		power.CreateMinerParams{},
 		power.EnrollCronEventParams{},
 		power.UpdateClaimedPowerParams{},
 		// method returns


### PR DESCRIPTION
Feel free to close if this is necessary for some reason. I made the change to make sure that it was holding nothing up, but the extra serialization and deserialization and copy didn't make any sense.