### PR TITLE
Cap 32GiB sector initial pledge to 1FIL for Space Race (hotfix)

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -732,6 +732,9 @@ func (a Actor) ConfirmSectorProofsValid(rt Runtime, params *builtin.ConfirmSecto
 
 			power := QAPowerForWeight(info.SectorSize, duration, precommit.DealWeight, precommit.VerifiedDealWeight)
 			dayReward := ExpectedRewardForPower(rewardStats.ThisEpochRewardSmoothed, pwrTotal.QualityAdjPowerSmoothed, power, builtin.EpochsInDay)
+			// The storage pledge is recorded for use in computing the penalty if this sector is terminated
+			// before its declared expiration.
+			// It's not capped to 1 FIL for Space Race, so likely exceeds the actual initial pledge requirement.
 			storagePledge := ExpectedRewardForPower(rewardStats.ThisEpochRewardSmoothed, pwrTotal.QualityAdjPowerSmoothed, power, InitialPledgeProjectionPeriod)
 
 			initialPledge := InitialPledgeForPower(power, rewardStats.ThisEpochBaselinePower, pwrTotal.PledgeCollateral,

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -240,7 +240,7 @@ func TestCommitments(t *testing.T) {
 		assert.Equal(t, big.NewInt(int64(sectorSize/2)), onChainPrecommit.VerifiedDealWeight)
 
 		qaPower := miner.QAPowerForWeight(sectorSize, precommit.Expiration-precommitEpoch, onChainPrecommit.DealWeight, onChainPrecommit.VerifiedDealWeight)
-		expectedDeposit := miner.InitialPledgeForPower(qaPower, actor.baselinePower, actor.networkPledge, actor.epochRewardSmooth, actor.epochQAPowerSmooth, rt.TotalFilCircSupply())
+		expectedDeposit := miner.PreCommitDepositForPower(actor.epochRewardSmooth, actor.epochQAPowerSmooth, qaPower)
 		assert.Equal(t, expectedDeposit, onChainPrecommit.PreCommitDeposit)
 
 		// expect total precommit deposit to equal our new deposit
@@ -461,7 +461,7 @@ func TestCommitments(t *testing.T) {
 		assert.True(t, upgrade.Info.ReplaceCapacity)
 		assert.Equal(t, upgradeParams.ReplaceSectorNumber, upgrade.Info.ReplaceSectorNumber)
 		// Require new sector's pledge to be at least that of the old sector.
-		assert.Equal(t, oldSector.InitialPledge, upgrade.PreCommitDeposit)
+		assert.True(t, upgrade.PreCommitDeposit.GreaterThanEqual(oldSector.InitialPledge))
 
 		// Old sector is unchanged
 		oldSectorAgain := actor.getSector(rt, oldSector.SectorNumber)
@@ -1793,7 +1793,7 @@ func TestWithdrawBalance(t *testing.T) {
 
 		// alter initial pledge requirement to simulate undercollateralization
 		st := getState(rt)
-		st.InitialPledgeRequirement = big.Mul(big.NewInt(300000), st.InitialPledgeRequirement)
+		st.InitialPledgeRequirement = big.Mul(big.NewInt(1e7), st.InitialPledgeRequirement)
 		rt.ReplaceState(st)
 
 		// withdraw 1% of balance


### PR DESCRIPTION
Computes a per-byte initial pledge cap so that a 32GiB sector is fractionally under 1 FIL.

- Pre-commit deposit remains BR(20)
- Termination fee is unchanged; still includes BR(20) plus the approximation of rewards earned.

The cap is a `var`, and evaluated only when a pledge calculation is made, so Lotus can override this, e.g. effectively disabling it by setting a higher value.

This PR is against the `release/v0.9` branch, not `master`. After merge, a new release can be made from this branch head.