### PR TITLE
miner capacity upgrade scenario test

### DIFF
--- a/actors/builtin/power/power_state.go
+++ b/actors/builtin/power/power_state.go
@@ -143,6 +143,14 @@ func (st *State) AddToClaim(s adt.Store, miner addr.Address, power abi.StoragePo
 	return nil
 }
 
+func (st *State) GetClaim(s adt.Store, a addr.Address) (*Claim, bool, error) {
+	claims, err := adt.AsMap(s, st.Claims)
+	if err != nil {
+		return nil, false, xerrors.Errorf("failed to load claims: %w", err)
+	}
+	return getClaim(claims, a)
+}
+
 func (st *State) addToClaim(claims *adt.Map, miner addr.Address, power abi.StoragePower, qapower abi.StoragePower) error {
 	oldClaim, ok, err := getClaim(claims, miner)
 	if err != nil {

--- a/actors/builtin/power/power_test.go
+++ b/actors/builtin/power/power_test.go
@@ -409,6 +409,22 @@ func TestPowerAndPledgeAccounting(t *testing.T) {
 		require.EqualValues(t, mul(powerUnit, 4), st.TotalRawBytePower)
 	})
 
+	t.Run("claimed power is externally available", func(t *testing.T) {
+		// Setup four miners above threshold
+		rt := builder.Build(t)
+		actor.constructAndVerify(rt)
+
+		actor.createMinerBasic(rt, owner, owner, miner1)
+		actor.updateClaimedPower(rt, miner1, powerUnit, powerUnit)
+		st := getState(rt)
+
+		claim, found, err := st.GetClaim(rt.AdtStore(), miner1)
+		require.NoError(t, err)
+		require.True(t, found)
+
+		assert.Equal(t, powerUnit, claim.RawBytePower)
+		assert.Equal(t, powerUnit, claim.QualityAdjPower)
+	})
 }
 
 func TestCron(t *testing.T) {

--- a/actors/test/commit_post_test.go
+++ b/actors/test/commit_post_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"context"

--- a/actors/test/commit_post_test.go
+++ b/actors/test/commit_post_test.go
@@ -196,7 +196,7 @@ func TestCommitPoStFlow(t *testing.T) {
 	//
 
 	// advance to proving period
-	dlInfo, pIdx, v := vm.AdvanceTillProvingPeriod(t, v, minerAddrs.IDAddress, sectorNumber)
+	dlInfo, pIdx, v := vm.AdvanceTillProvingDeadline(t, v, minerAddrs.IDAddress, sectorNumber)
 	err = v.GetState(minerAddrs.IDAddress, &minerState)
 	require.NoError(t, err)
 

--- a/actors/test/commit_post_test.go
+++ b/actors/test/commit_post_test.go
@@ -195,20 +195,14 @@ func TestCommitPoStFlow(t *testing.T) {
 	// Submit PoSt
 	//
 
-	// find information about committed sector
+	// advance to proving period
+	dlInfo, pIdx, v := vm.AdvanceTillProvingPeriod(t, v, minerAddrs.IDAddress, sectorNumber)
 	err = v.GetState(minerAddrs.IDAddress, &minerState)
 	require.NoError(t, err)
 
-	dlIdx, pIdx, err := minerState.FindSector(v.Store(), sectorNumber)
-	require.NoError(t, err)
 	sector, found, err := minerState.GetSector(v.Store(), sectorNumber)
 	require.NoError(t, err)
 	require.True(t, found)
-
-	// advance time to next proving period
-	v, dlInfo = vm.AdvanceByDeadlineTillIndex(t, v, minerAddrs.IDAddress, dlIdx)
-	v, err = v.WithEpoch(dlInfo.Open)
-	require.NoError(t, err)
 
 	t.Run("submit PoSt succeeds", func(t *testing.T) {
 		tv, err := v.WithEpoch(v.GetEpoch())
@@ -216,7 +210,7 @@ func TestCommitPoStFlow(t *testing.T) {
 
 		// Submit PoSt
 		submitParams := miner.SubmitWindowedPoStParams{
-			Deadline: dlIdx,
+			Deadline: dlInfo.Index,
 			Partitions: []miner.PoStPartition{{
 				Index:   pIdx,
 				Skipped: bitfield.New(),
@@ -267,7 +261,7 @@ func TestCommitPoStFlow(t *testing.T) {
 
 		// Submit PoSt
 		submitParams := miner.SubmitWindowedPoStParams{
-			Deadline: dlIdx,
+			Deadline: dlInfo.Index,
 			Partitions: []miner.PoStPartition{{
 				Index:   pIdx,
 				Skipped: bitfield.NewFromSet([]uint64{uint64(sectorNumber)}),

--- a/actors/test/committed_capacity_scenario_test.go
+++ b/actors/test/committed_capacity_scenario_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"context"

--- a/actors/test/committed_capacity_scenario_test.go
+++ b/actors/test/committed_capacity_scenario_test.go
@@ -342,5 +342,11 @@ func publishDeal(t *testing.T, v *vm.VM, provider, dealClient, minerID addr.Addr
 		})
 	}
 
+	vm.ExpectInvocation{
+		To:             builtin.StorageMarketActorAddr,
+		Method:         builtin.MethodsMarket.PublishStorageDeals,
+		SubInvocations: expectedPublishSubinvocations,
+	}.Matches(t, v.LastInvocation())
+
 	return ret.(*market.PublishStorageDealsReturn)
 }

--- a/actors/test/committed_capacity_scenario_test.go
+++ b/actors/test/committed_capacity_scenario_test.go
@@ -46,10 +46,6 @@ func TestReplaceCommittedCapacitySectorWithDealLadenSector(t *testing.T) {
 	minerAddrs, ok := ret.(*power.CreateMinerReturn)
 	require.True(t, ok)
 
-	// advance vm so we can have seal randomness epoch in the past
-	v, err := v.WithEpoch(200)
-	require.NoError(t, err)
-
 	//
 	// Precommit, prove and PoSt empty sector (more fully tested in TestCommitPoStFlow)
 	//
@@ -71,7 +67,7 @@ func TestReplaceCommittedCapacitySectorWithDealLadenSector(t *testing.T) {
 	v, _ = vm.AdvanceByDeadlineTillEpoch(t, v, minerAddrs.IDAddress, proveTime)
 
 	// Prove commit sector after max seal duration
-	v, err = v.WithEpoch(proveTime)
+	v, err := v.WithEpoch(proveTime)
 	require.NoError(t, err)
 	proveCommitParams := miner.ProveCommitSectorParams{
 		SectorNumber: sectorNumber,

--- a/actors/test/committed_capacity_scenario_test.go
+++ b/actors/test/committed_capacity_scenario_test.go
@@ -80,7 +80,7 @@ func TestReplaceCommittedCapacitySectorWithDealLadenSector(t *testing.T) {
 	require.Equal(t, exitcode.Ok, code)
 
 	// advance to proving period and submit post
-	dlInfo, pIdx, v := vm.AdvanceTillProvingPeriod(t, v, minerAddrs.IDAddress, sectorNumber)
+	dlInfo, pIdx, v := vm.AdvanceTillProvingDeadline(t, v, minerAddrs.IDAddress, sectorNumber)
 
 	submitParams := miner.SubmitWindowedPoStParams{
 		Deadline: dlInfo.Index,
@@ -240,7 +240,7 @@ func TestReplaceCommittedCapacitySectorWithDealLadenSector(t *testing.T) {
 	assert.Equal(t, sectorPower.QA, networkStats.TotalQABytesCommitted)
 
 	// advance to proving period and submit post
-	dlInfo, pIdx, v = vm.AdvanceTillProvingPeriod(t, v, minerAddrs.IDAddress, ccSectorNumber)
+	dlInfo, pIdx, v = vm.AdvanceTillProvingDeadline(t, v, minerAddrs.IDAddress, ccSectorNumber)
 
 	submitParams = miner.SubmitWindowedPoStParams{
 		Deadline: dlInfo.Index,
@@ -280,7 +280,7 @@ func TestReplaceCommittedCapacitySectorWithDealLadenSector(t *testing.T) {
 	assert.Equal(t, combinedPower.QA, networkStats.TotalQABytesCommitted)
 
 	// advance to proving period of old sector
-	dlInfo, _, v = vm.AdvanceTillProvingPeriod(t, v, minerAddrs.IDAddress, ccSectorNumber)
+	dlInfo, _, v = vm.AdvanceTillProvingDeadline(t, v, minerAddrs.IDAddress, ccSectorNumber)
 
 	// proving period cron removes sector reducing the miner's power to that of the new sector
 	v, err = v.WithEpoch(dlInfo.Last())

--- a/actors/test/committed_capacity_scenario_test.go
+++ b/actors/test/committed_capacity_scenario_test.go
@@ -1,0 +1,307 @@
+package test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/specs-actors/actors/builtin"
+	"github.com/filecoin-project/specs-actors/actors/builtin/market"
+	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
+	"github.com/filecoin-project/specs-actors/actors/builtin/power"
+	"github.com/filecoin-project/specs-actors/actors/builtin/verifreg"
+	"github.com/filecoin-project/specs-actors/actors/crypto"
+	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	tutil "github.com/filecoin-project/specs-actors/support/testing"
+	vm "github.com/filecoin-project/specs-actors/support/vm"
+
+	addr "github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-bitfield"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReplaceCommittedCapacitySectorWithDealLadenSector(t *testing.T) {
+	ctx := context.Background()
+	v := vm.NewVMWithSingletons(ctx, t)
+	addrs := vm.CreateAccounts(ctx, t, v, 4, big.Mul(big.NewInt(10_000), vm.FIL), 93837778)
+	worker, verifier, unverifiedClient, verifiedClient := addrs[0], addrs[1], addrs[2], addrs[3]
+
+	minerBalance := big.Mul(big.NewInt(1_000), vm.FIL)
+	sectorNumber := abi.SectorNumber(100)
+	sealedCid := tutil.MakeCID("100", &miner.SealedCIDPrefix)
+	sealProof := abi.RegisteredSealProof_StackedDrg32GiBV1
+	sectorSize, err := sealProof.SectorSize()
+	require.NoError(t, err)
+
+	// create miner
+	params := power.CreateMinerParams{
+		Owner:         worker,
+		Worker:        worker,
+		SealProofType: sealProof,
+		Peer:          abi.PeerID("not really a peer id"),
+	}
+	ret, code := v.ApplyMessage(addrs[0], builtin.StoragePowerActorAddr, minerBalance, builtin.MethodsPower.CreateMiner, &params)
+	require.Equal(t, exitcode.Ok, code)
+
+	minerAddrs, ok := ret.(*power.CreateMinerReturn)
+	require.True(t, ok)
+
+	// advance vm so we can have seal randomness epoch in the past
+	v, err = v.WithEpoch(200)
+	require.NoError(t, err)
+
+	//
+	// Precommit, prove and PoSt empty sector (more fully tested in TestCommitPoStFlow)
+	//
+
+	// precommit sector
+	preCommitParams := miner.SectorPreCommitInfo{
+		SealProof:     sealProof,
+		SectorNumber:  sectorNumber,
+		SealedCID:     sealedCid,
+		SealRandEpoch: v.GetEpoch() - 1,
+		DealIDs:       nil,
+		Expiration:    v.GetEpoch() + miner.MinSectorExpiration + miner.MaxProveCommitDuration[sealProof] + 100,
+	}
+	_, code = v.ApplyMessage(addrs[0], minerAddrs.RobustAddress, big.Zero(), builtin.MethodsMiner.PreCommitSector, &preCommitParams)
+	require.Equal(t, exitcode.Ok, code)
+
+	// advance time to max seal duration
+	proveTime := v.GetEpoch() + miner.MaxProveCommitDuration[sealProof]
+	v, _ = vm.AdvanceByDeadlineTillEpoch(t, v, minerAddrs.IDAddress, proveTime)
+
+	// Prove commit sector after max seal duration
+	v, err = v.WithEpoch(proveTime)
+	require.NoError(t, err)
+	proveCommitParams := miner.ProveCommitSectorParams{
+		SectorNumber: sectorNumber,
+	}
+	_, code = v.ApplyMessage(worker, minerAddrs.RobustAddress, big.Zero(), builtin.MethodsMiner.ProveCommitSector, &proveCommitParams)
+	require.Equal(t, exitcode.Ok, code)
+
+	// In the same epoch, trigger cron to validate prove commit
+	_, code = v.ApplyMessage(builtin.SystemActorAddr, builtin.CronActorAddr, big.Zero(), builtin.MethodsCron.EpochTick, nil)
+	require.Equal(t, exitcode.Ok, code)
+
+	// advance to proving period and submit post
+	dlInfo, pIdx, v := vm.AdvanceTillProvingPeriod(t, v, minerAddrs.IDAddress, sectorNumber)
+
+	submitParams := miner.SubmitWindowedPoStParams{
+		Deadline: dlInfo.Index,
+		Partitions: []miner.PoStPartition{{
+			Index:   pIdx,
+			Skipped: bitfield.New(),
+		}},
+		Proofs: []abi.PoStProof{{
+			PoStProof: abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
+		}},
+		ChainCommitRand: []byte("not really random"),
+	}
+	_, code = v.ApplyMessage(addrs[0], minerAddrs.RobustAddress, big.Zero(), builtin.MethodsMiner.SubmitWindowedPoSt, &submitParams)
+	require.Equal(t, exitcode.Ok, code)
+
+	// miner still has initial pledge
+	balances := vm.GetMinerBalances(t, v, minerAddrs.IDAddress)
+	assert.True(t, balances.InitialPledge.GreaterThan(big.Zero()))
+
+	// committed bytes are added (miner would have gained power if minimum requirement were met)
+	networkStats := vm.GetNetworkStats(t, v)
+	assert.Equal(t, big.NewInt(int64(sectorSize)), networkStats.TotalBytesCommitted)
+	assert.Equal(t, big.NewInt(int64(sectorSize)), networkStats.TotalQABytesCommitted)
+
+	//
+	// publish verified and unverified deals
+	//
+
+	// register verifier then verified client
+	addVerifierParams := verifreg.AddVerifierParams{
+		Address:   verifier,
+		Allowance: abi.NewStoragePower(32 << 40),
+	}
+	_, code = v.ApplyMessage(vm.VerifregRoot, builtin.VerifiedRegistryActorAddr, big.Zero(), builtin.MethodsVerifiedRegistry.AddVerifier, &addVerifierParams)
+	require.Equal(t, exitcode.Ok, code)
+
+	addClientParams := verifreg.AddVerifiedClientParams{
+		Address:   verifiedClient,
+		Allowance: abi.NewStoragePower(32 << 40),
+	}
+	_, code = v.ApplyMessage(verifier, builtin.VerifiedRegistryActorAddr, big.Zero(), builtin.MethodsVerifiedRegistry.AddVerifiedClient, &addClientParams)
+	require.Equal(t, exitcode.Ok, code)
+
+	// add market collateral for clients and miner
+	collateral := big.Mul(big.NewInt(3), vm.FIL)
+	_, code = v.ApplyMessage(unverifiedClient, builtin.StorageMarketActorAddr, collateral, builtin.MethodsMarket.AddBalance, &unverifiedClient)
+	require.Equal(t, exitcode.Ok, code)
+	_, code = v.ApplyMessage(verifiedClient, builtin.StorageMarketActorAddr, collateral, builtin.MethodsMarket.AddBalance, &verifiedClient)
+	require.Equal(t, exitcode.Ok, code)
+	collateral = big.Mul(big.NewInt(64), vm.FIL)
+	_, code = v.ApplyMessage(worker, builtin.StorageMarketActorAddr, collateral, builtin.MethodsMarket.AddBalance, &minerAddrs.IDAddress)
+	require.Equal(t, exitcode.Ok, code)
+
+	// create 3 deals, some verified and some not
+	dealIDs := []abi.DealID{}
+	dealStart := v.GetEpoch() + miner.MaxProveCommitDuration[sealProof]
+	deals := publishDeal(t, v, worker, verifiedClient, minerAddrs.IDAddress, "deal1", 1<<30, true, dealStart, 181*builtin.EpochsInDay)
+	dealIDs = append(dealIDs, deals.IDs...)
+	deals = publishDeal(t, v, worker, verifiedClient, minerAddrs.IDAddress, "deal2", 1<<32, true, dealStart, 200*builtin.EpochsInDay)
+	dealIDs = append(dealIDs, deals.IDs...)
+	deals = publishDeal(t, v, worker, unverifiedClient, minerAddrs.IDAddress, "deal3", 1<<34, false, dealStart, 210*builtin.EpochsInDay)
+	dealIDs = append(dealIDs, deals.IDs...)
+
+	//
+	// Precommit, Prove, Verify and PoSt committed capacity sector
+	//
+
+	// precommit capacity upgrade sector with deals
+	ccSectorNumber := abi.SectorNumber(101)
+	ccSealedCid := tutil.MakeCID("101", &miner.SealedCIDPrefix)
+	preCommitParams = miner.SectorPreCommitInfo{
+		SealProof:              sealProof,
+		SectorNumber:           ccSectorNumber,
+		SealedCID:              ccSealedCid,
+		SealRandEpoch:          v.GetEpoch() - 1,
+		DealIDs:                dealIDs,
+		Expiration:             v.GetEpoch() + 220*builtin.EpochsInDay,
+		ReplaceCapacity:        true,
+		ReplaceSectorDeadline:  dlInfo.Index,
+		ReplaceSectorPartition: pIdx,
+		ReplaceSectorNumber:    sectorNumber,
+	}
+
+	// prove commit, verify and PoSt
+	_, code = v.ApplyMessage(addrs[0], minerAddrs.RobustAddress, big.Zero(), builtin.MethodsMiner.PreCommitSector, &preCommitParams)
+	require.Equal(t, exitcode.Ok, code)
+
+	// assert successful precommit invocation
+	none := []vm.ExpectInvocation{}
+	vm.ExpectInvocation{
+		To:     minerAddrs.IDAddress,
+		Method: builtin.MethodsMiner.PreCommitSector,
+		Params: vm.ExpectObject(&preCommitParams),
+		SubInvocations: []vm.ExpectInvocation{
+			{To: builtin.RewardActorAddr, Method: builtin.MethodsReward.ThisEpochReward, SubInvocations: none},
+			{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.CurrentTotalPower, SubInvocations: none},
+			// addtion of deal ids prompts call to verify deals for activation
+			{To: builtin.StorageMarketActorAddr, Method: builtin.MethodsMarket.VerifyDealsForActivation, SubInvocations: none},
+		},
+	}.Matches(t, v.LastInvocation())
+
+	// advance time to min seal duration
+	proveTime = v.GetEpoch() + miner.PreCommitChallengeDelay + 1
+	v, _ = vm.AdvanceByDeadlineTillEpoch(t, v, minerAddrs.IDAddress, proveTime)
+
+	// Prove commit sector after max seal duration
+	v, err = v.WithEpoch(proveTime)
+	require.NoError(t, err)
+	proveCommitParams = miner.ProveCommitSectorParams{
+		SectorNumber: ccSectorNumber,
+	}
+	_, code = v.ApplyMessage(worker, minerAddrs.RobustAddress, big.Zero(), builtin.MethodsMiner.ProveCommitSector, &proveCommitParams)
+	require.Equal(t, exitcode.Ok, code)
+
+	vm.ExpectInvocation{
+		To:     minerAddrs.IDAddress,
+		Method: builtin.MethodsMiner.ProveCommitSector,
+		Params: vm.ExpectObject(&proveCommitParams),
+		SubInvocations: []vm.ExpectInvocation{
+			{To: builtin.StorageMarketActorAddr, Method: builtin.MethodsMarket.ComputeDataCommitment, SubInvocations: none},
+			{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.SubmitPoRepForBulkVerify, SubInvocations: none},
+		},
+	}.Matches(t, v.LastInvocation())
+
+	// In the same epoch, trigger cron to validate prove commit
+	_, code = v.ApplyMessage(builtin.SystemActorAddr, builtin.CronActorAddr, big.Zero(), builtin.MethodsCron.EpochTick, nil)
+	require.Equal(t, exitcode.Ok, code)
+
+	vm.ExpectInvocation{
+		To:     builtin.CronActorAddr,
+		Method: builtin.MethodsCron.EpochTick,
+		SubInvocations: []vm.ExpectInvocation{
+			{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.OnEpochTickEnd, SubInvocations: []vm.ExpectInvocation{
+				{To: minerAddrs.IDAddress, Method: builtin.MethodsMiner.ConfirmSectorProofsValid, SubInvocations: []vm.ExpectInvocation{
+					{To: builtin.RewardActorAddr, Method: builtin.MethodsReward.ThisEpochReward},
+					{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.CurrentTotalPower},
+					// deals are now activated
+					{To: builtin.StorageMarketActorAddr, Method: builtin.MethodsMarket.ActivateDeals},
+					{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.UpdatePledgeTotal},
+				}},
+				{To: builtin.RewardActorAddr, Method: builtin.MethodsReward.UpdateNetworkKPI},
+			}},
+			{To: builtin.StorageMarketActorAddr, Method: builtin.MethodsMarket.CronTick},
+		},
+	}.Matches(t, v.LastInvocation())
+
+	// advance to proving period and submit post
+	dlInfo, pIdx, v = vm.AdvanceTillProvingPeriod(t, v, minerAddrs.IDAddress, ccSectorNumber)
+
+	submitParams = miner.SubmitWindowedPoStParams{
+		Deadline: dlInfo.Index,
+		Partitions: []miner.PoStPartition{{
+			Index:   pIdx,
+			Skipped: bitfield.New(),
+		}},
+		Proofs: []abi.PoStProof{{
+			PoStProof: abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
+		}},
+		ChainCommitRand: []byte("not really random"),
+	}
+	_, code = v.ApplyMessage(addrs[0], minerAddrs.RobustAddress, big.Zero(), builtin.MethodsMiner.SubmitWindowedPoSt, &submitParams)
+	require.Equal(t, exitcode.Ok, code)
+
+	vm.ExpectInvocation{
+		To:     minerAddrs.IDAddress,
+		Method: builtin.MethodsMiner.SubmitWindowedPoSt,
+		Params: vm.ExpectObject(&submitParams),
+		SubInvocations: []vm.ExpectInvocation{
+			{To: builtin.RewardActorAddr, Method: builtin.MethodsReward.ThisEpochReward},
+			{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.CurrentTotalPower},
+			// This call to the power actor indicates power has been added for the replaced sector
+			{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.UpdateClaimedPower},
+		},
+	}.Matches(t, v.LastInvocation())
+}
+
+func publishDeal(t *testing.T, v *vm.VM, provider, dealClient, minerID addr.Address, dealLabel string,
+	pieceSize abi.PaddedPieceSize, verifiedDeal bool, dealStart abi.ChainEpoch, dealLifetime abi.ChainEpoch,
+) *market.PublishStorageDealsReturn {
+	deal := market.DealProposal{
+		PieceCID:             tutil.MakeCID(dealLabel, &market.PieceCIDPrefix),
+		PieceSize:            pieceSize,
+		VerifiedDeal:         verifiedDeal,
+		Client:               dealClient,
+		Provider:             minerID,
+		Label:                dealLabel,
+		StartEpoch:           dealStart,
+		EndEpoch:             dealStart + dealLifetime,
+		StoragePricePerEpoch: abi.NewTokenAmount(1 << 20),
+		ProviderCollateral:   big.Mul(big.NewInt(2), vm.FIL),
+		ClientCollateral:     big.Mul(big.NewInt(1), vm.FIL),
+	}
+
+	publishDealParams := market.PublishStorageDealsParams{
+		Deals: []market.ClientDealProposal{{
+			Proposal:        deal,
+			ClientSignature: crypto.Signature{},
+		}},
+	}
+	ret, code := v.ApplyMessage(provider, builtin.StorageMarketActorAddr, big.Zero(), builtin.MethodsMarket.PublishStorageDeals, &publishDealParams)
+	require.Equal(t, exitcode.Ok, code)
+
+	expectedPublishSubinvocations := []vm.ExpectInvocation{
+		{To: minerID, Method: builtin.MethodsMiner.ControlAddresses, SubInvocations: []vm.ExpectInvocation{}},
+		{To: builtin.RewardActorAddr, Method: builtin.MethodsReward.ThisEpochReward, SubInvocations: []vm.ExpectInvocation{}},
+		{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.CurrentTotalPower, SubInvocations: []vm.ExpectInvocation{}},
+	}
+
+	if verifiedDeal {
+		expectedPublishSubinvocations = append(expectedPublishSubinvocations, vm.ExpectInvocation{
+			To:             builtin.VerifiedRegistryActorAddr,
+			Method:         builtin.MethodsVerifiedRegistry.UseBytes,
+			SubInvocations: []vm.ExpectInvocation{},
+		})
+	}
+
+	return ret.(*market.PublishStorageDealsReturn)
+}

--- a/actors/test/committed_capacity_scenario_test.go
+++ b/actors/test/committed_capacity_scenario_test.go
@@ -57,7 +57,7 @@ func TestReplaceCommittedCapacitySectorWithDealLadenSector(t *testing.T) {
 		SealedCID:     sealedCid,
 		SealRandEpoch: v.GetEpoch() - 1,
 		DealIDs:       nil,
-		Expiration:    v.GetEpoch() + miner.MinSectorExpiration + miner.MaxProveCommitDuration[sealProof] + 100,
+		Expiration:    v.GetEpoch() + 200*builtin.EpochsInDay,
 	}
 	_, code = v.ApplyMessage(addrs[0], minerAddrs.RobustAddress, big.Zero(), builtin.MethodsMiner.PreCommitSector, &preCommitParams)
 	require.Equal(t, exitcode.Ok, code)

--- a/support/vm/invocation_context.go
+++ b/support/vm/invocation_context.go
@@ -204,7 +204,7 @@ func (ic *invocationContext) Abortf(errExitCode exitcode.ExitCode, msg string, a
 }
 
 func (ic *invocationContext) ResolveAddress(address address.Address) (address.Address, bool) {
-	return ic.rt.normalizeAddress(address)
+	return ic.rt.NormalizeAddress(address)
 }
 
 func (ic *invocationContext) NewActorAddress() address.Address {

--- a/support/vm/testing.go
+++ b/support/vm/testing.go
@@ -312,7 +312,7 @@ func AdvanceByDeadlineTillIndex(t *testing.T, v *VM, minerIDAddr address.Address
 // Advance to the epoch when the sector is due to be proven.
 // Returns the deadline info for proving deadline for sector, partition index of sector, and a VM at the opening of
 // the deadline (ready for SubmitWindowedPoSt).
-func AdvanceTillProvingPeriod(t *testing.T, v *VM, minerIDAddress address.Address, sectorNumber abi.SectorNumber) (*miner.DeadlineInfo, uint64, *VM) {
+func AdvanceTillProvingDeadline(t *testing.T, v *VM, minerIDAddress address.Address, sectorNumber abi.SectorNumber) (*miner.DeadlineInfo, uint64, *VM) {
 	var minerState miner.State
 	err := v.GetState(minerIDAddress, &minerState)
 	require.NoError(t, err)

--- a/support/vm/testing.go
+++ b/support/vm/testing.go
@@ -355,6 +355,32 @@ func GetMinerBalances(t *testing.T, vm *VM, minerIdAddr address.Address) MinerBa
 	}
 }
 
+func PowerForMinerSector(t *testing.T, vm *VM, minerIdAddr address.Address, sectorNumber abi.SectorNumber) miner.PowerPair {
+	var state miner.State
+	err := vm.GetState(minerIdAddr, &state)
+	require.NoError(t, err)
+
+	sector, found, err := state.GetSector(vm.store, sectorNumber)
+	require.NoError(t, err)
+	require.True(t, found)
+
+	sectorSize, err := sector.SealProof.SectorSize()
+	require.NoError(t, err)
+	return miner.PowerForSector(sectorSize, sector)
+}
+
+func MinerPower(t *testing.T, vm *VM, minerIdAddr address.Address) miner.PowerPair {
+	var state power.State
+	err := vm.GetState(builtin.StoragePowerActorAddr, &state)
+	require.NoError(t, err)
+
+	claim, found, err := state.GetClaim(vm.store, minerIdAddr)
+	require.NoError(t, err)
+	require.True(t, found)
+
+	return miner.NewPowerPair(claim.RawBytePower, claim.QualityAdjPower)
+}
+
 type NetworkStats struct {
 	power.State
 	TotalRawBytePower         abi.StoragePower

--- a/support/vm/testing.go
+++ b/support/vm/testing.go
@@ -33,6 +33,15 @@ import (
 )
 
 var FIL = big.NewInt(1e18)
+var VerifregRoot address.Address
+
+func init() {
+	var err error
+	VerifregRoot, err = address.NewIDAddress(80)
+	if err != nil {
+		panic("could not create id address 80")
+	}
+}
 
 //
 // Genesis like setup
@@ -74,9 +83,8 @@ func NewVMWithSingletons(ctx context.Context, t *testing.T) *VM {
 	initializeActor(ctx, t, vm, marketState, builtin.StorageMarketActorCodeID, builtin.StorageMarketActorAddr, big.Zero())
 
 	// this will need to be replaced with the address of a multisig actor for the verified registry to be tested accurately
-	rootVerifier, err := address.NewIDAddress(80)
-	require.NoError(t, err)
-	vrState := verifreg.ConstructState(emptyMapCID, rootVerifier)
+	initializeActor(ctx, t, vm, &account.State{Address: VerifregRoot}, builtin.AccountActorCodeID, VerifregRoot, big.Zero())
+	vrState := verifreg.ConstructState(emptyMapCID, VerifregRoot)
 	initializeActor(ctx, t, vm, vrState, builtin.VerifiedRegistryActorCodeID, builtin.VerifiedRegistryActorAddr, big.Zero())
 
 	// burnt funds
@@ -162,14 +170,18 @@ func (ei ExpectInvocation) matches(t *testing.T, breadcrumb string, invocation *
 	if ei.SubInvocations != nil {
 		for i, invk := range invocation.SubInvocations {
 			subidentifier := fmt.Sprintf("%s%d:", identifier, i)
-			require.True(t, len(ei.SubInvocations) > i, "%s unexpected subinvocation [%s:%d]", subidentifier, invk.Msg.to, invk.Msg.method)
+			// attempt match only if methods match
+			require.True(t, len(ei.SubInvocations) > i && ei.SubInvocations[i].To == invk.Msg.to && ei.SubInvocations[i].Method == invk.Msg.method,
+				"%s unexpected subinvocation [%s:%d]\nexpected:\n%s\nactual:\n%s",
+				subidentifier, invk.Msg.to, invk.Msg.method, ei.listSubinvocations(), listInvocations(invocation.SubInvocations))
 			ei.SubInvocations[i].matches(t, subidentifier, invk)
 		}
 		missingInvocations := len(ei.SubInvocations) - len(invocation.SubInvocations)
 		if missingInvocations > 0 {
 			missingIndex := len(invocation.SubInvocations)
 			missingExpect := ei.SubInvocations[missingIndex]
-			require.Fail(t, "%s%d: expected invocation [%s:%d]", identifier, missingIndex, missingExpect.To, missingExpect.From)
+			require.Failf(t, "missing expected invocations", "%s%d: expected invocation [%s:%d]\nexpected:\n%s\nactual:\n%s",
+				identifier, missingIndex, missingExpect.To, missingExpect.Method, ei.listSubinvocations(), listInvocations(invocation.SubInvocations))
 		}
 	}
 
@@ -178,6 +190,28 @@ func (ei ExpectInvocation) matches(t *testing.T, breadcrumb string, invocation *
 	if ei.Ret != nil {
 		assert.True(t, ei.Ret.matches(invocation.Ret), "%s unexpected return value (%v != %v)", identifier, ei.Ret, invocation.Ret)
 	}
+}
+
+func (ei ExpectInvocation) listSubinvocations() string {
+	if len(ei.SubInvocations) == 0 {
+		return "[no invocations]\n"
+	}
+	list := ""
+	for i, si := range ei.SubInvocations {
+		list = fmt.Sprintf("%s%2d: [%s:%d]\n", list, i, si.To, si.Method)
+	}
+	return list
+}
+
+func listInvocations(invocations []*Invocation) string {
+	if len(invocations) == 0 {
+		return "[no invocations]\n"
+	}
+	list := ""
+	for i, si := range invocations {
+		list = fmt.Sprintf("%s%2d: [%s:%d]\n", list, i, si.Msg.to, si.Msg.method)
+	}
+	return list
 }
 
 // helpers to simplify pointer creation
@@ -273,6 +307,24 @@ func AdvanceByDeadlineTillIndex(t *testing.T, v *VM, minerIDAddr address.Address
 	return AdvanceByDeadline(t, v, minerIDAddr, func(dlInfo *miner.DeadlineInfo) bool {
 		return dlInfo.Index != i
 	})
+}
+
+// Advance to the epoch when the sector is due to be proven.
+// Returns the deadline info for proving deadline for sector, partition index of sector, and a VM at the opening of
+// the deadline (ready for SubmitWindowedPoSt).
+func AdvanceTillProvingPeriod(t *testing.T, v *VM, minerIDAddress address.Address, sectorNumber abi.SectorNumber) (*miner.DeadlineInfo, uint64, *VM) {
+	var minerState miner.State
+	err := v.GetState(minerIDAddress, &minerState)
+	require.NoError(t, err)
+
+	dlIdx, pIdx, err := minerState.FindSector(v.Store(), sectorNumber)
+	require.NoError(t, err)
+
+	// advance time to next proving period
+	v, dlInfo := AdvanceByDeadlineTillIndex(t, v, minerIDAddress, dlIdx)
+	v, err = v.WithEpoch(dlInfo.Open)
+	require.NoError(t, err)
+	return dlInfo, pIdx, v
 }
 
 //

--- a/support/vm/vm.go
+++ b/support/vm/vm.go
@@ -188,7 +188,7 @@ func (vm *VM) checkpoint() (cid.Cid, error) {
 	return root, nil
 }
 
-func (vm *VM) normalizeAddress(addr address.Address) (address.Address, bool) {
+func (vm *VM) NormalizeAddress(addr address.Address) (address.Address, bool) {
 	// short-circuit if the address is already an ID address
 	if addr.Protocol() == address.ID {
 		return addr, true
@@ -224,7 +224,7 @@ func (vm *VM) ApplyMessage(from, to address.Address, value abi.TokenAmount, meth
 
 	// load actor from global state
 	var ok bool
-	if from, ok = vm.normalizeAddress(from); !ok {
+	if from, ok = vm.NormalizeAddress(from); !ok {
 		return nil, exitcode.SysErrSenderInvalid
 	}
 
@@ -388,6 +388,10 @@ func (vm *VM) endInvocation(code exitcode.ExitCode, ret runtime.CBORMarshaler) {
 
 func (vm *VM) Invocations() []*Invocation {
 	return vm.invocations
+}
+
+func (vm *VM) LastInvocation() *Invocation {
+	return vm.invocations[len(vm.invocations)-1]
 }
 
 //


### PR DESCRIPTION
### Motivation

We want to integration test more of the actor code, and a capacity upgrade for a sector containing deals is a good way to hit a lot of different actor functionality including the verified registry and market actor

### Proposed Changes

1. Add `TestReplaceCommittedCapacitySectorWithDealLadenSector`
2. Move scenario tests into their own files named after flow under test instead of primary actor.
3. Add public `GetClaim` method to `power.State` to permit retrieval power.
4. Various small changes to test vm to ease testing.
5. Additions to vm testing to advance till a sectors proving period and methods to inspect power state.

cc @wadeAlexC