### PR TITLE
allow/require PoSt in miner's first proving period

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -2155,6 +2155,7 @@ func currentProvingPeriodStart(currEpoch abi.ChainEpoch, offset abi.ChainEpoch) 
 // Computes the deadline index for the current epoch for a given period start.
 // currEpoch must be within the proving period that starts at provingPeriodStart to produce a valid index.
 func currentDeadlineIndex(currEpoch abi.ChainEpoch, periodStart abi.ChainEpoch) uint64 {
+	Assert(currEpoch >= periodStart)
 	return uint64((currEpoch - periodStart) / WPoStChallengeWindow)
 }
 

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -138,7 +138,7 @@ func (a Actor) Constructor(rt Runtime, params *ConstructorParams) *adt.EmptyValu
 	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalArgument, "failed to construct state")
 	rt.State().Create(state)
 
-	// Register first cron callback for epoch before the next proving period starts.
+	// Register first cron callback for epoch before the next deadline starts.
 	deadlineClose := periodStart + WPoStChallengeWindow*abi.ChainEpoch(1+deadlineIndex)
 	enrollCronEvent(rt, deadlineClose-1, &CronEventPayload{
 		EventType: CronEventProvingDeadline,

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -127,7 +127,7 @@ func (a Actor) Constructor(rt Runtime, params *ConstructorParams) *adt.EmptyValu
 	offset, err := assignProvingPeriodOffset(rt.Message().Receiver(), currEpoch, rt.Syscalls().HashBlake2b)
 	builtin.RequireNoErr(rt, err, exitcode.ErrSerialization, "failed to assign proving period offset")
 	periodStart := currentProvingPeriodStart(currEpoch, offset)
-	deadlineIndex := uint64((currEpoch - periodStart) / WPoStChallengeWindow)
+	deadlineIndex := currentDeadlineIndex(currEpoch, periodStart)
 	Assert(deadlineIndex < WPoStPeriodDeadlines)
 
 	info, err := ConstructMinerInfo(owner, worker, controlAddrs, params.PeerId, params.Multiaddrs, params.SealProofType)
@@ -2150,6 +2150,12 @@ func currentProvingPeriodStart(currEpoch abi.ChainEpoch, offset abi.ChainEpoch) 
 	periodStart := currEpoch - periodProgress
 	Assert(periodStart <= currEpoch)
 	return periodStart
+}
+
+// Computes the deadline index for the current epoch for a given period start.
+// currEpoch must be within the proving period that starts at provingPeriodStart to produce a valid index.
+func currentDeadlineIndex(currEpoch abi.ChainEpoch, periodStart abi.ChainEpoch) uint64 {
+	return uint64((currEpoch - periodStart) / WPoStChallengeWindow)
 }
 
 func asMapBySectorNumber(sectors []*SectorOnChainInfo) map[abi.SectorNumber]*SectorOnChainInfo {

--- a/actors/builtin/miner/miner_internal_test.go
+++ b/actors/builtin/miner/miner_internal_test.go
@@ -40,56 +40,57 @@ func TestAssignProvingPeriodBoundary(t *testing.T) {
 	}
 }
 
-func TestNextProvingPeriodStart(t *testing.T) {
+func TestCurrentProvingPeriodStart(t *testing.T) {
 	// At epoch zero...
 	curr := e(0)
-	// ... with offset zero, the first period start skips one period ahead, ...
-	assert.Equal(t, WPoStProvingPeriod, nextProvingPeriodStart(curr, 0))
 
-	// ... and all non-zero offsets are simple.
-	assert.Equal(t, e(1), nextProvingPeriodStart(curr, 1))
-	assert.Equal(t, e(10), nextProvingPeriodStart(curr, 10))
-	assert.Equal(t, WPoStProvingPeriod-1, nextProvingPeriodStart(curr, WPoStProvingPeriod-1))
+	// ... with offset zero, the current proving period starts now, ...
+	assert.Equal(t, e(0), currentProvingPeriodStart(curr, 0))
 
-	// At epoch 1, offsets 0 and 1 start a long way forward, but offsets 2 and later start soon.
+	// ... and all other offsets are negative.
+	assert.Equal(t, -WPoStProvingPeriod+1, currentProvingPeriodStart(curr, 1))
+	assert.Equal(t, -WPoStProvingPeriod+10, currentProvingPeriodStart(curr, 10))
+	assert.Equal(t, e(-1), currentProvingPeriodStart(curr, WPoStProvingPeriod-1))
+
+	// At epoch 1, offsets 0 and 1 start at offset, but offsets 2 and later start in the past.
 	curr = 1
-	assert.Equal(t, WPoStProvingPeriod, nextProvingPeriodStart(curr, 0))
-	assert.Equal(t, WPoStProvingPeriod+1, nextProvingPeriodStart(curr, 1))
-	assert.Equal(t, e(2), nextProvingPeriodStart(curr, 2))
-	assert.Equal(t, e(3), nextProvingPeriodStart(curr, 3))
-	assert.Equal(t, WPoStProvingPeriod-1, nextProvingPeriodStart(curr, WPoStProvingPeriod-1))
+	assert.Equal(t, e(0), currentProvingPeriodStart(curr, 0))
+	assert.Equal(t, e(1), currentProvingPeriodStart(curr, 1))
+	assert.Equal(t, -WPoStProvingPeriod+2, currentProvingPeriodStart(curr, 2))
+	assert.Equal(t, -WPoStProvingPeriod+3, currentProvingPeriodStart(curr, 3))
+	assert.Equal(t, e(-1), currentProvingPeriodStart(curr, WPoStProvingPeriod-1))
 
 	// An arbitrary mid-period epoch.
 	curr = 123
-	assert.Equal(t, WPoStProvingPeriod, nextProvingPeriodStart(curr, 0))
-	assert.Equal(t, WPoStProvingPeriod+1, nextProvingPeriodStart(curr, 1))
-	assert.Equal(t, WPoStProvingPeriod+122, nextProvingPeriodStart(curr, 122))
-	assert.Equal(t, WPoStProvingPeriod+123, nextProvingPeriodStart(curr, 123))
-	assert.Equal(t, e(124), nextProvingPeriodStart(curr, 124))
-	assert.Equal(t, WPoStProvingPeriod-1, nextProvingPeriodStart(curr, WPoStProvingPeriod-1))
+	assert.Equal(t, e(0), currentProvingPeriodStart(curr, 0))
+	assert.Equal(t, e(1), currentProvingPeriodStart(curr, 1))
+	assert.Equal(t, e(122), currentProvingPeriodStart(curr, 122))
+	assert.Equal(t, e(123), currentProvingPeriodStart(curr, 123))
+	assert.Equal(t, -WPoStProvingPeriod+124, currentProvingPeriodStart(curr, 124))
+	assert.Equal(t, e(-1), currentProvingPeriodStart(curr, WPoStProvingPeriod-1))
 
 	// The final epoch in the chain's first full period
 	curr = WPoStProvingPeriod - 1
-	assert.Equal(t, WPoStProvingPeriod, nextProvingPeriodStart(curr, 0))
-	assert.Equal(t, WPoStProvingPeriod+1, nextProvingPeriodStart(curr, 1))
-	assert.Equal(t, WPoStProvingPeriod+2, nextProvingPeriodStart(curr, 2))
-	assert.Equal(t, WPoStProvingPeriod+WPoStProvingPeriod-2, nextProvingPeriodStart(curr, WPoStProvingPeriod-2))
-	assert.Equal(t, WPoStProvingPeriod+WPoStProvingPeriod-1, nextProvingPeriodStart(curr, WPoStProvingPeriod-1))
+	assert.Equal(t, e(0), currentProvingPeriodStart(curr, 0))
+	assert.Equal(t, e(1), currentProvingPeriodStart(curr, 1))
+	assert.Equal(t, e(2), currentProvingPeriodStart(curr, 2))
+	assert.Equal(t, WPoStProvingPeriod-2, currentProvingPeriodStart(curr, WPoStProvingPeriod-2))
+	assert.Equal(t, WPoStProvingPeriod-1, currentProvingPeriodStart(curr, WPoStProvingPeriod-1))
 
 	// Into the chain's second period
 	curr = WPoStProvingPeriod
-	assert.Equal(t, 2*WPoStProvingPeriod, nextProvingPeriodStart(curr, 0))
-	assert.Equal(t, WPoStProvingPeriod+1, nextProvingPeriodStart(curr, 1))
-	assert.Equal(t, WPoStProvingPeriod+2, nextProvingPeriodStart(curr, 2))
-	assert.Equal(t, WPoStProvingPeriod+WPoStProvingPeriod-1, nextProvingPeriodStart(curr, WPoStProvingPeriod-1))
+	assert.Equal(t, WPoStProvingPeriod, currentProvingPeriodStart(curr, 0))
+	assert.Equal(t, e(1), currentProvingPeriodStart(curr, 1))
+	assert.Equal(t, e(2), currentProvingPeriodStart(curr, 2))
+	assert.Equal(t, WPoStProvingPeriod-1, currentProvingPeriodStart(curr, WPoStProvingPeriod-1))
 
 	curr = WPoStProvingPeriod + 234
-	assert.Equal(t, 2*WPoStProvingPeriod, nextProvingPeriodStart(curr, 0))
-	assert.Equal(t, 2*WPoStProvingPeriod+1, nextProvingPeriodStart(curr, 1))
-	assert.Equal(t, 2*WPoStProvingPeriod+233, nextProvingPeriodStart(curr, 233))
-	assert.Equal(t, 2*WPoStProvingPeriod+234, nextProvingPeriodStart(curr, 234))
-	assert.Equal(t, WPoStProvingPeriod+235, nextProvingPeriodStart(curr, 235))
-	assert.Equal(t, WPoStProvingPeriod+WPoStProvingPeriod-1, nextProvingPeriodStart(curr, WPoStProvingPeriod-1))
+	assert.Equal(t, WPoStProvingPeriod, currentProvingPeriodStart(curr, 0))
+	assert.Equal(t, WPoStProvingPeriod+1, currentProvingPeriodStart(curr, 1))
+	assert.Equal(t, WPoStProvingPeriod+233, currentProvingPeriodStart(curr, 233))
+	assert.Equal(t, WPoStProvingPeriod+234, currentProvingPeriodStart(curr, 234))
+	assert.Equal(t, e(235), currentProvingPeriodStart(curr, 235))
+	assert.Equal(t, WPoStProvingPeriod-1, currentProvingPeriodStart(curr, WPoStProvingPeriod-1))
 }
 
 type e = abi.ChainEpoch

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -1012,18 +1012,6 @@ func (st *State) AdvanceDeadline(store adt.Store, currEpoch abi.ChainEpoch) (*Ad
 	// we still use dlInfo.Last().
 	dlInfo := st.DeadlineInfo(currEpoch)
 
-	// This method is invoked once *before* the first proving period starts,
-	// after the actor is first constructed; this is detected by
-	// !dlInfo.PeriodStarted().
-	if !dlInfo.PeriodStarted() {
-		return &AdvanceDeadlineResult{
-			pledgeDelta,
-			powerDelta,
-			detectedFaultyPower,
-			NewPowerPairZero(),
-		}, nil
-	}
-
 	// Advance to the next deadline (in case we short-circuit below).
 	st.CurrentDeadline = (st.CurrentDeadline + 1) % WPoStPeriodDeadlines
 	if st.CurrentDeadline == 0 {

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -160,7 +160,7 @@ type SectorOnChainInfo struct {
 	ReplacedDayReward     abi.TokenAmount // Day reward of sector this sector replace or zero
 }
 
-func ConstructState(infoCid cid.Cid, periodStart abi.ChainEpoch, emptyBitfieldCid, emptyArrayCid, emptyMapCid, emptyDeadlinesCid cid.Cid,
+func ConstructState(infoCid cid.Cid, periodStart abi.ChainEpoch, deadlineIndex uint64, emptyBitfieldCid, emptyArrayCid, emptyMapCid, emptyDeadlinesCid cid.Cid,
 	emptyVestingFundsCid cid.Cid) (*State, error) {
 	return &State{
 		Info: infoCid,
@@ -178,7 +178,7 @@ func ConstructState(infoCid cid.Cid, periodStart abi.ChainEpoch, emptyBitfieldCi
 		AllocatedSectors:          emptyBitfieldCid,
 		Sectors:                   emptyArrayCid,
 		ProvingPeriodStart:        periodStart,
-		CurrentDeadline:           0,
+		CurrentDeadline:           deadlineIndex,
 		Deadlines:                 emptyDeadlinesCid,
 		EarlyTerminations:         bitfield.New(),
 	}, nil

--- a/actors/builtin/miner/miner_state_test.go
+++ b/actors/builtin/miner/miner_state_test.go
@@ -1026,7 +1026,7 @@ func constructStateHarness(t *testing.T, periodBoundary abi.ChainEpoch) *stateHa
 	emptyVestingFundsCid, err := store.Put(context.Background(), emptyVestingFunds)
 	require.NoError(t, err)
 
-	state, err := miner.ConstructState(infoCid, periodBoundary, emptyBitfieldCid, emptyArray, emptyMap, emptyDeadlinesCid,
+	state, err := miner.ConstructState(infoCid, periodBoundary, 0, emptyBitfieldCid, emptyArray, emptyMap, emptyDeadlinesCid,
 		emptyVestingFundsCid)
 	require.NoError(t, err)
 

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -669,7 +669,8 @@ func TestCommitments(t *testing.T) {
 			WithBalance(bigBalance, big.Zero()).
 			Build(t)
 
-		// at epoch 101, the miner will get an initial proving period start thousands of epochs in the future
+		// Epoch 101 should be at the beginning of the miner's proving period so there will be time to commit
+		// and PoSt a sector.
 		rt.SetEpoch(101)
 		actor.constructAndVerify(rt)
 

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -674,11 +674,6 @@ func TestCommitments(t *testing.T) {
 		rt.SetEpoch(101)
 		actor.constructAndVerify(rt)
 
-		// require current epoch is just after miner proving period offset to ensure post will happen within
-		// same proving period. If this fails, adjust the epoch above.
-		st := getState(rt)
-		require.True(t, rt.Epoch() > st.ProvingPeriodStart%miner.WPoStProvingPeriod)
-
 		// Commit a sector the very next epoch
 		rt.SetEpoch(102)
 		sector := actor.commitAndProveSector(rt, abi.MaxSectorNumber, defaultSectorExpiration, nil)


### PR DESCRIPTION
closes #946

### Motivation

Previously, a new miner's first (partial) proving period was special in that we did not run the proving period cron until the end of the first proving period after the miner's creation. This creates an undesirable situation where a miner can pre-commit and prove-commit sectors before they are in a proving period. They cannot however PoSt for these sectors or gain power from them, but they would not be faulted for failing to PoSt when a PoSt is due.

This PR eliminates the special period between miner's creation and the first proving period. This is done by initializing miner state with a `ProvingPeriodStart` that precedes the current epoch and setting the `CurrentDeadline` to the index appropriate to the current epoch. We then set the next proving period cron for the last epoch in the current deadline.

### Proposed Changes

1. Initialize miner state with `ProvingPeriodStart` and `CurrentDeadline` consistent with those expected for the current epoch.
2. Set miner's first proving period cron to last epcoh of current deadline.
3. Remove logic in `miner.State.AdvanceDeadline` that skips most of deadline processing for the first call (it will no longer be called).
4. Fix test that broke with specific expectations for miner state initialization.
5. Add test that sector can be proven before the end of a miner's first proving period.