### PR TITLE
Add LockBalance method to set vesting schedule on non-vesting multisig (v0.9)

### DIFF
--- a/actors/builtin/methods.go
+++ b/actors/builtin/methods.go
@@ -40,7 +40,8 @@ var MethodsMultisig = struct {
 	RemoveSigner                abi.MethodNum
 	SwapSigner                  abi.MethodNum
 	ChangeNumApprovalsThreshold abi.MethodNum
-}{MethodConstructor, 2, 3, 4, 5, 6, 7, 8}
+	LockBalance                 abi.MethodNum
+}{MethodConstructor, 2, 3, 4, 5, 6, 7, 8, 9}
 
 var MethodsPaych = struct {
 	Constructor        abi.MethodNum

--- a/actors/builtin/multisig/cbor_gen.go
+++ b/actors/builtin/multisig/cbor_gen.go
@@ -1166,6 +1166,128 @@ func (t *SwapSignerParams) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
+var lengthBufLockBalanceParams = []byte{131}
+
+func (t *LockBalanceParams) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write(lengthBufLockBalanceParams); err != nil {
+		return err
+	}
+
+	scratch := make([]byte, 9)
+
+	// t.StartEpoch (abi.ChainEpoch) (int64)
+	if t.StartEpoch >= 0 {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.StartEpoch)); err != nil {
+			return err
+		}
+	} else {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.StartEpoch-1)); err != nil {
+			return err
+		}
+	}
+
+	// t.UnlockDuration (abi.ChainEpoch) (int64)
+	if t.UnlockDuration >= 0 {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.UnlockDuration)); err != nil {
+			return err
+		}
+	} else {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.UnlockDuration-1)); err != nil {
+			return err
+		}
+	}
+
+	// t.Amount (big.Int) (struct)
+	if err := t.Amount.MarshalCBOR(w); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *LockBalanceParams) UnmarshalCBOR(r io.Reader) error {
+	*t = LockBalanceParams{}
+
+	br := cbg.GetPeeker(r)
+	scratch := make([]byte, 8)
+
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 3 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.StartEpoch (abi.ChainEpoch) (int64)
+	{
+		maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+		var extraI int64
+		if err != nil {
+			return err
+		}
+		switch maj {
+		case cbg.MajUnsignedInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 positive overflow")
+			}
+		case cbg.MajNegativeInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 negative oveflow")
+			}
+			extraI = -1 - extraI
+		default:
+			return fmt.Errorf("wrong type for int64 field: %d", maj)
+		}
+
+		t.StartEpoch = abi.ChainEpoch(extraI)
+	}
+	// t.UnlockDuration (abi.ChainEpoch) (int64)
+	{
+		maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+		var extraI int64
+		if err != nil {
+			return err
+		}
+		switch maj {
+		case cbg.MajUnsignedInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 positive overflow")
+			}
+		case cbg.MajNegativeInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 negative oveflow")
+			}
+			extraI = -1 - extraI
+		default:
+			return fmt.Errorf("wrong type for int64 field: %d", maj)
+		}
+
+		t.UnlockDuration = abi.ChainEpoch(extraI)
+	}
+	// t.Amount (big.Int) (struct)
+
+	{
+
+		if err := t.Amount.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.Amount: %w", err)
+		}
+
+	}
+	return nil
+}
+
 var lengthBufApproveReturn = []byte{131}
 
 func (t *ApproveReturn) MarshalCBOR(w io.Writer) error {

--- a/actors/builtin/multisig/multisig_actor.go
+++ b/actors/builtin/multisig/multisig_actor.go
@@ -417,6 +417,14 @@ type LockBalanceParams struct {
 }
 
 func (a Actor) LockBalance(rt runtime.Runtime, params *LockBalanceParams) *abi.EmptyValue {
+	// This method was introduced at network version 2 in testnet.
+	// Prior to that, the method did not exist so the VM would abort.
+	// Lotus does not enforce that actors shall not abort with system exit codes (at network versions 0 and 1),
+	// so we can exploit this to make the change backwards compatible.
+	if rt.NetworkVersion() < 2 {
+		rt.Abortf(exitcode.SysErrInvalidMethod, "invalid method until network version 2")
+	}
+
 	// Can only be called by the multisig wallet itself.
 	rt.ValidateImmediateCallerIs(rt.Message().Receiver())
 

--- a/actors/builtin/multisig/multisig_state.go
+++ b/actors/builtin/multisig/multisig_state.go
@@ -38,10 +38,11 @@ func (st *State) AmountLocked(elapsedEpoch abi.ChainEpoch) abi.TokenAmount {
 	if elapsedEpoch >= st.UnlockDuration {
 		return abi.NewTokenAmount(0)
 	}
-	if elapsedEpoch <= 0 {
+	if elapsedEpoch < 0 {
 		return st.InitialBalance
 	}
 
+	// TODO: fix division truncation https://github.com/filecoin-project/specs-actors/issues/1131
 	unitLocked := big.Div(st.InitialBalance, big.NewInt(int64(st.UnlockDuration)))
 	return big.Mul(unitLocked, big.Sub(big.NewInt(int64(st.UnlockDuration)), big.NewInt(int64(elapsedEpoch))))
 }

--- a/actors/builtin/multisig/multisig_test.go
+++ b/actors/builtin/multisig/multisig_test.go
@@ -1151,7 +1151,7 @@ func TestAddSigner(t *testing.T) {
 
 			actor.constructAndVerify(rt, tc.initialApprovals, noUnlockDuration, tc.initialSigners...)
 
-			rt.SetCaller(multisigWalletAdd, builtin.AccountActorCodeID)
+			rt.SetCaller(multisigWalletAdd, builtin.MultisigActorCodeID)
 			rt.ExpectValidateCallerAddr(multisigWalletAdd)
 
 			if tc.code != exitcode.Ok {
@@ -1321,7 +1321,7 @@ func TestRemoveSigner(t *testing.T) {
 
 			actor.constructAndVerify(rt, tc.initialApprovals, noUnlockDuration, tc.initialSigners...)
 
-			rt.SetCaller(multisigWalletAdd, builtin.AccountActorCodeID)
+			rt.SetCaller(multisigWalletAdd, builtin.MultisigActorCodeID)
 			rt.ExpectValidateCallerAddr(multisigWalletAdd)
 			if tc.code != exitcode.Ok {
 				rt.ExpectAbort(tc.code, func() {
@@ -1446,7 +1446,7 @@ func TestSwapSigners(t *testing.T) {
 
 			actor.constructAndVerify(rt, numApprovals, noUnlockDuration, tc.initialSigner...)
 
-			rt.SetCaller(multisigWalletAdd, builtin.AccountActorCodeID)
+			rt.SetCaller(multisigWalletAdd, builtin.MultisigActorCodeID)
 			rt.ExpectValidateCallerAddr(multisigWalletAdd)
 			if tc.code != exitcode.Ok {
 				rt.ExpectAbort(tc.code, func() {
@@ -1517,7 +1517,7 @@ func TestChangeThreshold(t *testing.T) {
 
 			actor.constructAndVerify(rt, tc.initialThreshold, noUnlockDuration, initialSigner...)
 
-			rt.SetCaller(multisigWalletAdd, builtin.AccountActorCodeID)
+			rt.SetCaller(multisigWalletAdd, builtin.MultisigActorCodeID)
 			rt.ExpectValidateCallerAddr(multisigWalletAdd)
 			if tc.code != exitcode.Ok {
 				rt.ExpectAbort(tc.code, func() {
@@ -1532,6 +1532,167 @@ func TestChangeThreshold(t *testing.T) {
 			rt.Verify()
 		})
 	}
+}
+
+func TestLockBalance(t *testing.T) {
+	actor := msActorHarness{multisig.Actor{}, t}
+	receiver := tutil.NewIDAddr(t, 100)
+	anne := tutil.NewIDAddr(t, 101)
+	bob := tutil.NewIDAddr(t, 102)
+
+	builder := mock.NewBuilder(context.Background(), receiver).
+		WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID).
+		WithEpoch(0).
+		WithHasher(blake2b.Sum256)
+
+	t.Run("retroactive vesting", func(t *testing.T) {
+		rt := builder.Build(t)
+
+		// Create empty multisig
+		rt.SetEpoch(100)
+		actor.constructAndVerify(rt, 1, 0, anne)
+
+		// Some time later, initialize vesting
+		rt.SetEpoch(200)
+		vestStart := abi.ChainEpoch(0)
+		lockAmount := abi.NewTokenAmount(100_000)
+		vestDuration := abi.ChainEpoch(1000)
+		rt.SetCaller(receiver, builtin.MultisigActorCodeID)
+		rt.ExpectValidateCallerAddr(receiver)
+		actor.lockBalance(rt, vestStart, vestDuration, lockAmount)
+
+		rt.SetEpoch(300)
+		vested := abi.NewTokenAmount(30_000) // Since vestStart
+		rt.SetCaller(anne, builtin.AccountActorCodeID)
+
+		// Fail to spend balance the multisig doesn't have
+		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
+		rt.ExpectAbort(exitcode.ErrInsufficientFunds, func() {
+			actor.proposeOK(rt, bob, vested, builtin.MethodSend, nil, nil)
+		})
+		rt.Reset()
+
+		// Fail to spend more than the vested amount
+		rt.SetBalance(lockAmount)
+		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
+		rt.ExpectAbort(exitcode.ErrInsufficientFunds, func() {
+			actor.proposeOK(rt, bob, big.Add(vested, big.NewInt(1)), builtin.MethodSend, nil, nil)
+		})
+		rt.Reset()
+
+		// Can fully spend the vested amount
+		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
+		rt.ExpectSend(bob, builtin.MethodSend, nil, vested, nil, exitcode.Ok)
+		actor.proposeOK(rt, bob, vested, builtin.MethodSend, nil, nil)
+
+		// Can't spend more
+		rt.SetBalance(big.Sub(lockAmount, vested))
+		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
+		rt.ExpectAbort(exitcode.ErrInsufficientFunds, func() {
+			actor.proposeOK(rt, bob, abi.NewTokenAmount(1), builtin.MethodSend, nil, nil)
+		})
+		rt.Reset()
+
+		// Later, can spend the rest
+		rt.SetEpoch(vestStart+vestDuration)
+		rested := big.NewInt(70_000)
+		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
+		rt.ExpectSend(bob, builtin.MethodSend, nil, rested, nil, exitcode.Ok)
+		actor.proposeOK(rt, bob, rested, builtin.MethodSend, nil, nil)
+	})
+
+	t.Run("prospective vesting", func(t *testing.T) {
+		rt := builder.Build(t)
+
+		// Create empty multisig
+		rt.SetEpoch(100)
+		actor.constructAndVerify(rt, 1, 0, anne)
+
+		// Some time later, initialize vesting
+		rt.SetEpoch(200)
+		vestStart := abi.ChainEpoch(1000)
+		lockAmount := abi.NewTokenAmount(100_000)
+		vestDuration := abi.ChainEpoch(1000)
+		rt.SetCaller(receiver, builtin.MultisigActorCodeID)
+		rt.ExpectValidateCallerAddr(receiver)
+		actor.lockBalance(rt, vestStart, vestDuration, lockAmount)
+
+		rt.SetEpoch(300)
+		rt.SetCaller(anne, builtin.AccountActorCodeID)
+
+		// Oversupply the wallet, allow spending the oversupply.
+		rt.SetBalance(big.Add(lockAmount, abi.NewTokenAmount(1)))
+		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
+		rt.ExpectSend(bob, builtin.MethodSend, nil, abi.NewTokenAmount(1), nil, exitcode.Ok)
+		actor.proposeOK(rt, bob, abi.NewTokenAmount(1), builtin.MethodSend, nil, nil)
+
+		// Fail to spend locked funds before vesting starts
+		rt.SetBalance(lockAmount)
+		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
+		rt.ExpectAbort(exitcode.ErrInsufficientFunds, func() {
+			actor.proposeOK(rt, bob, abi.NewTokenAmount(1), builtin.MethodSend, nil, nil)
+		})
+		rt.Reset()
+
+		// Can spend partially vested amount
+		rt.SetEpoch(vestStart + 200)
+		vested := abi.NewTokenAmount(20_000)
+		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
+		rt.ExpectSend(bob, builtin.MethodSend, nil, vested, nil, exitcode.Ok)
+		actor.proposeOK(rt, bob, vested, builtin.MethodSend, nil, nil)
+
+		// Can't spend more
+		rt.SetBalance(big.Sub(lockAmount, vested))
+		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
+		rt.ExpectAbort(exitcode.ErrInsufficientFunds, func() {
+			actor.proposeOK(rt, bob, abi.NewTokenAmount(1), builtin.MethodSend, nil, nil)
+		})
+		rt.Reset()
+
+		// Later, can spend the rest
+		rt.SetEpoch(vestStart+vestDuration)
+		rested := big.NewInt(80_000)
+		rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
+		rt.ExpectSend(bob, builtin.MethodSend, nil, rested, nil, exitcode.Ok)
+		actor.proposeOK(rt, bob, rested, builtin.MethodSend, nil, nil)
+	})
+
+	t.Run("can't alter vesting", func(t *testing.T) {
+		rt := builder.Build(t)
+
+		// Create empty multisig
+		rt.SetEpoch(100)
+		actor.constructAndVerify(rt, 1, 0, anne)
+
+		// Initialize vesting from zero
+		vestStart := abi.ChainEpoch(0)
+		lockAmount := abi.NewTokenAmount(100_000)
+		vestDuration := abi.ChainEpoch(1000)
+		rt.SetCaller(receiver, builtin.MultisigActorCodeID)
+		rt.ExpectValidateCallerAddr(receiver)
+		actor.lockBalance(rt, vestStart, vestDuration, lockAmount)
+
+		// Can't change vest start
+		rt.ExpectValidateCallerAddr(receiver)
+		rt.ExpectAbort(exitcode.ErrForbidden, func() {
+			actor.lockBalance(rt, vestStart-1, vestDuration, lockAmount)
+		})
+		rt.Reset()
+
+		// Can't change lock duration
+		rt.ExpectValidateCallerAddr(receiver)
+		rt.ExpectAbort(exitcode.ErrForbidden, func() {
+			actor.lockBalance(rt, vestStart, vestDuration - 1, lockAmount)
+		})
+		rt.Reset()
+
+		// Can't change locked amount
+		rt.ExpectValidateCallerAddr(receiver)
+		rt.ExpectAbort(exitcode.ErrForbidden, func() {
+			actor.lockBalance(rt, vestStart, vestDuration, big.Sub(lockAmount, big.NewInt(1)))
+		})
+		rt.Reset()
+	})
 }
 
 //
@@ -1652,11 +1813,22 @@ func (h *msActorHarness) swapSigners(rt *mock.Runtime, oldSigner, newSigner addr
 		To:   newSigner,
 	}
 	rt.Call(h.a.SwapSigner, swpParams)
+	rt.Verify()
 }
 
 func (h *msActorHarness) changeNumApprovalsThreshold(rt *mock.Runtime, newThreshold uint64) {
 	thrshParams := &multisig.ChangeNumApprovalsThresholdParams{NewThreshold: newThreshold}
 	rt.Call(h.a.ChangeNumApprovalsThreshold, thrshParams)
+}
+
+func (h *msActorHarness) lockBalance(rt *mock.Runtime, start, duration abi.ChainEpoch, amount abi.TokenAmount) {
+	params := &multisig.LockBalanceParams{
+		StartEpoch:     start,
+		UnlockDuration: duration,
+		Amount:         amount,
+	}
+	rt.Call(h.a.LockBalance, params)
+	rt.Verify()
 }
 
 func (h *msActorHarness) assertTransactions(rt *mock.Runtime, expected ...multisig.Transaction) {

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -99,6 +99,7 @@ func main() {
 		multisig.TxnIDParams{},
 		multisig.ChangeNumApprovalsThresholdParams{},
 		multisig.SwapSignerParams{},
+		multisig.LockBalanceParams{},
 		// method returns
 		multisig.ApproveReturn{},
 		multisig.ProposeReturn{},


### PR DESCRIPTION
In actors v2, a multisig's vesting start epoch can be set at construction, but in testnet it is always set to the epoch of construction. This PR adds a `LockBalance` method which allows the same vesting initialization for a multisig that was not initially configured with a locked amount. The vesting can only be configured via proposal from the multisig itself

This allows integration partners using the testnet to test out multisig vesting workflows etc prior to a full upgrade to v2.

~We can deploy this into the testnet as a backwards compatible change **if the  Lotus VM rejects method `9` for a multisig actor before the upgrade epoch**.~
Edit: Lotus does not yet prevent actors aborting with system exit codes, so I've added a test of the network version, and abort with `SysErrInvalidMethod` until network version 2.

I'll replicate this on `master` too, though we can consider it's use deprecated.