### PR TITLE
remove ValidateImmediateCallerType from market WithdrawBalance

### DIFF
--- a/actors/builtin/market/market_actor.go
+++ b/actors/builtin/market/market_actor.go
@@ -74,8 +74,6 @@ func (a Actor) WithdrawBalance(rt Runtime, params *WithdrawBalanceParams) *adt.E
 	if params.Amount.LessThan(big.Zero()) {
 		rt.Abortf(exitcode.ErrIllegalArgument, "negative amount %v", params.Amount)
 	}
-	// withdrawal can ONLY be done by a signing party.
-	rt.ValidateImmediateCallerType(builtin.CallerTypesSignable...)
 
 	nominal, recipient, approvedCallers := escrowAddress(rt, params.ProviderOrClientAddress)
 	// for providers -> only corresponding owner or worker can withdraw

--- a/actors/builtin/market/market_test.go
+++ b/actors/builtin/market/market_test.go
@@ -216,7 +216,6 @@ func TestMarketActor(t *testing.T) {
 			rt.GetState(&st)
 			assert.Equal(t, abi.NewTokenAmount(20), actor.getEscrowBalance(rt, client))
 
-			rt.ExpectValidateCallerType(builtin.CallerTypesSignable...)
 			rt.ExpectValidateCallerAddr(client)
 			params := market.WithdrawBalanceParams{
 				ProviderOrClientAddress: client,
@@ -243,7 +242,6 @@ func TestMarketActor(t *testing.T) {
 			assert.Equal(t, abi.NewTokenAmount(20), actor.getEscrowBalance(rt, provider))
 
 			// only signing parties can add balance for client AND provider.
-			rt.ExpectValidateCallerType(builtin.CallerTypesSignable...)
 			rt.ExpectValidateCallerAddr(owner, worker)
 			params := market.WithdrawBalanceParams{
 				ProviderOrClientAddress: provider,
@@ -2586,7 +2584,6 @@ func (h *marketActorTestHarness) expectProviderControlAddresses(rt *mock.Runtime
 
 func (h *marketActorTestHarness) withdrawProviderBalance(rt *mock.Runtime, withDrawAmt, expectedSend abi.TokenAmount, miner *minerAddrs) {
 	rt.SetCaller(miner.worker, builtin.AccountActorCodeID)
-	rt.ExpectValidateCallerType(builtin.CallerTypesSignable...)
 	rt.ExpectValidateCallerAddr(miner.owner, miner.worker)
 	h.expectProviderControlAddresses(rt, miner.provider, miner.owner, miner.worker)
 
@@ -2602,7 +2599,6 @@ func (h *marketActorTestHarness) withdrawProviderBalance(rt *mock.Runtime, withD
 
 func (h *marketActorTestHarness) withdrawClientBalance(rt *mock.Runtime, client address.Address, withDrawAmt, expectedSend abi.TokenAmount) {
 	rt.SetCaller(client, builtin.AccountActorCodeID)
-	rt.ExpectValidateCallerType(builtin.CallerTypesSignable...)
 	rt.ExpectSend(client, builtin.MethodSend, nil, expectedSend, nil, exitcode.Ok)
 	rt.ExpectValidateCallerAddr(client)
 

--- a/actors/test/market_withdrawl_test.go
+++ b/actors/test/market_withdrawl_test.go
@@ -1,0 +1,46 @@
+package test_test
+
+import (
+	"context"
+	"github.com/filecoin-project/specs-actors/actors/builtin/market"
+	"testing"
+
+	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/specs-actors/actors/builtin"
+	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	vm "github.com/filecoin-project/specs-actors/support/vm"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarketWithdrawl(t *testing.T) {
+	ctx := context.Background()
+	v := vm.NewVMWithSingletons(ctx, t)
+	initialBalance := big.Mul(big.NewInt(6), big.NewInt(1e18))
+	addrs := vm.CreateAccounts(ctx, t, v, 1, initialBalance, 93837778)
+	caller := addrs[0]
+
+	// add market collateral for clients and miner
+	collateral := big.Mul(big.NewInt(3), vm.FIL)
+	_, code := v.ApplyMessage(caller, builtin.StorageMarketActorAddr, collateral, builtin.MethodsMarket.AddBalance, &caller)
+	require.Equal(t, exitcode.Ok, code)
+
+	a, found, err := v.GetActor(caller)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, big.Sub(initialBalance, collateral), a.Balance)
+
+	// withdraw collateral from market
+	params := &market.WithdrawBalanceParams{
+		ProviderOrClientAddress: caller,
+		Amount:                  collateral,
+	}
+	_, code = v.ApplyMessage(caller, builtin.StorageMarketActorAddr, big.Zero(), builtin.MethodsMarket.WithdrawBalance, params)
+	require.Equal(t, exitcode.Ok, code)
+
+	a, found, err = v.GetActor(caller)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, initialBalance, a.Balance)
+}

--- a/actors/test/market_withdrawl_test.go
+++ b/actors/test/market_withdrawl_test.go
@@ -2,16 +2,16 @@ package test_test
 
 import (
 	"context"
-	"github.com/filecoin-project/specs-actors/actors/builtin/market"
 	"testing"
-
-	"github.com/filecoin-project/specs-actors/actors/abi/big"
-	"github.com/filecoin-project/specs-actors/actors/builtin"
-	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
-	vm "github.com/filecoin-project/specs-actors/support/vm"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/specs-actors/actors/builtin"
+	"github.com/filecoin-project/specs-actors/actors/builtin/market"
+	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	vm "github.com/filecoin-project/specs-actors/support/vm"
 )
 
 func TestMarketWithdraw(t *testing.T) {

--- a/actors/test/market_withdrawl_test.go
+++ b/actors/test/market_withdrawl_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMarketWithdrawl(t *testing.T) {
+func TestMarketWithdraw(t *testing.T) {
 	ctx := context.Background()
 	v := vm.NewVMWithSingletons(ctx, t)
 	initialBalance := big.Mul(big.NewInt(6), big.NewInt(1e18))

--- a/support/vm/vm.go
+++ b/support/vm/vm.go
@@ -131,8 +131,12 @@ func (vm *VM) rollback(root cid.Cid) error {
 }
 
 func (vm *VM) GetActor(a address.Address) (*TestActor, bool, error) {
+	na, found := vm.NormalizeAddress(a)
+	if !found {
+		return nil, false, nil
+	}
 	var act TestActor
-	found, err := vm.actors.Get(adt.AddrKey(a), &act)
+	found, err := vm.actors.Get(adt.AddrKey(na), &act)
 	return &act, found, err
 }
 


### PR DESCRIPTION
closes #1075

### Motivation

Although nothing specifically prevents it in actor code, validating caller types more than once in a method is prohibited and causes an abort in Lotus. This double validation occurs in `market.Actor.WithdrawBalance`. The call to `ValidateImmediateCallerType` is unnecessary, so we should remove it.

### Proposed Changes

1. Simulate multiple validation calls abort in scenario test vm.
2. Add scenario test for adding and withdrawing collateral to demonstrate the problem.
3. Delete `ValidateImmediateCallerType` in `market.Actor.WithrdrawBalance`.