### PR TITLE
docs: add pkg.go.dev badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Filecoin actors
 [![CircleCI](https://circleci.com/gh/filecoin-project/specs-actors.svg?style=svg)](https://circleci.com/gh/filecoin-project/specs-actors)
 [![codecov](https://codecov.io/gh/filecoin-project/specs-actors/branch/master/graph/badge.svg)](https://codecov.io/gh/filecoin-project/specs-actors)
+[![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white)](https://pkg.go.dev/github.com/filecoin-project/specs-actors)
 
 This repo is the specification of the Filecoin builtin actors, in the form of executable code.
 


### PR DESCRIPTION
pkg.go.dev provides slightly better DX to browsing github when refering to the API