### PR TITLE
prevent faults from double subtracting cc upgrade power

### DIFF
--- a/actors/builtin/miner/expiration_queue.go
+++ b/actors/builtin/miner/expiration_queue.go
@@ -794,7 +794,7 @@ func (q *ExpirationQueue) findSectorsByExpiration(sectorSize abi.SectorSize, sec
 	if len(allRemaining) > 0 {
 		err := q.traverse(func(epoch abi.ChainEpoch, es *ExpirationSet) (bool, error) {
 			// If this set's epoch is one of our declared epochs, we've already processed it in the loop above,
-			// so skip processing here.
+			// so skip processing here. Sectors rescheduled to this epoch would have been included in the earlier processing.
 			if _, found := declaredExpirations[epoch]; found {
 				return true, nil
 			}

--- a/actors/builtin/miner/expiration_queue.go
+++ b/actors/builtin/miner/expiration_queue.go
@@ -802,7 +802,8 @@ func (q *ExpirationQueue) findSectorsByExpiration(sectorSize abi.SectorSize, sec
 		return nil, err
 	} else if !empty {
 		err := q.traverse(func(epoch abi.ChainEpoch, es *ExpirationSet) (bool, error) {
-			// skip if we've processed this epoch above
+			// If this set's epoch is one of our declared epochs, we've already processed it in the loop above,
+			// so skip processing here.
 			if _, found := declaredExpirations[epoch]; found {
 				return true, nil
 			}

--- a/actors/builtin/miner/expiration_queue.go
+++ b/actors/builtin/miner/expiration_queue.go
@@ -781,15 +781,14 @@ func (q *ExpirationQueue) findSectorsByExpiration(sectorSize abi.SectorSize, sec
 	// Traverse expiration sets first by expected expirations. This will find all groups if no sectors have been rescheduled.
 	// This map iteration is non-deterministic but safe because we sort by epoch below.
 	for expiration := range declaredExpirations { //nolint:nomaprange // result is subsequently sorted
-		var es ExpirationSet
-		if err := q.mustGet(expiration, &es); err != nil {
+		es, err := q.mayGet(expiration)
+		if err != nil {
 			return nil, err
 		}
 
 		// create group from overlap
 		var group sectorExpirationSet
-		var err error
-		group, allNotFound, err = groupExpirationSet(sectorSize, sectorsByNumber, allNotFound, &es, expiration)
+		group, allNotFound, err = groupExpirationSet(sectorSize, sectorsByNumber, allNotFound, es, expiration)
 		if err != nil {
 			return nil, err
 		}

--- a/actors/builtin/miner/expiration_queue.go
+++ b/actors/builtin/miner/expiration_queue.go
@@ -830,6 +830,12 @@ func (q *ExpirationQueue) findSectorsByExpiration(sectorSize abi.SectorSize, sec
 		}
 	}
 
+	if isEmpty, err := allNotFound.IsEmpty(); err != nil {
+		return nil, err
+	} else if !isEmpty {
+		return nil, xerrors.New("some sectors not found in expiration queue")
+	}
+
 	// sort groups, earliest first.
 	sort.Slice(expirationGroups, func(i, j int) bool {
 		return expirationGroups[i].epoch < expirationGroups[j].epoch

--- a/actors/builtin/miner/expiration_queue.go
+++ b/actors/builtin/miner/expiration_queue.go
@@ -852,7 +852,7 @@ func groupExpirationSet(sectorSize abi.SectorSize, sectors map[uint64]*SectorOnC
 		return sectorExpirationSet{}, bitfield.New(), err
 	}
 
-	sectorNumbers := []uint64{}
+	var sectorNumbers []uint64
 	totalPower := NewPowerPairZero()
 	totalPledge := big.Zero()
 	err = matches.ForEach(func(u uint64) error {

--- a/actors/builtin/miner/expiration_queue_internal_test.go
+++ b/actors/builtin/miner/expiration_queue_internal_test.go
@@ -17,7 +17,7 @@ func TestExpirations(t *testing.T) {
 		testSector(14, 3, 0, 0, 0),
 		testSector(13, 4, 0, 0, 0),
 	}
-	result := groupSectorsByExpiration(2048, sectors, quant)
+	result := groupNewSectorsByDeclaredExpiration(2048, sectors, quant)
 	expected := []*sectorEpochSet{{
 		epoch:   13,
 		sectors: []uint64{1, 2, 4},
@@ -37,7 +37,7 @@ func TestExpirations(t *testing.T) {
 
 func TestExpirationsEmpty(t *testing.T) {
 	sectors := []*SectorOnChainInfo{}
-	result := groupSectorsByExpiration(2048, sectors, NoQuantization)
+	result := groupNewSectorsByDeclaredExpiration(2048, sectors, NoQuantization)
 	expected := []sectorEpochSet{}
 	require.Equal(t, expected, result)
 }

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -1005,7 +1005,7 @@ func (st *State) AdvanceDeadline(store adt.Store, currEpoch abi.ChainEpoch) (*Ad
 	pledgeDelta := abi.NewTokenAmount(0)
 	powerDelta := NewPowerPairZero()
 
-	totalFaultyPower := NewPowerPairZero()
+	var totalFaultyPower PowerPair
 	detectedFaultyPower := NewPowerPairZero()
 
 	// Note: Use dlInfo.Last() rather than rt.CurrEpoch unless certain

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -1005,6 +1005,7 @@ func (st *State) AdvanceDeadline(store adt.Store, currEpoch abi.ChainEpoch) (*Ad
 	pledgeDelta := abi.NewTokenAmount(0)
 	powerDelta := NewPowerPairZero()
 
+	totalFaultyPower := NewPowerPairZero()
 	detectedFaultyPower := NewPowerPairZero()
 
 	// Note: Use dlInfo.Last() rather than rt.CurrEpoch unless certain
@@ -1047,6 +1048,10 @@ func (st *State) AdvanceDeadline(store adt.Store, currEpoch abi.ChainEpoch) (*Ad
 		if err != nil {
 			return nil, xerrors.Errorf("failed to process end of deadline %d: %w", dlInfo.Index, err)
 		}
+
+		// Capture deadline's faulty power after new faults have been detected, but before it is
+		// dropped along with faulty sectors expiring this round.
+		totalFaultyPower = deadline.FaultyPower
 	}
 	{
 		// Expire sectors that are due, either for on-time expiration or "early" faulty-for-too-long.
@@ -1095,7 +1100,7 @@ func (st *State) AdvanceDeadline(store adt.Store, currEpoch abi.ChainEpoch) (*Ad
 		pledgeDelta,
 		powerDelta,
 		detectedFaultyPower,
-		deadline.FaultyPower,
+		totalFaultyPower,
 	}, nil
 }
 

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -1058,12 +1058,12 @@ func TestCommitments(t *testing.T) {
 
 		// At proving period cron expect to pay declared fee for new sector
 		// and to have its pledge requirement deducted indicating it has expired.
-		//oldPower := miner.QAPowerForSector(actor.sectorSize, oldSector)
+		oldPower := miner.QAPowerForSector(actor.sectorSize, oldSector)
 		//expectedPowerDelta := miner.NewPowerPair(big.NewInt(int64(actor.sectorSize)), oldPower).Neg()
-		//expectedFee := miner.PledgePenaltyForDeclaredFault(actor.epochRewardSmooth, actor.epochQAPowerSmooth, oldPower)
-		//actor.applyRewards(rt, expectedFee, big.Zero())
+		expectedFee := miner.PledgePenaltyForDeclaredFault(actor.epochRewardSmooth, actor.epochQAPowerSmooth, oldPower)
+		actor.applyRewards(rt, expectedFee, big.Zero())
 		actor.onDeadlineCron(rt, &cronConfig{
-			//detectedFaultsPenalty:     expectedFee,
+			detectedFaultsPenalty:     expectedFee,
 			expiredSectorsPledgeDelta: oldSector.InitialPledge.Neg(),
 			expectedEnrollment:        rt.Epoch() + miner.WPoStChallengeWindow,
 		})

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -1176,7 +1176,7 @@ func TestCCUpgrade(t *testing.T) {
 		// The partition is registered with an expiry at both epochs.
 		dQueue := actor.collectDeadlineExpirations(rt, deadline)
 		dlInfo := miner.NewDeadlineInfo(st.ProvingPeriodStart, dlIdx, rt.Epoch())
-		quantizedExpiration := dlInfo.QuantSpec().QuantizeUp(oldSector.Expiration)
+		quantizedExpiration := miner.QuantSpecForDeadline(dlInfo).QuantizeUp(oldSector.Expiration)
 		assert.Equal(t, map[abi.ChainEpoch][]uint64{
 			dlInfo.NextNotElapsed().Last(): {uint64(0)},
 			quantizedExpiration:            {uint64(0)},

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -987,8 +987,7 @@ func TestCommitments(t *testing.T) {
 
 		// Prove new sector
 		rt.SetEpoch(upgrade.PreCommitEpoch + miner.PreCommitChallengeDelay + 1)
-		newSector := actor.proveCommitSectorAndConfirm(rt, &upgrade.Info, upgrade.PreCommitEpoch,
-			makeProveCommit(upgrade.Info.SectorNumber), proveCommitConf{})
+		newSector := actor.proveCommitSectorAndConfirm(rt, upgrade, makeProveCommit(upgrade.Info.SectorNumber), proveCommitConf{})
 
 		// Both sectors are present (in the same deadline/partition).
 		deadline, partition := actor.getDeadlineAndPartition(rt, dlIdx, partIdx)
@@ -3925,7 +3924,7 @@ func (h *actorHarness) preCommitSector(rt *mock.Runtime, params *miner.PreCommit
 	}
 	st := getState(rt)
 
-	pledgeDelta :=  immediatelyVestingFunds(rt, st).Neg()
+	pledgeDelta := immediatelyVestingFunds(rt, st).Neg()
 	if !pledgeDelta.IsZero() {
 		rt.ExpectSend(builtin.StoragePowerActorAddr, builtin.MethodsPower.UpdatePledgeTotal, &pledgeDelta, big.Zero(), nil, exitcode.Ok)
 	}


### PR DESCRIPTION
closes #1100

### Motivation

All sectors live within an expiration set within an expiration queue within a partition within a deadline. This expiration set is the set at the sectors `Expiration` field. When we reschedule expirations (say for a CC upgrade or a fault), we move it into a different set to trigger an earlier expiration. We do not change the sector's `Expiration` field, so the new set can not necessarily be determined from the sector's on chain info.

Whenever we perform an operation that affects sector expirations, we group the sectors by expiration and operate on the set _en mass_. If sectors have been rescheduled, we end up altering expiration set stats for sectors that are no longer there, and failing to update the stats for the sets to which they have moved. In the case of declaring a fault for a cc upgraded sector, the end result is that we subtract the sectors power twice from the miner's claim (among other accounting mistakes).

The solution implemented in this PR is to check whether sectors expected to be in an expiration set are actually there. Sectors that are not are grouped by iterating through the expiration queue's sets instead. Not adding sectors to groups for expiration sets don't contain them should be sufficient to avoid breaking accounting invariants, whereas finding the sectors in the correct sets should deliver the intended behavior.

### Proposed Changes

1. Implement `findSectorsByExpiration` that groups sectors in the correct expiration set even if they have been rescheduled.
2. Use `findSectorsByExpiration` in `ExpirationQueue.RescheduleAsFaults` and `ExpirationQueue.removeActiveSectors`.
3. Fix regression discovered in this PR that prevented faulty expiring sectors from being penalized in their last proving period cron.
4. Add test for cc upgrading a sector before it is proven.
5. Add test for declaring a fault for a cc replaced sector before it expires.
6. Add test for skipping a cc replaced sector in its last PoSt.
7. Add test for missed PoSt in proving deadline where cc replaced sector expires.
8. Add test for terminating cc replaced sector before it expires.
9. Add test for extending expiration of cc replaced sector before it expires.
10. Add test for faulting and recovering a cc replaced sector before it expires.
11. Rearranged miner tests so tests related to cc upgrades have their own section.

Without the changes to grouping, only 4 and 7 would have behaved as expected.

__Note 11.__: Tests that do not appear in the list have been moved without change and don't require the scrutiny of the rest.