### PR TITLE
Skip requesting deal weight for no deals; fix confusing deal weight in tests

### DIFF
--- a/actors/abi/big/int.go
+++ b/actors/abi/big/int.go
@@ -340,3 +340,7 @@ func (bi *Int) IsZero() bool {
 func (bi *Int) Nil() bool {
 	return bi.Int == nil
 }
+
+func (bi *Int) NilOrZero() bool {
+	return bi.Int == nil || bi.Int.Sign() == 0
+}

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -1968,6 +1968,13 @@ func requestUnsealedSectorCID(rt Runtime, proofType abi.RegisteredSealProof, dea
 }
 
 func requestDealWeight(rt Runtime, dealIDs []abi.DealID, sectorStart, sectorExpiry abi.ChainEpoch) market.VerifyDealsForActivationReturn {
+	if len(dealIDs) == 0 {
+		return market.VerifyDealsForActivationReturn{
+			DealWeight:         big.Zero(),
+			VerifiedDealWeight: big.Zero(),
+		}
+	}
+
 	var dealWeights market.VerifyDealsForActivationReturn
 	ret, code := rt.Send(
 		builtin.StorageMarketActorAddr,
@@ -1982,7 +1989,6 @@ func requestDealWeight(rt Runtime, dealIDs []abi.DealID, sectorStart, sectorExpi
 	builtin.RequireSuccess(rt, code, "failed to verify deals and get deal weight")
 	AssertNoError(ret.Into(&dealWeights))
 	return dealWeights
-
 }
 
 func commitWorkerKeyChange(rt Runtime) *adt.EmptyValue {

--- a/actors/test/commit_post_test.go
+++ b/actors/test/commit_post_test.go
@@ -70,8 +70,7 @@ func TestCommitPoStFlow(t *testing.T) {
 		Params: vm.ExpectObject(&preCommitParams),
 		SubInvocations: []vm.ExpectInvocation{
 			{To: builtin.RewardActorAddr, Method: builtin.MethodsReward.ThisEpochReward},
-			{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.CurrentTotalPower},
-			{To: builtin.StorageMarketActorAddr, Method: builtin.MethodsMarket.VerifyDealsForActivation}},
+			{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.CurrentTotalPower}},
 	}.Matches(t, v.Invocations()[0])
 
 	balances := vm.GetMinerBalances(t, v, minerAddrs.IDAddress)

--- a/support/vm/invocation_context.go
+++ b/support/vm/invocation_context.go
@@ -490,7 +490,7 @@ func (ic *invocationContext) invoke() (ret returnWrapper, errcode exitcode.ExitC
 	ic.toActor, ic.msg.to = ic.resolveTarget(ic.msg.to)
 
 	// 3. transfer funds carried by the msg
-	if !ic.msg.value.Nil() && !ic.msg.value.IsZero() {
+	if !ic.msg.value.NilOrZero() {
 		if ic.msg.value.LessThan(big.Zero()) {
 			ic.Abortf(exitcode.SysErrForbidden, "attempt to transfer negative value %s from %s to %s",
 				ic.msg.value, ic.msg.from, ic.msg.to)


### PR DESCRIPTION
The miner actor harness previously reported an amount of verified deal weight even when a sector has no deals, which confused me a lot when debugging some pre-commit deposit calculations. It now records non-zero deal weight only if the sector has a deal.

The weight reported was an odd amount: the sector size. I fixed this to be a product of sector size and duration, and discovered #1038.

I also removed an unnecessary call to the market actor to compute deal weight for no deals.

- [x] Depends on #1036 for passing tests.