### PR TITLE
add method to repay debt

### DIFF
--- a/actors/builtin/methods.go
+++ b/actors/builtin/methods.go
@@ -94,7 +94,8 @@ var MethodsMiner = struct {
 	CompactPartitions        abi.MethodNum
 	CompactSectorNumbers     abi.MethodNum
 	ConfirmUpdateWorkerKey   abi.MethodNum
-}{MethodConstructor, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21}
+	RepayDebt                abi.MethodNum
+}{MethodConstructor, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22}
 
 var MethodsVerifiedRegistry = struct {
 	Constructor       abi.MethodNum

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -1601,8 +1601,7 @@ func (a Actor) RepayDebt(rt Runtime, params *adt.EmptyValue) *adt.EmptyValue {
 		info := getMinerInfo(rt, &st)
 		rt.ValidateImmediateCallerIs(append(info.ControlAddresses, info.Owner, info.Worker)...)
 
-		// Verify unlocked funds cover both InitialPledgeRequirement and FeeDebt
-		// and repay fee debt now.
+		// Repay as much fee debt as possible.
 		fromVesting, fromBalance, err = st.RepayPartialDebtInPriorityOrder(adt.AsStore(rt), rt.CurrEpoch(), rt.CurrentBalance())
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to unlock fee debt")
 	})

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -1607,7 +1607,7 @@ func (a Actor) RepayDebt(rt Runtime, params *adt.EmptyValue) *adt.EmptyValue {
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to unlock fee debt")
 	})
 
-	notifyPledgeChanged(rt, fromVesting)
+	notifyPledgeChanged(rt, fromVesting.Neg())
 	burnFunds(rt, big.Sum(fromVesting, fromBalance))
 	st.AssertBalanceInvariants(rt.CurrentBalance())
 	return nil

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -2547,7 +2547,7 @@ func TestRepayDebts(t *testing.T) {
 
 		amountToLock := big.Mul(big.NewInt(3), big.NewInt(1e18))
 		rt.SetBalance(amountToLock)
-		actor.addLockedFunds(rt, amountToLock)
+		actor.applyRewards(rt, amountToLock, big.Zero())
 
 		// introduce fee debt
 		st := getState(rt)
@@ -3175,7 +3175,7 @@ func TestApplyRewards(t *testing.T) {
 	t.Run("penalty is burnt", func(t *testing.T) {
 		rt := builder.Build(t)
 		actor.constructAndVerify(rt)
-		
+
 		reward := abi.NewTokenAmount(600_000)
 		penalty := abi.NewTokenAmount(300_000)
 		rt.SetBalance(big.Add(rt.Balance(), reward))

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -2036,7 +2036,6 @@ func TestDeclareRecoveries(t *testing.T) {
 			actor.declareRecoveries(rt, dlIdx, pIdx, bf(uint64(oneSector[0].SectorNumber)), big.Zero())
 		})
 	})
-
 }
 
 func TestExtendSectorExpiration(t *testing.T) {
@@ -2484,6 +2483,86 @@ func TestWithdrawBalance(t *testing.T) {
 		requested := rt.Balance()
 		expectedWithdraw := big.Sub(requested, feeDebt)
 		actor.withdrawFunds(rt, requested, expectedWithdraw, feeDebt)
+	})
+}
+
+func TestRepayDebts(t *testing.T) {
+	actor := newHarness(t, abi.ChainEpoch(100))
+	builder := builderForHarness(actor).
+		WithBalance(big.Zero(), big.Zero())
+
+	t.Run("repay with no avaialable funds does nothing", func(t *testing.T) {
+		rt := builder.Build(t)
+		actor.constructAndVerify(rt)
+
+		// introduce fee debt
+		st := getState(rt)
+		feeDebt := big.Mul(big.NewInt(4), big.NewInt(1e18))
+		st.FeeDebt = feeDebt
+		rt.ReplaceState(st)
+
+		actor.repayDebt(rt, big.Zero(), big.Zero(), big.Zero())
+
+		st = getState(rt)
+		assert.Equal(t, feeDebt, st.FeeDebt)
+	})
+
+	t.Run("pay debt entirely from balance", func(t *testing.T) {
+		rt := builder.Build(t)
+		actor.constructAndVerify(rt)
+
+		// introduce fee debt
+		st := getState(rt)
+		feeDebt := big.Mul(big.NewInt(4), big.NewInt(1e18))
+		st.FeeDebt = feeDebt
+		rt.ReplaceState(st)
+
+		debtToRepay := big.Mul(big.NewInt(2), feeDebt)
+		actor.repayDebt(rt, debtToRepay, big.Zero(), feeDebt)
+
+		st = getState(rt)
+		assert.Equal(t, big.Zero(), st.FeeDebt)
+	})
+
+	t.Run("partially repay debt", func(t *testing.T) {
+		rt := builder.Build(t)
+		actor.constructAndVerify(rt)
+
+		// introduce fee debt
+		st := getState(rt)
+		feeDebt := big.Mul(big.NewInt(4), big.NewInt(1e18))
+		st.FeeDebt = feeDebt
+		rt.ReplaceState(st)
+
+		debtToRepay := big.Mul(big.NewInt(3), big.Div(feeDebt, big.NewInt(4)))
+		actor.repayDebt(rt, debtToRepay, big.Zero(), debtToRepay)
+
+		st = getState(rt)
+		assert.Equal(t, big.Div(feeDebt, big.NewInt(4)), st.FeeDebt)
+	})
+
+	t.Run("pay debt partially from vested funds", func(t *testing.T) {
+		rt := builder.Build(t)
+		actor.constructAndVerify(rt)
+
+		amountToLock := big.Mul(big.NewInt(3), big.NewInt(1e18))
+		rt.SetBalance(amountToLock)
+		actor.addLockedFunds(rt, amountToLock)
+
+		// introduce fee debt
+		st := getState(rt)
+		feeDebt := big.Mul(big.NewInt(4), big.NewInt(1e18))
+		st.FeeDebt = feeDebt
+		rt.ReplaceState(st)
+
+		// send 1 FIL and repay all debt from vesting funds and balance
+		actor.repayDebt(rt,
+			big.NewInt(1e18), // send 1 FIL
+			amountToLock,     // 3 FIL comes from vesting funds
+			big.NewInt(1e18)) // 1 FIL sent from balance
+
+		st = getState(rt)
+		assert.Equal(t, big.Zero(), st.FeeDebt)
 	})
 }
 
@@ -4267,6 +4346,26 @@ func (h *actorHarness) withdrawFunds(rt *mock.Runtime, amountRequested, amountWi
 	rt.Call(h.a.WithdrawBalance, &miner.WithdrawBalanceParams{
 		AmountRequested: amountRequested,
 	})
+
+	rt.Verify()
+}
+
+func (h *actorHarness) repayDebt(rt *mock.Runtime, value, expectedRepayedFromVest, expectedRepaidFromBalance abi.TokenAmount) {
+	rt.SetCaller(h.worker, builtin.AccountActorCodeID)
+	rt.ExpectValidateCallerAddr(append(h.controlAddrs, h.owner, h.worker)...)
+
+	rt.SetBalance(big.Sum(rt.Balance(), value))
+	rt.SetReceived(value)
+	if expectedRepayedFromVest.GreaterThan(big.Zero()) {
+		pledgeDelta := expectedRepayedFromVest.Neg()
+		rt.ExpectSend(builtin.StoragePowerActorAddr, builtin.MethodsPower.UpdatePledgeTotal, &pledgeDelta, big.Zero(), nil, exitcode.Ok)
+	}
+
+	totalRepaid := big.Sum(expectedRepayedFromVest, expectedRepaidFromBalance)
+	if totalRepaid.GreaterThan((big.Zero())) {
+		rt.ExpectSend(builtin.BurntFundsActorAddr, builtin.MethodSend, nil, totalRepaid, nil, exitcode.Ok)
+	}
+	rt.Call(h.a.RepayDebt, nil)
 
 	rt.Verify()
 }


### PR DESCRIPTION
closes #1072

### Motivation

If a miner goes into fee debt, the worker can pay it off by adding balance and then pre-committing a sector, recovering a fault. If the worker doesn't have a sector to precommit or a recovered fault they must wait for the deadline end for the debt to be paid. This PR adds a `RepayDebt` method to trigger that mechanism immediately.

### Proposed Changes

1. Add `miner.RepayDebt` that calls `miner.State.RepayPartialDebtInPriorityOrder` and burns the appropriate funds and notifies of any pledge change due to fee payment from vesting funds.
2. Add unit tests for new method.