### PR TITLE
Explicitly limit the number of declarations in miner methods

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -876,8 +876,8 @@ type ExpirationExtension struct {
 // The sector must not be terminated or faulty.
 // The sector's power is recomputed for the new expiration.
 func (a Actor) ExtendSectorExpiration(rt Runtime, params *ExtendSectorExpirationParams) *adt.EmptyValue {
-	if uint64(len(params.Extensions)) > AddressedPartitionsMax {
-		rt.Abortf(exitcode.ErrIllegalArgument, "too many declarations %d, max %d", len(params.Extensions), AddressedPartitionsMax)
+	if uint64(len(params.Extensions)) > DeclarationsMax {
+		rt.Abortf(exitcode.ErrIllegalArgument, "too many declarations %d, max %d", len(params.Extensions), DeclarationsMax)
 	}
 
 	// limit the number of sectors declared at once
@@ -1055,6 +1055,13 @@ func (a Actor) TerminateSectors(rt Runtime, params *TerminateSectorsParams) *Ter
 	// Note: this cannot terminate pre-committed but un-proven sectors.
 	// They must be allowed to expire (and deposit burnt).
 
+	if len(params.Terminations) > DeclarationsMax {
+		rt.Abortf(exitcode.ErrIllegalArgument,
+			"too many declarations when terminating sectors: %d > %d",
+			len(params.Terminations), DeclarationsMax,
+		)
+	}
+
 	toProcess := make(DeadlineSectorMap)
 	for _, term := range params.Terminations {
 		err := toProcess.Add(term.Deadline, term.Partition, term.Sectors)
@@ -1142,6 +1149,13 @@ type FaultDeclaration struct {
 }
 
 func (a Actor) DeclareFaults(rt Runtime, params *DeclareFaultsParams) *adt.EmptyValue {
+	if len(params.Faults) > DeclarationsMax {
+		rt.Abortf(exitcode.ErrIllegalArgument,
+			"too many fault declarations for a single message: %d > %d",
+			len(params.Faults), DeclarationsMax,
+		)
+	}
+
 	toProcess := make(DeadlineSectorMap)
 	for _, term := range params.Faults {
 		err := toProcess.Add(term.Deadline, term.Partition, term.Sectors)
@@ -1215,6 +1229,13 @@ type RecoveryDeclaration struct {
 }
 
 func (a Actor) DeclareFaultsRecovered(rt Runtime, params *DeclareFaultsRecoveredParams) *adt.EmptyValue {
+	if len(params.Recoveries) > DeclarationsMax {
+		rt.Abortf(exitcode.ErrIllegalArgument,
+			"too many recovery declarations for a single message: %d > %d",
+			len(params.Recoveries), DeclarationsMax,
+		)
+	}
+
 	toProcess := make(DeadlineSectorMap)
 	for _, term := range params.Recoveries {
 		err := toProcess.Add(term.Deadline, term.Partition, term.Sectors)

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -48,6 +48,9 @@ func init() {
 // We set this to same as MaxPartitionsPerDeadline so we can process that many partitions every deadline.
 const AddressedPartitionsMax = MaxPartitionsPerDeadline
 
+// Maximum number of unique "declarations" in batch operations.
+const DeclarationsMax = AddressedPartitionsMax
+
 // The maximum number of sector infos that can be loaded in a single invocation.
 // This limits the amount of state to be read in a single message execution.
 const AddressedSectorsMax = 10_000 // PARAM_SPEC
@@ -207,7 +210,7 @@ var consensusFaultReporterInitialShare = builtin.BigFrac{
 
 // Per-epoch growth rate of the consensus fault reporter reward.
 var consensusFaultReporterShareGrowthRate = builtin.BigFrac{
-	Numerator:   big.NewInt(101251), 	// PARAM_FINISH PARAM_SPEC
+	Numerator:   big.NewInt(101251), // PARAM_FINISH PARAM_SPEC
 	Denominator: big.NewInt(100000),
 }
 


### PR DESCRIPTION
The total number of operations is implicitly specified in the partition limits, but we might as well limit the number of declarations as well. Otherwise, a miner could force the chain to perform additional work handling inefficiently encoded messages.

part of #416