### PR TITLE
IP accounting refactor

### DIFF
--- a/actors/builtin/miner/cbor_gen.go
+++ b/actors/builtin/miner/cbor_gen.go
@@ -55,8 +55,8 @@ func (t *State) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.InitialPledgeRequirement (big.Int) (struct)
-	if err := t.InitialPledgeRequirement.MarshalCBOR(w); err != nil {
+	// t.InitialPledge (big.Int) (struct)
+	if err := t.InitialPledge.MarshalCBOR(w); err != nil {
 		return err
 	}
 
@@ -183,12 +183,12 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 		}
 
 	}
-	// t.InitialPledgeRequirement (big.Int) (struct)
+	// t.InitialPledge (big.Int) (struct)
 
 	{
 
-		if err := t.InitialPledgeRequirement.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.InitialPledgeRequirement: %w", err)
+		if err := t.InitialPledge.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.InitialPledge: %w", err)
 		}
 
 	}

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -1716,15 +1716,14 @@ func handleProvingDeadline(rt Runtime) {
 			pledgeDeltaTotal = big.Add(pledgeDeltaTotal, result.PledgeDelta)
 
 			penaltyTarget := big.Add(declaredPenalty, undeclaredPenalty)
-			if !penaltyTarget.IsZero() {
-				err = st.ApplyPenalty(penaltyTarget)
-				builtin.RequireNoErr(rt, err, exitcode.Unwrap(err, exitcode.ErrIllegalState), "failed to apply penalty")
 
-				penaltyFromVesting, penaltyFromBalance, err := st.RepayPartialDebtInPriorityOrder(store, currEpoch, rt.CurrentBalance())
-				builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to unlock penalty")
-				penaltyTotal = big.Add(penaltyFromVesting, penaltyFromBalance)
-				pledgeDeltaTotal = big.Sub(pledgeDeltaTotal, penaltyFromVesting)
-			}
+			err = st.ApplyPenalty(penaltyTarget)
+			builtin.RequireNoErr(rt, err, exitcode.Unwrap(err, exitcode.ErrIllegalState), "failed to apply penalty")
+
+			penaltyFromVesting, penaltyFromBalance, err := st.RepayPartialDebtInPriorityOrder(store, currEpoch, rt.CurrentBalance())
+			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to unlock penalty")
+			penaltyTotal = big.Add(penaltyFromVesting, penaltyFromBalance)
+			pledgeDeltaTotal = big.Sub(pledgeDeltaTotal, penaltyFromVesting)
 		}
 	})
 

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -2962,7 +2962,7 @@ func TestAddLockedFund(t *testing.T) {
 		st = getState(rt)
 		// no funds used to pay off ip debt
 		assert.Equal(t, availableBefore, st.GetAvailableBalance(newBalance))
-		assert.False(t, st.MeetsInitialPledgeCondition())
+		assert.False(t, st.IsDebtFree())
 		// all funds locked in vesting table
 		assert.Equal(t, amt, st.LockedFunds)
 	})

--- a/actors/builtin/miner/monies.go
+++ b/actors/builtin/miner/monies.go
@@ -129,7 +129,7 @@ func InitialPledgeForPower(qaPower, baselinePower abi.StoragePower, rewardEstima
 func RepayDebtsOrAbort(rt Runtime, st *State) abi.TokenAmount {
 	currBalance := rt.CurrentBalance()
 	toBurn, err := st.repayDebts(currBalance)
-	builtin.RequireNoErr(rt, err, exitcode.Unwrap(err, exitcode.ErrIllegalState), "unlocked balance can not repay fee debt")
+	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "unlocked balance can not repay fee debt")
 
 	return toBurn
 }

--- a/support/vm/testing.go
+++ b/support/vm/testing.go
@@ -296,10 +296,10 @@ func GetMinerBalances(t *testing.T, vm *VM, minerIdAddr address.Address) MinerBa
 	require.NoError(t, err)
 
 	return MinerBalances{
-		AvailableBalance: big.Subtract(a.Balance, state.PreCommitDeposits, state.InitialPledgeRequirement, state.InitialPledgeRequirement, state.FeeDebt),
+		AvailableBalance: big.Subtract(a.Balance, state.PreCommitDeposits, state.InitialPledge, state.LockedFunds, state.FeeDebt),
 		PreCommitDeposit: state.PreCommitDeposits,
 		VestingBalance:   state.LockedFunds,
-		InitialPledge:    state.InitialPledgeRequirement,
+		InitialPledge:    state.InitialPledge,
 	}
 }
 


### PR DESCRIPTION
After a proposal from @wadeAlexC and brief discussion with @acruikshank and @anorth I wanted to see how this refactor looks.  This is to help make the discussion concrete -- we're not necessarily going to merge this.

Pros: the simplification is real, both in the actor code, the mental model and in the reduction of separate cases to test.  By doing all fee debt repayment lazily very little new code needs to be added.

Cons: one upside that's come to light with the current strategy of applying initial pledge to fee payment up front is that dead miners that have incurred fees always pay all of their initial pledge requirement to burnt funds without intervention.  After this refactor it is possible for a miner that is no longer worth maintaining to be abandoned with lots of fee debt and lots of funds free in its balance as initial pledge is unlocked on sector expiry.  

We could fix this easily with an unpermissioned `RepayFee` method that burns free balance up to FeeDebt, or some more complicated automatic payment.  Not sure if that is worth the trade off.

