### PR TITLE
Fix finality and epochs per year

### DIFF
--- a/actors/abi/sector.go
+++ b/actors/abi/sector.go
@@ -102,7 +102,7 @@ type SealProofInfo struct {
 }
 
 // For all Stacked DRG sectors, the max is 5 years
-const epochsPerYear = 1_262_277
+const epochsPerYear = 1_051_200
 const fiveYears = ChainEpoch(5 * epochsPerYear)
 
 // Partition sizes must match those used by the proofs library.

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -76,7 +76,7 @@ func loadPartitionsSectorsMax(partitionSectorCount uint64) uint64 {
 
 // Epochs after which chain state is final with overwhelming probability (hence the likelihood of two fork of this size is negligible)
 // This is a conservative value that is chosen via simulations of all known attacks.
-const ChainFinality = abi.ChainEpoch(1400) // PARAM_SPEC
+const ChainFinality = abi.ChainEpoch(900) // PARAM_SPEC
 
 // Prefix for sealed sector CIDs (CommR).
 var SealedCIDPrefix = cid.Prefix{


### PR DESCRIPTION
From @anorth's [comment in slack](https://filecoinproject.slack.com/archives/C015KQQLQQ1/p1598870159002300):
> @zenground0 some quick fixes following the param  audit PR
> - the number 1_262_277 in sector.go is wrong for 30s epochs. I thought I'd fixed it, but must be lost in rebases
> - the PR changed finality to 1400 - I think I just missed this. Plz change it back to 900 and we can continue discussion in https://github.com/filecoin-project/specs-actors/pull/702

For epochs in year I maintained consistency by dividing `SECONDS_PER_YEAR` from `reward/reward_calc.py` by 30.