### PR TITLE
Remove change worker cron and add confirm update worker key method

### DIFF
--- a/actors/builtin/methods.go
+++ b/actors/builtin/methods.go
@@ -93,7 +93,8 @@ var MethodsMiner = struct {
 	ChangeMultiaddrs         abi.MethodNum
 	CompactPartitions        abi.MethodNum
 	CompactSectorNumbers     abi.MethodNum
-}{MethodConstructor, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}
+	ConfirmUpdateWorkerKey   abi.MethodNum
+}{MethodConstructor, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21}
 
 var MethodsVerifiedRegistry = struct {
 	Constructor       abi.MethodNum

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -31,7 +31,7 @@ type Runtime = vmr.Runtime
 type CronEventType int64
 
 const (
-	CronEventProvingDeadline CronEventType = iota
+	CronEventProvingDeadline CronEventType = iota + 1
 	CronEventProcessEarlyTerminations
 )
 
@@ -202,9 +202,6 @@ func (a Actor) ChangeWorkerAddress(rt Runtime, params *ChangeWorkerAddressParams
 				NewWorker:   newWorker,
 				EffectiveAt: rt.CurrEpoch() + WorkerKeyChangeDelay,
 			}
-		} else {
-			// Allow owner to cancel existing update by supplying existing worker address
-			info.PendingWorkerKey = nil
 		}
 
 		err := st.SaveInfo(adt.AsStore(rt), info)

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -196,8 +196,7 @@ func (a Actor) ChangeWorkerAddress(rt Runtime, params *ChangeWorkerAddressParams
 		info.ControlAddresses = controlAddrs
 
 		// save newWorker addr key change request
-		// This may replace another pending key change.
-		if newWorker != info.Worker {
+		if newWorker != info.Worker && info.PendingWorkerKey == nil {
 			info.PendingWorkerKey = &WorkerKeyChange{
 				NewWorker:   newWorker,
 				EffectiveAt: rt.CurrEpoch() + WorkerKeyChangeDelay,

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -31,8 +31,7 @@ type Runtime = vmr.Runtime
 type CronEventType int64
 
 const (
-	CronEventWorkerKeyChange CronEventType = iota
-	CronEventProvingDeadline
+	CronEventProvingDeadline CronEventType = iota
 	CronEventProcessEarlyTerminations
 )
 
@@ -70,6 +69,7 @@ func (a Actor) Exports() []interface{} {
 		18:                        a.ChangeMultiaddrs,
 		19:                        a.CompactPartitions,
 		20:                        a.CompactSectorNumbers,
+		21:                        a.ConfirmUpdateWorkerKey,
 	}
 }
 
@@ -177,8 +177,6 @@ type ChangeWorkerAddressParams struct {
 func (a Actor) ChangeWorkerAddress(rt Runtime, params *ChangeWorkerAddressParams) *adt.EmptyValue {
 	checkControlAddresses(rt, params.NewControlAddrs)
 
-	var effectiveEpoch abi.ChainEpoch
-
 	newWorker := resolveWorkerAddress(rt, params.NewWorker)
 
 	var controlAddrs []addr.Address
@@ -188,44 +186,45 @@ func (a Actor) ChangeWorkerAddress(rt Runtime, params *ChangeWorkerAddressParams
 	}
 
 	var st State
-	isWorkerChange := false
 	rt.State().Transaction(&st, func() {
 		info := getMinerInfo(rt, &st)
 
 		// Only the Owner is allowed to change the newWorker and control addresses.
 		rt.ValidateImmediateCallerIs(info.Owner)
 
-		{
-			// save the new control addresses
-			info.ControlAddresses = controlAddrs
-		}
+		// save the new control addresses
+		info.ControlAddresses = controlAddrs
 
-		{
-			// save newWorker addr key change request
-			// This may replace another pending key change.
-			if newWorker != info.Worker {
-				isWorkerChange = true
-				effectiveEpoch = rt.CurrEpoch() + WorkerKeyChangeDelay
-
-				info.PendingWorkerKey = &WorkerKeyChange{
-					NewWorker:   newWorker,
-					EffectiveAt: effectiveEpoch,
-				}
+		// save newWorker addr key change request
+		// This may replace another pending key change.
+		if newWorker != info.Worker {
+			info.PendingWorkerKey = &WorkerKeyChange{
+				NewWorker:   newWorker,
+				EffectiveAt: rt.CurrEpoch() + WorkerKeyChangeDelay,
 			}
+		} else {
+			// Allow owner to cancel existing update by supplying existing worker address
+			info.PendingWorkerKey = nil
 		}
 
 		err := st.SaveInfo(adt.AsStore(rt), info)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "could not save miner info")
 	})
 
-	// we only need to enroll the cron event for newWorker key change as we change the control
-	// addresses immediately
-	if isWorkerChange {
-		cronPayload := CronEventPayload{
-			EventType: CronEventWorkerKeyChange,
-		}
-		enrollCronEvent(rt, effectiveEpoch, &cronPayload)
-	}
+	return nil
+}
+
+// Triggers a worker address change if a change has been requested and its effective epoch has arrived.
+func (a Actor) ConfirmUpdateWorkerKey(rt Runtime, params *adt.EmptyValue) *adt.EmptyValue {
+	var st State
+	rt.State().Transaction(&st, func() {
+		info := getMinerInfo(rt, &st)
+
+		// Only the Owner is allowed to change the newWorker.
+		rt.ValidateImmediateCallerIs(info.Owner)
+
+		processPendingWorker(info, rt, &st)
+	})
 
 	return nil
 }
@@ -1560,8 +1559,6 @@ func (a Actor) OnDeferredCronEvent(rt Runtime, payload *CronEventPayload) *adt.E
 	switch payload.EventType {
 	case CronEventProvingDeadline:
 		handleProvingDeadline(rt)
-	case CronEventWorkerKeyChange:
-		commitWorkerKeyChange(rt)
 	case CronEventProcessEarlyTerminations:
 		if processEarlyTerminations(rt) {
 			scheduleEarlyTerminationWork(rt)
@@ -1687,6 +1684,12 @@ func handleProvingDeadline(rt Runtime) {
 			newlyVested, err := st.UnlockVestedFunds(store, rt.CurrEpoch())
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to vest funds")
 			pledgeDeltaTotal = big.Add(pledgeDeltaTotal, newlyVested.Neg())
+		}
+
+		{
+			// Process pending worker change if any
+			info := getMinerInfo(rt, &st)
+			processPendingWorker(info, rt, &st)
 		}
 
 		{
@@ -1997,24 +2000,6 @@ func requestDealWeight(rt Runtime, dealIDs []abi.DealID, sectorStart, sectorExpi
 	return dealWeights
 }
 
-func commitWorkerKeyChange(rt Runtime) *adt.EmptyValue {
-	var st State
-	rt.State().Transaction(&st, func() {
-		info := getMinerInfo(rt, &st)
-		// A previously scheduled key change could have been replaced with a new key change request
-		// scheduled in the future. This case should be treated as a no-op.
-		if info.PendingWorkerKey == nil || info.PendingWorkerKey.EffectiveAt > rt.CurrEpoch() {
-			return
-		}
-
-		info.Worker = info.PendingWorkerKey.NewWorker
-		info.PendingWorkerKey = nil
-		err := st.SaveInfo(adt.AsStore(rt), info)
-		builtin.RequireNoErr(rt, err, exitcode.ErrSerialization, "failed to save miner info")
-	})
-	return nil
-}
-
 // Requests the current epoch target block reward from the reward actor.
 // return value includes reward, smoothed estimate of reward, and baseline power
 func requestCurrentEpochBlockReward(rt Runtime) reward.ThisEpochRewardReturn {
@@ -2164,6 +2149,19 @@ func replacedSectorParameters(rt Runtime, precommit *SectorPreCommitOnChainInfo,
 	return replaced.InitialPledge,
 		maxEpoch(0, rt.CurrEpoch()-replaced.Activation),
 		replaced.ExpectedDayReward
+}
+
+// Update worker address with pending worker key if exists and delay has passed
+func processPendingWorker(info *MinerInfo, rt Runtime, st *State) {
+	if info.PendingWorkerKey == nil || rt.CurrEpoch() < info.PendingWorkerKey.EffectiveAt {
+		return
+	}
+
+	info.Worker = info.PendingWorkerKey.NewWorker
+	info.PendingWorkerKey = nil
+
+	err := st.SaveInfo(adt.AsStore(rt), info)
+	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "could not save miner info")
 }
 
 // Computes deadline information for a fault or recovery declaration.

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -2691,33 +2691,59 @@ func TestChangeWorkerAddress(t *testing.T) {
 
 		newWorker := tutil.NewIDAddr(t, 999)
 
-		currentEpoch := abi.ChainEpoch(5)
+		// set epoch to something close to next deadline so first cron will be before effective date
+		currentEpoch := abi.ChainEpoch(2970)
 		rt.SetEpoch(currentEpoch)
 
 		effectiveEpoch := currentEpoch + miner.WorkerKeyChangeDelay
 		actor.changeWorkerAddress(rt, newWorker, effectiveEpoch, originalControlAddrs)
 
 		// no change if current epoch is less than effective epoch
-		rt.SetEpoch(effectiveEpoch - 1)
-		rt.SetCaller(builtin.StoragePowerActorAddr, builtin.StoragePowerActorCodeID)
-		rt.ExpectValidateCallerAddr(builtin.StoragePowerActorAddr)
-		rt.Call(actor.a.OnDeferredCronEvent, &miner.CronEventPayload{
-			EventType: miner.CronEventWorkerKeyChange,
-		})
-		rt.Verify()
+		actor.advancePastDeadlineEndWithCron(rt)
+
 		st := getState(rt)
 		info, err := st.GetInfo(adt.AsStore(rt))
 		require.NoError(t, err)
 		require.NotNil(t, info.PendingWorkerKey)
 		require.EqualValues(t, actor.worker, info.Worker)
 
-		// set current epoch to effective epoch and ask to change the address
-		actor.cronWorkerAddrChange(rt, effectiveEpoch, newWorker)
+		// set current epoch to effective epoch and run deadline cron
+		rt.SetEpoch(effectiveEpoch)
+		actor.advancePastDeadlineEndWithCron(rt)
 
 		// assert control addresses are unchanged
 		st = getState(rt)
 		info, err = st.GetInfo(adt.AsStore(rt))
 		require.NoError(t, err)
+		require.NotEmpty(t, info.ControlAddresses)
+		require.Equal(t, originalControlAddrs, info.ControlAddresses)
+	})
+
+	t.Run("owner can cancel worker address change", func(t *testing.T) {
+		rt, actor := setupFunc()
+		actor.constructAndVerify(rt)
+		originalControlAddrs := actor.controlAddrs
+
+		newWorker := tutil.NewIDAddr(t, 999)
+
+		currentEpoch := abi.ChainEpoch(5)
+		rt.SetEpoch(currentEpoch)
+
+		effectiveEpoch := currentEpoch + miner.WorkerKeyChangeDelay
+		actor.changeWorkerAddress(rt, newWorker, effectiveEpoch, originalControlAddrs)
+
+		// now reset to old worker
+		actor.changeWorkerAddress(rt, actor.worker, effectiveEpoch, originalControlAddrs)
+
+		// set current epoch to effective epoch and run deadline cron
+		rt.SetEpoch(effectiveEpoch)
+		actor.advancePastDeadlineEndWithCron(rt)
+
+		// assert worker and control addresses are unchanged
+		st := getState(rt)
+		info, err := st.GetInfo(adt.AsStore(rt))
+		require.NoError(t, err)
+		require.Equal(t, actor.worker, info.Worker)
 		require.NotEmpty(t, info.ControlAddresses)
 		require.Equal(t, originalControlAddrs, info.ControlAddresses)
 	})
@@ -2761,8 +2787,9 @@ func TestChangeWorkerAddress(t *testing.T) {
 		effectiveEpoch := currentEpoch + miner.WorkerKeyChangeDelay
 		actor.changeWorkerAddress(rt, newWorker, effectiveEpoch, []addr.Address{c1, c2})
 
-		// set current epoch to effective epoch and ask to change the address
-		actor.cronWorkerAddrChange(rt, effectiveEpoch, newWorker)
+		// set current epoch the run deadline cron
+		rt.SetEpoch(effectiveEpoch)
+		actor.advancePastDeadlineEndWithCron(rt)
 
 		// assert both worker and control addresses have changed
 		st := getState(rt)
@@ -2886,6 +2913,67 @@ func TestChangeWorkerAddress(t *testing.T) {
 			rt.Call(actor.a.ChangeWorkerAddress, param)
 		})
 		rt.Verify()
+	})
+}
+
+func TestConfirmUpdateWorkerKey(t *testing.T) {
+	periodOffset := abi.ChainEpoch(100)
+	newWorker := tutil.NewIDAddr(t, 999)
+	currentEpoch := abi.ChainEpoch(5)
+	actor := newHarness(t, periodOffset)
+	builder := builderForHarness(actor).
+		WithBalance(bigBalance, big.Zero())
+
+	t.Run("successfully changes the worker address", func(t *testing.T) {
+		rt := builder.Build(t)
+		rt.SetEpoch(currentEpoch)
+		actor.constructAndVerify(rt)
+
+		effectiveEpoch := currentEpoch + miner.WorkerKeyChangeDelay
+		actor.changeWorkerAddress(rt, newWorker, effectiveEpoch, actor.controlAddrs)
+
+		// confirm at effective epoch
+		rt.SetEpoch(effectiveEpoch)
+		actor.confirmUpdateWorkerKey(rt)
+
+		st := getState(rt)
+		info, err := st.GetInfo(adt.AsStore(rt))
+		require.NoError(t, err)
+		require.Equal(t, info.Worker, newWorker)
+		require.Nil(t, info.PendingWorkerKey)
+	})
+
+	t.Run("does nothing before the effective date", func(t *testing.T) {
+		rt := builder.Build(t)
+		rt.SetEpoch(currentEpoch)
+		actor.constructAndVerify(rt)
+
+		effectiveEpoch := currentEpoch + miner.WorkerKeyChangeDelay
+		actor.changeWorkerAddress(rt, newWorker, effectiveEpoch, actor.controlAddrs)
+
+		// confirm right before the effective epoch
+		rt.SetEpoch(effectiveEpoch - 1)
+		actor.confirmUpdateWorkerKey(rt)
+
+		st := getState(rt)
+		info, err := st.GetInfo(adt.AsStore(rt))
+		require.NoError(t, err)
+		require.Equal(t, actor.worker, info.Worker)
+		require.NotNil(t, info.PendingWorkerKey)
+	})
+
+	t.Run("does nothing when no update is set", func(t *testing.T) {
+		rt := builder.Build(t)
+		rt.SetEpoch(currentEpoch)
+		actor.constructAndVerify(rt)
+
+		actor.confirmUpdateWorkerKey(rt)
+
+		st := getState(rt)
+		info, err := st.GetInfo(adt.AsStore(rt))
+		require.NoError(t, err)
+		require.Equal(t, actor.worker, info.Worker)
+		require.Nil(t, info.PendingWorkerKey)
 	})
 }
 
@@ -3321,22 +3409,6 @@ func (h *actorHarness) changeWorkerAddress(rt *mock.Runtime, newWorker addr.Addr
 	param.NewWorker = newWorker
 	rt.ExpectSend(newWorker, builtin.MethodsAccount.PubkeyAddress, nil, big.Zero(), &h.key, exitcode.Ok)
 
-	if newWorker != h.worker {
-		cronPayload := miner.CronEventPayload{
-			EventType: miner.CronEventWorkerKeyChange,
-		}
-		payload := new(bytes.Buffer)
-		err := cronPayload.MarshalCBOR(payload)
-		require.NoError(h.t, err)
-		cronEvt := &power.EnrollCronEventParams{
-			EventEpoch: effectiveEpoch,
-			Payload:    payload.Bytes(),
-		}
-
-		rt.ExpectSend(builtin.StoragePowerActorAddr, builtin.MethodsPower.EnrollCronEvent,
-			cronEvt, big.Zero(), nil, exitcode.Ok)
-	}
-
 	rt.ExpectValidateCallerAddr(h.owner)
 	rt.SetCaller(h.owner, builtin.AccountActorCodeID)
 	rt.Call(h.a.ChangeWorkerAddress, param)
@@ -3359,6 +3431,13 @@ func (h *actorHarness) changeWorkerAddress(rt *mock.Runtime, newWorker addr.Addr
 	}
 	require.EqualValues(h.t, controlAddrs, info.ControlAddresses)
 
+}
+
+func (h *actorHarness) confirmUpdateWorkerKey(rt *mock.Runtime) {
+	rt.ExpectValidateCallerAddr(h.owner)
+	rt.SetCaller(h.owner, builtin.AccountActorCodeID)
+	rt.Call(h.a.ConfirmUpdateWorkerKey, nil)
+	rt.Verify()
 }
 
 func (h *actorHarness) checkSectorProven(rt *mock.Runtime, sectorNum abi.SectorNumber) {
@@ -3396,22 +3475,6 @@ func (h *actorHarness) changePeerID(rt *mock.Runtime, newPID abi.PeerID) {
 	info, err := st.GetInfo(adt.AsStore(rt))
 	require.NoError(h.t, err)
 	require.EqualValues(h.t, newPID, info.PeerId)
-}
-
-func (h *actorHarness) cronWorkerAddrChange(rt *mock.Runtime, effectiveEpoch abi.ChainEpoch, newWorker addr.Address) {
-	rt.SetEpoch(effectiveEpoch)
-	rt.SetCaller(builtin.StoragePowerActorAddr, builtin.StoragePowerActorCodeID)
-	rt.ExpectValidateCallerAddr(builtin.StoragePowerActorAddr)
-	rt.Call(h.a.OnDeferredCronEvent, &miner.CronEventPayload{
-		EventType: miner.CronEventWorkerKeyChange,
-	})
-	rt.Verify()
-
-	st := getState(rt)
-	info, err := st.GetInfo(adt.AsStore(rt))
-	require.NoError(h.t, err)
-	require.Nil(h.t, info.PendingWorkerKey)
-	require.EqualValues(h.t, newWorker, info.Worker)
 }
 
 func (h *actorHarness) controlAddresses(rt *mock.Runtime) (owner, worker addr.Address, control []addr.Address) {
@@ -3658,6 +3721,17 @@ func (h *actorHarness) advancePastProvingPeriodWithCron(rt *mock.Runtime) {
 	deadline := st.DeadlineInfo(rt.Epoch())
 	rt.SetEpoch(deadline.PeriodEnd())
 	nextCron := deadline.NextPeriodStart() + miner.WPoStProvingPeriod - 1
+	h.onDeadlineCron(rt, &cronConfig{
+		expectedEnrollment: nextCron,
+	})
+	rt.SetEpoch(deadline.NextPeriodStart())
+}
+
+func (h *actorHarness) advancePastDeadlineEndWithCron(rt *mock.Runtime) {
+	st := getState(rt)
+	deadline := st.DeadlineInfo(rt.Epoch())
+	rt.SetEpoch(deadline.PeriodEnd())
+	nextCron := deadline.Last() + miner.WPoStChallengeWindow
 	h.onDeadlineCron(rt, &cronConfig{
 		expectedEnrollment: nextCron,
 	})

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -2719,35 +2719,6 @@ func TestChangeWorkerAddress(t *testing.T) {
 		require.Equal(t, originalControlAddrs, info.ControlAddresses)
 	})
 
-	t.Run("owner can cancel worker address change", func(t *testing.T) {
-		rt, actor := setupFunc()
-		actor.constructAndVerify(rt)
-		originalControlAddrs := actor.controlAddrs
-
-		newWorker := tutil.NewIDAddr(t, 999)
-
-		currentEpoch := abi.ChainEpoch(5)
-		rt.SetEpoch(currentEpoch)
-
-		effectiveEpoch := currentEpoch + miner.WorkerKeyChangeDelay
-		actor.changeWorkerAddress(rt, newWorker, effectiveEpoch, originalControlAddrs)
-
-		// now reset to old worker
-		actor.changeWorkerAddress(rt, actor.worker, effectiveEpoch, originalControlAddrs)
-
-		// set current epoch to effective epoch and run deadline cron
-		rt.SetEpoch(effectiveEpoch)
-		actor.advancePastDeadlineEndWithCron(rt)
-
-		// assert worker and control addresses are unchanged
-		st := getState(rt)
-		info, err := st.GetInfo(adt.AsStore(rt))
-		require.NoError(t, err)
-		require.Equal(t, actor.worker, info.Worker)
-		require.NotEmpty(t, info.ControlAddresses)
-		require.Equal(t, originalControlAddrs, info.ControlAddresses)
-	})
-
 	t.Run("successfully resolve AND change ONLY control addresses", func(t *testing.T) {
 		rt, actor := setupFunc()
 		actor.constructAndVerify(rt)


### PR DESCRIPTION
closes #982
closes #806

### Motivation

Cron calls are costly. We don't need to be adding them for worker key updates. Instead we can check for worker updates in existing cron calls at deadline end and and provide an additional actor call if more precision is required.

### Proposed Changes

1. Add `miner.ConfirmUpdateWorkerKey` method to immediately enact a worker key change if one is ready to be enacted.
2. Modify `ChangeWorkerAddress` to skip enrolling a cron job to enact the worker change.
3. Modify `ChangeWorkerAddress` to cancel an existing change if a change exists and the worker address is the same as the original.
4. Process PendingWorkerKeys in `provingPeriodUpdate` by check if the effective time has past and updating worker address if so.
5. Remove code related to `commitWorkerKeyChange` cron call.
6. test

cc @wadeAlexC, @nicola , @sternhenri