### PR TITLE
miner create->PoSt scenario test

### DIFF
--- a/actors/test/miner_scenario_test.go
+++ b/actors/test/miner_scenario_test.go
@@ -1,0 +1,160 @@
+package test
+
+import (
+	"context"
+	"github.com/filecoin-project/go-bitfield"
+	"testing"
+
+	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/specs-actors/actors/builtin"
+	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
+	"github.com/filecoin-project/specs-actors/actors/builtin/power"
+	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	tutil "github.com/filecoin-project/specs-actors/support/testing"
+	vm "github.com/filecoin-project/specs-actors/support/vm"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommitPoStFlow(t *testing.T) {
+	ctx := context.Background()
+	v := vm.NewVMWithSingletons(ctx, t)
+	addrs := vm.CreateAccounts(ctx, t, v, 1, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
+
+	minerBalance := big.Mul(big.NewInt(10_000), vm.FIL)
+	sectorNumber := abi.SectorNumber(100)
+	sealedCid := tutil.MakeCID("100", &miner.SealedCIDPrefix)
+	sealProof := abi.RegisteredSealProof_StackedDrg32GiBV1
+
+	// create miner
+	params := power.CreateMinerParams{
+		Owner:         addrs[0],
+		Worker:        addrs[0],
+		SealProofType: sealProof,
+		Peer:          abi.PeerID("not really a peer id"),
+	}
+	ret, code := v.ApplyMessage(addrs[0], builtin.StoragePowerActorAddr, minerBalance, builtin.MethodsPower.CreateMiner, &params)
+	require.Equal(t, exitcode.Ok, code)
+
+	minerAddrs, ok := ret.(*power.CreateMinerReturn)
+	require.True(t, ok)
+
+	// advance vm so we can have seal randomness epoch in the past
+	v, err := v.WithEpoch(200)
+	require.NoError(t, err)
+
+	// precommit sector
+	preCommitParams := miner.SectorPreCommitInfo{
+		SealProof:     sealProof,
+		SectorNumber:  sectorNumber,
+		SealedCID:     sealedCid,
+		SealRandEpoch: v.GetEpoch() - 1,
+		DealIDs:       nil,
+		Expiration:    v.GetEpoch() + miner.MinSectorExpiration + miner.MaxSealDuration[sealProof] + 100,
+	}
+	_, code = v.ApplyMessage(addrs[0], minerAddrs.RobustAddress, big.Zero(), builtin.MethodsMiner.PreCommitSector, &preCommitParams)
+	require.Equal(t, exitcode.Ok, code)
+
+	// assert successful precommit invocation
+	vm.ExpectInvocation{
+		// Original send to storage power actor
+		To:     minerAddrs.IDAddress,
+		Method: builtin.MethodsMiner.PreCommitSector,
+		Params: vm.ExpectObject(&preCommitParams),
+		SubInvocations: []vm.ExpectInvocation{
+			{To: builtin.RewardActorAddr, Method: builtin.MethodsReward.ThisEpochReward},
+			{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.CurrentTotalPower},
+			{To: builtin.StorageMarketActorAddr, Method: builtin.MethodsMarket.VerifyDealsForActivation}},
+	}.Matches(t, v.Invocations()[0])
+
+	// advance time to max seal duration
+	proveTime := v.GetEpoch() + miner.MaxSealDuration[sealProof]
+	v, _ = vm.AdvanceTillEpoch(t, v, minerAddrs.IDAddress, proveTime)
+
+	// Prove commit sector after max seal duration
+	v, err = v.WithEpoch(proveTime)
+	require.NoError(t, err)
+	proveCommitParams := miner.ProveCommitSectorParams{
+		SectorNumber: sectorNumber,
+	}
+	_, code = v.ApplyMessage(addrs[0], minerAddrs.RobustAddress, big.Zero(), builtin.MethodsMiner.ProveCommitSector, &proveCommitParams)
+	require.Equal(t, exitcode.Ok, code)
+
+	vm.ExpectInvocation{
+		// Original send to storage power actor
+		To:     minerAddrs.IDAddress,
+		Method: builtin.MethodsMiner.ProveCommitSector,
+		Params: vm.ExpectObject(&proveCommitParams),
+		SubInvocations: []vm.ExpectInvocation{
+			{To: builtin.StorageMarketActorAddr, Method: builtin.MethodsMarket.ComputeDataCommitment},
+			{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.SubmitPoRepForBulkVerify},
+		},
+	}.Matches(t, v.Invocations()[0])
+
+	// In the same epoch, trigger cron to validate prove commit
+	_, code = v.ApplyMessage(builtin.SystemActorAddr, builtin.CronActorAddr, big.Zero(), builtin.MethodsCron.EpochTick, nil)
+	require.Equal(t, exitcode.Ok, code)
+
+	vm.ExpectInvocation{
+		// Original send to storage power actor
+		To:     builtin.CronActorAddr,
+		Method: builtin.MethodsCron.EpochTick,
+		SubInvocations: []vm.ExpectInvocation{
+			{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.OnEpochTickEnd, SubInvocations: []vm.ExpectInvocation{
+				{To: minerAddrs.IDAddress, Method: builtin.MethodsMiner.OnDeferredCronEvent, SubInvocations: []vm.ExpectInvocation{
+					{To: builtin.RewardActorAddr, Method: builtin.MethodsReward.ThisEpochReward},
+					{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.CurrentTotalPower},
+					{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.EnrollCronEvent},
+				}},
+				{To: minerAddrs.IDAddress, Method: builtin.MethodsMiner.ConfirmSectorProofsValid, SubInvocations: []vm.ExpectInvocation{
+					{To: builtin.RewardActorAddr, Method: builtin.MethodsReward.ThisEpochReward},
+					{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.CurrentTotalPower},
+					{To: builtin.StorageMarketActorAddr, Method: builtin.MethodsMarket.ActivateDeals},
+					{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.UpdateClaimedPower},
+					{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.UpdatePledgeTotal},
+				}},
+				{To: builtin.RewardActorAddr, Method: builtin.MethodsReward.UpdateNetworkKPI},
+			}},
+			{To: builtin.StorageMarketActorAddr, Method: builtin.MethodsMarket.CronTick},
+		},
+	}.Matches(t, v.Invocations()[1])
+
+	// advance time to next proving period
+	var minerState miner.State
+	err = v.GetState(minerAddrs.IDAddress, &minerState)
+	require.NoError(t, err)
+
+	dlIdx, pIdx, err := minerState.FindSector(v.Store(), sectorNumber)
+	require.NoError(t, err)
+	v, dlInfo := vm.AdvanceTillIndex(t, v, minerAddrs.IDAddress, dlIdx)
+	v, err = v.WithEpoch(dlInfo.Open)
+	require.NoError(t, err)
+
+	// Submit PoSt
+	submitParams := miner.SubmitWindowedPoStParams{
+		Deadline: dlIdx,
+		Partitions: []miner.PoStPartition{{
+			Index:   pIdx,
+			Skipped: bitfield.New(),
+		}},
+		Proofs: []abi.PoStProof{{
+			PoStProof: abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
+		}},
+		ChainCommitEpoch: v.GetEpoch() - 1,
+		ChainCommitRand:  []byte("not really random"),
+	}
+	_, code = v.ApplyMessage(addrs[0], minerAddrs.RobustAddress, big.Zero(), builtin.MethodsMiner.SubmitWindowedPoSt, &submitParams)
+	require.Equal(t, exitcode.Ok, code)
+
+	vm.ExpectInvocation{
+		// Original send to storage power actor
+		To:     minerAddrs.IDAddress,
+		Method: builtin.MethodsMiner.SubmitWindowedPoSt,
+		Params: vm.ExpectObject(&submitParams),
+		SubInvocations: []vm.ExpectInvocation{
+			{To: builtin.RewardActorAddr, Method: builtin.MethodsReward.ThisEpochReward},
+			{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.CurrentTotalPower},
+		},
+	}.Matches(t, v.Invocations()[0])
+}

--- a/actors/test/miner_scenario_test.go
+++ b/actors/test/miner_scenario_test.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"context"
-	"github.com/filecoin-project/go-bitfield"
 	"testing"
 
 	"github.com/filecoin-project/specs-actors/actors/abi"
@@ -14,6 +13,7 @@ import (
 	tutil "github.com/filecoin-project/specs-actors/support/testing"
 	vm "github.com/filecoin-project/specs-actors/support/vm"
 
+	"github.com/filecoin-project/go-bitfield"
 	"github.com/stretchr/testify/require"
 )
 

--- a/actors/test/miner_scenario_test.go
+++ b/actors/test/miner_scenario_test.go
@@ -65,7 +65,6 @@ func TestCommitPoStFlow(t *testing.T) {
 
 	// assert successful precommit invocation
 	vm.ExpectInvocation{
-		// Original send to storage power actor
 		To:     minerAddrs.IDAddress,
 		Method: builtin.MethodsMiner.PreCommitSector,
 		Params: vm.ExpectObject(&preCommitParams),
@@ -105,7 +104,6 @@ func TestCommitPoStFlow(t *testing.T) {
 		require.Equal(t, exitcode.Ok, code)
 
 		vm.ExpectInvocation{
-			// Original send to storage power actor
 			To:     builtin.CronActorAddr,
 			Method: builtin.MethodsCron.EpochTick,
 			SubInvocations: []vm.ExpectInvocation{
@@ -152,7 +150,6 @@ func TestCommitPoStFlow(t *testing.T) {
 	require.Equal(t, exitcode.Ok, code)
 
 	vm.ExpectInvocation{
-		// Original send to storage power actor
 		To:     minerAddrs.IDAddress,
 		Method: builtin.MethodsMiner.ProveCommitSector,
 		Params: vm.ExpectObject(&proveCommitParams),
@@ -167,7 +164,6 @@ func TestCommitPoStFlow(t *testing.T) {
 	require.Equal(t, exitcode.Ok, code)
 
 	vm.ExpectInvocation{
-		// Original send to storage power actor
 		To:     builtin.CronActorAddr,
 		Method: builtin.MethodsCron.EpochTick,
 		SubInvocations: []vm.ExpectInvocation{
@@ -237,7 +233,6 @@ func TestCommitPoStFlow(t *testing.T) {
 		require.Equal(t, exitcode.Ok, code)
 
 		vm.ExpectInvocation{
-			// Original send to storage power actor
 			To:     minerAddrs.IDAddress,
 			Method: builtin.MethodsMiner.SubmitWindowedPoSt,
 			Params: vm.ExpectObject(&submitParams),
@@ -284,7 +279,6 @@ func TestCommitPoStFlow(t *testing.T) {
 		}
 
 		vm.ExpectInvocation{
-			// Original send to storage power actor
 			To:     minerAddrs.IDAddress,
 			Method: builtin.MethodsMiner.SubmitWindowedPoSt,
 			Params: vm.ExpectObject(&submitParams),
@@ -326,7 +320,6 @@ func TestCommitPoStFlow(t *testing.T) {
 		}
 
 		vm.ExpectInvocation{
-			// Original send to storage power actor
 			To:     builtin.CronActorAddr,
 			Method: builtin.MethodsCron.EpochTick,
 			SubInvocations: []vm.ExpectInvocation{

--- a/support/vm/invocation_context.go
+++ b/support/vm/invocation_context.go
@@ -156,7 +156,7 @@ func (ic *invocationContext) CurrEpoch() abi.ChainEpoch {
 }
 
 func (ic *invocationContext) CurrentBalance() abi.TokenAmount {
-	return ic.fromActor.Balance
+	return ic.toActor.Balance
 }
 
 func (ic *invocationContext) GetActorCodeCID(a address.Address) (cid.Cid, bool) {

--- a/support/vm/testing.go
+++ b/support/vm/testing.go
@@ -242,6 +242,8 @@ func MinerDLInfo(t *testing.T, v *VM, minerIDAddr address.Address) *miner.Deadli
 	return minerState.DeadlineInfo(v.GetEpoch())
 }
 
+// AdvanceByDeadline creates a new VM advanced to an epoch specified by the predicate while keeping the
+// miner state upu-to-date by running a cron at the end of each deadline period.
 func AdvanceByDeadline(t *testing.T, v *VM, minerIDAddr address.Address, predicate advanceDeadlinePredicate) (*VM, *miner.DeadlineInfo) {
 	dlInfo := MinerDLInfo(t, v, minerIDAddr)
 	var err error
@@ -257,12 +259,16 @@ func AdvanceByDeadline(t *testing.T, v *VM, minerIDAddr address.Address, predica
 	return v, dlInfo
 }
 
+// Advances by deadline until e is contained within the deadline period represented by the returned deadline info.
+// The VM returned will be set to the last deadline close, not at e.
 func AdvanceByDeadlineTillEpoch(t *testing.T, v *VM, minerIDAddr address.Address, e abi.ChainEpoch) (*VM, *miner.DeadlineInfo) {
 	return AdvanceByDeadline(t, v, minerIDAddr, func(dlInfo *miner.DeadlineInfo) bool {
 		return dlInfo.Close <= e
 	})
 }
 
+// Advances by deadline until the deadline index matches the given index.
+// The vm returned will be set to the close epoch of the previous deadline.
 func AdvanceByDeadlineTillIndex(t *testing.T, v *VM, minerIDAddr address.Address, i uint64) (*VM, *miner.DeadlineInfo) {
 	return AdvanceByDeadline(t, v, minerIDAddr, func(dlInfo *miner.DeadlineInfo) bool {
 		return dlInfo.Index != i

--- a/support/vm/testing.go
+++ b/support/vm/testing.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/filecoin-project/specs-actors/actors/util/smoothing"
 	"testing"
 
 	"github.com/filecoin-project/specs-actors/actors/abi"
@@ -20,13 +19,14 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/builtin/reward"
 	"github.com/filecoin-project/specs-actors/actors/builtin/system"
 	"github.com/filecoin-project/specs-actors/actors/builtin/verifreg"
+	"github.com/filecoin-project/specs-actors/actors/runtime"
 	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
+	"github.com/filecoin-project/specs-actors/actors/util/smoothing"
 	"github.com/filecoin-project/specs-actors/support/ipld"
 	actor_testing "github.com/filecoin-project/specs-actors/support/testing"
 
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/specs-actors/actors/runtime"
 	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/support/vm/testing.go
+++ b/support/vm/testing.go
@@ -145,7 +145,7 @@ func (ei ExpectInvocation) matches(t *testing.T, breadcrumb string, invocation *
 	identifier := fmt.Sprintf("%s[%s:%d]", breadcrumb, invocation.Msg.to, invocation.Msg.method)
 
 	// mismatch of to or method probably indicates skipped message or messages out of order. halt.
-	require.Equal(t, ei.To, invocation.Msg.to, "%s unexpected `to` address", identifier)
+	require.Equal(t, ei.To, invocation.Msg.to, "%s unexpected 'to' address", identifier)
 	require.Equal(t, ei.Method, invocation.Msg.method, "%s unexpected method", identifier)
 
 	// other expectations are optional
@@ -256,7 +256,7 @@ func AdvanceByMinerDeadline(t *testing.T, v *VM, minerIDAddr address.Address, pr
 
 func AdvanceTillEpoch(t *testing.T, v *VM, minerIDAddr address.Address, e abi.ChainEpoch) (*VM, *miner.DeadlineInfo) {
 	return AdvanceByMinerDeadline(t, v, minerIDAddr, func(dlInfo *miner.DeadlineInfo) bool {
-		return dlInfo.Close < e
+		return dlInfo.Close <= e
 	})
 }
 

--- a/support/vm/testing.go
+++ b/support/vm/testing.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
 	"testing"
 
 	"github.com/filecoin-project/specs-actors/actors/abi"
@@ -15,6 +14,7 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/builtin/exported"
 	initactor "github.com/filecoin-project/specs-actors/actors/builtin/init"
 	"github.com/filecoin-project/specs-actors/actors/builtin/market"
+	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
 	"github.com/filecoin-project/specs-actors/actors/builtin/power"
 	"github.com/filecoin-project/specs-actors/actors/builtin/reward"
 	"github.com/filecoin-project/specs-actors/actors/builtin/system"

--- a/support/vm/vm.go
+++ b/support/vm/vm.go
@@ -298,6 +298,11 @@ func (vm *VM) Store() adt.Store {
 	return vm.store
 }
 
+// Get the chain epoch for this vm
+func (vm *VM) GetEpoch() abi.ChainEpoch {
+	return vm.currentEpoch
+}
+
 // transfer debits money from one account and credits it to another.
 // avoid calling this method with a zero amount else it will perform unnecessary actor loading.
 //


### PR DESCRIPTION
### Motivation

We want to have confidence that the flow from creating a miner through committing a sector, all the way through submitting a PoSt work. This test does that at a high level. It confirms that All the method invocations involved in that flow and all their sub-invocations succeed. It does this without getting into the details of what the logic does or specifying inputs and outputs which should be handled by various unit tests.

### Proposed Changes

1. Add `TestCommitPoStFlow` with happy path and a few error cases.
2. Fix bug in VM that returns the wrong current balance.
3. Fix bug in construction of market actor in testing setup.
4. Add functions to advance time by miner deadlines and get current epoch.

Error cases are forthcoming.