### PR TITLE
Power: Don't track last epoch for cron

### DIFF
--- a/actors/builtin/power/cbor_gen.go
+++ b/actors/builtin/power/cbor_gen.go
@@ -15,7 +15,7 @@ import (
 
 var _ = xerrors.Errorf
 
-var lengthBufState = []byte{144}
+var lengthBufState = []byte{143}
 
 func (t *State) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -112,17 +112,6 @@ func (t *State) MarshalCBOR(w io.Writer) error {
 		}
 	}
 
-	// t.LastProcessedCronEpoch (abi.ChainEpoch) (int64)
-	if t.LastProcessedCronEpoch >= 0 {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.LastProcessedCronEpoch)); err != nil {
-			return err
-		}
-	} else {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.LastProcessedCronEpoch-1)); err != nil {
-			return err
-		}
-	}
-
 	// t.Claims (cid.Cid) (struct)
 
 	if err := cbg.WriteCidBuf(scratch, w, t.Claims); err != nil {
@@ -158,7 +147,7 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 16 {
+	if extra != 15 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -339,31 +328,6 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 		}
 
 		t.FirstCronEpoch = abi.ChainEpoch(extraI)
-	}
-	// t.LastProcessedCronEpoch (abi.ChainEpoch) (int64)
-	{
-		maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
-		var extraI int64
-		if err != nil {
-			return err
-		}
-		switch maj {
-		case cbg.MajUnsignedInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 positive overflow")
-			}
-		case cbg.MajNegativeInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 negative oveflow")
-			}
-			extraI = -1 - extraI
-		default:
-			return fmt.Errorf("wrong type for int64 field: %d", maj)
-		}
-
-		t.LastProcessedCronEpoch = abi.ChainEpoch(extraI)
 	}
 	// t.Claims (cid.Cid) (struct)
 

--- a/actors/builtin/power/power_actor.go
+++ b/actors/builtin/power/power_actor.go
@@ -210,10 +210,8 @@ func (a Actor) OnEpochTickEnd(rt Runtime, _ *adt.EmptyValue) *adt.EmptyValue {
 		st.ThisEpochPledgeCollateral = st.TotalPledgeCollateral
 		st.ThisEpochQualityAdjPower = qaPower
 		st.ThisEpochRawBytePower = rawBytePower
-		delta := rt.CurrEpoch() - st.LastProcessedCronEpoch
-		st.updateSmoothedEstimate(delta)
-
-		st.LastProcessedCronEpoch = rt.CurrEpoch()
+		// we can now assume delta is one since cron is invoked on every epoch.
+		st.updateSmoothedEstimate(abi.ChainEpoch(1))
 	})
 
 	// update network KPI in RewardActor

--- a/actors/builtin/power/power_state.go
+++ b/actors/builtin/power/power_state.go
@@ -19,6 +19,7 @@ import (
 
 // genesis power in bytes = 750,000 GiB
 var InitialQAPowerEstimatePosition = big.Mul(big.NewInt(750_000), big.NewInt(1<<30))
+
 // max chain throughput in bytes per epoch = 120 ProveCommits / epoch = 3,840 GiB
 var InitialQAPowerEstimateVelocity = big.Mul(big.NewInt(3_840), big.NewInt(1<<30))
 
@@ -48,9 +49,6 @@ type State struct {
 	// First epoch in which a cron task may be stored.
 	// Cron will iterate every epoch between this and the current epoch inclusively to find tasks to execute.
 	FirstCronEpoch abi.ChainEpoch
-
-	// Last epoch power cron tick has been processed.
-	LastProcessedCronEpoch abi.ChainEpoch
 
 	// Claimed power for each miner.
 	Claims cid.Cid // Map, HAMT[address]Claim
@@ -85,7 +83,6 @@ func ConstructState(emptyMapCid, emptyMMapCid cid.Cid) *State {
 		ThisEpochPledgeCollateral: abi.NewTokenAmount(0),
 		ThisEpochQAPowerSmoothed:  smoothing.NewEstimate(InitialQAPowerEstimatePosition, InitialQAPowerEstimateVelocity),
 		FirstCronEpoch:            0,
-		LastProcessedCronEpoch:    abi.ChainEpoch(-1),
 		CronEventQueue:            emptyMMapCid,
 		Claims:                    emptyMapCid,
 		MinerCount:                0,


### PR DESCRIPTION
Closes #906 .

@anorth I am not sure if further simplification is possible. 
We need to keep the `FirstCronEpoch` around because it allows us to schedule past epochs in call to `EnrollCronEvent`.
Let me know if you have any ideas.