### PR TITLE
Rename deprecated exit codes SysErrSerialization and SysErrInvalidParameters

### DIFF
--- a/actors/runtime/exitcode/reserved.go
+++ b/actors/runtime/exitcode/reserved.go
@@ -22,8 +22,8 @@ const (
 	// Indicates failure to find a method in an actor.
 	SysErrInvalidMethod = ExitCode(3)
 
-	// Indicates non-decodeable or syntactically invalid parameters for a method.
-	SysErrInvalidParameters = ExitCode(4)
+	// Unused.
+	SysErrReserved1 = ExitCode(4)
 
 	// Indicates that the receiver of a message is not valid (and cannot be implicitly created).
 	SysErrInvalidReceiver = ExitCode(5)
@@ -48,13 +48,12 @@ const (
 	// Indicates an invalid argument passed to a runtime method.
 	SysErrorIllegalArgument = ExitCode(10)
 
-	// Indicates  an object failed to de/serialize for storage.
-	SysErrSerialization = ExitCode(11)
-
-	SysErrorReserved3 = ExitCode(12)
-	SysErrorReserved4 = ExitCode(13)
-	SysErrorReserved5 = ExitCode(14)
-	SysErrorReserved6 = ExitCode(15)
+	// Unused
+	SysErrReserved2 = ExitCode(11)
+	SysErrReserved3 = ExitCode(12)
+	SysErrReserved4 = ExitCode(13)
+	SysErrReserved5 = ExitCode(14)
+	SysErrReserved6 = ExitCode(15)
 )
 
 // The initial range of exit codes is reserved for system errors.
@@ -66,16 +65,16 @@ var names = map[ExitCode]string{
 	SysErrSenderInvalid:      "SysErrSenderInvalid",
 	SysErrSenderStateInvalid: "SysErrSenderStateInvalid",
 	SysErrInvalidMethod:      "SysErrInvalidMethod",
-	SysErrInvalidParameters:  "SysErrInvalidParameters",
+	SysErrReserved1:          "SysErrReserved1",
 	SysErrInvalidReceiver:    "SysErrInvalidReceiver",
 	SysErrInsufficientFunds:  "SysErrInsufficientFunds",
 	SysErrOutOfGas:           "SysErrOutOfGas",
 	SysErrForbidden:          "SysErrForbidden",
 	SysErrorIllegalActor:     "SysErrorIllegalActor",
 	SysErrorIllegalArgument:  "SysErrorIllegalArgument",
-	SysErrSerialization:      "SysErrSerialization",
-	SysErrorReserved3:        "SysErrorReserved3",
-	SysErrorReserved4:        "SysErrorReserved4",
-	SysErrorReserved5:        "SysErrorReserved5",
-	SysErrorReserved6:        "SysErrorReserved6",
+	SysErrReserved2:          "SysErrReserved2",
+	SysErrReserved3:          "SysErrReserved3",
+	SysErrReserved4:          "SysErrReserved4",
+	SysErrReserved5:          "SysErrReserved5",
+	SysErrReserved6:          "SysErrReserved6",
 }

--- a/support/mock/mockrt.go
+++ b/support/mock/mockrt.go
@@ -443,14 +443,14 @@ func (rt *Runtime) checkArgument(predicate bool, msg string, args ...interface{}
 func (rt *Runtime) get(c cid.Cid) ([]byte, bool) {
 	prefix := c.Prefix()
 	if prefix.Codec != cid.DagCBOR {
-		rt.Abortf(exitcode.SysErrSerialization, "tried to fetch a non-cbor object: %s", c)
+		rt.Abortf(exitcode.ErrSerialization, "tried to fetch a non-cbor object: %s", c)
 	}
 
 	var data []byte
 	if prefix.MhType == mh.IDENTITY {
 		decoded, err := mh.Decode(c.Hash())
 		if err != nil {
-			rt.Abortf(exitcode.SysErrSerialization, "failed to parse identity cid %s: %s", c, err)
+			rt.Abortf(exitcode.ErrSerialization, "failed to parse identity cid %s: %s", c, err)
 		}
 		data = decoded.Digest
 	} else if stored, found := rt.store[c]; found {
@@ -474,7 +474,7 @@ func (rt *Runtime) Get(c cid.Cid, o runtime.CBORUnmarshaler) bool {
 	if found {
 		err := o.UnmarshalCBOR(bytes.NewReader(data))
 		if err != nil {
-			rt.Abortf(exitcode.SysErrSerialization, err.Error())
+			rt.Abortf(exitcode.ErrSerialization, err.Error())
 		}
 	}
 
@@ -486,12 +486,12 @@ func (rt *Runtime) Put(o runtime.CBORMarshaler) cid.Cid {
 	r := bytes.Buffer{}
 	err := o.MarshalCBOR(&r)
 	if err != nil {
-		rt.Abortf(exitcode.SysErrSerialization, err.Error())
+		rt.Abortf(exitcode.ErrSerialization, err.Error())
 	}
 	data := r.Bytes()
 	key, err := abi.CidBuilder.Sum(data)
 	if err != nil {
-		rt.Abortf(exitcode.SysErrSerialization, err.Error())
+		rt.Abortf(exitcode.ErrSerialization, err.Error())
 	}
 	rt.put(key, data)
 	return key


### PR DESCRIPTION
`SysErrSerialization` is already unused in Lotus. https://github.com/filecoin-project/lotus/pull/3184 removes use of `SysErrInvalidParameters`.

Serialization is logically part of actor code, not VM code, so we use `ErrSerialization` instead.

FYI @raulk