### PR TITLE
abort consensus fault reports when miner is already under fault

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -1511,8 +1511,8 @@ func (a Actor) ReportConsensusFault(rt Runtime, params *ReportConsensusFaultPara
 		info := getMinerInfo(rt, &st)
 
 		// verify miner hasn't already been faulted
-		if rt.CurrEpoch() < info.ConsensusFaultElapsed {
-			rt.Abortf(exitcode.ErrForbidden, "consensus fault has already been reported")
+		if fault.Epoch < info.ConsensusFaultElapsed {
+			rt.Abortf(exitcode.ErrForbidden, "miner has existing fault that has not expired (this may be a duplicate)")
 		}
 
 		err := st.ApplyPenalty(faultPenalty)

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -1512,7 +1512,7 @@ func (a Actor) ReportConsensusFault(rt Runtime, params *ReportConsensusFaultPara
 
 		// verify miner hasn't already been faulted
 		if fault.Epoch < info.ConsensusFaultElapsed {
-			rt.Abortf(exitcode.ErrForbidden, "miner has existing fault that has not expired (this may be a duplicate)")
+			rt.Abortf(exitcode.ErrForbidden, "fault epoch %d is too old, last exclusion period ended at %d", fault.Epoch, info.ConsensusFaultElapsed)
 		}
 
 		err := st.ApplyPenalty(faultPenalty)

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -3196,20 +3196,20 @@ func TestReportConsensusFault(t *testing.T) {
 		endInfo := actor.getInfo(rt)
 		assert.Equal(t, reportEpoch+miner.ConsensusFaultIneligibilityDuration, endInfo.ConsensusFaultElapsed)
 
-		rt.ExpectAbortContainsMessage(exitcode.ErrForbidden, "consensus fault has already been reported", func() {
+		rt.ExpectAbortContainsMessage(exitcode.ErrForbidden, "miner has existing fault that has not expired", func() {
 			actor.reportConsensusFault(rt, addr.TestAddress)
 		})
 		rt.Reset()
 
 		// new consensus faults are forbidden until original has elapsed
-		rt.SetEpoch(endInfo.ConsensusFaultElapsed - 1)
-		rt.ExpectAbortContainsMessage(exitcode.ErrForbidden, "consensus fault has already been reported", func() {
+		rt.SetEpoch(endInfo.ConsensusFaultElapsed) // actor.reportConsensusFault reports a fault for previous epoch
+		rt.ExpectAbortContainsMessage(exitcode.ErrForbidden, "miner has existing fault that has not expired", func() {
 			actor.reportConsensusFault(rt, addr.TestAddress)
 		})
 		rt.Reset()
 
 		// a new consensus fault can be reported once fault has elapsed
-		rt.SetEpoch(endInfo.ConsensusFaultElapsed)
+		rt.SetEpoch(endInfo.ConsensusFaultElapsed + 1)
 		actor.reportConsensusFault(rt, addr.TestAddress)
 		endInfo = actor.getInfo(rt)
 		assert.Equal(t, rt.Epoch()+miner.ConsensusFaultIneligibilityDuration, endInfo.ConsensusFaultElapsed)


### PR DESCRIPTION
closes #1008

### Motivation

A miner should only be penalized (and reported rewarded) once for a consensus fault. The most straightforward way to do this is to prevent any consensus fault reports for a miner until the miner's existing consensus fault penalization period has expired.

### Proposed Changes

1. Abort `ReportConsensusFault` if current epoch < `miner.Info.ConsensusFaultElapsed`.
2. Test that this prevents duplicate consensus fault reports.