### PR TITLE
Implement cap of 1 FIL / 32GiB cap on initial pledge

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -788,6 +788,9 @@ func (a Actor) ConfirmSectorProofsValid(rt Runtime, params *builtin.ConfirmSecto
 
 			pwr := QAPowerForWeight(info.SectorSize, duration, precommit.DealWeight, precommit.VerifiedDealWeight)
 			dayReward := ExpectedRewardForPower(rewardStats.ThisEpochRewardSmoothed, pwrTotal.QualityAdjPowerSmoothed, pwr, builtin.EpochsInDay)
+			// The storage pledge is recorded for use in computing the penalty if this sector is terminated
+			// before its declared expiration.
+			// It's not capped to 1 FIL, so can exceed the actual initial pledge requirement.
 			storagePledge := ExpectedRewardForPower(rewardStats.ThisEpochRewardSmoothed, pwrTotal.QualityAdjPowerSmoothed, pwr, InitialPledgeProjectionPeriod)
 			initialPledge := InitialPledgeForPower(pwr, rewardStats.ThisEpochBaselinePower, rewardStats.ThisEpochRewardSmoothed,
 				pwrTotal.QualityAdjPowerSmoothed, circulatingSupply)


### PR DESCRIPTION
This was implemented on the 0.9 branch for Space Race in #997, and is to be preserved for mainnet.

This is a cherry-pick, followed by a fix to a test with a now-broken assumption.