### PR TITLE
confirm deal space does not exceed sector size in precommit.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 .idea
 
 support/tools/bin
+gen/command-line-arguments

--- a/actors/builtin/market/cbor_gen.go
+++ b/actors/builtin/market/cbor_gen.go
@@ -515,6 +515,68 @@ func (t *ActivateDealsParams) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
+var lengthBufActivateDealsReturn = []byte{130}
+
+func (t *ActivateDealsReturn) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write(lengthBufActivateDealsReturn); err != nil {
+		return err
+	}
+
+	// t.DealWeight (big.Int) (struct)
+	if err := t.DealWeight.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.VerifiedDealWeight (big.Int) (struct)
+	if err := t.VerifiedDealWeight.MarshalCBOR(w); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *ActivateDealsReturn) UnmarshalCBOR(r io.Reader) error {
+	*t = ActivateDealsReturn{}
+
+	br := cbg.GetPeeker(r)
+	scratch := make([]byte, 8)
+
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 2 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.DealWeight (big.Int) (struct)
+
+	{
+
+		if err := t.DealWeight.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.DealWeight: %w", err)
+		}
+
+	}
+	// t.VerifiedDealWeight (big.Int) (struct)
+
+	{
+
+		if err := t.VerifiedDealWeight.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.VerifiedDealWeight: %w", err)
+		}
+
+	}
+	return nil
+}
+
 var lengthBufVerifyDealsForActivationParams = []byte{131}
 
 func (t *VerifyDealsForActivationParams) MarshalCBOR(w io.Writer) error {

--- a/actors/builtin/market/cbor_gen.go
+++ b/actors/builtin/market/cbor_gen.go
@@ -693,7 +693,7 @@ func (t *VerifyDealsForActivationReturn) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.DealSpace (abi.SectorSize) (uint64)
+	// t.DealSpace (uint64) (uint64)
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.DealSpace)); err != nil {
 		return err
@@ -738,7 +738,7 @@ func (t *VerifyDealsForActivationReturn) UnmarshalCBOR(r io.Reader) error {
 		}
 
 	}
-	// t.DealSpace (abi.SectorSize) (uint64)
+	// t.DealSpace (uint64) (uint64)
 
 	{
 
@@ -749,7 +749,7 @@ func (t *VerifyDealsForActivationReturn) UnmarshalCBOR(r io.Reader) error {
 		if maj != cbg.MajUnsignedInt {
 			return fmt.Errorf("wrong type for uint64 field")
 		}
-		t.DealSpace = abi.SectorSize(extra)
+		t.DealSpace = uint64(extra)
 
 	}
 	return nil

--- a/actors/builtin/market/cbor_gen.go
+++ b/actors/builtin/market/cbor_gen.go
@@ -515,68 +515,6 @@ func (t *ActivateDealsParams) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
-var lengthBufActivateDealsReturn = []byte{130}
-
-func (t *ActivateDealsReturn) MarshalCBOR(w io.Writer) error {
-	if t == nil {
-		_, err := w.Write(cbg.CborNull)
-		return err
-	}
-	if _, err := w.Write(lengthBufActivateDealsReturn); err != nil {
-		return err
-	}
-
-	// t.DealWeight (big.Int) (struct)
-	if err := t.DealWeight.MarshalCBOR(w); err != nil {
-		return err
-	}
-
-	// t.VerifiedDealWeight (big.Int) (struct)
-	if err := t.VerifiedDealWeight.MarshalCBOR(w); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (t *ActivateDealsReturn) UnmarshalCBOR(r io.Reader) error {
-	*t = ActivateDealsReturn{}
-
-	br := cbg.GetPeeker(r)
-	scratch := make([]byte, 8)
-
-	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
-	if err != nil {
-		return err
-	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
-	}
-
-	if extra != 2 {
-		return fmt.Errorf("cbor input had wrong number of fields")
-	}
-
-	// t.DealWeight (big.Int) (struct)
-
-	{
-
-		if err := t.DealWeight.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.DealWeight: %w", err)
-		}
-
-	}
-	// t.VerifiedDealWeight (big.Int) (struct)
-
-	{
-
-		if err := t.VerifiedDealWeight.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.VerifiedDealWeight: %w", err)
-		}
-
-	}
-	return nil
-}
-
 var lengthBufVerifyDealsForActivationParams = []byte{131}
 
 func (t *VerifyDealsForActivationParams) MarshalCBOR(w io.Writer) error {
@@ -732,7 +670,7 @@ func (t *VerifyDealsForActivationParams) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
-var lengthBufVerifyDealsForActivationReturn = []byte{130}
+var lengthBufVerifyDealsForActivationReturn = []byte{131}
 
 func (t *VerifyDealsForActivationReturn) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -743,6 +681,8 @@ func (t *VerifyDealsForActivationReturn) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
+	scratch := make([]byte, 9)
+
 	// t.DealWeight (big.Int) (struct)
 	if err := t.DealWeight.MarshalCBOR(w); err != nil {
 		return err
@@ -752,6 +692,13 @@ func (t *VerifyDealsForActivationReturn) MarshalCBOR(w io.Writer) error {
 	if err := t.VerifiedDealWeight.MarshalCBOR(w); err != nil {
 		return err
 	}
+
+	// t.DealSpace (abi.SectorSize) (uint64)
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.DealSpace)); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -769,7 +716,7 @@ func (t *VerifyDealsForActivationReturn) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 2 {
+	if extra != 3 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -789,6 +736,20 @@ func (t *VerifyDealsForActivationReturn) UnmarshalCBOR(r io.Reader) error {
 		if err := t.VerifiedDealWeight.UnmarshalCBOR(br); err != nil {
 			return xerrors.Errorf("unmarshaling t.VerifiedDealWeight: %w", err)
 		}
+
+	}
+	// t.DealSpace (abi.SectorSize) (uint64)
+
+	{
+
+		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.DealSpace = abi.SectorSize(extra)
 
 	}
 	return nil

--- a/actors/builtin/market/market_actor.go
+++ b/actors/builtin/market/market_actor.go
@@ -267,7 +267,7 @@ type VerifyDealsForActivationParams struct {
 type VerifyDealsForActivationReturn struct {
 	DealWeight         abi.DealWeight
 	VerifiedDealWeight abi.DealWeight
-	DealSpace          abi.SectorSize
+	DealSpace          uint64
 }
 
 // Verify that a given set of storage deals is valid for a sector currently being PreCommitted
@@ -613,7 +613,7 @@ func deleteDealProposalAndState(dealId abi.DealID, states *DealMetaArray, propos
 // split into regular deal weight and verified deal weight.
 func ValidateDealsForActivation(
 	st *State, store adt.Store, dealIDs []abi.DealID, minerAddr addr.Address, sectorExpiry, currEpoch abi.ChainEpoch,
-) (big.Int, big.Int, abi.SectorSize, error) {
+) (big.Int, big.Int, uint64, error) {
 
 	proposals, err := AsDealProposalArray(store, st.Proposals)
 	if err != nil {
@@ -622,7 +622,7 @@ func ValidateDealsForActivation(
 
 	seenDealIDs := make(map[abi.DealID]struct{}, len(dealIDs))
 
-	totalDealSpace := abi.SectorSize(0)
+	totalDealSpace := uint64(0)
 	totalDealSpaceTime := big.Zero()
 	totalVerifiedSpaceTime := big.Zero()
 	for _, dealID := range dealIDs {
@@ -644,7 +644,7 @@ func ValidateDealsForActivation(
 		}
 
 		// Compute deal weight
-		totalDealSpace += abi.SectorSize(proposal.PieceSize)
+		totalDealSpace += uint64(proposal.PieceSize)
 		dealSpaceTime := DealWeight(proposal)
 		if proposal.VerifiedDeal {
 			totalVerifiedSpaceTime = big.Add(totalVerifiedSpaceTime, dealSpaceTime)

--- a/actors/builtin/market/market_test.go
+++ b/actors/builtin/market/market_test.go
@@ -957,15 +957,8 @@ func TestActivateDeals(t *testing.T) {
 		dealId5 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch+1, startEpoch)
 
 		// provider1 activates deal 1 and deal2 but that does not activate deal3 to deal5
-		dealWeights := actor.activateDeals(rt, sectorExpiry, provider, currentEpoch, dealId1, dealId2)
+		actor.activateDeals(rt, sectorExpiry, provider, currentEpoch, dealId1, dealId2)
 		actor.assertDealsNotActivated(rt, currentEpoch, dealId3, dealId4, dealId5)
-
-		// expect weight to be sum of deal1 and deal2
-		d1 := actor.getDealProposal(rt, dealId1)
-		d2 := actor.getDealProposal(rt, dealId2)
-		expectedDealWeight := big.Add(market.DealWeight(d1), market.DealWeight(d2))
-		assert.Equal(t, expectedDealWeight, dealWeights.DealWeight)
-		assert.Equal(t, big.Zero(), dealWeights.VerifiedDealWeight)
 
 		// provider3 activates deal5 but that does not activate deal3 or deal4
 		actor.activateDeals(rt, sectorExpiry, provider2, currentEpoch, dealId5)
@@ -2766,9 +2759,7 @@ func (h *marketActorTestHarness) assertDealsNotActivated(rt *mock.Runtime, epoch
 	}
 }
 
-func (h *marketActorTestHarness) activateDeals(rt *mock.Runtime, sectorExpiry abi.ChainEpoch,
-	provider address.Address, currentEpoch abi.ChainEpoch, dealIDs ...abi.DealID,
-) *market.ActivateDealsReturn {
+func (h *marketActorTestHarness) activateDeals(rt *mock.Runtime, sectorExpiry abi.ChainEpoch, provider address.Address, currentEpoch abi.ChainEpoch, dealIDs ...abi.DealID) {
 	rt.SetCaller(provider, builtin.StorageMinerActorCodeID)
 	rt.ExpectValidateCallerType(builtin.StorageMinerActorCodeID)
 
@@ -2777,14 +2768,12 @@ func (h *marketActorTestHarness) activateDeals(rt *mock.Runtime, sectorExpiry ab
 	ret := rt.Call(h.ActivateDeals, params)
 	rt.Verify()
 
-	adr, ok := ret.(*market.ActivateDealsReturn)
-	require.True(h.t, ok)
+	require.Nil(h.t, ret)
 
 	for _, d := range dealIDs {
 		s := h.getDealState(rt, d)
 		require.EqualValues(h.t, currentEpoch, s.SectorStartEpoch)
 	}
-	return adr
 }
 
 func (h *marketActorTestHarness) getDealProposal(rt *mock.Runtime, dealID abi.DealID) *market.DealProposal {

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -1982,18 +1982,23 @@ func requestDealWeight(rt Runtime, dealIDs []abi.DealID, sectorStart, sectorExpi
 	}
 
 	var dealWeights market.VerifyDealsForActivationReturn
-	ret, code := rt.Send(
-		builtin.StorageMarketActorAddr,
-		builtin.MethodsMarket.VerifyDealsForActivation,
-		&market.VerifyDealsForActivationParams{
-			DealIDs:      dealIDs,
-			SectorStart:  sectorStart,
-			SectorExpiry: sectorExpiry,
-		},
-		abi.NewTokenAmount(0),
-	)
-	builtin.RequireSuccess(rt, code, "failed to verify deals and get deal weight")
-	AssertNoError(ret.Into(&dealWeights))
+	if len(dealIDs) > 0 {
+		ret, code := rt.Send(
+			builtin.StorageMarketActorAddr,
+			builtin.MethodsMarket.VerifyDealsForActivation,
+			&market.VerifyDealsForActivationParams{
+				DealIDs:      dealIDs,
+				SectorStart:  sectorStart,
+				SectorExpiry: sectorExpiry,
+			},
+			abi.NewTokenAmount(0),
+		)
+		builtin.RequireSuccess(rt, code, "failed to verify deals and get deal weight")
+		AssertNoError(ret.Into(&dealWeights))
+	} else {
+		dealWeights.DealWeight = big.Zero()
+		dealWeights.VerifiedDealWeight = big.Zero()
+	}
 	return dealWeights
 }
 

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -534,6 +534,7 @@ func (a Actor) PreCommitSector(rt Runtime, params *SectorPreCommitInfo) *adt.Emp
 			rt.Abortf(exitcode.ErrIllegalArgument, "too many deals for sector %d > %d", len(params.DealIDs), dealCountMax)
 		}
 
+		// Ensure total deal space does not exceed sector size.
 		if dealWeight.DealSpace > info.SectorSize {
 			rt.Abortf(exitcode.ErrIllegalArgument, "deals too large to fit in sector %d > %d", dealWeight.DealSpace, info.SectorSize)
 		}
@@ -769,8 +770,6 @@ func (a Actor) ConfirmSectorProofsValid(rt Runtime, params *builtin.ConfirmSecto
 				rt.Log(vmr.WARN, "precommit %d has lifetime %d less than minimum. ignoring", precommit.Info.SectorNumber, duration, MinSectorExpiration)
 				continue
 			}
-
-			// Ensure total deal space does not exceed sector size.
 
 			pwr := QAPowerForWeight(info.SectorSize, duration, precommit.DealWeight, precommit.VerifiedDealWeight)
 			dayReward := ExpectedRewardForPower(rewardStats.ThisEpochRewardSmoothed, pwrTotal.QualityAdjPowerSmoothed, pwr, builtin.EpochsInDay)

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -535,7 +535,7 @@ func (a Actor) PreCommitSector(rt Runtime, params *SectorPreCommitInfo) *adt.Emp
 		}
 
 		// Ensure total deal space does not exceed sector size.
-		if dealWeight.DealSpace > info.SectorSize {
+		if dealWeight.DealSpace > uint64(info.SectorSize) {
 			rt.Abortf(exitcode.ErrIllegalArgument, "deals too large to fit in sector %d > %d", dealWeight.DealSpace, info.SectorSize)
 		}
 

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -437,9 +437,9 @@ func TestCommitments(t *testing.T) {
 		sector := actor.getSector(rt, sectorNo)
 		sectorPower := miner.NewPowerPair(big.NewIntUnsigned(uint64(actor.sectorSize)), qaPower)
 
-		// expect deal weights to be transfered to on chain info
-		assert.Equal(t, onChainPrecommit.DealWeight, sector.DealWeight)
-		assert.Equal(t, onChainPrecommit.VerifiedDealWeight, sector.VerifiedDealWeight)
+		// expect deal weights to be recomputed
+		assert.Equal(t, actor.dealWeight, sector.DealWeight)
+		assert.Equal(t, actor.verifiedDealWeight, sector.VerifiedDealWeight)
 
 		// expect activation epoch to be current epoch
 		assert.Equal(t, rt.Epoch(), sector.Activation)
@@ -3098,6 +3098,11 @@ type actorHarness struct {
 
 	epochRewardSmooth  *smoothing.FilterEstimate
 	epochQAPowerSmooth *smoothing.FilterEstimate
+
+	precommitDealWeight         abi.DealWeight
+	precommitVerifiedDealWeight abi.DealWeight
+	dealWeight                  abi.DealWeight
+	verifiedDealWeight          abi.DealWeight
 }
 
 func newHarness(t testing.TB, provingPeriodOffset abi.ChainEpoch) *actorHarness {
@@ -3132,6 +3137,11 @@ func newHarness(t testing.TB, provingPeriodOffset abi.ChainEpoch) *actorHarness 
 
 		epochRewardSmooth:  smoothing.TestingConstantEstimate(rwd),
 		epochQAPowerSmooth: smoothing.TestingConstantEstimate(pwr),
+
+		precommitDealWeight:         big.NewInt(1 << 29),
+		precommitVerifiedDealWeight: big.NewInt(1 << 28),
+		dealWeight:                  big.NewInt(1<<29 - 1),
+		verifiedDealWeight:          big.NewInt(1<<28 - 1),
 	}
 	h.setProofType(abi.RegisteredSealProof_StackedDrg32GiBV1)
 	return h

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -3448,7 +3448,7 @@ func (h *actorHarness) preCommitSector(rt *mock.Runtime, params *miner.SectorPre
 		vdReturn := market.VerifyDealsForActivationReturn{
 			DealWeight:         conf.dealWeight,
 			VerifiedDealWeight: conf.verifiedDealWeight,
-			DealSpace:          conf.dealSpace,
+			DealSpace:          uint64(conf.dealSpace),
 		}
 		if vdReturn.DealWeight.Nil() {
 			vdReturn.DealWeight = big.Zero()

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -150,6 +150,7 @@ func main() {
 		market.WithdrawBalanceParams{},
 		market.PublishStorageDealsParams{},
 		market.ActivateDealsParams{},
+		market.ActivateDealsReturn{},
 		market.VerifyDealsForActivationParams{},
 		market.VerifyDealsForActivationReturn{},
 		market.ComputeDataCommitmentParams{},

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -150,7 +150,6 @@ func main() {
 		market.WithdrawBalanceParams{},
 		market.PublishStorageDealsParams{},
 		market.ActivateDealsParams{},
-		market.ActivateDealsReturn{},
 		market.VerifyDealsForActivationParams{},
 		market.VerifyDealsForActivationReturn{},
 		market.ComputeDataCommitmentParams{},


### PR DESCRIPTION
closes #1038 

### Motivation

That the total spacetime of a sector's deals does not exceed the spacetime of the sector is an invariant of the system. We assert this in `QAPowerForWeight` to avoid a nonsensical result. Our market actor deal verification ensures that a miner cannot publish a deal for a sector that exceeds the sector's time bounds (either estimated at precommit, or actual at prove commit). The syscall to compute the unsealed CID must fail if the space of all deals exceeds the sector size (else it would be forced to compute with negative padding), so sector commitment will fail at `ProveCommitSector` if deal space is too large.

It is still possible for a miner to violate the deal spacetime invariant in precommit, however by publishing deals that are too large prior to calling `PreCommitSector`. In this case, our assertion in `QAPowerForWeight` will fail.

The solution in this PR is to return the total deal size along with deal weight and verified deal weight, and have precommit check that it does not exceed sector size. 

### Proposed Changes

1. Return computed deal space from market.VerifyDealsForActivation (necessitating a new field in return type).
2. Add check in `PreCommitSector` to ensure deal space does not exceed sector size.
3. Test.
4. Remove `gen/command-line-arguments` from repo. This build product of `gen/gen.go` doesn't belong in the repo. It's out of date and confusing.