### PR TITLE
Remove ThisEpochReward from ThisEpochRewardReturn, and use smoothed value for conesnsus fault penalty

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -1437,7 +1437,7 @@ func (a Actor) ReportConsensusFault(rt Runtime, params *ReportConsensusFaultPara
 	rewardStats := requestCurrentEpochBlockReward(rt)
 	// The policy amounts we should burn and send to reporter
 	// These may differ from actual funds send when miner goes into fee debt
-	faultPenalty := ConsensusFaultPenalty(rewardStats.ThisEpochReward)
+	faultPenalty := ConsensusFaultPenalty(rewardStats.ThisEpochRewardSmoothed.Estimate())
 	slasherReward := RewardForConsensusSlashReport(faultAge, faultPenalty)
 	pledgeDelta := big.Zero()
 

--- a/actors/builtin/reward/cbor_gen.go
+++ b/actors/builtin/reward/cbor_gen.go
@@ -344,7 +344,7 @@ func (t *AwardBlockRewardParams) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
-var lengthBufThisEpochRewardReturn = []byte{131}
+var lengthBufThisEpochRewardReturn = []byte{130}
 
 func (t *ThisEpochRewardReturn) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -352,11 +352,6 @@ func (t *ThisEpochRewardReturn) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 	if _, err := w.Write(lengthBufThisEpochRewardReturn); err != nil {
-		return err
-	}
-
-	// t.ThisEpochReward (big.Int) (struct)
-	if err := t.ThisEpochReward.MarshalCBOR(w); err != nil {
 		return err
 	}
 
@@ -386,19 +381,10 @@ func (t *ThisEpochRewardReturn) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 3 {
+	if extra != 2 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
-	// t.ThisEpochReward (big.Int) (struct)
-
-	{
-
-		if err := t.ThisEpochReward.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.ThisEpochReward: %w", err)
-		}
-
-	}
 	// t.ThisEpochRewardSmoothed (smoothing.FilterEstimate) (struct)
 
 	{

--- a/actors/builtin/reward/reward_actor.go
+++ b/actors/builtin/reward/reward_actor.go
@@ -126,7 +126,6 @@ func (a Actor) AwardBlockReward(rt vmr.Runtime, params *AwardBlockRewardParams) 
 }
 
 type ThisEpochRewardReturn struct {
-	ThisEpochReward         abi.TokenAmount
 	ThisEpochRewardSmoothed *smoothing.FilterEstimate
 	ThisEpochBaselinePower  abi.StoragePower
 }
@@ -140,9 +139,8 @@ func (a Actor) ThisEpochReward(rt vmr.Runtime, _ *adt.EmptyValue) *ThisEpochRewa
 	var st State
 	rt.State().Readonly(&st)
 	return &ThisEpochRewardReturn{
-		ThisEpochReward:         st.ThisEpochReward,
-		ThisEpochBaselinePower:  st.ThisEpochBaselinePower,
 		ThisEpochRewardSmoothed: st.ThisEpochRewardSmoothed,
+		ThisEpochBaselinePower:  st.ThisEpochBaselinePower,
 	}
 }
 

--- a/actors/builtin/reward/reward_state.go
+++ b/actors/builtin/reward/reward_state.go
@@ -96,7 +96,6 @@ func (st *State) updateToNextEpochWithReward(currRealizedPower abi.StoragePower)
 	currRewardTheta := computeRTheta(st.EffectiveNetworkTime, st.EffectiveBaselinePower, st.CumsumRealized, st.CumsumBaseline)
 
 	st.ThisEpochReward = computeReward(st.Epoch, prevRewardTheta, currRewardTheta)
-
 }
 
 func (st *State) updateSmoothedEstimates(delta abi.ChainEpoch) {

--- a/actors/builtin/reward/reward_test.go
+++ b/actors/builtin/reward/reward_test.go
@@ -227,7 +227,6 @@ func TestThisEpochReward(t *testing.T) {
 		resp := actor.thisEpochReward(rt)
 		st := getState(rt)
 
-		require.EqualValues(t, st.ThisEpochReward, resp.ThisEpochReward)
 		require.EqualValues(t, st.ThisEpochBaselinePower, resp.ThisEpochBaselinePower)
 		require.EqualValues(t, st.ThisEpochRewardSmoothed, resp.ThisEpochRewardSmoothed)
 	})


### PR DESCRIPTION
I think using the instantaneous version was an oversight, since all other penalties use the smoothed version.

Removed the now-unused instantaneous version from the return struct to prevent accidental use.