### PR TITLE
Rework election eligibilty predicates

### DIFF
--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -15,7 +15,6 @@ import (
 	xerrors "golang.org/x/xerrors"
 
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
-	"github.com/filecoin-project/specs-actors/v2/actors/builtin/power"
 	. "github.com/filecoin-project/specs-actors/v2/actors/util"
 	"github.com/filecoin-project/specs-actors/v2/actors/util/adt"
 )
@@ -1097,39 +1096,6 @@ func (st *State) AdvanceDeadline(store adt.Store, currEpoch abi.ChainEpoch) (*Ad
 		detectedFaultyPower,
 		deadline.FaultyPower,
 	}, nil
-}
-
-func MinerEligibleForElection(store adt.Store, mAddr addr.Address, mSt *State, pSt *power.State, thisEpochReward abi.TokenAmount, currEpoch abi.ChainEpoch) (bool, error) {
-	// Minimum power requirements
-	powerOK, err := pSt.MinerNominalPowerMeetsConsensusMinimum(store, mAddr)
-	if err != nil {
-		return false, err
-	}
-	if !powerOK {
-		return false, nil
-	}
-
-	// IP requirements are met.  This includes zero fee debt
-	if !mSt.IsDebtFree() {
-		return false, nil
-	}
-
-	// No active consensus faults
-	mInfo, err := mSt.GetInfo(store)
-	if err != nil {
-		return false, err
-	}
-	if ConsensusFaultActive(mInfo, currEpoch) {
-		return false, nil
-	}
-
-	// IP requirement is sufficient to cover fee for a consensus fault
-	electionRequirement := ConsensusFaultPenalty(thisEpochReward)
-	if mSt.InitialPledge.LessThan(electionRequirement) {
-		return false, nil
-	}
-
-	return true, nil
 }
 
 //

--- a/actors/states/election.go
+++ b/actors/states/election.go
@@ -1,0 +1,55 @@
+package states
+
+import (
+	addr "github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+
+	"github.com/filecoin-project/specs-actors/v2/actors/builtin/miner"
+	"github.com/filecoin-project/specs-actors/v2/actors/builtin/power"
+	"github.com/filecoin-project/specs-actors/v2/actors/builtin/reward"
+	"github.com/filecoin-project/specs-actors/v2/actors/util/adt"
+)
+
+// Checks for miner election eligibility.
+// A miner must satisfy conditions on both the immediate parent state, as well as state at the
+// Winning PoSt election lookback.
+
+// Tests whether a miner is eligible to win an election given the immediately prior state of the
+// miner and system actors.
+func MinerEligibleForElection(store adt.Store, mstate *miner.State, pstate *power.State, rstate *reward.State, maddr addr.Address, currEpoch abi.ChainEpoch) (bool, error) {
+	// Non-empty power claim.
+	if claim, found, err := pstate.GetClaim(store, maddr); err != nil {
+		return false, err
+	} else if !found {
+		return false, err
+	} else if claim.QualityAdjPower.LessThanEqual(big.Zero()) {
+		return false, err
+	}
+
+	// No fee debt.
+	if !mstate.IsDebtFree() {
+		return false, nil
+	}
+
+	// No active consensus faults.
+	if mInfo, err := mstate.GetInfo(store); err != nil {
+		return false, err
+	} else if miner.ConsensusFaultActive(mInfo, currEpoch) {
+		return false, nil
+	}
+
+	// IP requirement is sufficient to cover fee for a consensus fault
+	electionRequirement := miner.ConsensusFaultPenalty(rstate.ThisEpochReward)
+	if mstate.InitialPledge.LessThan(electionRequirement) {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// Tests whether a miner is eligible for election given a Winning PoSt lookback state.
+func MinerEligibleForElectionAtPoStLookback(store adt.Store, pstate *power.State, mAddr addr.Address) (bool, error) {
+	// Minimum power requirements.
+	return pstate.MinerNominalPowerMeetsConsensusMinimum(store, mAddr)
+}

--- a/actors/states/election.go
+++ b/actors/states/election.go
@@ -49,7 +49,8 @@ func MinerEligibleForElection(store adt.Store, mstate *miner.State, pstate *powe
 }
 
 // Tests whether a miner is eligible for election given a Winning PoSt lookback state.
-func MinerEligibleForElectionAtPoStLookback(store adt.Store, pstate *power.State, mAddr addr.Address) (bool, error) {
+// The power state must be the state of the power actor at Winning PoSt lookback epoch.
+func MinerPoStLookbackEligibleForElection(store adt.Store, pstate *power.State, mAddr addr.Address) (bool, error) {
 	// Minimum power requirements.
 	return pstate.MinerNominalPowerMeetsConsensusMinimum(store, mAddr)
 }

--- a/actors/states/election_test.go
+++ b/actors/states/election_test.go
@@ -1,0 +1,253 @@
+package states_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-bitfield"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
+	"github.com/filecoin-project/specs-actors/v2/actors/builtin/miner"
+	"github.com/filecoin-project/specs-actors/v2/actors/builtin/power"
+	"github.com/filecoin-project/specs-actors/v2/actors/builtin/reward"
+	"github.com/filecoin-project/specs-actors/v2/actors/states"
+	"github.com/filecoin-project/specs-actors/v2/actors/util/adt"
+	"github.com/filecoin-project/specs-actors/v2/actors/util/smoothing"
+	"github.com/filecoin-project/specs-actors/v2/support/ipld"
+	tutil "github.com/filecoin-project/specs-actors/v2/support/testing"
+)
+
+func TestMinerEligibleForElection(t *testing.T) {
+	ctx := context.Background()
+	tenFIL := big.Mul(big.NewInt(1e18), big.NewInt(10))
+	store := ipld.NewADTStore(ctx)
+	proofType := abi.RegisteredSealProof_StackedDrg32GiBV1
+	pwr := abi.NewStoragePower(1)
+
+	owner := tutil.NewIDAddr(t, 100)
+	maddr := tutil.NewIDAddr(t, 101)
+
+	// Construct valid power state
+
+	t.Run("miner eligible", func(t *testing.T) {
+		mstate := constructMinerState(ctx, t, store, owner)
+		pstate := constructPowerStateWithMiner(t, store, maddr, pwr, proofType)
+		rstate := constructRewardState(t, tenFIL)
+		mstate.InitialPledge = miner.ConsensusFaultPenalty(rstate.ThisEpochReward)
+
+		currEpoch := abi.ChainEpoch(100000)
+		eligible, err := states.MinerEligibleForElection(store, mstate, pstate, rstate, maddr, currEpoch)
+		require.NoError(t, err)
+		assert.True(t, eligible)
+	})
+
+	t.Run("zero claim", func(t *testing.T) {
+		mstate := constructMinerState(ctx, t, store, owner)
+		pstate := constructPowerStateWithMiner(t, store, maddr, big.Zero(), proofType)
+		rstate := constructRewardState(t, tenFIL)
+		mstate.InitialPledge = miner.ConsensusFaultPenalty(rstate.ThisEpochReward)
+
+		currEpoch := abi.ChainEpoch(100000)
+		eligible, err := states.MinerEligibleForElection(store, mstate, pstate, rstate, maddr, currEpoch)
+		require.NoError(t, err)
+		assert.False(t, eligible)
+	})
+
+	t.Run("active consensus fault", func(t *testing.T) {
+		mstate := constructMinerState(ctx, t, store, owner)
+		pstate := constructPowerStateWithMiner(t, store, maddr, pwr, proofType)
+		rstate := constructRewardState(t, tenFIL)
+		mstate.InitialPledge = miner.ConsensusFaultPenalty(rstate.ThisEpochReward)
+
+		info, err := mstate.GetInfo(store)
+		require.NoError(t, err)
+		info.ConsensusFaultElapsed = abi.ChainEpoch(55)
+		err = mstate.SaveInfo(store, info)
+		require.NoError(t, err)
+
+		currEpoch := abi.ChainEpoch(33) // 33 less than 55 so consensus fault still active
+		eligible, err := states.MinerEligibleForElection(store, mstate, pstate, rstate, maddr, currEpoch)
+		require.NoError(t, err)
+		assert.False(t, eligible)
+	})
+
+	t.Run("fee debt", func(t *testing.T) {
+		mstate := constructMinerState(ctx, t, store, owner)
+		pstate := constructPowerStateWithMiner(t, store, maddr, pwr, proofType)
+		rstate := constructRewardState(t, tenFIL)
+		mstate.InitialPledge = miner.ConsensusFaultPenalty(rstate.ThisEpochReward)
+		mstate.FeeDebt = abi.NewTokenAmount(1000)
+
+		currEpoch := abi.ChainEpoch(100000)
+		eligible, err := states.MinerEligibleForElection(store, mstate, pstate, rstate, maddr, currEpoch)
+		require.NoError(t, err)
+		assert.False(t, eligible)
+	})
+
+	t.Run("ip requirement below consensus fault penalty", func(t *testing.T) {
+		mstate := constructMinerState(ctx, t, store, owner)
+		pstate := constructPowerStateWithMiner(t, store, maddr, pwr, proofType)
+		rstate := constructRewardState(t, tenFIL)
+		mstate.InitialPledge = big.Sub(miner.ConsensusFaultPenalty(rstate.ThisEpochReward), abi.NewTokenAmount(1))
+
+		currEpoch := abi.ChainEpoch(100000)
+		eligible, err := states.MinerEligibleForElection(store, mstate, pstate, rstate, maddr, currEpoch)
+		require.NoError(t, err)
+		assert.False(t, eligible)
+	})
+}
+
+func TestMinerEligibleAtLookback(t *testing.T) {
+	ctx := context.Background()
+	store := ipld.NewADTStore(ctx)
+	proofType := abi.RegisteredSealProof_StackedDrg32GiBV1
+	maddr := tutil.NewIDAddr(t, 101)
+
+	t.Run("power does not meet minimum", func(t *testing.T) {
+		// get minimums
+		pow32GiBMin, err := builtin.ConsensusMinerMinPower(proofType)
+		require.NoError(t, err)
+		pow64GiBMin, err := builtin.ConsensusMinerMinPower(abi.RegisteredSealProof_StackedDrg64GiBV1)
+		require.NoError(t, err)
+
+		for _, tc := range []struct {
+			consensusMiners int64
+			minerProof      abi.RegisteredSealProof
+			power           abi.StoragePower
+			eligible        bool
+		}{{
+			// below consensus minimum miners, power only needs to be positive to be eligible
+			consensusMiners: 0,
+			minerProof:      proofType,
+			power:           big.Zero(),
+			eligible:        false,
+		}, {
+			consensusMiners: 0,
+			minerProof:      proofType,
+			power:           big.NewInt(1),
+			eligible:        true,
+		}, {
+			// with enough miners above minimum, power must be at or above consensus min
+			consensusMiners: power.ConsensusMinerMinMiners,
+			minerProof:      proofType,
+			power:           big.Sub(pow32GiBMin, big.NewInt(1)),
+			eligible:        false,
+		}, {
+			consensusMiners: power.ConsensusMinerMinMiners,
+			minerProof:      proofType,
+			power:           pow32GiBMin,
+			eligible:        true,
+		}, {
+			// bigger sector size requires higher minimum
+			consensusMiners: power.ConsensusMinerMinMiners,
+			minerProof:      abi.RegisteredSealProof_StackedDrg64GiBV1,
+			power:           pow32GiBMin,
+			eligible:        false,
+		}, {
+			// bigger sector size requires higher minimum
+			consensusMiners: power.ConsensusMinerMinMiners,
+			minerProof:      abi.RegisteredSealProof_StackedDrg64GiBV1,
+			power:           pow64GiBMin,
+			eligible:        true,
+		}} {
+			pstate := constructPowerStateWithMiner(t, store, maddr, tc.power, tc.minerProof)
+			pstate.MinerAboveMinPowerCount = tc.consensusMiners
+			eligible, err := states.MinerEligibleForElectionAtPoStLookback(store, pstate, maddr)
+			require.NoError(t, err)
+			assert.Equal(t, tc.eligible, eligible)
+		}
+	})
+}
+
+func constructMinerState(ctx context.Context, t *testing.T, store adt.Store, owner address.Address) *miner.State {
+	proofType := abi.RegisteredSealProof_StackedDrg32GiBV1
+	ssize, err := proofType.SectorSize()
+	require.NoError(t, err)
+	psize, err := builtin.SealProofWindowPoStPartitionSectors(proofType)
+	require.NoError(t, err)
+
+	info := miner.MinerInfo{
+		Owner:                      owner,
+		Worker:                     owner,
+		ControlAddresses:           []address.Address{},
+		PendingWorkerKey:           nil,
+		PeerId:                     nil,
+		Multiaddrs:                 [][]byte{},
+		SealProofType:              proofType,
+		SectorSize:                 ssize,
+		WindowPoStPartitionSectors: psize,
+		ConsensusFaultElapsed:      0,
+	}
+	infoCid, err := store.Put(ctx, &info)
+	require.NoError(t, err)
+
+	periodStart := abi.ChainEpoch(0)
+
+	emptyMap, err := adt.MakeEmptyMap(store).Root()
+	require.NoError(t, err)
+
+	emptyArray, err := adt.MakeEmptyArray(store).Root()
+	require.NoError(t, err)
+
+	emptyBitfield := bitfield.NewFromSet(nil)
+	emptyBitfieldCid, err := store.Put(ctx, emptyBitfield)
+	require.NoError(t, err)
+
+	emptyDeadline := miner.ConstructDeadline(emptyArray)
+	emptyDeadlineCid, err := store.Put(ctx, emptyDeadline)
+	require.NoError(t, err)
+
+	emptyDeadlines := miner.ConstructDeadlines(emptyDeadlineCid)
+	emptyVestingFunds := miner.ConstructVestingFunds()
+	emptyDeadlinesCid, err := store.Put(ctx, emptyDeadlines)
+	require.NoError(t, err)
+
+	emptyVestingFundsCid, err := store.Put(ctx, emptyVestingFunds)
+	require.NoError(t, err)
+
+	st, err := miner.ConstructState(infoCid, periodStart, 0, emptyBitfieldCid, emptyArray, emptyMap, emptyDeadlinesCid, emptyVestingFundsCid)
+	require.NoError(t, err)
+
+	return st
+}
+
+func constructPowerStateWithMiner(t *testing.T, store adt.Store, maddr address.Address, pwr abi.StoragePower, proof abi.RegisteredSealProof) *power.State {
+	emptyMap, err := adt.MakeEmptyMap(store).Root()
+	require.NoError(t, err)
+	emptyMMap, err := adt.MakeEmptyMultimap(store).Root()
+	require.NoError(t, err)
+	pSt := power.ConstructState(emptyMap, emptyMMap)
+
+	claims, err := adt.AsMap(store, pSt.Claims)
+	require.NoError(t, err)
+
+	claim := &power.Claim{SealProofType: proof, RawBytePower: pwr, QualityAdjPower: pwr}
+
+	err = claims.Put(adt.AddrKey(maddr), claim)
+	require.NoError(t, err)
+
+	pSt.MinerCount += 1
+
+	pSt.Claims, err = claims.Root()
+	require.NoError(t, err)
+	return pSt
+}
+
+func constructRewardState(t *testing.T, epochReward abi.TokenAmount) *reward.State {
+	return &reward.State{
+		CumsumBaseline:          big.Zero(),
+		CumsumRealized:          big.Zero(),
+		EffectiveNetworkTime:    0,
+		EffectiveBaselinePower:  big.Zero(),
+		ThisEpochReward:         epochReward,
+		ThisEpochRewardSmoothed: smoothing.TestingConstantEstimate(big.Zero()),
+		ThisEpochBaselinePower:  big.Zero(),
+		Epoch:                   0,
+		TotalMined:              big.Zero(),
+	}
+}

--- a/actors/states/election_test.go
+++ b/actors/states/election_test.go
@@ -32,8 +32,6 @@ func TestMinerEligibleForElection(t *testing.T) {
 	owner := tutil.NewIDAddr(t, 100)
 	maddr := tutil.NewIDAddr(t, 101)
 
-	// Construct valid power state
-
 	t.Run("miner eligible", func(t *testing.T) {
 		mstate := constructMinerState(ctx, t, store, owner)
 		pstate := constructPowerStateWithMiner(t, store, maddr, pwr, proofType)
@@ -89,7 +87,7 @@ func TestMinerEligibleForElection(t *testing.T) {
 		assert.False(t, eligible)
 	})
 
-	t.Run("ip requirement below consensus fault penalty", func(t *testing.T) {
+	t.Run("IP below consensus fault penalty", func(t *testing.T) {
 		mstate := constructMinerState(ctx, t, store, owner)
 		pstate := constructPowerStateWithMiner(t, store, maddr, pwr, proofType)
 		rstate := constructRewardState(t, tenFIL)
@@ -157,7 +155,7 @@ func TestMinerEligibleAtLookback(t *testing.T) {
 		}} {
 			pstate := constructPowerStateWithMiner(t, store, maddr, tc.power, tc.minerProof)
 			pstate.MinerAboveMinPowerCount = tc.consensusMiners
-			eligible, err := states.MinerEligibleForElectionAtPoStLookback(store, pstate, maddr)
+			eligible, err := states.MinerPoStLookbackEligibleForElection(store, pstate, maddr)
 			require.NoError(t, err)
 			assert.Equal(t, tc.eligible, eligible)
 		}


### PR DESCRIPTION
The miner election eligibility predicates need to be split into one that operates on the parent state, and one at the Winning PoSt lookback.

- Move the predicates into a new `states` package intended for use from outside the actors themselves
- In `MinerEligibleForElection` change the consensus min power check to a non-zero claim check
- Add `MinerEligibleForElectionAtPoStLookback` which checks for consensus min power
- Rework tests to not use the mock runtime or other higher level stuff

Closes #1102
FYI @nicola @whyrusleeping @magik6k 