### PR TITLE
Reduce vesting cliff, penalties, min deal collateral on network v1

### DIFF
--- a/actors/builtin/market/market_test.go
+++ b/actors/builtin/market/market_test.go
@@ -507,7 +507,7 @@ func TestPublishStorageDeals(t *testing.T) {
 		// given power and circ supply cancel this should be 5*dealqapower / 100
 		dealSize := abi.PaddedPieceSize(2048) // generateDealProposal's deal size
 		providerCollateral := big.Div(
-			big.Mul(big.NewInt(int64(dealSize)), market.ProvCollateralPercentSupplyNum),
+			big.Mul(big.NewInt(int64(dealSize)), market.ProvCollateralPercentSupplyNumV0),
 			market.ProvCollateralPercentSupplyDenom,
 		)
 		deal := actor.generateDealWithCollateralAndAddFunds(rt, client, mAddr, providerCollateral, clientCollateral, startEpoch, endEpoch)
@@ -679,7 +679,7 @@ func TestPublishStorageDealsFailures(t *testing.T) {
 					rt.SetCirculatingSupply(h.networkQAPower)
 					dealSize := big.NewInt(2048) // default deal size used
 					providerMin := big.Div(
-						big.Mul(dealSize, market.ProvCollateralPercentSupplyNum),
+						big.Mul(dealSize, market.ProvCollateralPercentSupplyNumV0),
 						market.ProvCollateralPercentSupplyDenom,
 					)
 					d.ProviderCollateral = big.Sub(providerMin, big.NewInt(1))

--- a/actors/builtin/miner/miner_internal_test.go
+++ b/actors/builtin/miner/miner_internal_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/filecoin-project/specs-actors/actors/builtin"
+	"github.com/filecoin-project/specs-actors/actors/runtime"
 	"github.com/filecoin-project/specs-actors/actors/util/smoothing"
 	tutils "github.com/filecoin-project/specs-actors/support/testing"
 )
@@ -97,6 +98,7 @@ type e = abi.ChainEpoch
 func TestFaultFeeInvariants(t *testing.T) {
 
 	// Construct plausible reward and qa power filtered estimates
+	nv := runtime.NetworkVersion0
 	epochReward := abi.NewTokenAmount(100 << 53)
 	rewardEstimate := smoothing.TestingConstantEstimate(epochReward) // not too much growth over ~3000 epoch projection in BR
 
@@ -107,7 +109,7 @@ func TestFaultFeeInvariants(t *testing.T) {
 		faultySectorPower := abi.NewStoragePower(1 << 50)
 
 		ff := PledgePenaltyForDeclaredFault(rewardEstimate, powerEstimate, faultySectorPower)
-		sp := PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, faultySectorPower)
+		sp := PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, faultySectorPower, nv)
 		assert.True(t, sp.GreaterThan(ff))
 	})
 
@@ -174,11 +176,11 @@ func TestFaultFeeInvariants(t *testing.T) {
 		assert.True(t, diff.LessThan(big.NewInt(3)))
 
 		// Undeclared faults
-		spA := PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, faultySectorAPower)
-		spB := PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, faultySectorBPower)
-		spC := PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, faultySectorCPower)
+		spA := PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, faultySectorAPower, nv)
+		spB := PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, faultySectorBPower, nv)
+		spC := PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, faultySectorCPower, nv)
 
-		spAll := PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, totalFaultPower)
+		spAll := PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, totalFaultPower, nv)
 
 		// Because we can introduce rounding error between 1 and zero for every penalty calculation
 		// we can at best expect n calculations of 1 power to be within n of 1 calculation of n powers.

--- a/actors/builtin/miner/monies.go
+++ b/actors/builtin/miner/monies.go
@@ -34,8 +34,12 @@ var DeclaredFaultFactorDenom = 100
 var DeclaredFaultProjectionPeriod = abi.ChainEpoch((builtin.EpochsInDay * DeclaredFaultFactorNum) / DeclaredFaultFactorDenom)
 
 // SP = BR(t, UndeclaredFaultProjectionPeriod)
-var UndeclaredFaultProjectionPeriodV0 = abi.ChainEpoch(5) * builtin.EpochsInDay
-var UndeclaredFaultProjectionPeriodV1 = abi.ChainEpoch(3) * builtin.EpochsInDay
+var UndeclaredFaultFactorNumV0 = 50
+var UndeclaredFaultFactorNumV1 = 35
+var UndeclaredFaultFactorDenom = 10
+
+var UndeclaredFaultProjectionPeriodV0 = abi.ChainEpoch((builtin.EpochsInDay * UndeclaredFaultFactorNumV0) / UndeclaredFaultFactorDenom)
+var UndeclaredFaultProjectionPeriodV1 = abi.ChainEpoch((builtin.EpochsInDay * UndeclaredFaultFactorNumV1) / UndeclaredFaultFactorDenom)
 
 // Maximum number of days of BR a terminated sector can be penalized
 const TerminationLifetimeCap = abi.ChainEpoch(70)

--- a/actors/builtin/miner/monies.go
+++ b/actors/builtin/miner/monies.go
@@ -5,6 +5,7 @@ import (
 	"github.com/filecoin-project/go-state-types/big"
 
 	"github.com/filecoin-project/specs-actors/actors/builtin"
+	"github.com/filecoin-project/specs-actors/actors/runtime"
 	"github.com/filecoin-project/specs-actors/actors/util/math"
 	"github.com/filecoin-project/specs-actors/actors/util/smoothing"
 )
@@ -33,7 +34,8 @@ var DeclaredFaultFactorDenom = 100
 var DeclaredFaultProjectionPeriod = abi.ChainEpoch((builtin.EpochsInDay * DeclaredFaultFactorNum) / DeclaredFaultFactorDenom)
 
 // SP = BR(t, UndeclaredFaultProjectionPeriod)
-var UndeclaredFaultProjectionPeriod = abi.ChainEpoch(5) * builtin.EpochsInDay
+var UndeclaredFaultProjectionPeriodV0 = abi.ChainEpoch(5) * builtin.EpochsInDay
+var UndeclaredFaultProjectionPeriodV1 = abi.ChainEpoch(3) * builtin.EpochsInDay
 
 // Maximum number of days of BR a terminated sector can be penalized
 const TerminationLifetimeCap = abi.ChainEpoch(70)
@@ -60,18 +62,29 @@ func PledgePenaltyForDeclaredFault(rewardEstimate, networkQAPowerEstimate *smoot
 
 // This is the SP(t) penalty for a newly faulty sector that has not been declared.
 // SP(t) = UndeclaredFaultFactor * BR(t)
-func PledgePenaltyForUndeclaredFault(rewardEstimate, networkQAPowerEstimate *smoothing.FilterEstimate, qaSectorPower abi.StoragePower) abi.TokenAmount {
-	return ExpectedRewardForPower(rewardEstimate, networkQAPowerEstimate, qaSectorPower, UndeclaredFaultProjectionPeriod)
+func PledgePenaltyForUndeclaredFault(rewardEstimate, networkQAPowerEstimate *smoothing.FilterEstimate, qaSectorPower abi.StoragePower,
+	networkVersion runtime.NetworkVersion) abi.TokenAmount {
+	projectionPeriod := UndeclaredFaultProjectionPeriodV0
+	if networkVersion >= runtime.NetworkVersion1 {
+		projectionPeriod = UndeclaredFaultProjectionPeriodV1
+	}
+	return ExpectedRewardForPower(rewardEstimate, networkQAPowerEstimate, qaSectorPower, projectionPeriod)
 }
 
 // Penalty to locked pledge collateral for the termination of a sector before scheduled expiry.
 // SectorAge is the time between the sector's activation and termination.
-func PledgePenaltyForTermination(dayRewardAtActivation, twentyDayRewardAtActivation abi.TokenAmount, sectorAge abi.ChainEpoch, rewardEstimate, networkQAPowerEstimate *smoothing.FilterEstimate, qaSectorPower abi.StoragePower) abi.TokenAmount {
+func PledgePenaltyForTermination(dayRewardAtActivation, twentyDayRewardAtActivation abi.TokenAmount, sectorAge abi.ChainEpoch,
+	rewardEstimate, networkQAPowerEstimate *smoothing.FilterEstimate, qaSectorPower abi.StoragePower, networkVersion runtime.NetworkVersion) abi.TokenAmount {
 	// max(SP(t), BR(StartEpoch, 20d) + BR(StartEpoch, 1d)*min(SectorAgeInDays, 70))
 	// and sectorAgeInDays = sectorAge / EpochsInDay
+
 	cappedSectorAge := big.NewInt(int64(minEpoch(sectorAge, TerminationLifetimeCap*builtin.EpochsInDay)))
+	if networkVersion >= runtime.NetworkVersion1 {
+		cappedSectorAge = big.NewInt(int64(minEpoch(sectorAge / 2, TerminationLifetimeCap*builtin.EpochsInDay)))
+	}
+
 	return big.Max(
-		PledgePenaltyForUndeclaredFault(rewardEstimate, networkQAPowerEstimate, qaSectorPower),
+		PledgePenaltyForUndeclaredFault(rewardEstimate, networkQAPowerEstimate, qaSectorPower, networkVersion),
 		big.Add(
 			twentyDayRewardAtActivation,
 			big.Div(

--- a/actors/builtin/miner/monies_test.go
+++ b/actors/builtin/miner/monies_test.go
@@ -9,11 +9,13 @@ import (
 
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
+	"github.com/filecoin-project/specs-actors/actors/runtime"
 	"github.com/filecoin-project/specs-actors/actors/util/smoothing"
 )
 
 // Test termination fee
 func TestPledgePenaltyForTermination(t *testing.T) {
+	nv := runtime.NetworkVersion0
 	epochTargetReward := abi.NewTokenAmount(1 << 50)
 	qaSectorPower := abi.NewStoragePower(1 << 36)
 	networkQAPower := abi.NewStoragePower(1 << 50)
@@ -21,7 +23,7 @@ func TestPledgePenaltyForTermination(t *testing.T) {
 	rewardEstimate := smoothing.TestingConstantEstimate(epochTargetReward)
 	powerEstimate := smoothing.TestingConstantEstimate(networkQAPower)
 
-	undeclaredPenalty := miner.PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, qaSectorPower)
+	undeclaredPenalty := miner.PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, qaSectorPower, nv)
 	bigInitialPledgeFactor := big.NewInt(int64(miner.InitialPledgeFactor))
 
 	t.Run("when undeclared fault fee exceeds expected reward, returns undeclaraed fault fee", func(t *testing.T) {
@@ -31,7 +33,7 @@ func TestPledgePenaltyForTermination(t *testing.T) {
 		twentyDayReward := big.Mul(dayReward, big.NewInt(int64(miner.InitialPledgeFactor)))
 		sectorAge := 20 * abi.ChainEpoch(builtin.EpochsInDay)
 
-		fee := miner.PledgePenaltyForTermination(dayReward, twentyDayReward, sectorAge, rewardEstimate, powerEstimate, qaSectorPower)
+		fee := miner.PledgePenaltyForTermination(dayReward, twentyDayReward, sectorAge, rewardEstimate, powerEstimate, qaSectorPower, nv)
 
 		assert.Equal(t, undeclaredPenalty, fee)
 	})
@@ -44,7 +46,7 @@ func TestPledgePenaltyForTermination(t *testing.T) {
 		sectorAgeInDays := int64(20)
 		sectorAge := abi.ChainEpoch(sectorAgeInDays * builtin.EpochsInDay)
 
-		fee := miner.PledgePenaltyForTermination(dayReward, twentyDayReward, sectorAge, rewardEstimate, powerEstimate, qaSectorPower)
+		fee := miner.PledgePenaltyForTermination(dayReward, twentyDayReward, sectorAge, rewardEstimate, powerEstimate, qaSectorPower, nv)
 
 		// expect fee to be pledge * br * age where br = pledge/initialPledgeFactor
 		expectedFee := big.Add(
@@ -62,7 +64,7 @@ func TestPledgePenaltyForTermination(t *testing.T) {
 		sectorAgeInDays := 500
 		sectorAge := abi.ChainEpoch(sectorAgeInDays * builtin.EpochsInDay)
 
-		fee := miner.PledgePenaltyForTermination(dayReward, twentyDayReward, sectorAge, rewardEstimate, powerEstimate, qaSectorPower)
+		fee := miner.PledgePenaltyForTermination(dayReward, twentyDayReward, sectorAge, rewardEstimate, powerEstimate, qaSectorPower, nv)
 
 		// expect fee to be pledge * br * age where br = pledge/initialPledgeFactor
 		expectedFee := big.Add(

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -185,15 +185,15 @@ type VestSpec struct {
 	Quantization abi.ChainEpoch // Maximum precision of vesting table (limits cardinality of table).
 }
 
-var PledgeVestingSpec = VestSpec{
-	InitialDelay: abi.ChainEpoch(180 * builtin.EpochsInDay), // PARAM_FINISH
+var RewardVestingSpecV0 = VestSpec{
+	InitialDelay: abi.ChainEpoch(20 * builtin.EpochsInDay),  // PARAM_FINISH
 	VestPeriod:   abi.ChainEpoch(180 * builtin.EpochsInDay), // PARAM_FINISH
 	StepDuration: abi.ChainEpoch(1 * builtin.EpochsInDay),   // PARAM_FINISH
 	Quantization: 12 * builtin.EpochsInHour,                 // PARAM_FINISH
 }
 
-var RewardVestingSpec = VestSpec{
-	InitialDelay: abi.ChainEpoch(20 * builtin.EpochsInDay),  // PARAM_FINISH
+var RewardVestingSpecV1 = VestSpec{
+	InitialDelay: abi.ChainEpoch(0),                         // PARAM_FINISH
 	VestPeriod:   abi.ChainEpoch(180 * builtin.EpochsInDay), // PARAM_FINISH
 	StepDuration: abi.ChainEpoch(1 * builtin.EpochsInDay),   // PARAM_FINISH
 	Quantization: 12 * builtin.EpochsInHour,                 // PARAM_FINISH

--- a/actors/runtime/runtime.go
+++ b/actors/runtime/runtime.go
@@ -32,9 +32,21 @@ const (
 	ERROR
 )
 
+// Enumeration of network upgrades where actor behaviour can change (without necessarily
+// vendoring and versioning the whole actor codebase).
+type NetworkVersion uint
+
+const (
+	NetworkVersion0 = NetworkVersion(iota) // specs-actors v0.9.3
+	NetworkVersion1                        // specs-actors v0.9.?
+)
+
 // Runtime is the VM's internal runtime object.
 // this is everything that is accessible to actors, beyond parameters.
 type Runtime interface {
+	// The network protocol version number at the current epoch.
+	NetworkVersion() NetworkVersion
+
 	// Information related to the current message being executed.
 	// When an actor invokes a method on another actor as a sub-call, these values reflect
 	// the sub-call context, rather than the top-level context.

--- a/support/mock/mockrt.go
+++ b/support/mock/mockrt.go
@@ -29,6 +29,7 @@ type Runtime struct {
 	// Execution context
 	ctx               context.Context
 	epoch             abi.ChainEpoch
+	networkVersion    runtime.NetworkVersion
 	receiver          addr.Address
 	caller            addr.Address
 	callerType        cid.Cid
@@ -166,6 +167,10 @@ var typeOfCborUnmarshaler = reflect.TypeOf((*runtime.CBORUnmarshaler)(nil)).Elem
 var typeOfCborMarshaler = reflect.TypeOf((*runtime.CBORMarshaler)(nil)).Elem()
 
 ///// Implementation of the runtime API /////
+
+func (rt *Runtime) NetworkVersion() runtime.NetworkVersion {
+	return rt.networkVersion
+}
 
 func (rt *Runtime) Message() runtime.Message {
 	rt.requireInCall()
@@ -750,6 +755,10 @@ func (rt *Runtime) SetBalance(amt abi.TokenAmount) {
 
 func (rt *Runtime) SetReceived(amt abi.TokenAmount) {
 	rt.valueReceived = amt
+}
+
+func (rt *Runtime) SetNetworkVersion(v runtime.NetworkVersion) {
+	rt.networkVersion = v
 }
 
 func (rt *Runtime) SetEpoch(epoch abi.ChainEpoch) {


### PR DESCRIPTION
This is an inline upgrade for Space Race, adjusting some crypto-economic parameters to reduce penalties and deal collateral. From version `1` the actor code will behave differently, but no existing state will be migrated.

This PR is against the release/v0.9 branch. The changes are to be subsequently cherry-picked to master, where we can drop the handling of network v0 (which will be handled by major release versioning).

- Adds `NetworkVersion()` call to Runtime
- v1: Reduce reward vesting cliff to zero
- v1: Reduce undeclared fault penalty to 3BR
- v1: Halve the sector age penalised in termination fee
- v1: Reduce min provider deal collateral to 1% of share, based on _raw_ power

- [ ] Wait for @nicola to ack the reduced undeclared fault penalty

FYI @whyrusleeping @magik6k @Stebalien 