### PR TITLE
Limit chain-commit randomness length to 32 bytes.

### DIFF
--- a/actors/abi/primitives.go
+++ b/actors/abi/primitives.go
@@ -61,6 +61,9 @@ func NewTokenAmount(t int64) TokenAmount {
 // Randomness is a string of random bytes
 type Randomness []byte
 
+// RandomnessLength is the length of the randomness slice.
+const RandomnessLength = 32
+
 // Multiaddrs is a byte array representing a Libp2p MultiAddress
 type Multiaddrs = []byte
 

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -304,6 +304,12 @@ func (a Actor) SubmitWindowedPoSt(rt Runtime, params *SubmitWindowedPoStParams) 
 	if params.Deadline >= WPoStPeriodDeadlines {
 		rt.Abortf(exitcode.ErrIllegalArgument, "invalid deadline %d of %d", params.Deadline, WPoStPeriodDeadlines)
 	}
+	// Technically, ChainCommitRand should be _exactly_ 32 bytes. However:
+	// 1. It's convenient to allow smaller slices when testing.
+	// 2. Nothing bad will happen if the caller provides too little randomness.
+	if len(params.ChainCommitRand) > abi.RandomnessLength {
+		rt.Abortf(exitcode.ErrIllegalArgument, "expected at most %d bytes of randomness, got %d", abi.RandomnessLength, len(params.ChainCommitRand))
+	}
 
 	// Get the total power/reward. We need these to compute penalties.
 	rewardStats := requestCurrentEpochBlockReward(rt)


### PR DESCRIPTION
It should never be larger than this.