### PR TITLE
delete miner claim after cron failure

### DIFF
--- a/actors/builtin/power/power_actor.go
+++ b/actors/builtin/power/power_actor.go
@@ -340,7 +340,7 @@ func (a Actor) processBatchProofVerifies(rt Runtime) {
 			found, err := claims.Has(AddrKey(a))
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to look up claim")
 			if !found {
-				rt.Log(vmr.WARN, "skipping batch verifies for unknown miner %s", a)
+				rt.Log(runtime.WARN, "skipping batch verifies for unknown miner %s", a)
 				return nil
 			}
 
@@ -420,7 +420,7 @@ func (a Actor) processDeferredCronEvents(rt Runtime) {
 				found, err := claims.Has(AddrKey(evt.MinerAddr))
 				builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to look up claim")
 				if !found {
-					rt.Log(vmr.WARN, "skipping cron event for unknown miner %v", evt.MinerAddr)
+					rt.Log(runtime.WARN, "skipping cron event for unknown miner %v", evt.MinerAddr)
 					continue
 				}
 				cronEvents = append(cronEvents, evt)
@@ -462,7 +462,7 @@ func (a Actor) processDeferredCronEvents(rt Runtime) {
 
 			// Remove miner claim and leave miner frozen
 			for _, minerAddr := range failedMinerCrons {
-				err := claims.Delete(AddrKey(minerAddr))
+				err := st.deleteClaim(claims, minerAddr)
 				if err != nil {
 					rt.Log(runtime.ERROR, "failed to delete claim for miner %s after failing OnDeferredCronEvent: %s", minerAddr, err)
 					continue

--- a/actors/builtin/power/power_actor.go
+++ b/actors/builtin/power/power_actor.go
@@ -420,7 +420,7 @@ func (a Actor) processDeferredCronEvents(rt Runtime) {
 				found, err := claims.Has(AddrKey(evt.MinerAddr))
 				builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to look up claim")
 				if !found {
-					rt.Log(vmr.WARN, "skipping cron event for unknown miner %s", a)
+					rt.Log(vmr.WARN, "skipping cron event for unknown miner %v", evt.MinerAddr)
 					continue
 				}
 				cronEvents = append(cronEvents, evt)

--- a/actors/builtin/power/power_state.go
+++ b/actors/builtin/power/power_state.go
@@ -208,6 +208,22 @@ func (st *State) addToClaim(claims *adt.Map, miner addr.Address, power abi.Stora
 	return setClaim(claims, miner, &newClaim)
 }
 
+func (st *State) deleteClaim(claims *adt.Map, miner addr.Address) error {
+	oldClaim, ok, err := getClaim(claims, miner)
+	if err != nil {
+		return fmt.Errorf("failed to get claim: %w", err)
+	}
+	if !ok {
+		return nil // no record, we're done
+	}
+
+	// subtract from stats as if we were simply removing power
+	st.addToClaim(claims, miner, oldClaim.RawBytePower.Neg(), oldClaim.QualityAdjPower.Neg())
+
+	// delete claim from state to invalidate miner
+	return claims.Delete(AddrKey(miner))
+}
+
 func getClaim(claims *adt.Map, a addr.Address) (*Claim, bool, error) {
 	var out Claim
 	found, err := claims.Get(AddrKey(a), &out)

--- a/actors/builtin/power/power_state.go
+++ b/actors/builtin/power/power_state.go
@@ -218,7 +218,10 @@ func (st *State) deleteClaim(claims *adt.Map, miner addr.Address) error {
 	}
 
 	// subtract from stats as if we were simply removing power
-	st.addToClaim(claims, miner, oldClaim.RawBytePower.Neg(), oldClaim.QualityAdjPower.Neg())
+	err = st.addToClaim(claims, miner, oldClaim.RawBytePower.Neg(), oldClaim.QualityAdjPower.Neg())
+	if err != nil {
+		return fmt.Errorf("failed to subtract miner power before deleting claim: %w", err)
+	}
 
 	// delete claim from state to invalidate miner
 	return claims.Delete(AddrKey(miner))

--- a/actors/util/adt/map.go
+++ b/actors/util/adt/map.go
@@ -3,8 +3,8 @@ package adt
 import (
 	"bytes"
 
-	cid "github.com/ipfs/go-cid"
 	hamt "github.com/filecoin-project/go-hamt-ipld"
+	cid "github.com/ipfs/go-cid"
 	"github.com/minio/sha256-simd"
 	errors "github.com/pkg/errors"
 	cbg "github.com/whyrusleeping/cbor-gen"
@@ -84,6 +84,17 @@ func (m *Map) Put(k Keyer, v runtime.CBORMarshaler) error {
 // Get puts the value at `k` into `out`.
 func (m *Map) Get(k Keyer, out runtime.CBORUnmarshaler) (bool, error) {
 	if err := m.root.Find(m.store.Context(), k.Key(), out); err != nil {
+		if err == hamt.ErrNotFound {
+			return false, nil
+		}
+		return false, errors.Wrapf(err, "map get failed find in node %v with key %v", m.lastCid, k.Key())
+	}
+	return true, nil
+}
+
+// Has checks for the existance of a key without deserializing its value.
+func (m *Map) Has(k Keyer) (bool, error) {
+	if _, err := m.root.FindRaw(m.store.Context(), k.Key()); err != nil {
 		if err == hamt.ErrNotFound {
 			return false, nil
 		}


### PR DESCRIPTION
closes #1056

### Motivation

When a miner's cron tasks fail, the miner is in a bad state and could potentially put power in a progressively worse state as time progresses. Zeroing out miner power helps, but it is not enough. This PR deletes the miner claim altogether when cron fails and makes the existence of a claim a requirement for most interactions between the miner and the power actor.

### Proposed Changes

1. On failure in `processDeferredCronEvents` delete miner's claim altogether.
2. In `UpdatePledgeTotal` and `SubmitPoRepForBulkVerify`, abort if miner has no claim.
3. In `processBatchProofVerifies` and `processDeferredCronEvents` skip and log actions for miner's that have no claim.
4. Fix existing power tests that mostly broke because miner was never initialized.
5. Add tests for new functionality.
6. Skip transaction and claims initialization and save if no cron failures were detected. This is a small optimization, for the case were there are no failures (hopefully always).