### PR TITLE
PledgeVestingSpec is not used any more

### DIFF
--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -2155,7 +2155,7 @@ func TestWithdrawBalance(t *testing.T) {
 		feeDebt := big.Sub(bigBalance, onePercentBigBalance)
 		st.FeeDebt = feeDebt
 		rt.ReplaceState(st)
-		
+
 		requested := rt.Balance()
 		expectedWithdraw := big.Sub(requested, feeDebt)
 		actor.withdrawFunds(rt, requested, expectedWithdraw, feeDebt)
@@ -2601,7 +2601,7 @@ func TestReportConsensusFault(t *testing.T) {
 
 		actor.reportConsensusFault(rt, addr.TestAddress, params)
 		endInfo := actor.getInfo(rt)
-		assert.Equal(t, reportEpoch + miner.ConsensusFaultIneligibilityDuration, endInfo.ConsensusFaultElapsed)
+		assert.Equal(t, reportEpoch+miner.ConsensusFaultIneligibilityDuration, endInfo.ConsensusFaultElapsed)
 	})
 
 }
@@ -2635,11 +2635,11 @@ func TestAddLockedFund(t *testing.T) {
 		require.Len(t, vestingFunds.Funds, 180)
 
 		// Vested FIL pays out on epochs with expected offset
-		expectedOffset := periodOffset % miner.PledgeVestingSpec.Quantization
+		expectedOffset := periodOffset % miner.RewardVestingSpec.Quantization
 
 		for i := range vestingFunds.Funds {
 			vf := vestingFunds.Funds[i]
-			require.EqualValues(t, expectedOffset, int64(vf.Epoch)%int64(miner.PledgeVestingSpec.Quantization))
+			require.EqualValues(t, expectedOffset, int64(vf.Epoch)%int64(miner.RewardVestingSpec.Quantization))
 		}
 
 		assert.Equal(t, amt, st.LockedFunds)
@@ -3744,7 +3744,6 @@ func (h *actorHarness) withdrawFunds(rt *mock.Runtime, amountRequested, amountWi
 	rt.Call(h.a.WithdrawBalance, &miner.WithdrawBalanceParams{
 		AmountRequested: amountRequested,
 	})
-	
 
 	rt.Verify()
 }

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -138,7 +138,7 @@ const MaxSectorExpirationExtension = 540 * builtin.EpochsInDay
 // which limits 32GiB sectors to 256 deals and 64GiB sectors to 512
 const DealLimitDenominator = 134217728
 
-// Number of epochs after a consensus fault for which a miner is ineligible 
+// Number of epochs after a consensus fault for which a miner is ineligible
 // for permissioned actor methods and winning block elections.
 const ConsensusFaultIneligibilityDuration = ChainFinality
 
@@ -201,13 +201,6 @@ type VestSpec struct {
 	VestPeriod   abi.ChainEpoch // Period over which the total should vest, after the initial delay.
 	StepDuration abi.ChainEpoch // Duration between successive incremental vests (independent of vesting period).
 	Quantization abi.ChainEpoch // Maximum precision of vesting table (limits cardinality of table).
-}
-
-var PledgeVestingSpec = VestSpec{
-	InitialDelay: abi.ChainEpoch(180 * builtin.EpochsInDay), // PARAM_FINISH
-	VestPeriod:   abi.ChainEpoch(180 * builtin.EpochsInDay), // PARAM_FINISH
-	StepDuration: abi.ChainEpoch(1 * builtin.EpochsInDay),   // PARAM_FINISH
-	Quantization: 12 * builtin.EpochsInHour,                 // PARAM_FINISH
 }
 
 var RewardVestingSpec = VestSpec{


### PR DESCRIPTION
There is on need to have pledgeVestingSpec, since the InitialPledgeRequest is for and only for the effective power. 