### PR TITLE
Randomize deadline assignment

### DIFF
--- a/actors/builtin/miner/deadline_assignment_test.go
+++ b/actors/builtin/miner/deadline_assignment_test.go
@@ -19,20 +19,22 @@ func TestDeadlineAssignment(t *testing.T) {
 
 	type testCase struct {
 		sectors   uint64
+		offset    uint64
 		deadlines [WPoStPeriodDeadlines]*deadline
 	}
 
 	testCases := []testCase{{
 		// Even assignment and striping.
 		sectors: 10,
+		offset:  1,
 		deadlines: [WPoStPeriodDeadlines]*deadline{
-			0: {
+			1: {
 				expectSectors: []uint64{
 					0, 1, 2, 3,
 					8, 9,
 				},
 			},
-			1: {
+			2: {
 				expectSectors: []uint64{
 					4, 5, 6, 7,
 				},
@@ -54,12 +56,13 @@ func TestDeadlineAssignment(t *testing.T) {
 	}, {
 		// Assign to deadline with least number of live partitions.
 		sectors: 1,
+		offset:  6,
 		deadlines: [WPoStPeriodDeadlines]*deadline{
-			0: {
+			6: {
 				// 2 live partitions. +1 would add another.
 				liveSectors: 8,
 			},
-			1: {
+			7: {
 				// 2 live partitions. +1 wouldn't add another.
 				// 1 dead partition.
 				liveSectors:   7,
@@ -152,7 +155,7 @@ func TestDeadlineAssignment(t *testing.T) {
 		for i := range sectors {
 			sectors[i] = &SectorOnChainInfo{SectorNumber: abi.SectorNumber(i)}
 		}
-		assignment, err := assignDeadlines(maxPartitions, partitionSize, &deadlines, sectors)
+		assignment, err := assignDeadlines(tc.offset, maxPartitions, partitionSize, &deadlines, sectors)
 		require.NoError(t, err)
 		for i, sectors := range assignment {
 			dl := tc.deadlines[i]
@@ -192,7 +195,7 @@ func TestMaxPartitionsPerDeadline(t *testing.T) {
 			sectors[i] = &SectorOnChainInfo{SectorNumber: abi.SectorNumber(i)}
 		}
 
-		_, err := assignDeadlines(maxPartitions, partitionSize, &deadlines, sectors)
+		_, err := assignDeadlines(0, maxPartitions, partitionSize, &deadlines, sectors)
 		require.Error(t, err)
 	})
 
@@ -212,7 +215,7 @@ func TestMaxPartitionsPerDeadline(t *testing.T) {
 			sectors[i] = &SectorOnChainInfo{SectorNumber: abi.SectorNumber(i)}
 		}
 
-		deadlineToSectors, err := assignDeadlines(maxPartitions, partitionSize, &deadlines, sectors)
+		deadlineToSectors, err := assignDeadlines(0, maxPartitions, partitionSize, &deadlines, sectors)
 		require.NoError(t, err)
 
 		for _, sectors := range deadlineToSectors {
@@ -236,7 +239,7 @@ func TestMaxPartitionsPerDeadline(t *testing.T) {
 			sectors[i] = &SectorOnChainInfo{SectorNumber: abi.SectorNumber(i)}
 		}
 
-		_, err := assignDeadlines(maxPartitions, partitionSize, &deadlines, sectors)
+		_, err := assignDeadlines(0, maxPartitions, partitionSize, &deadlines, sectors)
 		require.Error(t, err)
 	})
 }

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -496,6 +496,7 @@ func (st *State) RescheduleSectorExpirations(
 func (st *State) AssignSectorsToDeadlines(
 	store adt.Store,
 	currentEpoch abi.ChainEpoch,
+	randomness uint64,
 	sectors []*SectorOnChainInfo,
 	partitionSize uint64,
 	sectorSize abi.SectorSize,
@@ -523,7 +524,7 @@ func (st *State) AssignSectorsToDeadlines(
 	}
 
 	activatedPower := NewPowerPairZero()
-	deadlineToSectors, err := assignDeadlines(MaxPartitionsPerDeadline, partitionSize, &deadlineArr, sectors)
+	deadlineToSectors, err := assignDeadlines(randomness, MaxPartitionsPerDeadline, partitionSize, &deadlineArr, sectors)
 	if err != nil {
 		return NewPowerPairZero(), xerrors.Errorf("failed to assign sectors to deadlines: %w", err)
 	}

--- a/actors/builtin/miner/miner_state_test.go
+++ b/actors/builtin/miner/miner_state_test.go
@@ -646,7 +646,7 @@ func TestSectorAssignment(t *testing.T) {
 	t.Run("assign sectors to deadlines", func(t *testing.T) {
 		harness := constructStateHarness(t, abi.ChainEpoch(0))
 
-		newPower, err := harness.s.AssignSectorsToDeadlines(harness.store, 0, sectorInfos,
+		newPower, err := harness.s.AssignSectorsToDeadlines(harness.store, 0, 0, sectorInfos,
 			partitionSectors, sectorSize)
 
 		sectorArr := sectorsArr(t, harness.store, sectorInfos)

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -3526,6 +3526,10 @@ func (h *actorHarness) confirmSectorProofsValid(rt *mock.Runtime, conf proveComm
 
 	// expected pledge is the sum of initial pledges
 	if len(validPrecommits) > 0 {
+		randBuf := bytes.NewBuffer(nil)
+		require.NoError(h.t, h.receiver.MarshalCBOR(randBuf))
+		rt.ExpectGetRandomnessBeacon(crypto.DomainSeparationTag_WindowedPoStDeadlineAssignment, rt.Epoch(), randBuf.Bytes(), make([]byte, 32))
+
 		expectPledge := big.Zero()
 
 		expectQAPower := big.Zero()


### PR DESCRIPTION
This commit randomizes deadline assignment by starting deadline assignment at a random offset.

fixes #432