### PR TITLE
Reduce vesting cliff, penalties, min deal collateral.

### DIFF
--- a/actors/builtin/market/market_actor.go
+++ b/actors/builtin/market/market_actor.go
@@ -174,7 +174,7 @@ func (a Actor) PublishStorageDeals(rt Runtime, params *PublishStorageDealsParams
 
 	resolvedAddrs := make(map[addr.Address]addr.Address, len(params.Deals))
 	baselinePower := requestCurrentBaselinePower(rt)
-	networkQAPower := requestCurrentNetworkQAPower(rt)
+	networkRawPower, networkQAPower := requestCurrentNetworkPower(rt)
 
 	var newDealIds []abi.DealID
 	var st State
@@ -186,7 +186,7 @@ func (a Actor) PublishStorageDeals(rt Runtime, params *PublishStorageDealsParams
 
 		// All storage dealProposals will be added in an atomic transaction; this operation will be unrolled if any of them fails.
 		for di, deal := range params.Deals {
-			validateDeal(rt, deal, baselinePower, networkQAPower)
+			validateDeal(rt, deal, baselinePower, networkRawPower, networkQAPower)
 
 			if deal.Proposal.Provider != provider && deal.Proposal.Provider != providerRaw {
 				rt.Abortf(exitcode.ErrIllegalArgument, "cannot publish deals from different providers at the same time")
@@ -680,7 +680,7 @@ func validateDealCanActivate(proposal *DealProposal, minerAddr addr.Address, sec
 	return nil
 }
 
-func validateDeal(rt Runtime, deal ClientDealProposal, baselinePower, networkQAPower abi.StoragePower) {
+func validateDeal(rt Runtime, deal ClientDealProposal, baselinePower, networkRawPower, networkQAPower abi.StoragePower) {
 	if err := dealProposalIsInternallyValid(rt, deal); err != nil {
 		rt.Abortf(exitcode.ErrIllegalArgument, "Invalid deal proposal: %s", err)
 	}
@@ -722,7 +722,7 @@ func validateDeal(rt Runtime, deal ClientDealProposal, baselinePower, networkQAP
 	}
 
 	minProviderCollateral, maxProviderCollateral := DealProviderCollateralBounds(proposal.PieceSize, proposal.VerifiedDeal,
-		networkQAPower, baselinePower, rt.TotalFilCircSupply())
+		networkRawPower, networkQAPower, baselinePower, rt.TotalFilCircSupply(), rt.NetworkVersion())
 	if proposal.ProviderCollateral.LessThan(minProviderCollateral) || proposal.ProviderCollateral.GreaterThan(maxProviderCollateral) {
 		rt.Abortf(exitcode.ErrIllegalArgument, "Provider collateral out of bounds.")
 	}
@@ -783,11 +783,11 @@ func requestCurrentBaselinePower(rt Runtime) abi.StoragePower {
 }
 
 // Requests the current network total power and pledge from the power actor.
-func requestCurrentNetworkQAPower(rt Runtime) abi.StoragePower {
+func requestCurrentNetworkPower(rt Runtime) (rawPower, qaPower abi.StoragePower) {
 	pwret, code := rt.Send(builtin.StoragePowerActorAddr, builtin.MethodsPower.CurrentTotalPower, nil, big.Zero())
 	builtin.RequireSuccess(rt, code, "failed to check current power")
 	var pwr power.CurrentTotalPowerReturn
 	err := pwret.Into(&pwr)
 	builtin.RequireNoErr(rt, err, exitcode.ErrSerialization, "failed to unmarshal power total value")
-	return pwr.QualityAdjPower
+	return pwr.RawBytePower, pwr.QualityAdjPower
 }

--- a/actors/builtin/market/market_actor.go
+++ b/actors/builtin/market/market_actor.go
@@ -186,7 +186,7 @@ func (a Actor) PublishStorageDeals(rt Runtime, params *PublishStorageDealsParams
 
 		// All storage dealProposals will be added in an atomic transaction; this operation will be unrolled if any of them fails.
 		for di, deal := range params.Deals {
-			validateDeal(rt, deal, baselinePower, networkRawPower, networkQAPower)
+			validateDeal(rt, deal, networkRawPower, networkQAPower, baselinePower)
 
 			if deal.Proposal.Provider != provider && deal.Proposal.Provider != providerRaw {
 				rt.Abortf(exitcode.ErrIllegalArgument, "cannot publish deals from different providers at the same time")
@@ -680,7 +680,7 @@ func validateDealCanActivate(proposal *DealProposal, minerAddr addr.Address, sec
 	return nil
 }
 
-func validateDeal(rt Runtime, deal ClientDealProposal, baselinePower, networkRawPower, networkQAPower abi.StoragePower) {
+func validateDeal(rt Runtime, deal ClientDealProposal, networkRawPower, networkQAPower, baselinePower abi.StoragePower) {
 	if err := dealProposalIsInternallyValid(rt, deal); err != nil {
 		rt.Abortf(exitcode.ErrIllegalArgument, "Invalid deal proposal: %s", err)
 	}
@@ -722,7 +722,7 @@ func validateDeal(rt Runtime, deal ClientDealProposal, baselinePower, networkRaw
 	}
 
 	minProviderCollateral, maxProviderCollateral := DealProviderCollateralBounds(proposal.PieceSize, proposal.VerifiedDeal,
-		networkRawPower, networkQAPower, baselinePower, rt.TotalFilCircSupply(), rt.NetworkVersion())
+		networkRawPower, networkQAPower, baselinePower, rt.TotalFilCircSupply())
 	if proposal.ProviderCollateral.LessThan(minProviderCollateral) || proposal.ProviderCollateral.GreaterThan(maxProviderCollateral) {
 		rt.Abortf(exitcode.ErrIllegalArgument, "Provider collateral out of bounds.")
 	}

--- a/actors/builtin/market/market_test.go
+++ b/actors/builtin/market/market_test.go
@@ -506,8 +506,8 @@ func TestPublishStorageDeals(t *testing.T) {
 		// given power and circ supply cancel this should be 1*dealqapower / 100
 		dealSize := abi.PaddedPieceSize(2048) // generateDealProposal's deal size
 		providerCollateral := big.Div(
-			big.Mul(big.NewInt(int64(dealSize)), market.ProviderCollateralSupplyTargetV1.Numerator),
-			market.ProviderCollateralSupplyTargetV1.Denominator,
+			big.Mul(big.NewInt(int64(dealSize)), market.ProviderCollateralSupplyTarget.Numerator),
+			market.ProviderCollateralSupplyTarget.Denominator,
 		)
 		deal := actor.generateDealWithCollateralAndAddFunds(rt, client, mAddr, providerCollateral, clientCollateral, startEpoch, endEpoch)
 		rt.SetCirculatingSupply(actor.networkQAPower) // convenient for these two numbers to cancel out
@@ -678,8 +678,8 @@ func TestPublishStorageDealsFailures(t *testing.T) {
 					rt.SetCirculatingSupply(h.networkQAPower)
 					dealSize := big.NewInt(2048) // default deal size used
 					providerMin := big.Div(
-						big.Mul(dealSize, market.ProviderCollateralSupplyTargetV1.Numerator),
-						market.ProviderCollateralSupplyTargetV1.Denominator,
+						big.Mul(dealSize, market.ProviderCollateralSupplyTarget.Numerator),
+						market.ProviderCollateralSupplyTarget.Denominator,
 					)
 					d.ProviderCollateral = big.Sub(providerMin, big.NewInt(1))
 				},

--- a/actors/builtin/market/market_test.go
+++ b/actors/builtin/market/market_test.go
@@ -503,11 +503,11 @@ func TestPublishStorageDeals(t *testing.T) {
 
 		clientCollateral := abi.NewTokenAmount(10) // min is zero so this is placeholder
 
-		// given power and circ supply cancel this should be 5*dealqapower / 100
+		// given power and circ supply cancel this should be 1*dealqapower / 100
 		dealSize := abi.PaddedPieceSize(2048) // generateDealProposal's deal size
 		providerCollateral := big.Div(
-			big.Mul(big.NewInt(int64(dealSize)), market.ProviderCollateralSupplyTarget.Numerator),
-			market.ProviderCollateralSupplyTarget.Denominator,
+			big.Mul(big.NewInt(int64(dealSize)), market.ProviderCollateralSupplyTargetV1.Numerator),
+			market.ProviderCollateralSupplyTargetV1.Denominator,
 		)
 		deal := actor.generateDealWithCollateralAndAddFunds(rt, client, mAddr, providerCollateral, clientCollateral, startEpoch, endEpoch)
 		rt.SetCirculatingSupply(actor.networkQAPower) // convenient for these two numbers to cancel out
@@ -678,8 +678,8 @@ func TestPublishStorageDealsFailures(t *testing.T) {
 					rt.SetCirculatingSupply(h.networkQAPower)
 					dealSize := big.NewInt(2048) // default deal size used
 					providerMin := big.Div(
-						big.Mul(dealSize, market.ProviderCollateralSupplyTarget.Numerator),
-						market.ProviderCollateralSupplyTarget.Denominator,
+						big.Mul(dealSize, market.ProviderCollateralSupplyTargetV1.Numerator),
+						market.ProviderCollateralSupplyTargetV1.Denominator,
 					)
 					d.ProviderCollateral = big.Sub(providerMin, big.NewInt(1))
 				},

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -413,9 +413,7 @@ func (a Actor) SubmitWindowedPoSt(rt Runtime, params *SubmitWindowedPoStParams) 
 		// These pay a higher fee than faults declared before the deadline challenge window opened.
 		undeclaredPenaltyPower := postResult.PenaltyPower()
 		undeclaredPenaltyTarget := PledgePenaltyForUndeclaredFault(
-			rewardStats.ThisEpochRewardSmoothed, pwrTotal.QualityAdjPowerSmoothed, undeclaredPenaltyPower.QA,
-			rt.NetworkVersion(),
-		)
+			rewardStats.ThisEpochRewardSmoothed, pwrTotal.QualityAdjPowerSmoothed, undeclaredPenaltyPower.QA)
 		// Subtract the "ongoing" fault fee from the amount charged now, since it will be charged at
 		// the end-of-deadline cron.
 		undeclaredPenaltyTarget = big.Sub(undeclaredPenaltyTarget, PledgePenaltyForDeclaredFault(
@@ -1441,7 +1439,6 @@ func (a Actor) ApplyRewards(rt Runtime, params *builtin.ApplyRewardParams) *abi.
 	if params.Penalty.Sign() < 0 {
 		rt.Abortf(exitcode.ErrIllegalArgument, "cannot penalize a negative amount of funds")
 	}
- 	vestingSchedule := &RewardVestingSpecV1
 
 	var st State
 	pledgeDeltaTotal := big.Zero()
@@ -1458,7 +1455,7 @@ func (a Actor) ApplyRewards(rt Runtime, params *builtin.ApplyRewardParams) *abi.
 			rt.Abortf(exitcode.ErrInsufficientFunds, "insufficient funds to lock, available: %v, requested: %v", unlockedBalance, params.Reward)
 		}
 
-		newlyVested, err := st.AddLockedFunds(store, rt.CurrEpoch(), params.Reward, vestingSchedule)
+		newlyVested, err := st.AddLockedFunds(store, rt.CurrEpoch(), params.Reward, &RewardVestingSpec)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to lock funds in vesting table")
 		pledgeDeltaTotal = big.Sub(pledgeDeltaTotal, newlyVested)
 		pledgeDeltaTotal = big.Add(pledgeDeltaTotal, params.Reward)
@@ -1678,7 +1675,6 @@ func (a Actor) OnDeferredCronEvent(rt Runtime, payload *CronEventPayload) *abi.E
 
 func processEarlyTerminations(rt Runtime) (more bool) {
 	store := adt.AsStore(rt)
-	networkVersion := rt.NetworkVersion()
 
 	// TODO: We're using the current power+epoch reward. Technically, we
 	// should use the power/reward at the time of termination.
@@ -1724,7 +1720,7 @@ func processEarlyTerminations(rt Runtime) (more bool) {
 				params.DealIDs = append(params.DealIDs, sector.DealIDs...)
 				totalInitialPledge = big.Add(totalInitialPledge, sector.InitialPledge)
 			}
-			penalty = big.Add(penalty, terminationPenalty(info.SectorSize, epoch, networkVersion,
+			penalty = big.Add(penalty, terminationPenalty(info.SectorSize, epoch,
 				rewardStats.ThisEpochRewardSmoothed, pwrTotal.QualityAdjPowerSmoothed, sectors))
 			dealsToTerminate = append(dealsToTerminate, params)
 
@@ -1770,7 +1766,6 @@ func processEarlyTerminations(rt Runtime) (more bool) {
 // Invoked at the end of the last epoch for each proving deadline.
 func handleProvingDeadline(rt Runtime) {
 	currEpoch := rt.CurrEpoch()
-	networkVersion := rt.NetworkVersion()
 	store := adt.AsStore(rt)
 
 	epochReward := requestCurrentEpochBlockReward(rt)
@@ -1820,7 +1815,6 @@ func handleProvingDeadline(rt Runtime) {
 				epochReward.ThisEpochRewardSmoothed,
 				pwrTotal.QualityAdjPowerSmoothed,
 				result.DetectedFaultyPower.QA,
-				networkVersion,
 			)
 			// Charge the rest as declared.
 			declaredPenalty := PledgePenaltyForDeclaredFault(
@@ -2312,13 +2306,13 @@ func validatePartitionContainsSectors(partition *Partition, sectors bitfield.Bit
 	return nil
 }
 
-func terminationPenalty(sectorSize abi.SectorSize, currEpoch abi.ChainEpoch, networkVersion runtime.NetworkVersion,
+func terminationPenalty(sectorSize abi.SectorSize, currEpoch abi.ChainEpoch,
 	rewardEstimate, networkQAPowerEstimate smoothing.FilterEstimate, sectors []*SectorOnChainInfo) abi.TokenAmount {
 	totalFee := big.Zero()
 	for _, s := range sectors {
 		sectorPower := QAPowerForSector(sectorSize, s)
 		fee := PledgePenaltyForTermination(s.ExpectedDayReward, currEpoch-s.Activation, s.ExpectedStoragePledge,
-			networkQAPowerEstimate, sectorPower, rewardEstimate, s.ReplacedDayReward, s.ReplacedSectorAge, networkVersion)
+			networkQAPowerEstimate, sectorPower, rewardEstimate, s.ReplacedDayReward, s.ReplacedSectorAge)
 		totalFee = big.Add(fee, totalFee)
 	}
 	return totalFee

--- a/actors/builtin/miner/miner_internal_test.go
+++ b/actors/builtin/miner/miner_internal_test.go
@@ -3,12 +3,13 @@ package miner
 import (
 	"testing"
 
-	"github.com/minio/blake2b-simd"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
+	"github.com/minio/blake2b-simd"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
+	"github.com/filecoin-project/specs-actors/v2/actors/runtime"
 	"github.com/filecoin-project/specs-actors/v2/actors/util/smoothing"
 	tutils "github.com/filecoin-project/specs-actors/v2/support/testing"
 )
@@ -98,6 +99,7 @@ type e = abi.ChainEpoch
 func TestFaultFeeInvariants(t *testing.T) {
 
 	// Construct plausible reward and qa power filtered estimates
+	nv := runtime.NetworkVersionLatest
 	epochReward := abi.NewTokenAmount(100 << 53)
 	rewardEstimate := smoothing.TestingConstantEstimate(epochReward) // not too much growth over ~3000 epoch projection in BR
 
@@ -108,7 +110,7 @@ func TestFaultFeeInvariants(t *testing.T) {
 		faultySectorPower := abi.NewStoragePower(1 << 50)
 
 		ff := PledgePenaltyForDeclaredFault(rewardEstimate, powerEstimate, faultySectorPower)
-		sp := PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, faultySectorPower)
+		sp := PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, faultySectorPower, nv)
 		assert.True(t, sp.GreaterThan(ff))
 	})
 
@@ -175,11 +177,11 @@ func TestFaultFeeInvariants(t *testing.T) {
 		assert.True(t, diff.LessThan(big.NewInt(3)))
 
 		// Undeclared faults
-		spA := PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, faultySectorAPower)
-		spB := PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, faultySectorBPower)
-		spC := PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, faultySectorCPower)
+		spA := PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, faultySectorAPower, nv)
+		spB := PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, faultySectorBPower, nv)
+		spC := PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, faultySectorCPower, nv)
 
-		spAll := PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, totalFaultPower)
+		spAll := PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, totalFaultPower, nv)
 
 		// Because we can introduce rounding error between 1 and zero for every penalty calculation
 		// we can at best expect n calculations of 1 power to be within n of 1 calculation of n powers.

--- a/actors/builtin/miner/miner_internal_test.go
+++ b/actors/builtin/miner/miner_internal_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
-	"github.com/filecoin-project/specs-actors/v2/actors/runtime"
 	"github.com/filecoin-project/specs-actors/v2/actors/util/smoothing"
 	tutils "github.com/filecoin-project/specs-actors/v2/support/testing"
 )
@@ -99,7 +98,6 @@ type e = abi.ChainEpoch
 func TestFaultFeeInvariants(t *testing.T) {
 
 	// Construct plausible reward and qa power filtered estimates
-	nv := runtime.NetworkVersionLatest
 	epochReward := abi.NewTokenAmount(100 << 53)
 	rewardEstimate := smoothing.TestingConstantEstimate(epochReward) // not too much growth over ~3000 epoch projection in BR
 
@@ -110,7 +108,7 @@ func TestFaultFeeInvariants(t *testing.T) {
 		faultySectorPower := abi.NewStoragePower(1 << 50)
 
 		ff := PledgePenaltyForDeclaredFault(rewardEstimate, powerEstimate, faultySectorPower)
-		sp := PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, faultySectorPower, nv)
+		sp := PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, faultySectorPower)
 		assert.True(t, sp.GreaterThan(ff))
 	})
 
@@ -177,11 +175,11 @@ func TestFaultFeeInvariants(t *testing.T) {
 		assert.True(t, diff.LessThan(big.NewInt(3)))
 
 		// Undeclared faults
-		spA := PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, faultySectorAPower, nv)
-		spB := PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, faultySectorBPower, nv)
-		spC := PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, faultySectorCPower, nv)
+		spA := PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, faultySectorAPower)
+		spB := PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, faultySectorBPower)
+		spC := PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, faultySectorCPower)
 
-		spAll := PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, totalFaultPower, nv)
+		spAll := PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, totalFaultPower)
 
 		// Because we can introduce rounding error between 1 and zero for every penalty calculation
 		// we can at best expect n calculations of 1 power to be within n of 1 calculation of n powers.

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -1873,7 +1873,7 @@ func TestDeadlineCron(t *testing.T) {
 
 		// Retracted recovery is penalized as an undetected fault, but power is unchanged
 		retractedPwr := miner.PowerForSectors(actor.sectorSize, allSectors[1:])
-		retractedPenalty := miner.PledgePenaltyForUndeclaredFault(actor.epochRewardSmooth, actor.epochQAPowerSmooth, retractedPwr.QA, rt.NetworkVersion())
+		retractedPenalty := miner.PledgePenaltyForUndeclaredFault(actor.epochRewardSmooth, actor.epochQAPowerSmooth, retractedPwr.QA)
 
 		// Un-recovered faults are charged as ongoing faults
 		ongoingPwr := miner.PowerForSectors(actor.sectorSize, allSectors[:1])
@@ -1919,7 +1919,7 @@ func TestDeadlineCron(t *testing.T) {
 
 		// run cron and expect all sectors to be penalized as undetected faults
 		pwr := miner.PowerForSectors(actor.sectorSize, allSectors)
-		undetectedPenalty := miner.PledgePenaltyForUndeclaredFault(actor.epochRewardSmooth, actor.epochQAPowerSmooth, pwr.QA, rt.NetworkVersion())
+		undetectedPenalty := miner.PledgePenaltyForUndeclaredFault(actor.epochRewardSmooth, actor.epochQAPowerSmooth, pwr.QA)
 
 		// power for sectors is removed
 		powerDeltaClaim := miner.NewPowerPair(pwr.Raw.Neg(), pwr.QA.Neg())
@@ -2412,7 +2412,7 @@ func TestTerminateSectors(t *testing.T) {
 		dayReward := miner.ExpectedRewardForPower(actor.epochRewardSmooth, actor.epochQAPowerSmooth, sectorPower, builtin.EpochsInDay)
 		twentyDayReward := miner.ExpectedRewardForPower(actor.epochRewardSmooth, actor.epochQAPowerSmooth, sectorPower, miner.InitialPledgeProjectionPeriod)
 		sectorAge := rt.Epoch() - sector.Activation
-		expectedFee := miner.PledgePenaltyForTermination(dayReward, sectorAge, twentyDayReward, actor.epochQAPowerSmooth, sectorPower, actor.epochRewardSmooth, big.Zero(), 0, rt.NetworkVersion())
+		expectedFee := miner.PledgePenaltyForTermination(dayReward, sectorAge, twentyDayReward, actor.epochQAPowerSmooth, sectorPower, actor.epochRewardSmooth, big.Zero(), 0)
 
 		sectors := bf(uint64(sector.SectorNumber))
 		actor.terminateSectors(rt, sectors, expectedFee)
@@ -2486,7 +2486,7 @@ func TestTerminateSectors(t *testing.T) {
 		newSectorAge := rt.Epoch() - newSector.Activation
 		oldSectorAge := newSector.Activation - oldSector.Activation
 		expectedFee := miner.PledgePenaltyForTermination(newSector.ExpectedDayReward, newSectorAge, twentyDayReward,
-			actor.epochQAPowerSmooth, sectorPower, actor.epochRewardSmooth, oldSector.ExpectedDayReward, oldSectorAge, rt.NetworkVersion())
+			actor.epochQAPowerSmooth, sectorPower, actor.epochRewardSmooth, oldSector.ExpectedDayReward, oldSectorAge)
 
 		sectors := bf(uint64(newSector.SectorNumber))
 		actor.terminateSectors(rt, sectors, expectedFee)
@@ -2682,7 +2682,7 @@ func TestCompactPartitions(t *testing.T) {
 		twentyDayReward := miner.ExpectedRewardForPower(actor.epochRewardSmooth, actor.epochQAPowerSmooth, sectorPower, miner.InitialPledgeProjectionPeriod)
 		sectorAge := rt.Epoch() - tsector.Activation
 		expectedFee := miner.PledgePenaltyForTermination(dayReward, sectorAge, twentyDayReward, actor.epochQAPowerSmooth,
-			sectorPower, actor.epochRewardSmooth, big.Zero(), 0, rt.NetworkVersion())
+			sectorPower, actor.epochRewardSmooth, big.Zero(), 0)
 
 		sectors := bitfield.NewFromSet([]uint64{uint64(sector1)})
 		actor.terminateSectors(rt, sectors, expectedFee)
@@ -3258,11 +3258,11 @@ func TestApplyRewards(t *testing.T) {
 		require.Len(t, vestingFunds.Funds, 180)
 
 		// Vested FIL pays out on epochs with expected offset
-		expectedOffset := periodOffset % miner.RewardVestingSpecV1.Quantization
+		expectedOffset := periodOffset % miner.RewardVestingSpec.Quantization
 
 		for i := range vestingFunds.Funds {
 			vf := vestingFunds.Funds[i]
-			require.EqualValues(t, expectedOffset, int64(vf.Epoch)%int64(miner.RewardVestingSpecV1.Quantization))
+			require.EqualValues(t, expectedOffset, int64(vf.Epoch)%int64(miner.RewardVestingSpec.Quantization))
 		}
 
 		assert.Equal(t, amt, st.LockedFunds)
@@ -4494,7 +4494,7 @@ func (h *actorHarness) declaredFaultPenalty(sectors []*miner.SectorOnChainInfo) 
 
 func (h *actorHarness) undeclaredFaultPenalty(sectors []*miner.SectorOnChainInfo, nv runtime.NetworkVersion) abi.TokenAmount {
 	_, qa := powerForSectors(h.sectorSize, sectors)
-	return miner.PledgePenaltyForUndeclaredFault(h.epochRewardSmooth, h.epochQAPowerSmooth, qa, nv)
+	return miner.PledgePenaltyForUndeclaredFault(h.epochRewardSmooth, h.epochQAPowerSmooth, qa)
 }
 
 func (h *actorHarness) powerPairForSectors(sectors []*miner.SectorOnChainInfo) miner.PowerPair {

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -229,7 +229,7 @@ type VestSpec struct {
 }
 
 // The vesting schedule for block rewards earned by a block producer.
-var RewardVestingSpecV1 = VestSpec{
+var RewardVestingSpec = VestSpec{
 	InitialDelay: abi.ChainEpoch(0),                         // PARAM_FINISH
 	VestPeriod:   abi.ChainEpoch(180 * builtin.EpochsInDay), // PARAM_FINISH
 	StepDuration: abi.ChainEpoch(1 * builtin.EpochsInDay),   // PARAM_FINISH

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -229,8 +229,8 @@ type VestSpec struct {
 }
 
 // The vesting schedule for block rewards earned by a block producer.
-var RewardVestingSpec = VestSpec{ // PARAM_SPEC
-	InitialDelay: abi.ChainEpoch(20 * builtin.EpochsInDay),  // PARAM_FINISH
+var RewardVestingSpecV1 = VestSpec{
+	InitialDelay: abi.ChainEpoch(0),                         // PARAM_FINISH
 	VestPeriod:   abi.ChainEpoch(180 * builtin.EpochsInDay), // PARAM_FINISH
 	StepDuration: abi.ChainEpoch(1 * builtin.EpochsInDay),   // PARAM_FINISH
 	Quantization: 12 * builtin.EpochsInHour,                 // PARAM_FINISH

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -229,7 +229,7 @@ type VestSpec struct {
 }
 
 // The vesting schedule for block rewards earned by a block producer.
-var RewardVestingSpec = VestSpec{
+var RewardVestingSpec = VestSpec{ // PARAM_SPEC
 	InitialDelay: abi.ChainEpoch(0),                         // PARAM_FINISH
 	VestPeriod:   abi.ChainEpoch(180 * builtin.EpochsInDay), // PARAM_FINISH
 	StepDuration: abi.ChainEpoch(1 * builtin.EpochsInDay),   // PARAM_FINISH

--- a/actors/runtime/runtime.go
+++ b/actors/runtime/runtime.go
@@ -22,6 +22,9 @@ import (
 // Runtime is the interface to the execution environment for actor methods..
 // This is everything that is accessible to actors, beyond parameters.
 type Runtime interface {
+	// The network protocol version number at the current epoch.
+	NetworkVersion() NetworkVersion
+
 	// Information related to the current message being executed.
 	// When an actor invokes a method on another actor as a sub-call, these values reflect
 	// the sub-call context, rather than the top-level context.

--- a/actors/runtime/types.go
+++ b/actors/runtime/types.go
@@ -6,6 +6,18 @@ import (
 
 // Concrete types associated with the runtime interface.
 
+// Enumeration of network upgrades where actor behaviour can change (without necessarily
+// vendoring and versioning the whole actor codebase).
+type NetworkVersion uint // FIXME move to types
+
+const (
+	NetworkVersion0 = NetworkVersion(iota) // specs-actors v0.9.3
+	NetworkVersion1                        // specs-actors v0.9.7
+	NetworkVersion2                        // specs-actors v2.0.?
+
+	NetworkVersionLatest = NetworkVersion2
+)
+
 // Specifies importance of message, LogLevel numbering is consistent with the uber-go/zap package.
 type LogLevel = runtime0.LogLevel
 

--- a/support/mock/builder.go
+++ b/support/mock/builder.go
@@ -5,10 +5,11 @@ import (
 	"testing"
 
 	addr "github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/ipfs/go-cid"
 	"github.com/minio/blake2b-simd"
 
-	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/specs-actors/v2/actors/runtime"
 )
 
 // Build for fluent initialization of a mock runtime.
@@ -21,6 +22,7 @@ func NewBuilder(ctx context.Context, receiver addr.Address) *RuntimeBuilder {
 	m := &Runtime{
 		ctx:               ctx,
 		epoch:             0,
+		networkVersion:    runtime.NetworkVersionLatest,
 		receiver:          receiver,
 		caller:            addr.Address{},
 		callerType:        cid.Undef,

--- a/support/mock/mockrt.go
+++ b/support/mock/mockrt.go
@@ -32,6 +32,7 @@ type Runtime struct {
 	// Execution context
 	ctx               context.Context
 	epoch             abi.ChainEpoch
+	networkVersion    runtime.NetworkVersion
 	receiver          addr.Address
 	caller            addr.Address
 	callerType        cid.Cid
@@ -169,6 +170,10 @@ var typeOfCborUnmarshaler = reflect.TypeOf((*runtime.CBORUnmarshaler)(nil)).Elem
 var typeOfCborMarshaler = reflect.TypeOf((*runtime.CBORMarshaler)(nil)).Elem()
 
 ///// Implementation of the runtime API /////
+
+func (rt *Runtime) NetworkVersion() runtime.NetworkVersion {
+	return rt.networkVersion
+}
 
 func (rt *Runtime) Message() runtime.Message {
 	rt.requireInCall()
@@ -766,6 +771,10 @@ func (rt *Runtime) SetBalance(amt abi.TokenAmount) {
 
 func (rt *Runtime) SetReceived(amt abi.TokenAmount) {
 	rt.valueReceived = amt
+}
+
+func (rt *Runtime) SetNetworkVersion(v runtime.NetworkVersion) {
+	rt.networkVersion = v
 }
 
 func (rt *Runtime) SetEpoch(epoch abi.ChainEpoch) {

--- a/support/vm/invocation_context.go
+++ b/support/vm/invocation_context.go
@@ -153,6 +153,10 @@ func (ic *invocationContext) State() runtime.StateHandle {
 	return ic
 }
 
+func (ic *invocationContext) NetworkVersion() runtime.NetworkVersion {
+	return ic.rt.networkVersion
+}
+
 func (ic *invocationContext) CurrEpoch() abi.ChainEpoch {
 	return ic.rt.currentEpoch
 }

--- a/support/vm/vm.go
+++ b/support/vm/vm.go
@@ -27,7 +27,8 @@ type VM struct {
 	ctx   context.Context
 	store adt.Store
 
-	currentEpoch abi.ChainEpoch
+	currentEpoch   abi.ChainEpoch
+	networkVersion runtime.NetworkVersion
 
 	actorImpls  ActorImplLookup
 	stateRoot   cid.Cid  // The last committed root.
@@ -82,17 +83,15 @@ func NewVM(ctx context.Context, actorImpls ActorImplLookup, store adt.Store) *VM
 		panic(err)
 	}
 
-	if err != nil {
-		panic("could not create empty actor root")
-	}
 	return &VM{
-		ctx:         ctx,
-		actorImpls:  actorImpls,
-		store:       store,
-		actors:      actors,
-		stateRoot:   actorRoot,
-		actorsDirty: false,
-		emptyObject: emptyObject,
+		ctx:            ctx,
+		actorImpls:     actorImpls,
+		store:          store,
+		actors:         actors,
+		stateRoot:      actorRoot,
+		actorsDirty:    false,
+		emptyObject:    emptyObject,
+		networkVersion: runtime.NetworkVersionLatest,
 	}
 }
 
@@ -108,14 +107,15 @@ func (vm *VM) WithEpoch(epoch abi.ChainEpoch) (*VM, error) {
 	}
 
 	return &VM{
-		ctx:          vm.ctx,
-		actorImpls:   vm.actorImpls,
-		store:        vm.store,
-		actors:       actors,
-		stateRoot:    vm.stateRoot,
-		actorsDirty:  false,
-		emptyObject:  vm.emptyObject,
-		currentEpoch: epoch,
+		ctx:            vm.ctx,
+		actorImpls:     vm.actorImpls,
+		store:          vm.store,
+		actors:         actors,
+		stateRoot:      vm.stateRoot,
+		actorsDirty:    false,
+		emptyObject:    vm.emptyObject,
+		currentEpoch:   epoch,
+		networkVersion: vm.networkVersion,
 	}, nil
 }
 


### PR DESCRIPTION
This is #1104, interpreted for v2.

- Add network version to runtime
- Implement reduced sector penalties and reward vesting cliff
- Reduce deal min provider collateral
- Fix tests missing expectations about rewards vesting after only 1 proving period

This version does not implement the `if rt.NetworkVersion() >= 1` tests because actors v2 is never intended to run on any before 2. To evaluate network versions 0 and 1, use `release/v0.9`. This demonstrates that those inline upgrades do not accumulate over time.

Based on c6ce28641f59c44af1594058f92bac67edb17664 from release/v0.9.

FYI @Stebalien @arajasek @magik6k 