### PR TITLE
adjust min miner size for 64 g

### DIFF
--- a/actors/abi/sector.go
+++ b/actors/abi/sector.go
@@ -99,6 +99,7 @@ type SealProofInfo struct {
 	WinningPoStProof           RegisteredPoStProof
 	WindowPoStProof            RegisteredPoStProof
 	SectorMaxLifetime          ChainEpoch
+	ConsensusMinerMinPower     StoragePower
 }
 
 // For all Stacked DRG sectors, the max is 5 years
@@ -114,6 +115,7 @@ var SealProofInfos = map[RegisteredSealProof]*SealProofInfo{
 		WinningPoStProof:           RegisteredPoStProof_StackedDrgWinning2KiBV1,
 		WindowPoStProof:            RegisteredPoStProof_StackedDrgWindow2KiBV1,
 		SectorMaxLifetime:          fiveYears,
+		ConsensusMinerMinPower:     NewStoragePower(0),
 	},
 	RegisteredSealProof_StackedDrg8MiBV1: {
 		SectorSize:                 8 << 20,
@@ -121,6 +123,7 @@ var SealProofInfos = map[RegisteredSealProof]*SealProofInfo{
 		WinningPoStProof:           RegisteredPoStProof_StackedDrgWinning8MiBV1,
 		WindowPoStProof:            RegisteredPoStProof_StackedDrgWindow8MiBV1,
 		SectorMaxLifetime:          fiveYears,
+		ConsensusMinerMinPower:     NewStoragePower(0),
 	},
 	RegisteredSealProof_StackedDrg512MiBV1: {
 		SectorSize:                 512 << 20,
@@ -128,6 +131,7 @@ var SealProofInfos = map[RegisteredSealProof]*SealProofInfo{
 		WinningPoStProof:           RegisteredPoStProof_StackedDrgWinning512MiBV1,
 		WindowPoStProof:            RegisteredPoStProof_StackedDrgWindow512MiBV1,
 		SectorMaxLifetime:          fiveYears,
+		ConsensusMinerMinPower:     NewStoragePower(0),
 	},
 	RegisteredSealProof_StackedDrg32GiBV1: {
 		SectorSize:                 32 << 30,
@@ -135,6 +139,7 @@ var SealProofInfos = map[RegisteredSealProof]*SealProofInfo{
 		WinningPoStProof:           RegisteredPoStProof_StackedDrgWinning32GiBV1,
 		WindowPoStProof:            RegisteredPoStProof_StackedDrgWindow32GiBV1,
 		SectorMaxLifetime:          fiveYears,
+		ConsensusMinerMinPower:     NewStoragePower(100 << 40),
 	},
 	RegisteredSealProof_StackedDrg64GiBV1: {
 		SectorSize:                 64 << 30,
@@ -142,6 +147,7 @@ var SealProofInfos = map[RegisteredSealProof]*SealProofInfo{
 		WinningPoStProof:           RegisteredPoStProof_StackedDrgWinning64GiBV1,
 		WindowPoStProof:            RegisteredPoStProof_StackedDrgWindow64GiBV1,
 		SectorMaxLifetime:          fiveYears,
+		ConsensusMinerMinPower:     NewStoragePower(200 << 40),
 	},
 }
 
@@ -197,6 +203,22 @@ func (p RegisteredSealProof) SectorMaximumLifetime() (ChainEpoch, error) {
 	return info.SectorMaxLifetime, nil
 }
 
+// The minimum power of an individual miner to meet the threshold for leader election (in bytes).
+// Motivation:
+// - Limits sybil generation
+// - Improves consensus fault detection
+// - Guarantees a minimum fee for consensus faults
+// - Ensures that a specific soundness for the power table
+// Note: We may be able to reduce this in the future, addressing consensus faults with more complicated penalties,
+// sybil generation with crypto-economic mechanism, and PoSt soundness by increasing the challenges for small miners.
+func (p RegisteredSealProof) ConsensusMinerMinPower() (StoragePower, error) {
+	info, ok := SealProofInfos[p]
+	if !ok {
+		return NewStoragePower(0), errors.Errorf("unsupported proof type: %v", p)
+	}
+	return info.ConsensusMinerMinPower, nil
+}
+
 var PoStSealProofTypes = map[RegisteredPoStProof]RegisteredSealProof{
 	RegisteredPoStProof_StackedDrgWinning2KiBV1:   RegisteredSealProof_StackedDrg2KiBV1,
 	RegisteredPoStProof_StackedDrgWindow2KiBV1:    RegisteredSealProof_StackedDrg2KiBV1,
@@ -236,8 +258,6 @@ func (p RegisteredPoStProof) WindowPoStPartitionSectors() (uint64, error) {
 	}
 	return sp.WindowPoStPartitionSectors()
 }
-
-
 
 ///
 /// Sealing

--- a/actors/abi/sector.go
+++ b/actors/abi/sector.go
@@ -123,7 +123,7 @@ var SealProofInfos = map[RegisteredSealProof]*SealProofInfo{
 		WinningPoStProof:           RegisteredPoStProof_StackedDrgWinning8MiBV1,
 		WindowPoStProof:            RegisteredPoStProof_StackedDrgWindow8MiBV1,
 		SectorMaxLifetime:          fiveYears,
-		ConsensusMinerMinPower:     NewStoragePower(0),
+		ConsensusMinerMinPower:     NewStoragePower(16 << 20),
 	},
 	RegisteredSealProof_StackedDrg512MiBV1: {
 		SectorSize:                 512 << 20,
@@ -131,7 +131,7 @@ var SealProofInfos = map[RegisteredSealProof]*SealProofInfo{
 		WinningPoStProof:           RegisteredPoStProof_StackedDrgWinning512MiBV1,
 		WindowPoStProof:            RegisteredPoStProof_StackedDrgWindow512MiBV1,
 		SectorMaxLifetime:          fiveYears,
-		ConsensusMinerMinPower:     NewStoragePower(0),
+		ConsensusMinerMinPower:     NewStoragePower(1 << 30),
 	},
 	RegisteredSealProof_StackedDrg32GiBV1: {
 		SectorSize:                 32 << 30,

--- a/actors/builtin/miner/miner_state_test.go
+++ b/actors/builtin/miner/miner_state_test.go
@@ -1091,7 +1091,10 @@ func newSectorPreCommitInfo(sectorNo abi.SectorNumber, sealed cid.Cid) *miner.Se
 }
 
 func constructEligibilePowerState(t *testing.T, mAddr address.Address, rt *mock.Runtime) *power.State {
-	pSt := constructPowerStateWithPowerAtAddr(t, power.ConsensusMinerMinPower, mAddr, rt)
+	minPower, err := abi.RegisteredSealProof_StackedDrg32GiBV1.ConsensusMinerMinPower()
+	require.NoError(t, err)
+
+	pSt := constructPowerStateWithPowerAtAddr(t, minPower, mAddr, rt)
 
 	// Ensure that this the mAddr passes min power check
 	ok, err := pSt.MinerNominalPowerMeetsConsensusMinimum(adt.AsStore(rt), mAddr)
@@ -1111,7 +1114,7 @@ func constructPowerStateWithPowerAtAddr(t *testing.T, pow abi.StoragePower, mAdd
 	claims, err := adt.AsMap(adt.AsStore(rt), pSt.Claims)
 	require.NoError(t, err)
 
-	claim := &power.Claim{RawBytePower: pow, QualityAdjPower: pow}
+	claim := &power.Claim{SealProofType: abi.RegisteredSealProof_StackedDrg32GiBV1, RawBytePower: pow, QualityAdjPower: pow}
 
 	err = claims.Put(adt.AddrKey(mAddr), claim)
 	require.NoError(t, err)

--- a/actors/builtin/power/policy.go
+++ b/actors/builtin/power/policy.go
@@ -1,23 +1,9 @@
 package power
 
-import (
-	"github.com/filecoin-project/specs-actors/actors/abi"
-)
-
 // The number of miners that must meet the consensus minimum miner power before that minimum power is enforced
 // as a condition of leader election.
 // This ensures a network still functions before any miners reach that threshold.
 const ConsensusMinerMinMiners = 4 // PARAM_SPEC
-
-// The minimum power of an individual miner to meet the threshold for leader election (in bytes).
-// Motivation:
-// - Limits sybil generation
-// - Improves consensus fault detection
-// - Guarantees a minimum fee for consensus faults
-// - Ensures that a specific soundness for the power table
-// Note: We may be able to reduce this in the future, addressing consensus faults with more complicated penalties,
-// sybil generation with crypto-economic mechanism, and PoSt soundness by increasing the challenges for small miners.
-var ConsensusMinerMinPower = abi.NewStoragePower(100 << 40) // PARAM_SPEC PARAM_FINISH
 
 // Maximum number of prove-commits each miner can submit in one epoch.
 //

--- a/actors/builtin/power/power_actor.go
+++ b/actors/builtin/power/power_actor.go
@@ -121,7 +121,7 @@ func (a Actor) CreateMiner(rt Runtime, params *CreateMinerParams) *CreateMinerRe
 		claims, err := adt.AsMap(adt.AsStore(rt), st.Claims)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load claims")
 
-		err = setClaim(claims, addresses.IDAddress, &Claim{abi.NewStoragePower(0), abi.NewStoragePower(0)})
+		err = setClaim(claims, addresses.IDAddress, &Claim{params.SealProofType, abi.NewStoragePower(0), abi.NewStoragePower(0)})
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to put power in claimed table while creating miner")
 
 		st.MinerCount += 1

--- a/actors/builtin/power/power_test.go
+++ b/actors/builtin/power/power_test.go
@@ -66,7 +66,7 @@ func TestConstruction(t *testing.T) {
 		found, err_ := claim.Get(asKey(keys[0]), &actualClaim)
 		require.NoError(t, err_)
 		assert.True(t, found)
-		assert.Equal(t, power.Claim{big.Zero(), big.Zero()}, actualClaim) // miner has not proven anything
+		assert.Equal(t, power.Claim{abi.RegisteredSealProof_StackedDrg2KiBV1, big.Zero(), big.Zero()}, actualClaim) // miner has not proven anything
 
 		verifyEmptyMap(t, rt, st.CronEventQueue)
 	})
@@ -245,7 +245,9 @@ func TestPowerAndPledgeAccounting(t *testing.T) {
 	miner5 := tutil.NewIDAddr(t, 115)
 
 	// These tests use the min power for consensus to check the accounting above and below that value.
-	powerUnit := power.ConsensusMinerMinPower
+	powerUnit, err := abi.RegisteredSealProof_StackedDrg32GiBV1.ConsensusMinerMinPower()
+	require.NoError(t, err)
+
 	mul := func(a big.Int, b int64) big.Int {
 		return big.Mul(a, big.NewInt(b))
 	}
@@ -253,7 +255,7 @@ func TestPowerAndPledgeAccounting(t *testing.T) {
 		return big.Div(a, big.NewInt(b))
 	}
 	smallPowerUnit := big.NewInt(1_000_000)
-	require.True(t, smallPowerUnit.LessThan(powerUnit), "power.CosensusMinerMinPower has changed requiring update to this test")
+	require.True(t, smallPowerUnit.LessThan(powerUnit), "power.ConsensusMinerMinPower has changed requiring update to this test")
 	// Subtests implicitly rely on ConsensusMinerMinMiners = 3
 	require.Equal(t, 4, power.ConsensusMinerMinMiners, "power.ConsensusMinerMinMiners has changed requiring update to this test")
 
@@ -359,7 +361,7 @@ func TestPowerAndPledgeAccounting(t *testing.T) {
 		actor.updateClaimedPower(rt, miner2, powerUnit, powerUnit)
 		actor.updateClaimedPower(rt, miner3, powerUnit, powerUnit)
 		actor.updateClaimedPower(rt, miner4, powerUnit, powerUnit)
-		actor.updateClaimedPower(rt, miner5, powerUnit, powerUnit)		
+		actor.updateClaimedPower(rt, miner5, powerUnit, powerUnit)
 
 		expectedTotal := mul(powerUnit, 5)
 		actor.expectTotalPowerEager(rt, expectedTotal, expectedTotal)
@@ -452,7 +454,9 @@ func TestCron(t *testing.T) {
 	})
 
 	t.Run("test amount sent to reward actor and state change", func(t *testing.T) {
-		powerUnit := power.ConsensusMinerMinPower
+		powerUnit, err := abi.RegisteredSealProof_StackedDrg2KiBV1.ConsensusMinerMinPower()
+		require.NoError(t, err)
+
 		miner3 := tutil.NewIDAddr(t, 103)
 		miner4 := tutil.NewIDAddr(t, 104)
 
@@ -572,7 +576,9 @@ func TestCron(t *testing.T) {
 		actor.createMinerBasic(rt, owner, owner, miner1)
 		actor.createMinerBasic(rt, owner, owner, miner2)
 
-		rawPow := power.ConsensusMinerMinPower
+		rawPow, err := abi.RegisteredSealProof_StackedDrg2KiBV1.ConsensusMinerMinPower()
+		require.NoError(t, err)
+
 		qaPow := rawPow
 		actor.updateClaimedPower(rt, miner1, rawPow, qaPow)
 		actor.expectTotalPowerEager(rt, rawPow, qaPow)
@@ -997,7 +1003,7 @@ func (h *spActorHarness) createMinerBasic(rt *mock.Runtime, owner, worker, miner
 	label := strconv.Itoa(h.minerSeq)
 	actrAddr := tutil.NewActorAddr(h.t, label)
 	h.minerSeq += 1
-	h.createMiner(rt, owner, worker, miner, actrAddr, abi.PeerID(label), nil, abi.RegisteredSealProof_StackedDrg2KiBV1, big.Zero())
+	h.createMiner(rt, owner, worker, miner, actrAddr, abi.PeerID(label), nil, abi.RegisteredSealProof_StackedDrg32GiBV1, big.Zero())
 }
 
 func (h *spActorHarness) updateClaimedPower(rt *mock.Runtime, miner addr.Address, rawDelta, qaDelta abi.StoragePower) {


### PR DESCRIPTION
closes #1027

### Motivation

The security of a miner's eligibility for election is affected by the total power the miner has on the network, but also on the miner's sector size. This PR modifies all consensus power threshold calculations to be a function of miner sector size (proof type) and sets the value for 64GiB sectors to twice the previous minimum which is still appropriate for 32GiB sectors.

### Proposed Changes

1. Add `ConsensusMinerMinPower` to seal proof info.
2. Set values for the above: 32GiB is unchanged, 64GiB is 2x, all the rest (unused in production) are zero.
3. Add `SealProofType` to power actor's `Claim` type.
4. Initialize above to miner `SealProofType` to miner's proof type when miner is created. Copy it for each claim update.
5. Use above to derive minimum power in `power.State.addToClaim` and `power.State.MinerNominalPowerMeetsConsensusMinimum`.
6. Fix tests that did not use 32GiB proof type and computed minimum consensus power.
7. Augment tests to check the new behavior in `power.State.addToClaim` and `power.State.MinerNominalPowerMeetsConsensusMinimum`.