### PR TITLE
Change the WPoSt commit randomness lookback to match the proof challenge epoch

### DIFF
--- a/actors/builtin/miner/cbor_gen.go
+++ b/actors/builtin/miner/cbor_gen.go
@@ -2259,7 +2259,7 @@ func (t *VestingFund) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
-var lengthBufSubmitWindowedPoStParams = []byte{133}
+var lengthBufSubmitWindowedPoStParams = []byte{132}
 
 func (t *SubmitWindowedPoStParams) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -2306,17 +2306,6 @@ func (t *SubmitWindowedPoStParams) MarshalCBOR(w io.Writer) error {
 		}
 	}
 
-	// t.ChainCommitEpoch (abi.ChainEpoch) (int64)
-	if t.ChainCommitEpoch >= 0 {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.ChainCommitEpoch)); err != nil {
-			return err
-		}
-	} else {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.ChainCommitEpoch-1)); err != nil {
-			return err
-		}
-	}
-
 	// t.ChainCommitRand (abi.Randomness) (slice)
 	if len(t.ChainCommitRand) > cbg.ByteArrayMaxLen {
 		return xerrors.Errorf("Byte array in field t.ChainCommitRand was too long")
@@ -2346,7 +2335,7 @@ func (t *SubmitWindowedPoStParams) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 5 {
+	if extra != 4 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -2422,31 +2411,6 @@ func (t *SubmitWindowedPoStParams) UnmarshalCBOR(r io.Reader) error {
 		t.Proofs[i] = v
 	}
 
-	// t.ChainCommitEpoch (abi.ChainEpoch) (int64)
-	{
-		maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
-		var extraI int64
-		if err != nil {
-			return err
-		}
-		switch maj {
-		case cbg.MajUnsignedInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 positive overflow")
-			}
-		case cbg.MajNegativeInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 negative oveflow")
-			}
-			extraI = -1 - extraI
-		default:
-			return fmt.Errorf("wrong type for int64 field: %d", maj)
-		}
-
-		t.ChainCommitEpoch = abi.ChainEpoch(extraI)
-	}
 	// t.ChainCommitRand (abi.Randomness) (slice)
 
 	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -1067,7 +1067,6 @@ func TestWindowPost(t *testing.T) {
 
 		// Submit a duplicate proof for the same partition, which should be ignored.
 		// The skipped fault declared here has no effect.
-		commitEpoch := rt.Epoch() - 1
 		commitRand := abi.Randomness("chaincommitment")
 		params := miner.SubmitWindowedPoStParams{
 			Deadline: dlIdx,
@@ -1075,14 +1074,13 @@ func TestWindowPost(t *testing.T) {
 				Index:   pIdx,
 				Skipped: bf(uint64(sector.SectorNumber)),
 			}},
-			Proofs:           makePoStProofs(actor.postProofType),
-			ChainCommitEpoch: commitEpoch,
-			ChainCommitRand:  commitRand,
+			Proofs:          makePoStProofs(actor.postProofType),
+			ChainCommitRand: commitRand,
 		}
 		expectQueryNetworkInfo(rt, actor)
 		rt.SetCaller(actor.worker, builtin.AccountActorCodeID)
 		rt.ExpectValidateCallerAddr(append(actor.controlAddrs, actor.owner, actor.worker)...)
-		rt.ExpectGetRandomnessTickets(crypto.DomainSeparationTag_PoStChainCommit, commitEpoch, nil, commitRand)
+		rt.ExpectGetRandomnessTickets(crypto.DomainSeparationTag_PoStChainCommit, dlinfo.Challenge, nil, commitRand)
 		rt.Call(actor.a.SubmitWindowedPoSt, &params)
 		rt.Verify()
 
@@ -3388,8 +3386,7 @@ type poStConfig struct {
 func (h *actorHarness) submitWindowPoSt(rt *mock.Runtime, deadline *miner.DeadlineInfo, partitions []miner.PoStPartition, infos []*miner.SectorOnChainInfo, poStCfg *poStConfig) {
 	rt.SetCaller(h.worker, builtin.AccountActorCodeID)
 	commitRand := abi.Randomness("chaincommitment")
-	commitEpoch := rt.Epoch() - 4
-	rt.ExpectGetRandomnessTickets(crypto.DomainSeparationTag_PoStChainCommit, commitEpoch, nil, commitRand)
+	rt.ExpectGetRandomnessTickets(crypto.DomainSeparationTag_PoStChainCommit, deadline.Challenge, nil, commitRand)
 
 	rt.ExpectValidateCallerAddr(append(h.controlAddrs, h.owner, h.worker)...)
 
@@ -3477,11 +3474,10 @@ func (h *actorHarness) submitWindowPoSt(rt *mock.Runtime, deadline *miner.Deadli
 	}
 
 	params := miner.SubmitWindowedPoStParams{
-		Deadline:         deadline.Index,
-		Partitions:       partitions,
-		Proofs:           proofs,
-		ChainCommitEpoch: commitEpoch,
-		ChainCommitRand:  commitRand,
+		Deadline:        deadline.Index,
+		Partitions:      partitions,
+		Proofs:          proofs,
+		ChainCommitRand: commitRand,
 	}
 
 	rt.Call(h.a.SubmitWindowedPoSt, &params)

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -21,9 +21,6 @@ var WPoStChallengeWindow = abi.ChainEpoch(30 * 60 / builtin.EpochDurationSeconds
 // The number of non-overlapping PoSt deadlines in each proving period.
 const WPoStPeriodDeadlines = uint64(48)
 
-// WPoStMaxChainCommitAge is the maximum distance back that a valid Window PoSt must commit to the current chain.
-var WPoStMaxChainCommitAge = WPoStChallengeWindow
-
 func init() {
 	// Check that the challenge windows divide the proving period evenly.
 	if WPoStProvingPeriod%WPoStChallengeWindow != 0 {


### PR DESCRIPTION
This change gets rid of the variable ChainCommitRand parameter and fixes it to be `DeadlineOpen - WPoStChallengeLookback`.

This makes it easy for lotus to extract randomness from the chain at the beginning of the challenge window such that:

1. The randomness is stable and won't change due to reverts. The WPoStChallengeLookback should ensure this.
2. No WPoSt message will become _invalid_ before the challenge window ends.

Before, if lotus picked a commit epoch that was too far in the past, it ran the risk of not being able to submit the proof in time. However, if it picked a recent epoch, it ran the risk of a revert changing the chain.