### PR TITLE
Validate CBOR

### DIFF
--- a/actors/builtin/init/init_test.go
+++ b/actors/builtin/init/init_test.go
@@ -6,6 +6,7 @@ import (
 
 	cid "github.com/ipfs/go-cid"
 	assert "github.com/stretchr/testify/assert"
+	cbg "github.com/whyrusleeping/cbor-gen"
 
 	addr "github.com/filecoin-project/go-address"
 	abi "github.com/filecoin-project/specs-actors/actors/abi"
@@ -55,7 +56,7 @@ func TestExec(t *testing.T) {
 		})
 	})
 
-	var fakeParams = runtime.CBORBytes([]byte{'D', 'E', 'A', 'D', 'B', 'E', 'E', 'F'})
+	var fakeParams = runtime.CBORBytes(cbg.CborNull)
 	var balance = abi.NewTokenAmount(100)
 
 	t.Run("happy path exec create 2 payment channels", func(t *testing.T) {

--- a/actors/builtin/multisig/multisig_test.go
+++ b/actors/builtin/multisig/multisig_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/minio/blake2b-simd"
 	assert "github.com/stretchr/testify/assert"
 	require "github.com/stretchr/testify/require"
+	cbg "github.com/whyrusleeping/cbor-gen"
 
 	abi "github.com/filecoin-project/specs-actors/actors/abi"
 	big "github.com/filecoin-project/specs-actors/actors/abi/big"
@@ -197,7 +198,7 @@ func TestVesting(t *testing.T) {
 
 	const unlockDuration = 10
 	var multisigInitialBalance = abi.NewTokenAmount(100)
-	var fakeParams = runtime.CBORBytes([]byte{1, 2, 3, 4})
+	var fakeParams = runtime.CBORBytes(cbg.CborNull)
 
 	builder := mock.NewBuilder(context.Background(), receiver).
 		WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID).
@@ -326,7 +327,7 @@ func TestPropose(t *testing.T) {
 
 	const noUnlockDuration = int64(0)
 	var sendValue = abi.NewTokenAmount(10)
-	var fakeParams = runtime.CBORBytes([]byte{1, 2, 3, 4})
+	var fakeParams = runtime.CBORBytes(cbg.CborNull)
 	var signers = []addr.Address{anne, bob}
 
 	builder := mock.NewBuilder(context.Background(), receiver).WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID)
@@ -445,7 +446,7 @@ func TestApprove(t *testing.T) {
 	const txnID = int64(0)
 	const fakeMethod = abi.MethodNum(42)
 	var sendValue = abi.NewTokenAmount(10)
-	var fakeParams = runtime.CBORBytes([]byte{1, 2, 3, 4})
+	var fakeParams = runtime.CBORBytes(cbg.CborNull)
 	var signers = []addr.Address{anne, bob}
 
 	builder := mock.NewBuilder(context.Background(), receiver).
@@ -815,7 +816,7 @@ func TestCancel(t *testing.T) {
 	const numApprovals = uint64(2)
 	const txnID = int64(0)
 	const fakeMethod = abi.MethodNum(42)
-	var fakeParams = []byte{1, 2, 3, 4, 5}
+	var fakeParams = runtime.CBORBytes(cbg.CborNull)
 	var sendValue = abi.NewTokenAmount(10)
 	var signers = []addr.Address{anne, bob}
 

--- a/actors/runtime/runtime.go
+++ b/actors/runtime/runtime.go
@@ -8,6 +8,7 @@ import (
 	"github.com/filecoin-project/go-address"
 	addr "github.com/filecoin-project/go-address"
 	cid "github.com/ipfs/go-cid"
+	cbg "github.com/whyrusleeping/cbor-gen"
 
 	abi "github.com/filecoin-project/specs-actors/actors/abi"
 	crypto "github.com/filecoin-project/specs-actors/actors/crypto"
@@ -284,6 +285,13 @@ type CBORUnmarshaler interface {
 type CBORer interface {
 	CBORMarshaler
 	CBORUnmarshaler
+}
+
+func CheckCBOR(inp []byte) (CBORBytes, error) {
+	if err := cbg.ValidateCBOR(inp); err != nil {
+		return nil, err
+	}
+	return inp, nil
 }
 
 // Wraps already-serialized bytes as CBOR-marshalable.

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337 // indirect
 	github.com/stretchr/testify v1.6.1
 	github.com/warpfork/go-wish v0.0.0-20190328234359-8b3e70f8e830 // indirect
-	github.com/whyrusleeping/cbor-gen v0.0.0-20200812213548-958ddffe352c
+	github.com/whyrusleeping/cbor-gen v0.0.0-20200814232421-c568d328ad9d
 	github.com/xorcare/golden v0.6.0
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 )

--- a/go.sum
+++ b/go.sum
@@ -126,10 +126,9 @@ github.com/whyrusleeping/cbor-gen v0.0.0-20200123233031-1cdf64d27158/go.mod h1:X
 github.com/whyrusleeping/cbor-gen v0.0.0-20200414195334-429a0b5e922e/go.mod h1:Xj/M2wWU+QdTdRbu/L/1dIZY8/Wb2K9pAhtroQuxJJI=
 github.com/whyrusleeping/cbor-gen v0.0.0-20200504204219-64967432584d/go.mod h1:W5MvapuoHRP8rz4vxjwCK1pDqF1aQcWsV5PZ+AHbqdg=
 github.com/whyrusleeping/cbor-gen v0.0.0-20200715143311-227fab5a2377/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=
-github.com/whyrusleeping/cbor-gen v0.0.0-20200810223238-211df3b9e24c h1:BMg3YUwLEUIYBJoYZVhA4ZDTciXRj6r7ffOCshWrsoE=
 github.com/whyrusleeping/cbor-gen v0.0.0-20200810223238-211df3b9e24c/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=
-github.com/whyrusleeping/cbor-gen v0.0.0-20200812213548-958ddffe352c h1:otRnI08JoahNBxUFqX3372Ab9GnTj8L5J9iP5ImyxGU=
-github.com/whyrusleeping/cbor-gen v0.0.0-20200812213548-958ddffe352c/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=
+github.com/whyrusleeping/cbor-gen v0.0.0-20200814232421-c568d328ad9d h1:KK78rRDcb1C+jfxYlkN7KZyqWxS/Lx6zkWYPLoinu+Y=
+github.com/whyrusleeping/cbor-gen v0.0.0-20200814232421-c568d328ad9d/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=
 github.com/xorcare/golden v0.6.0 h1:E8emU8bhyMIEpYmgekkTUaw4vtcrRE+Wa0c5wYIcgXc=
 github.com/xorcare/golden v0.6.0/go.mod h1:7T39/ZMvaSEZlBPoYfVFmsBLmUl3uz9IuzWj/U6FtvQ=
 go.uber.org/atomic v1.6.0 h1:Ezj3JGmsOnG1MoRWQkPBsKLe9DwWD9QeXzTRzzldNVk=


### PR DESCRIPTION
~This change validates CBOR whenever accepted from the user as an arbitrary byte array.

Note:

1. For the multisig actor, we could _technically_ skip validating the CBOR on approval because it has already been validated on propose. But this shouldn't be that expensive.
2. We don't actually need to validate the CBOR in the cron actor. I'm happy to remove it, I just wanted to start with something paranoid and walk back from there.~

This change validates CBOR when "sending" it to other actor methods. Technically, actor message params are arbitrary bytes. Ideally, we'd just pass the raw bytes in.

However, for convenience, the runtime accepts any object implementing `CBORMarshaler`. Unfortunately, passing raw bytes as a `CBORMarshaler` without _checking_ them could lead to bugs down the road if we decide to treat this `CBORMarshaler` object as a valid CBOR object, so we validate them.

fixes #972, #973