### PR TITLE
Separate seal proof type metadata from policy

### DIFF
--- a/actors/abi/sector.go
+++ b/actors/abi/sector.go
@@ -159,7 +159,7 @@ func (p RegisteredSealProof) RegisteredWindowPoStProof() (RegisteredPoStProof, e
 type SealProofPolicy struct {
 	WindowPoStPartitionSectors uint64
 	SectorMaxLifetime          ChainEpoch
-  ConsensusMinerMinPower     StoragePower
+  	ConsensusMinerMinPower     StoragePower
 }
 
 // For all Stacked DRG sectors, the max is 5 years
@@ -172,27 +172,27 @@ var SealProofPolicies = map[RegisteredSealProof]*SealProofPolicy{
 	RegisteredSealProof_StackedDrg2KiBV1: {
 		WindowPoStPartitionSectors: 2,
 		SectorMaxLifetime:          fiveYears,
-    ConsensusMinerMinPower:     NewStoragePower(0),
+    	ConsensusMinerMinPower:     NewStoragePower(0),
 	},
 	RegisteredSealProof_StackedDrg8MiBV1: {
 		WindowPoStPartitionSectors: 2,
 		SectorMaxLifetime:          fiveYears,
-    ConsensusMinerMinPower:     NewStoragePower(16 << 20),
+    	ConsensusMinerMinPower:     NewStoragePower(16 << 20),
 	},
 	RegisteredSealProof_StackedDrg512MiBV1: {
 		WindowPoStPartitionSectors: 2,
 		SectorMaxLifetime:          fiveYears,
-    ConsensusMinerMinPower:     NewStoragePower(1 << 30),
+   		ConsensusMinerMinPower:     NewStoragePower(1 << 30),
 	},
 	RegisteredSealProof_StackedDrg32GiBV1: {
 		WindowPoStPartitionSectors: 2349,
 		SectorMaxLifetime:          fiveYears,
-    ConsensusMinerMinPower:     NewStoragePower(100 << 40),
+    	ConsensusMinerMinPower:     NewStoragePower(100 << 40),
 	},
 	RegisteredSealProof_StackedDrg64GiBV1: {
 		WindowPoStPartitionSectors: 2300,
 		SectorMaxLifetime:          fiveYears,
-    ConsensusMinerMinPower:     NewStoragePower(200 << 40),
+    	ConsensusMinerMinPower:     NewStoragePower(200 << 40),
 	},
 }
 
@@ -223,8 +223,8 @@ func SealProofSectorMaximumLifetime(p RegisteredSealProof) (ChainEpoch, error) {
 // - Ensures that a specific soundness for the power table
 // Note: We may be able to reduce this in the future, addressing consensus faults with more complicated penalties,
 // sybil generation with crypto-economic mechanism, and PoSt soundness by increasing the challenges for small miners.
-func (p RegisteredSealProof) ConsensusMinerMinPower() (StoragePower, error) {
-	info, ok := SealProofInfos[p]
+func ConsensusMinerMinPower(p RegisteredSealProof) (StoragePower, error) {
+	info, ok := SealProofPolicies[p]
 	if !ok {
 		return NewStoragePower(0), errors.Errorf("unsupported proof type: %v", p)
 	}

--- a/actors/abi/sector.go
+++ b/actors/abi/sector.go
@@ -95,53 +95,35 @@ const (
 // Metadata about a seal proof type.
 type SealProofInfo struct {
 	SectorSize                 SectorSize
-	WindowPoStPartitionSectors uint64
 	WinningPoStProof           RegisteredPoStProof
 	WindowPoStProof            RegisteredPoStProof
-	SectorMaxLifetime          ChainEpoch
 }
 
-// For all Stacked DRG sectors, the max is 5 years
-const epochsPerYear = 1_051_200
-const fiveYears = ChainEpoch(5 * epochsPerYear)
-
-// Partition sizes must match those used by the proofs library.
-// See https://github.com/filecoin-project/rust-fil-proofs/blob/master/filecoin-proofs/src/constants.rs#L85
 var SealProofInfos = map[RegisteredSealProof]*SealProofInfo{
 	RegisteredSealProof_StackedDrg2KiBV1: {
 		SectorSize:                 2 << 10,
-		WindowPoStPartitionSectors: 2,
 		WinningPoStProof:           RegisteredPoStProof_StackedDrgWinning2KiBV1,
 		WindowPoStProof:            RegisteredPoStProof_StackedDrgWindow2KiBV1,
-		SectorMaxLifetime:          fiveYears,
 	},
 	RegisteredSealProof_StackedDrg8MiBV1: {
 		SectorSize:                 8 << 20,
-		WindowPoStPartitionSectors: 2,
 		WinningPoStProof:           RegisteredPoStProof_StackedDrgWinning8MiBV1,
 		WindowPoStProof:            RegisteredPoStProof_StackedDrgWindow8MiBV1,
-		SectorMaxLifetime:          fiveYears,
 	},
 	RegisteredSealProof_StackedDrg512MiBV1: {
 		SectorSize:                 512 << 20,
-		WindowPoStPartitionSectors: 2,
 		WinningPoStProof:           RegisteredPoStProof_StackedDrgWinning512MiBV1,
 		WindowPoStProof:            RegisteredPoStProof_StackedDrgWindow512MiBV1,
-		SectorMaxLifetime:          fiveYears,
 	},
 	RegisteredSealProof_StackedDrg32GiBV1: {
 		SectorSize:                 32 << 30,
-		WindowPoStPartitionSectors: 2349,
 		WinningPoStProof:           RegisteredPoStProof_StackedDrgWinning32GiBV1,
 		WindowPoStProof:            RegisteredPoStProof_StackedDrgWindow32GiBV1,
-		SectorMaxLifetime:          fiveYears,
 	},
 	RegisteredSealProof_StackedDrg64GiBV1: {
 		SectorSize:                 64 << 30,
-		WindowPoStPartitionSectors: 2300,
 		WinningPoStProof:           RegisteredPoStProof_StackedDrgWinning64GiBV1,
 		WindowPoStProof:            RegisteredPoStProof_StackedDrgWindow64GiBV1,
-		SectorMaxLifetime:          fiveYears,
 	},
 }
 
@@ -151,16 +133,6 @@ func (p RegisteredSealProof) SectorSize() (SectorSize, error) {
 		return 0, errors.Errorf("unsupported proof type: %v", p)
 	}
 	return info.SectorSize, nil
-}
-
-// Returns the partition size, in sectors, associated with a proof type.
-// The partition size is the number of sectors proved in a single PoSt proof.
-func (p RegisteredSealProof) WindowPoStPartitionSectors() (uint64, error) {
-	info, ok := SealProofInfos[p]
-	if !ok {
-		return 0, errors.Errorf("unsupported proof type: %v", p)
-	}
-	return info.WindowPoStPartitionSectors, nil
 }
 
 // RegisteredWinningPoStProof produces the PoSt-specific RegisteredProof corresponding
@@ -183,14 +155,54 @@ func (p RegisteredSealProof) RegisteredWindowPoStProof() (RegisteredPoStProof, e
 	return info.WindowPoStProof, nil
 }
 
-// The maximum duration a sector sealed with this proof may exist between activation and expiration.
-// This ensures that SDR is secure in the cost model for Window PoSt and in the time model for Winning PoSt
-// This is based on estimation of hardware latency improvement and hardware and software cost reduction.
-const SectorMaximumLifetimeSDR = ChainEpoch(1_262_277 * 5)
+// Policy values for a seal proof type.
+type SealProofPolicy struct {
+	WindowPoStPartitionSectors uint64
+	SectorMaxLifetime          ChainEpoch
+}
+
+// For all Stacked DRG sectors, the max is 5 years
+const epochsPerYear = 1_051_200
+const fiveYears = ChainEpoch(5 * epochsPerYear)
+
+// Partition sizes must match those used by the proofs library.
+// See https://github.com/filecoin-project/rust-fil-proofs/blob/master/filecoin-proofs/src/constants.rs#L85
+var SealProofPolicies = map[RegisteredSealProof]*SealProofPolicy{
+	RegisteredSealProof_StackedDrg2KiBV1: {
+		WindowPoStPartitionSectors: 2,
+		SectorMaxLifetime:          fiveYears,
+	},
+	RegisteredSealProof_StackedDrg8MiBV1: {
+		WindowPoStPartitionSectors: 2,
+		SectorMaxLifetime:          fiveYears,
+	},
+	RegisteredSealProof_StackedDrg512MiBV1: {
+		WindowPoStPartitionSectors: 2,
+		SectorMaxLifetime:          fiveYears,
+	},
+	RegisteredSealProof_StackedDrg32GiBV1: {
+		WindowPoStPartitionSectors: 2349,
+		SectorMaxLifetime:          fiveYears,
+	},
+	RegisteredSealProof_StackedDrg64GiBV1: {
+		WindowPoStPartitionSectors: 2300,
+		SectorMaxLifetime:          fiveYears,
+	},
+}
+
+// Returns the partition size, in sectors, associated with a proof type.
+// The partition size is the number of sectors proved in a single PoSt proof.
+func SealProofWindowPoStPartitionSectors(p RegisteredSealProof) (uint64, error) {
+	info, ok := SealProofPolicies[p]
+	if !ok {
+		return 0, errors.Errorf("unsupported proof type: %v", p)
+	}
+	return info.WindowPoStPartitionSectors, nil
+}
 
 // SectorMaximumLifetime is the maximum duration a sector sealed with this proof may exist between activation and expiration
-func (p RegisteredSealProof) SectorMaximumLifetime() (ChainEpoch, error) {
-	info, ok := SealProofInfos[p]
+func SealProofSectorMaximumLifetime(p RegisteredSealProof) (ChainEpoch, error) {
+	info, ok := SealProofPolicies[p]
 	if !ok {
 		return 0, errors.Errorf("unsupported proof type: %v", p)
 	}
@@ -229,14 +241,13 @@ func (p RegisteredPoStProof) SectorSize() (SectorSize, error) {
 
 // Returns the partition size, in sectors, associated with a proof type.
 // The partition size is the number of sectors proved in a single PoSt proof.
-func (p RegisteredPoStProof) WindowPoStPartitionSectors() (uint64, error) {
+func PoStProofWindowPoStPartitionSectors(p RegisteredPoStProof) (uint64, error) {
 	sp, err := p.RegisteredSealProof()
 	if err != nil {
 		return 0, err
 	}
-	return sp.WindowPoStPartitionSectors()
+	return SealProofWindowPoStPartitionSectors(sp)
 }
-
 
 
 ///

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -1826,7 +1826,7 @@ func validateExpiration(rt Runtime, activation, expiration abi.ChainEpoch, sealP
 	}
 
 	// total sector lifetime cannot exceed SectorMaximumLifetime for the sector's seal proof
-	maxLifetime, err := sealProof.SectorMaximumLifetime()
+	maxLifetime, err := abi.SealProofSectorMaximumLifetime(sealProof)
 	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalArgument, "unrecognized seal proof type %d", sealProof)
 	if expiration-activation > maxLifetime {
 		rt.Abortf(exitcode.ErrIllegalArgument, "invalid expiration %d, total sector lifetime (%d) cannot exceed %d after activation %d",

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -192,7 +192,7 @@ func ConstructMinerInfo(owner addr.Address, worker addr.Address, controlAddrs []
 		return nil, err
 	}
 
-	partitionSectors, err := sealProofType.WindowPoStPartitionSectors()
+	partitionSectors, err := abi.SealProofWindowPoStPartitionSectors(sealProofType)
 	if err != nil {
 		return nil, err
 	}

--- a/actors/builtin/miner/miner_state_test.go
+++ b/actors/builtin/miner/miner_state_test.go
@@ -878,9 +878,9 @@ func TestMinerEligibleForElection(t *testing.T) {
 		currEpoch := abi.ChainEpoch(100000)
 
 		// get minimums
-		pow32GiBMin, err := abi.RegisteredSealProof_StackedDrg32GiBV1.ConsensusMinerMinPower()
+		pow32GiBMin, err := abi.ConsensusMinerMinPower(abi.RegisteredSealProof_StackedDrg32GiBV1)
 		require.NoError(t, err)
-		pow64GiBMin, err := abi.RegisteredSealProof_StackedDrg64GiBV1.ConsensusMinerMinPower()
+		pow64GiBMin, err := abi.ConsensusMinerMinPower(abi.RegisteredSealProof_StackedDrg64GiBV1)
 		require.NoError(t, err)
 
 		for _, tc := range []struct {
@@ -1140,7 +1140,7 @@ func newSectorPreCommitInfo(sectorNo abi.SectorNumber, sealed cid.Cid) *miner.Se
 }
 
 func constructEligibilePowerState(t *testing.T, mAddr address.Address, rt *mock.Runtime) *power.State {
-	minPower, err := abi.RegisteredSealProof_StackedDrg32GiBV1.ConsensusMinerMinPower()
+	minPower, err := abi.ConsensusMinerMinPower(abi.RegisteredSealProof_StackedDrg32GiBV1)
 	require.NoError(t, err)
 
 	pSt := constructPowerStateWithPowerAtAddr(t, minPower, mAddr, abi.RegisteredSealProof_StackedDrg32GiBV1, rt)

--- a/actors/builtin/miner/miner_state_test.go
+++ b/actors/builtin/miner/miner_state_test.go
@@ -624,7 +624,7 @@ func TestAddPreCommitExpiry(t *testing.T) {
 }
 
 func TestSectorAssignment(t *testing.T) {
-	partitionSectors, err := abi.RegisteredSealProof_StackedDrg32GiBV1.WindowPoStPartitionSectors()
+	partitionSectors, err := abi.SealProofWindowPoStPartitionSectors(abi.RegisteredSealProof_StackedDrg32GiBV1)
 	require.NoError(t, err)
 	sectorSize, err := abi.RegisteredSealProof_StackedDrg32GiBV1.SectorSize()
 	require.NoError(t, err)
@@ -1006,7 +1006,7 @@ func constructStateHarness(t *testing.T, periodBoundary abi.ChainEpoch) *stateHa
 	sectorSize, err := testSealProofType.SectorSize()
 	require.NoError(t, err)
 
-	partitionSectors, err := testSealProofType.WindowPoStPartitionSectors()
+	partitionSectors, err := abi.SealProofWindowPoStPartitionSectors(testSealProofType)
 	require.NoError(t, err)
 
 	info := miner.MinerInfo{

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -2114,7 +2114,7 @@ func TestExtendSectorExpiration(t *testing.T) {
 		// and prove it once to activate it.
 		advanceAndSubmitPoSts(rt, actor, sector)
 
-		maxLifetime, err := sector.SealProof.SectorMaximumLifetime()
+		maxLifetime, err := abi.SealProofSectorMaximumLifetime(sector.SealProof)
 		require.NoError(t, err)
 
 		st := getState(rt)
@@ -3362,7 +3362,7 @@ func (h *actorHarness) setProofType(proof abi.RegisteredSealProof) {
 	require.NoError(h.t, err)
 	h.sectorSize, err = proof.SectorSize()
 	require.NoError(h.t, err)
-	h.partitionSize, err = proof.WindowPoStPartitionSectors()
+	h.partitionSize, err = abi.SealProofWindowPoStPartitionSectors(proof)
 	require.NoError(h.t, err)
 }
 

--- a/actors/builtin/miner/partition_state_test.go
+++ b/actors/builtin/miner/partition_state_test.go
@@ -689,7 +689,7 @@ func TestPartitions(t *testing.T) {
 		proofType := abi.RegisteredSealProof_StackedDrg32GiBV1
 		sectorSize, err := proofType.SectorSize()
 		require.NoError(t, err)
-		partitionSectors, err := proofType.WindowPoStPartitionSectors()
+		partitionSectors, err := abi.SealProofWindowPoStPartitionSectors(proofType)
 		require.NoError(t, err)
 
 		manySectors := make([]*miner.SectorOnChainInfo, partitionSectors)

--- a/actors/builtin/power/power_state.go
+++ b/actors/builtin/power/power_state.go
@@ -112,7 +112,7 @@ func (st *State) MinerNominalPowerMeetsConsensusMinimum(s adt.Store, miner addr.
 	}
 
 	minerNominalPower := claim.QualityAdjPower
-	minerMinPower, err := claim.SealProofType.ConsensusMinerMinPower()
+	minerMinPower, err := abi.ConsensusMinerMinPower(claim.SealProofType)
 	if err != nil {
 		return false, errors.Wrap(err, "could not get miner min power from proof type")
 	}
@@ -177,7 +177,7 @@ func (st *State) addToClaim(claims *adt.Map, miner addr.Address, power abi.Stora
 		QualityAdjPower: big.Add(oldClaim.QualityAdjPower, qapower),
 	}
 
-	minPower, err := oldClaim.SealProofType.ConsensusMinerMinPower()
+	minPower, err := abi.ConsensusMinerMinPower(oldClaim.SealProofType)
 	if err != nil {
 		return fmt.Errorf("could not get consensus miner min power: %w", err)
 	}

--- a/actors/builtin/power/power_test.go
+++ b/actors/builtin/power/power_test.go
@@ -245,7 +245,7 @@ func TestPowerAndPledgeAccounting(t *testing.T) {
 	miner5 := tutil.NewIDAddr(t, 115)
 
 	// These tests use the min power for consensus to check the accounting above and below that value.
-	powerUnit, err := abi.RegisteredSealProof_StackedDrg32GiBV1.ConsensusMinerMinPower()
+	powerUnit, err := abi.ConsensusMinerMinPower(abi.RegisteredSealProof_StackedDrg32GiBV1)
 	require.NoError(t, err)
 
 	mul := func(a big.Int, b int64) big.Int {
@@ -397,7 +397,7 @@ func TestPowerAndPledgeAccounting(t *testing.T) {
 		actor.createMiner(rt, owner, owner, miner5, tutil.NewActorAddr(t, "m5"), abi.PeerID("m5"),
 			nil, abi.RegisteredSealProof_StackedDrg64GiBV1, big.Zero())
 
-		power64Unit, err := abi.RegisteredSealProof_StackedDrg64GiBV1.ConsensusMinerMinPower()
+		power64Unit, err := abi.ConsensusMinerMinPower(abi.RegisteredSealProof_StackedDrg64GiBV1)
 		require.NoError(t, err)
 		assert.True(t, power64Unit.GreaterThan(powerUnit))
 
@@ -500,7 +500,7 @@ func TestCron(t *testing.T) {
 	})
 
 	t.Run("test amount sent to reward actor and state change", func(t *testing.T) {
-		powerUnit, err := abi.RegisteredSealProof_StackedDrg2KiBV1.ConsensusMinerMinPower()
+		powerUnit, err := abi.ConsensusMinerMinPower(abi.RegisteredSealProof_StackedDrg2KiBV1)
 		require.NoError(t, err)
 
 		miner3 := tutil.NewIDAddr(t, 103)
@@ -622,7 +622,7 @@ func TestCron(t *testing.T) {
 		actor.createMinerBasic(rt, owner, owner, miner1)
 		actor.createMinerBasic(rt, owner, owner, miner2)
 
-		rawPow, err := abi.RegisteredSealProof_StackedDrg2KiBV1.ConsensusMinerMinPower()
+		rawPow, err := abi.ConsensusMinerMinPower(abi.RegisteredSealProof_StackedDrg2KiBV1)
 		require.NoError(t, err)
 
 		qaPow := rawPow


### PR DESCRIPTION
Separates the conceptually fixed associations between proof types from the policy about how they are used (that could conceivably change in a protocol upgrade).

This is in preparation for integrating https://github.com/filecoin-project/go-state-types/pull/1, which moves the values and metadata to a new repository.