### PR TITLE
Bound size of state

### DIFF
--- a/actors/builtin/market/market_actor.go
+++ b/actors/builtin/market/market_actor.go
@@ -679,6 +679,10 @@ func validateDeal(rt Runtime, deal ClientDealProposal, baselinePower, networkQAP
 
 	proposal := deal.Proposal
 
+	if len(proposal.Label) > DealMaxLabelSize {
+		rt.Abortf(exitcode.ErrIllegalArgument, "deal label can be at most %d bytes, is %d", DealMaxLabelSize, len(proposal.Label))
+	}
+
 	if err := proposal.PieceSize.Validate(); err != nil {
 		rt.Abortf(exitcode.ErrIllegalArgument, "proposal piece size is invalid: %v", err)
 	}

--- a/actors/builtin/market/policy.go
+++ b/actors/builtin/market/policy.go
@@ -22,6 +22,9 @@ var DealMinDuration = abi.ChainEpoch(180 * builtin.EpochsInDay) // PARAM_SPEC
 // Maximum deal duration
 var DealMaxDuration = abi.ChainEpoch(540 * builtin.EpochsInDay) // PARAM_SPEC
 
+// DealMaxLabelSize is the maximum size of a deal label.
+const DealMaxLabelSize = 256
+
 // Bounds (inclusive) on deal duration
 func dealDurationBounds(_ abi.PaddedPieceSize) (min abi.ChainEpoch, max abi.ChainEpoch) {
 	return DealMinDuration, DealMaxDuration // PARAM_FINISH

--- a/actors/builtin/multisig/multisig_actor.go
+++ b/actors/builtin/multisig/multisig_actor.go
@@ -78,6 +78,10 @@ func (a Actor) Constructor(rt vmr.Runtime, params *ConstructorParams) *adt.Empty
 		rt.Abortf(exitcode.ErrIllegalArgument, "must have at least one signer")
 	}
 
+	if len(params.Signers) > SignersMax {
+		rt.Abortf(exitcode.ErrIllegalArgument, "cannot add more than %d signers", SignersMax)
+	}
+
 	// resolve signer addresses and do not allow duplicate signers
 	resolvedSigners := make([]addr.Address, 0, len(params.Signers))
 	deDupSigners := make(map[addr.Address]struct{}, len(params.Signers))
@@ -293,6 +297,10 @@ func (a Actor) AddSigner(rt vmr.Runtime, params *AddSignerParams) *adt.EmptyValu
 
 	var st State
 	rt.State().Transaction(&st, func() {
+		if len(st.Signers) >= SignersMax {
+			rt.Abortf(exitcode.ErrForbidden, "cannot add more than %d signers", SignersMax)
+		}
+
 		isSigner := isSigner(resolvedNewSigner, st.Signers)
 		if isSigner {
 			rt.Abortf(exitcode.ErrForbidden, "%s is already a signer", resolvedNewSigner)

--- a/actors/builtin/multisig/multisig_state.go
+++ b/actors/builtin/multisig/multisig_state.go
@@ -16,8 +16,6 @@ type State struct {
 	// for a public key that has not yet received a message on chain.
 	// If any signer address is a public-key address, it will be resolved to an ID address and persisted
 	// in this state when the address is used.
-	// TODO: consider limiting the number of signers
-	// https://github.com/filecoin-project/specs-actors/issues/897
 	Signers               []address.Address
 	NumApprovalsThreshold uint64
 	NextTxnID             TxnID

--- a/actors/builtin/multisig/policy.go
+++ b/actors/builtin/multisig/policy.go
@@ -1,0 +1,5 @@
+package multisig
+
+// SignersMax is the maximum number of signers allowed in a multisig. If more
+// are required, please use a combining tree of multisigs.
+const SignersMax = 256


### PR DESCRIPTION
* Restrict deal label size to 256 bytes.
* Restrict number of multisig signers to 256 (~16KiB max).

fixes https://github.com/filecoin-project/specs-actors/issues/897