### PR TITLE
Add assertion that expiration set is valid

### DIFF
--- a/actors/builtin/miner/expiration_queue.go
+++ b/actors/builtin/miner/expiration_queue.go
@@ -140,7 +140,7 @@ func (es *ExpirationSet) ValidateState() error {
 	}
 
 	if es.FaultyPower.QA.LessThan(big.Zero()) {
-		return xerrors.Errorf("ESet left with negative qa active power: %+v", es)
+		return xerrors.Errorf("ESet left with negative qa faulty power: %+v", es)
 	}
 
 	return nil
@@ -302,7 +302,12 @@ func (q ExpirationQueue) RescheduleAllAsFaults(faultExpiration abi.ChainEpoch) e
 			rescheduledPower = rescheduledPower.Add(es.ActivePower)
 			rescheduledPower = rescheduledPower.Add(es.FaultyPower)
 		}
-		return es.ValidateState()
+
+		if err := es.ValidateState(); err != nil {
+			return err
+		}
+
+		return nil
 	}); err != nil {
 		return err
 	}
@@ -385,7 +390,11 @@ func (q ExpirationQueue) RescheduleRecovered(sectors []*SectorOnChainInfo, ssize
 			}
 		}
 
-		return changed, len(remaining) > 0, es.ValidateState()
+		if err = es.ValidateState(); err != nil {
+			return false, false, err
+		}
+
+		return changed, len(remaining) > 0, nil
 	}); err != nil {
 		return NewPowerPairZero(), err
 	}
@@ -507,7 +516,11 @@ func (q ExpirationQueue) RemoveSectors(sectors []*SectorOnChainInfo, faults bitf
 			}
 		}
 
-		return changed, len(remaining) > 0, es.ValidateState()
+		if err = es.ValidateState(); err != nil {
+			return false, false, err
+		}
+
+		return changed, len(remaining) > 0, nil
 	}); err != nil {
 		return nil, recoveringPower, err
 	}

--- a/actors/builtin/miner/expiration_queue.go
+++ b/actors/builtin/miner/expiration_queue.go
@@ -54,7 +54,7 @@ func (es *ExpirationSet) Add(onTimeSectors, earlySectors bitfield.BitField, onTi
 	es.OnTimePledge = big.Add(es.OnTimePledge, onTimePledge)
 	es.ActivePower = es.ActivePower.Add(activePower)
 	es.FaultyPower = es.FaultyPower.Add(faultyPower)
-	return nil
+	return es.ValidateState()
 }
 
 // Removes sectors and power from the expiration set in place.
@@ -88,7 +88,7 @@ func (es *ExpirationSet) Remove(onTimeSectors, earlySectors bitfield.BitField, o
 	if es.ActivePower.QA.LessThan(big.Zero()) || es.FaultyPower.QA.LessThan(big.Zero()) {
 		return xerrors.Errorf("expiration set power underflow: %v", es)
 	}
-	return nil
+	return es.ValidateState()
 }
 
 // A set is empty if it has no sectors.
@@ -119,6 +119,31 @@ func (es *ExpirationSet) Count() (count uint64, err error) {
 	}
 
 	return onTime + early, nil
+}
+
+// validates a set of assertions that must hold for expiration sets
+func (es *ExpirationSet) ValidateState() error {
+	if es.OnTimePledge.LessThan(big.Zero()) {
+		return xerrors.Errorf("ESet left with negative pledge: %+v", es)
+	}
+
+	if es.ActivePower.Raw.LessThan(big.Zero()) {
+		return xerrors.Errorf("ESet left with negative raw active power: %+v", es)
+	}
+
+	if es.ActivePower.QA.LessThan(big.Zero()) {
+		return xerrors.Errorf("ESet left with negative qa active power: %+v", es)
+	}
+
+	if es.FaultyPower.Raw.LessThan(big.Zero()) {
+		return xerrors.Errorf("ESet left with negative raw faulty power: %+v", es)
+	}
+
+	if es.FaultyPower.QA.LessThan(big.Zero()) {
+		return xerrors.Errorf("ESet left with negative qa active power: %+v", es)
+	}
+
+	return nil
 }
 
 // A queue of expiration sets by epoch, representing the on-time or early termination epoch for a collection of sectors.
@@ -228,6 +253,10 @@ func (q ExpirationQueue) RescheduleAsFaults(newExpiration abi.ChainEpoch, sector
 		if err = q.mustUpdateOrDelete(group.epoch, &es); err != nil {
 			return NewPowerPairZero(), err
 		}
+
+		if err = es.ValidateState(); err != nil {
+			return NewPowerPairZero(), err
+		}
 	}
 
 	if len(sectorsTotal) > 0 {
@@ -273,7 +302,7 @@ func (q ExpirationQueue) RescheduleAllAsFaults(faultExpiration abi.ChainEpoch) e
 			rescheduledPower = rescheduledPower.Add(es.ActivePower)
 			rescheduledPower = rescheduledPower.Add(es.FaultyPower)
 		}
-		return nil
+		return es.ValidateState()
 	}); err != nil {
 		return err
 	}
@@ -356,7 +385,7 @@ func (q ExpirationQueue) RescheduleRecovered(sectors []*SectorOnChainInfo, ssize
 			}
 		}
 
-		return changed, len(remaining) > 0, nil
+		return changed, len(remaining) > 0, es.ValidateState()
 	}); err != nil {
 		return NewPowerPairZero(), err
 	}
@@ -478,7 +507,7 @@ func (q ExpirationQueue) RemoveSectors(sectors []*SectorOnChainInfo, faults bitf
 			}
 		}
 
-		return changed, len(remaining) > 0, nil
+		return changed, len(remaining) > 0, es.ValidateState()
 	}); err != nil {
 		return nil, recoveringPower, err
 	}

--- a/actors/builtin/miner/expiration_queue_test.go
+++ b/actors/builtin/miner/expiration_queue_test.go
@@ -591,7 +591,7 @@ func TestExpirationQueue(t *testing.T) {
 		require.NoError(t, err)
 
 		// put queue in a state where some sectors are early and some are faulty
-		_, err = queue.RescheduleAsFaults(abi.ChainEpoch(6), sectors[1:5], sectorSize)
+		_, err = queue.RescheduleAsFaults(abi.ChainEpoch(6), sectors[1:6], sectorSize)
 		require.NoError(t, err)
 
 		_, err = queue.Root()
@@ -609,9 +609,9 @@ func TestExpirationQueue(t *testing.T) {
 		require.NoError(t, err)
 
 		// assert all return values are correct
-		assertBitfieldEquals(t, removed.OnTimeSectors, 1, 4, 6)
-		assertBitfieldEquals(t, removed.EarlySectors, 5)
-		assert.Equal(t, abi.NewTokenAmount(1000+1003+1005), removed.OnTimePledge) // only on-time sectors
+		assertBitfieldEquals(t, removed.OnTimeSectors, 1, 4)
+		assertBitfieldEquals(t, removed.EarlySectors, 5, 6)
+		assert.Equal(t, abi.NewTokenAmount(1000+1003), removed.OnTimePledge) // only on-time sectors
 		assert.True(t, removed.ActivePower.Equals(miner.PowerForSectors(sectorSize, []*miner.SectorOnChainInfo{sectors[0]})))
 		assert.True(t, removed.FaultyPower.Equals(miner.PowerForSectors(sectorSize, sectors[3:6])))
 		assert.True(t, recoveringPower.Equals(miner.PowerForSectors(sectorSize, sectors[5:6])))


### PR DESCRIPTION
closes #1064

### Motivation

The expiration set stores important state that affects power and pledge accounting. It is important that the accounting that happens in the expiration set and expiration queue, is correct. This PR adds validation of several expiration set invariants to all operations that alter expiration sets. 

### Proposed Changes

1. Add `ExpirationSet.ValidateState` method.
2. Call `ValidateState` after every operation that modifies expiration set state.
3. Fix a test that broke due to an invalid setup (it recovered a sector that had not been faulted).

cc @wadeAlexC