### PR TITLE
Add big.NewFromGo constructor

### DIFF
--- a/actors/abi/big/int.go
+++ b/actors/abi/big/int.go
@@ -24,8 +24,8 @@ func NewIntUnsigned(i uint64) Int {
 	return Int{big.NewInt(0).SetUint64(i)}
 }
 
-func NewFromGo(i big.Int) Int {
-	return Int{big.NewInt(0).Set(&i)}
+func NewFromGo(i *big.Int) Int {
+	return Int{big.NewInt(0).Set(i)}
 }
 
 func Zero() Int {

--- a/actors/abi/big/int.go
+++ b/actors/abi/big/int.go
@@ -24,6 +24,10 @@ func NewIntUnsigned(i uint64) Int {
 	return Int{big.NewInt(0).SetUint64(i)}
 }
 
+func NewFromGo(i big.Int) Int {
+	return Int{big.NewInt(0).Set(&i)}
+}
+
 func Zero() Int {
 	return NewInt(0)
 }

--- a/actors/abi/big/int_test.go
+++ b/actors/abi/big/int_test.go
@@ -58,7 +58,7 @@ func TestNewInt(t *testing.T) {
 	assert.True(t, ta.Equals(tc))
 	assert.Equal(t, "999", ta.String())
 
-	td := NewFromGo(*b)
+	td := NewFromGo(b)
 	assert.True(t, td.Equals(tb))
 	assert.Equal(t, td.Int, b)
 }

--- a/actors/abi/big/int_test.go
+++ b/actors/abi/big/int_test.go
@@ -57,6 +57,10 @@ func TestNewInt(t *testing.T) {
 	assert.True(t, ta.Equals(tb))
 	assert.True(t, ta.Equals(tc))
 	assert.Equal(t, "999", ta.String())
+
+	td := NewFromGo(*b)
+	assert.True(t, td.Equals(tb))
+	assert.Equal(t, td.Int, b)
 }
 
 func TestInt_MarshalUnmarshalJSON(t *testing.T) {

--- a/actors/builtin/reward/reward_logic.go
+++ b/actors/builtin/reward/reward_logic.go
@@ -87,8 +87,8 @@ func computeReward(epoch abi.ChainEpoch, prevTheta, currTheta big.Int) abi.Token
 	simpleReward := big.Mul(SimpleTotal, expLamSubOne)    //Q.0 * Q.128 =>  Q.128
 	epochLam := big.Mul(big.NewInt(int64(epoch)), lambda) // Q.0 * Q.128 => Q.128
 
-	simpleReward = big.Mul(simpleReward, big.Int{Int: expneg(epochLam.Int)}) // Q.128 * Q.128 => Q.256
-	simpleReward = big.Rsh(simpleReward, math.Precision)                     // Q.256 >> 128 => Q.128
+	simpleReward = big.Mul(simpleReward, big.NewFromGo(*expneg(epochLam.Int))) // Q.128 * Q.128 => Q.256
+	simpleReward = big.Rsh(simpleReward, math.Precision)                       // Q.256 >> 128 => Q.128
 
 	baselineReward := big.Sub(computeBaselineSupply(currTheta), computeBaselineSupply(prevTheta)) // Q.128
 
@@ -103,7 +103,7 @@ func computeBaselineSupply(theta big.Int) big.Int {
 	thetaLam := big.Mul(theta, lambda)           // Q.128 * Q.128 => Q.256
 	thetaLam = big.Rsh(thetaLam, math.Precision) // Q.256 >> 128 => Q.128
 
-	eTL := big.Int{Int: expneg(thetaLam.Int)} // Q.128
+	eTL := big.NewFromGo(*expneg(thetaLam.Int)) // Q.128
 
 	one := big.NewInt(1)
 	one = big.Lsh(one, math.Precision) // Q.0 => Q.128

--- a/actors/builtin/reward/reward_logic.go
+++ b/actors/builtin/reward/reward_logic.go
@@ -87,7 +87,7 @@ func computeReward(epoch abi.ChainEpoch, prevTheta, currTheta big.Int) abi.Token
 	simpleReward := big.Mul(SimpleTotal, expLamSubOne)    //Q.0 * Q.128 =>  Q.128
 	epochLam := big.Mul(big.NewInt(int64(epoch)), lambda) // Q.0 * Q.128 => Q.128
 
-	simpleReward = big.Mul(simpleReward, big.NewFromGo(*expneg(epochLam.Int))) // Q.128 * Q.128 => Q.256
+	simpleReward = big.Mul(simpleReward, big.NewFromGo(expneg(epochLam.Int))) // Q.128 * Q.128 => Q.256
 	simpleReward = big.Rsh(simpleReward, math.Precision)                       // Q.256 >> 128 => Q.128
 
 	baselineReward := big.Sub(computeBaselineSupply(currTheta), computeBaselineSupply(prevTheta)) // Q.128
@@ -103,7 +103,7 @@ func computeBaselineSupply(theta big.Int) big.Int {
 	thetaLam := big.Mul(theta, lambda)           // Q.128 * Q.128 => Q.256
 	thetaLam = big.Rsh(thetaLam, math.Precision) // Q.256 >> 128 => Q.128
 
-	eTL := big.NewFromGo(*expneg(thetaLam.Int)) // Q.128
+	eTL := big.NewFromGo(expneg(thetaLam.Int)) // Q.128
 
 	one := big.NewInt(1)
 	one = big.Lsh(one, math.Precision) // Q.0 => Q.128

--- a/actors/builtin/reward/reward_logic_test.go
+++ b/actors/builtin/reward/reward_logic_test.go
@@ -56,7 +56,7 @@ func TestBaselineReward(t *testing.T) {
 	simple := computeReward(0, big.Zero(), big.Zero())
 
 	for i := 0; i < 512; i++ {
-		reward := computeReward(0, big.Int{Int: prevTheta}, big.Int{Int: theta})
+		reward := computeReward(0, big.NewFromGo(*prevTheta), big.NewFromGo(*theta))
 		reward = big.Sub(reward, simple)
 		fmt.Fprintf(b, "%s,%s,%s\n", prevTheta, theta, reward.Int)
 		prevTheta = prevTheta.Add(prevTheta, step)

--- a/actors/builtin/reward/reward_logic_test.go
+++ b/actors/builtin/reward/reward_logic_test.go
@@ -56,7 +56,7 @@ func TestBaselineReward(t *testing.T) {
 	simple := computeReward(0, big.Zero(), big.Zero())
 
 	for i := 0; i < 512; i++ {
-		reward := computeReward(0, big.NewFromGo(*prevTheta), big.NewFromGo(*theta))
+		reward := computeReward(0, big.NewFromGo(prevTheta), big.NewFromGo(theta))
 		reward = big.Sub(reward, simple)
 		fmt.Fprintf(b, "%s,%s,%s\n", prevTheta, theta, reward.Int)
 		prevTheta = prevTheta.Add(prevTheta, step)

--- a/actors/util/smoothing/alpha_beta_filter.go
+++ b/actors/util/smoothing/alpha_beta_filter.go
@@ -61,10 +61,10 @@ func init() {
 	}
 	constBigs := math.Parse(constStrs)
 	_ = math.Parse(constStrs)
-	DefaultAlpha = big.NewFromGo(*constBigs[0])
-	DefaultBeta = big.NewFromGo(*constBigs[1])
-	ExtrapolatedCumSumRatioEpsilon = big.NewFromGo(*constBigs[2])
-	ln2 = big.NewFromGo(*constBigs[3])
+	DefaultAlpha = big.NewFromGo(constBigs[0])
+	DefaultBeta = big.NewFromGo(constBigs[1])
+	ExtrapolatedCumSumRatioEpsilon = big.NewFromGo(constBigs[2])
+	ln2 = big.NewFromGo(constBigs[3])
 }
 
 // Alpha Beta Filter "position" (value) and "velocity" (rate of change of value) estimates
@@ -209,7 +209,7 @@ func lnBetweenOneAndTwo(x big.Int) big.Int {
 	denom := math.Polyval(lnDenomCoef, x.Int) // Q.128
 
 	num = num.Lsh(num, math.Precision)        // Q.128 => Q.256
-	return big.NewFromGo(*num.Div(num, denom)) // Q.256 / Q.128 => Q.128
+	return big.NewFromGo(num.Div(num, denom)) // Q.256 / Q.128 => Q.128
 }
 
 // Extrapolate filter "position" delta epochs in the future.

--- a/actors/util/smoothing/alpha_beta_filter.go
+++ b/actors/util/smoothing/alpha_beta_filter.go
@@ -61,10 +61,10 @@ func init() {
 	}
 	constBigs := math.Parse(constStrs)
 	_ = math.Parse(constStrs)
-	DefaultAlpha = big.Int{Int: constBigs[0]}
-	DefaultBeta = big.Int{Int: constBigs[1]}
-	ExtrapolatedCumSumRatioEpsilon = big.Int{Int: constBigs[2]}
-	ln2 = big.Int{Int: constBigs[3]}
+	DefaultAlpha = big.NewFromGo(*constBigs[0])
+	DefaultBeta = big.NewFromGo(*constBigs[1])
+	ExtrapolatedCumSumRatioEpsilon = big.NewFromGo(*constBigs[2])
+	ln2 = big.NewFromGo(*constBigs[3])
 }
 
 // Alpha Beta Filter "position" (value) and "velocity" (rate of change of value) estimates
@@ -208,8 +208,8 @@ func lnBetweenOneAndTwo(x big.Int) big.Int {
 	num := math.Polyval(lnNumCoef, x.Int)     // Q.128
 	denom := math.Polyval(lnDenomCoef, x.Int) // Q.128
 
-	num = num.Lsh(num, math.Precision)       // Q.128 => Q.256
-	return big.Int{Int: num.Div(num, denom)} // Q.256 / Q.128 => Q.128
+	num = num.Lsh(num, math.Precision)        // Q.128 => Q.256
+	return big.NewFromGo(*num.Div(num, denom)) // Q.256 / Q.128 => Q.128
 }
 
 // Extrapolate filter "position" delta epochs in the future.

--- a/actors/util/smoothing/alpha_beta_filter_test.go
+++ b/actors/util/smoothing/alpha_beta_filter_test.go
@@ -174,9 +174,9 @@ func TestNaturalLog(t *testing.T) {
 	fmt.Printf("%v %v\n", lnInputs, expectedLnOutputs)
 	require.Equal(t, len(lnInputs), len(expectedLnOutputs))
 	for i := 0; i < len(lnInputs); i++ {
-		z := big.NewFromGo(*lnInputs[i])
+		z := big.NewFromGo(lnInputs[i])
 		lnOfZ := smoothing.Ln(z)
-		expectedZ := big.NewFromGo(*expectedLnOutputs[i])
+		expectedZ := big.NewFromGo(expectedLnOutputs[i])
 		assert.Equal(t, big.Rsh(expectedZ, math.Precision), big.Rsh(lnOfZ, math.Precision), "failed ln of %v", z)
 	}
 }

--- a/actors/util/smoothing/alpha_beta_filter_test.go
+++ b/actors/util/smoothing/alpha_beta_filter_test.go
@@ -174,9 +174,9 @@ func TestNaturalLog(t *testing.T) {
 	fmt.Printf("%v %v\n", lnInputs, expectedLnOutputs)
 	require.Equal(t, len(lnInputs), len(expectedLnOutputs))
 	for i := 0; i < len(lnInputs); i++ {
-		z := big.Int{Int: lnInputs[i]}
+		z := big.NewFromGo(*lnInputs[i])
 		lnOfZ := smoothing.Ln(z)
-		expectedZ := big.Int{Int: expectedLnOutputs[i]}
+		expectedZ := big.NewFromGo(*expectedLnOutputs[i])
 		assert.Equal(t, big.Rsh(expectedZ, math.Precision), big.Rsh(lnOfZ, math.Precision), "failed ln of %v", z)
 	}
 }


### PR DESCRIPTION
Avoid having to push through the abstraction every time. This was prompted by version/migration concerns.

This follows the docs recommendations about copying. Please lmk if you think this should take a `*big.Int` instead.