### PR TITLE
Revert some API changes to make the network upgrade easier

### DIFF
--- a/actors/builtin/methods.go
+++ b/actors/builtin/methods.go
@@ -68,9 +68,10 @@ var MethodsPower = struct {
 	EnrollCronEvent          abi.MethodNum
 	OnEpochTickEnd           abi.MethodNum
 	UpdatePledgeTotal        abi.MethodNum
+	Deprecated1              abi.MethodNum
 	SubmitPoRepForBulkVerify abi.MethodNum
 	CurrentTotalPower        abi.MethodNum
-}{MethodConstructor, 2, 3, 4, 5, 6, 7, 8}
+}{MethodConstructor, 2, 3, 4, 5, 6, 7, 8, 9}
 
 var MethodsMiner = struct {
 	Constructor              abi.MethodNum

--- a/actors/builtin/miner/cbor_gen.go
+++ b/actors/builtin/miner/cbor_gen.go
@@ -2287,7 +2287,7 @@ func (t *VestingFund) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
-var lengthBufSubmitWindowedPoStParams = []byte{132}
+var lengthBufSubmitWindowedPoStParams = []byte{133}
 
 func (t *SubmitWindowedPoStParams) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -2334,6 +2334,17 @@ func (t *SubmitWindowedPoStParams) MarshalCBOR(w io.Writer) error {
 		}
 	}
 
+	// t.ChainCommitEpoch (abi.ChainEpoch) (int64)
+	if t.ChainCommitEpoch >= 0 {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.ChainCommitEpoch)); err != nil {
+			return err
+		}
+	} else {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.ChainCommitEpoch-1)); err != nil {
+			return err
+		}
+	}
+
 	// t.ChainCommitRand (abi.Randomness) (slice)
 	if len(t.ChainCommitRand) > cbg.ByteArrayMaxLen {
 		return xerrors.Errorf("Byte array in field t.ChainCommitRand was too long")
@@ -2363,7 +2374,7 @@ func (t *SubmitWindowedPoStParams) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 4 {
+	if extra != 5 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -2439,6 +2450,31 @@ func (t *SubmitWindowedPoStParams) UnmarshalCBOR(r io.Reader) error {
 		t.Proofs[i] = v
 	}
 
+	// t.ChainCommitEpoch (abi.ChainEpoch) (int64)
+	{
+		maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+		var extraI int64
+		if err != nil {
+			return err
+		}
+		switch maj {
+		case cbg.MajUnsignedInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 positive overflow")
+			}
+		case cbg.MajNegativeInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 negative oveflow")
+			}
+			extraI = -1 - extraI
+		default:
+			return fmt.Errorf("wrong type for int64 field: %d", maj)
+		}
+
+		t.ChainCommitEpoch = abi.ChainEpoch(extraI)
+	}
 	// t.ChainCommitRand (abi.Randomness) (slice)
 
 	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -1343,8 +1343,9 @@ func TestWindowPost(t *testing.T) {
 				Index:   pIdx,
 				Skipped: bf(uint64(sector.SectorNumber)),
 			}},
-			Proofs:          makePoStProofs(actor.postProofType),
-			ChainCommitRand: commitRand,
+			Proofs:           makePoStProofs(actor.postProofType),
+			ChainCommitEpoch: dlinfo.Challenge,
+			ChainCommitRand:  commitRand,
 		}
 		expectQueryNetworkInfo(rt, actor)
 		rt.SetCaller(actor.worker, builtin.AccountActorCodeID)
@@ -4061,10 +4062,11 @@ func (h *actorHarness) submitWindowPoSt(rt *mock.Runtime, deadline *miner.Deadli
 	}
 
 	params := miner.SubmitWindowedPoStParams{
-		Deadline:        deadline.Index,
-		Partitions:      partitions,
-		Proofs:          proofs,
-		ChainCommitRand: commitRand,
+		Deadline:         deadline.Index,
+		Partitions:       partitions,
+		Proofs:           proofs,
+		ChainCommitEpoch: deadline.Challenge,
+		ChainCommitRand:  commitRand,
 	}
 
 	rt.Call(h.a.SubmitWindowedPoSt, &params)

--- a/actors/builtin/power/power_actor.go
+++ b/actors/builtin/power/power_actor.go
@@ -33,8 +33,9 @@ func (a Actor) Exports() []interface{} {
 		4:                         a.EnrollCronEvent,
 		5:                         a.OnEpochTickEnd,
 		6:                         a.UpdatePledgeTotal,
-		7:                         a.SubmitPoRepForBulkVerify,
-		8:                         a.CurrentTotalPower,
+		7:                         nil, // deprecated
+		8:                         a.SubmitPoRepForBulkVerify,
+		9:                         a.CurrentTotalPower,
 	}
 }
 

--- a/actors/test/commit_post_test.go
+++ b/actors/test/commit_post_test.go
@@ -217,7 +217,8 @@ func TestCommitPoStFlow(t *testing.T) {
 			Proofs: []abi.PoStProof{{
 				PoStProof: abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
 			}},
-			ChainCommitRand: []byte("not really random"),
+			ChainCommitEpoch: dlInfo.Challenge,
+			ChainCommitRand:  []byte("not really random"),
 		}
 		_, code = tv.ApplyMessage(addrs[0], minerAddrs.RobustAddress, big.Zero(), builtin.MethodsMiner.SubmitWindowedPoSt, &submitParams)
 		require.Equal(t, exitcode.Ok, code)
@@ -268,7 +269,8 @@ func TestCommitPoStFlow(t *testing.T) {
 			Proofs: []abi.PoStProof{{
 				PoStProof: abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
 			}},
-			ChainCommitRand: []byte("not really random"),
+			ChainCommitEpoch: dlInfo.Challenge,
+			ChainCommitRand:  []byte("not really random"),
 		}
 		_, code = tv.ApplyMessage(addrs[0], minerAddrs.RobustAddress, big.Zero(), builtin.MethodsMiner.SubmitWindowedPoSt, &submitParams)
 		require.Equal(t, exitcode.Ok, code)

--- a/actors/test/committed_capacity_scenario_test.go
+++ b/actors/test/committed_capacity_scenario_test.go
@@ -91,7 +91,8 @@ func TestReplaceCommittedCapacitySectorWithDealLadenSector(t *testing.T) {
 		Proofs: []abi.PoStProof{{
 			PoStProof: abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
 		}},
-		ChainCommitRand: []byte("not really random"),
+		ChainCommitEpoch: dlInfo.Challenge,
+		ChainCommitRand:  []byte("not really random"),
 	}
 
 	_, code = v.ApplyMessage(addrs[0], minerAddrs.RobustAddress, big.Zero(), builtin.MethodsMiner.SubmitWindowedPoSt, &submitParams)
@@ -334,7 +335,8 @@ func TestReplaceCommittedCapacitySectorWithDealLadenSector(t *testing.T) {
 			Proofs: []abi.PoStProof{{
 				PoStProof: abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
 			}},
-			ChainCommitRand: []byte("not really random"),
+			ChainCommitEpoch: dlInfo.Challenge,
+			ChainCommitRand:  []byte("not really random"),
 		}
 		_, code = tv.ApplyMessage(worker, minerAddrs.RobustAddress, big.Zero(), builtin.MethodsMiner.SubmitWindowedPoSt, &submitParams)
 		require.Equal(t, exitcode.Ok, code)
@@ -369,7 +371,8 @@ func TestReplaceCommittedCapacitySectorWithDealLadenSector(t *testing.T) {
 		Proofs: []abi.PoStProof{{
 			PoStProof: abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
 		}},
-		ChainCommitRand: []byte("not really random"),
+		ChainCommitEpoch: dlInfo.Challenge,
+		ChainCommitRand:  []byte("not really random"),
 	}
 	_, code = v.ApplyMessage(worker, minerAddrs.RobustAddress, big.Zero(), builtin.MethodsMiner.SubmitWindowedPoSt, &submitParams)
 	require.Equal(t, exitcode.Ok, code)

--- a/actors/test/cron_catches_expiries_scenario_test.go
+++ b/actors/test/cron_catches_expiries_scenario_test.go
@@ -85,7 +85,8 @@ func TestCronCatchedCCExpirationsAtDeadlineBoundary(t *testing.T) {
 		Proofs: []abi.PoStProof{{
 			PoStProof: abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
 		}},
-		ChainCommitRand: fakeChainRandomness,
+		ChainCommitEpoch: dlInfo.Challenge,
+		ChainCommitRand:  fakeChainRandomness,
 	}
 
 	_, code = v.ApplyMessage(addrs[0], minerAddrs.RobustAddress, big.Zero(), builtin.MethodsMiner.SubmitWindowedPoSt, &submitParams)
@@ -130,6 +131,7 @@ func TestCronCatchedCCExpirationsAtDeadlineBoundary(t *testing.T) {
 	dlInfo, _, v = vm.AdvanceTillProvingDeadline(t, v, minerAddrs.IDAddress, sectorNumber)
 
 	// prove original sector so it won't be faulted
+	submitParams.ChainCommitEpoch = dlInfo.Challenge
 	_, code = v.ApplyMessage(addrs[0], minerAddrs.RobustAddress, big.Zero(), builtin.MethodsMiner.SubmitWindowedPoSt, &submitParams)
 	require.Equal(t, exitcode.Ok, code)
 


### PR DESCRIPTION
1. Adds ChainCommitEpoch back to the SubmitWindowPoSt params.
2. Reverts the method number changes for SubmitPoRepForBulkVerify and CurrentTotalPower.