### PR TITLE
Fix incorrect comment about not validating sector replacement

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -548,9 +548,6 @@ func (a Actor) PreCommitSector(rt Runtime, params *SectorPreCommitInfo) *adt.Emp
 
 		depositMinimum := big.Zero()
 		if params.ReplaceCapacity {
-			// NOTE: we don't validate that the replacement sector
-			// lives at the target deadline/partition. If it
-			// doesn't, sealing may still succeed but replacement will fail.
 			replaceSector := validateReplaceSector(rt, &st, store, params)
 			// Note the replaced sector's initial pledge as a lower bound for the new sector's deposit
 			depositMinimum = replaceSector.InitialPledge


### PR DESCRIPTION
As @wadeAlexC points out, we do validate this in the function below the comment...

https://github.com/filecoin-project/specs-actors/pull/920/files/cb5759310247ca67fa9a0af5e8f6e0bafd06bcc2#r470699978