### PR TITLE
Add state check functions for verifreg and init

### DIFF
--- a/actors/builtin/init/testing.go
+++ b/actors/builtin/init/testing.go
@@ -1,0 +1,57 @@
+package init
+
+import (
+	addr "github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	cbg "github.com/whyrusleeping/cbor-gen"
+
+	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
+	"github.com/filecoin-project/specs-actors/v2/actors/util/adt"
+)
+
+type StateSummary struct {
+	AddrIDs map[addr.Address]abi.ActorID
+	NextID  abi.ActorID
+}
+
+// Checks internal invariants of init state.
+func CheckStateInvariants(st *State, store adt.Store) (*StateSummary, *builtin.MessageAccumulator, error) {
+	acc := &builtin.MessageAccumulator{}
+
+	acc.Require(len(st.NetworkName) > 0, "network name is empty")
+	acc.Require(st.NextID >= builtin.FirstNonSingletonActorId, "next id %d is too low", st.NextID)
+
+	lut, err := adt.AsMap(store, st.AddressMap)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	addrs := map[addr.Address]abi.ActorID{}
+	reverse := map[abi.ActorID]addr.Address{}
+	var value cbg.CborInt
+	if err = lut.ForEach(&value, func(key string) error {
+		actorId := abi.ActorID(value)
+		keyAddr, err := addr.NewFromBytes([]byte(key))
+		if err != nil {
+			return err
+		}
+
+		acc.Require(keyAddr.Protocol() != addr.ID, "key %v is an ID address", keyAddr)
+		acc.Require(keyAddr.Protocol() <= addr.BLS, "unknown address protocol for key %v", keyAddr)
+		acc.Require(actorId >= builtin.FirstNonSingletonActorId, "unexpected singleton ID value %v", actorId)
+
+		foundAddr, found := reverse[actorId]
+		acc.Require(!found, "duplicate mapping to ID %v: %v, %v", actorId, keyAddr, foundAddr)
+		reverse[actorId] = keyAddr
+
+		addrs[keyAddr] = actorId
+		return nil
+	}); err != nil {
+		return nil, nil, err
+	}
+
+	return &StateSummary{
+		AddrIDs: addrs,
+		NextID:  st.NextID,
+	}, acc, nil
+}

--- a/actors/builtin/testing.go
+++ b/actors/builtin/testing.go
@@ -1,0 +1,40 @@
+package builtin
+
+import (
+	"fmt"
+)
+
+// Accumulates a sequence of messages (e.g. validation failures).
+type MessageAccumulator struct {
+	msgs []string
+}
+
+func (ma *MessageAccumulator) IsEmpty() bool {
+	return len(ma.msgs) == 0
+}
+
+func (ma *MessageAccumulator) Messages() []string {
+	return ma.msgs[:]
+}
+
+// Adds messages to the accumulator.
+func (ma *MessageAccumulator) Add(msgs ...string) {
+	ma.msgs = append(ma.msgs, msgs...)
+}
+
+// Adds a message to the accumulator
+func (ma *MessageAccumulator) Addf(msg string, args ...interface{}) {
+	ma.Add(fmt.Sprintf(msg, args...))
+}
+
+// Adds messages from another accumulator to this one.
+func (ma *MessageAccumulator) AddAll(msgs *MessageAccumulator) {
+	ma.Add(msgs.msgs...)
+}
+
+// Adds a message if predicate is false.
+func (ma *MessageAccumulator) Require(predicate bool, msg string, args ...interface{}) {
+	if !predicate {
+		ma.Add(fmt.Sprintf(msg, args...))
+	}
+}

--- a/actors/builtin/verifreg/testing.go
+++ b/actors/builtin/verifreg/testing.go
@@ -1,0 +1,74 @@
+package verifreg
+
+import (
+	addr "github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+
+	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
+	"github.com/filecoin-project/specs-actors/v2/actors/util/adt"
+)
+
+type StateSummary struct {
+	Verifiers map[addr.Address]DataCap
+	Clients   map[addr.Address]DataCap
+}
+
+// Checks internal invariants of verified registry state.
+func CheckStateInvariants(st *State, store adt.Store) (*StateSummary, *builtin.MessageAccumulator, error) {
+	acc := &builtin.MessageAccumulator{}
+	acc.Require(st.RootKey.Protocol() == addr.ID, "root key %v should have ID protocol", st.RootKey)
+
+	// Check verifiers
+	verifiers, err := adt.AsMap(store, st.Verifiers)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	allVerifiers := map[addr.Address]DataCap{}
+	var vcap abi.StoragePower
+	if err = verifiers.ForEach(&vcap, func(key string) error {
+		verifier, err := addr.NewFromBytes([]byte(key))
+		if err != nil {
+			return err
+		}
+		acc.Require(verifier.Protocol() == addr.ID, "verifier %v should have ID protocol", verifier)
+		acc.Require(vcap.GreaterThanEqual(big.Zero()), "verifier %v cap %v is negative", verifier, vcap)
+		allVerifiers[verifier] = vcap.Copy()
+		return nil
+	}); err != nil {
+		return nil, nil, err
+	}
+
+	// Check clients
+	clients, err := adt.AsMap(store, st.VerifiedClients)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	allClients := map[addr.Address]DataCap{}
+	if err = clients.ForEach(&vcap, func(key string) error {
+		client, err := addr.NewFromBytes([]byte(key))
+		if err != nil {
+			return err
+		}
+		acc.Require(client.Protocol() == addr.ID, "client %v should have ID protocol", client)
+		acc.Require(vcap.GreaterThanEqual(big.Zero()), "client %v cap %v is negative", client, vcap)
+		allClients[client] = vcap.Copy()
+		return nil
+	}); err != nil {
+		return nil, nil, err
+	}
+
+	// Check verifiers and clients are disjoint.
+	for v := range allVerifiers { //nolint:nomaprange
+		_, found := allClients[v]
+		acc.Require(!found, "verifier %v is also a client", v)
+	}
+	// No need to iterate all clients; any overlap must have been one of all verifiers.
+
+	return &StateSummary{
+		Verifiers: allVerifiers,
+		Clients:   allClients,
+	}, acc, nil
+}

--- a/actors/builtin/verifreg/verified_registry_test.go
+++ b/actors/builtin/verifreg/verified_registry_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/exitcode"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
@@ -33,49 +34,40 @@ func TestConstruction(t *testing.T) {
 
 	t.Run("successful construction with root ID address", func(t *testing.T) {
 		rt := runtimeSetup().Build(t)
-		actor := verifreg.Actor{}
-		rt.ExpectValidateCallerAddr(builtin.SystemActorAddr)
-
 		raddr := tutil.NewIDAddr(t, 101)
-		ret := rt.Call(actor.Constructor, &raddr).(*abi.EmptyValue)
-		require.Nil(t, ret)
-		rt.Verify()
 
-		store := adt.AsStore(rt)
+		actor := verifRegActorTestHarness{t: t, rootkey: raddr}
+		actor.constructAndVerify(rt)
 
-		emptyMap, err := adt.MakeEmptyMap(store).Root()
+		emptyMap, err := adt.MakeEmptyMap(rt.AdtStore()).Root()
 		require.NoError(t, err)
 
-		var state verifreg.State
-		rt.GetState(&state)
-
-		require.Equal(t, emptyMap, state.VerifiedClients)
-		require.Equal(t, emptyMap, state.Verifiers)
-		require.Equal(t, raddr, state.RootKey)
+		state := actor.state(rt)
+		assert.Equal(t, emptyMap, state.VerifiedClients)
+		assert.Equal(t, emptyMap, state.Verifiers)
+		assert.Equal(t, raddr, state.RootKey)
+		actor.checkState(rt)
 	})
 
 	t.Run("non-ID address root is resolved to an ID address for construction", func(t *testing.T) {
 		rt := runtimeSetup().Build(t)
-		rt.ExpectValidateCallerAddr(builtin.SystemActorAddr)
-		actor := verifreg.Actor{}
 
 		raddr := tutil.NewBLSAddr(t, 101)
 		rootIdAddr := tutil.NewIDAddr(t, 201)
 		rt.AddIDAddress(raddr, rootIdAddr)
 
-		ret := rt.Call(actor.Constructor, &raddr).(*abi.EmptyValue)
-		require.Nil(t, ret)
-		rt.Verify()
+		actor := verifRegActorTestHarness{t: t, rootkey: raddr}
+		actor.constructAndVerify(rt)
 
-		store := adt.AsStore(rt)
-		emptyMap, err := adt.MakeEmptyMap(store).Root()
+		emptyMap, err := adt.MakeEmptyMap(rt.AdtStore()).Root()
 		require.NoError(t, err)
 
 		var state verifreg.State
 		rt.GetState(&state)
-		require.Equal(t, emptyMap, state.VerifiedClients)
-		require.Equal(t, emptyMap, state.Verifiers)
-		require.Equal(t, rootIdAddr, state.RootKey)
+		assert.Equal(t, emptyMap, state.VerifiedClients)
+		assert.Equal(t, emptyMap, state.Verifiers)
+		assert.Equal(t, rootIdAddr, state.RootKey)
+		actor.checkState(rt)
 	})
 
 	t.Run("fails if root cannot be resolved to an ID address", func(t *testing.T) {
@@ -99,16 +91,14 @@ func TestAddVerifier(t *testing.T) {
 
 	t.Run("fails when caller is not the root key", func(t *testing.T) {
 		rt, ac := basicVerifRegSetup(t, root)
-		verifier := ac.mkVerifierParams(va, allowance)
+		verifier := mkVerifierParams(va, allowance)
 
 		rt.ExpectValidateCallerAddr(ac.rootkey)
-
 		rt.SetCaller(tutil.NewIDAddr(t, 501), builtin.VerifiedRegistryActorCodeID)
 		rt.ExpectAbort(exitcode.ErrForbidden, func() {
 			rt.Call(ac.AddVerifier, verifier)
 		})
-		rt.Verify()
-
+		ac.checkState(rt)
 	})
 
 	t.Run("fails when allowance less than MinVerifiedDealSize", func(t *testing.T) {
@@ -117,6 +107,7 @@ func TestAddVerifier(t *testing.T) {
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			ac.addVerifier(rt, va, big.Sub(verifreg.MinVerifiedDealSize, big.NewInt(1)))
 		})
+		ac.checkState(rt)
 	})
 
 	t.Run("fails when root is added as a verifier", func(t *testing.T) {
@@ -125,6 +116,7 @@ func TestAddVerifier(t *testing.T) {
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			ac.addVerifier(rt, root, allowance)
 		})
+		ac.checkState(rt)
 	})
 
 	t.Run("fails when verified client is added as a verifier", func(t *testing.T) {
@@ -139,7 +131,7 @@ func TestAddVerifier(t *testing.T) {
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			ac.addVerifier(rt, clientAddr, allowance)
 		})
-		rt.Verify()
+		ac.checkState(rt)
 	})
 
 	t.Run("fails to add verifier with non-ID address if not resolvable to ID address", func(t *testing.T) {
@@ -152,11 +144,13 @@ func TestAddVerifier(t *testing.T) {
 		rt.ExpectAbort(exitcode.ErrIllegalState, func() {
 			ac.addNewVerifier(rt, verifierNonIdAddr, allowance)
 		})
+		ac.checkState(rt)
 	})
 
 	t.Run("successfully add a verifier", func(t *testing.T) {
 		rt, ac := basicVerifRegSetup(t, root)
 		ac.addNewVerifier(rt, va, allowance)
+		ac.checkState(rt)
 	})
 
 	t.Run("successfully add a verifier after resolving to ID address", func(t *testing.T) {
@@ -170,7 +164,8 @@ func TestAddVerifier(t *testing.T) {
 		ac.addNewVerifier(rt, verifierNonIdAddr, allowance)
 
 		dc := ac.getVerifierCap(rt, verifierIdAddr)
-		require.EqualValues(t, allowance, dc)
+		assert.EqualValues(t, allowance, dc)
+		ac.checkState(rt)
 	})
 }
 
@@ -185,25 +180,23 @@ func TestRemoveVerifier(t *testing.T) {
 		v := ac.addNewVerifier(rt, va, allowance)
 
 		rt.ExpectValidateCallerAddr(ac.rootkey)
-
 		rt.SetCaller(tutil.NewIDAddr(t, 501), builtin.VerifiedRegistryActorCodeID)
 		rt.ExpectAbort(exitcode.ErrForbidden, func() {
 			rt.Call(ac.RemoveVerifier, &v.Address)
 		})
-		rt.Verify()
+		ac.checkState(rt)
 	})
 
 	t.Run("fails when verifier does not exist", func(t *testing.T) {
 		rt, ac := basicVerifRegSetup(t, root)
 
 		rt.ExpectValidateCallerAddr(ac.rootkey)
-
 		rt.SetCaller(ac.rootkey, builtin.VerifiedRegistryActorCodeID)
 		v := tutil.NewIDAddr(t, 501)
 		rt.ExpectAbort(exitcode.ErrIllegalState, func() {
 			rt.Call(ac.RemoveVerifier, &v)
 		})
-		rt.Verify()
+		ac.checkState(rt)
 	})
 
 	t.Run("successfully remove a verifier", func(t *testing.T) {
@@ -211,6 +204,7 @@ func TestRemoveVerifier(t *testing.T) {
 		ac.addNewVerifier(rt, va, allowance)
 
 		ac.removeVerifier(rt, va)
+		ac.checkState(rt)
 	})
 
 	t.Run("add verifier with non ID address and then remove with its ID address", func(t *testing.T) {
@@ -226,6 +220,7 @@ func TestRemoveVerifier(t *testing.T) {
 		// remove using ID address
 		ac.removeVerifier(rt, verifierIdAddr)
 		ac.assertVerifierRemoved(rt, verifierIdAddr)
+		ac.checkState(rt)
 	})
 }
 
@@ -244,18 +239,18 @@ func TestAddVerifiedClient(t *testing.T) {
 	t.Run("successfully add multiple verified clients from different verifiers", func(t *testing.T) {
 		rt, ac := basicVerifRegSetup(t, root)
 
-		c1 := ac.mkClientParams(clientAddr, clientAllowance)
-		c2 := ac.mkClientParams(clientAddr2, clientAllowance)
-		c3 := ac.mkClientParams(clientAddr3, clientAllowance)
-		c4 := ac.mkClientParams(clientAddr4, clientAllowance)
+		c1 := mkClientParams(clientAddr, clientAllowance)
+		c2 := mkClientParams(clientAddr2, clientAllowance)
+		c3 := mkClientParams(clientAddr3, clientAllowance)
+		c4 := mkClientParams(clientAddr4, clientAllowance)
 
 		// verifier 1 should have enough allowance for both clients
-		verifier := ac.mkVerifierParams(verifierAddr, allowance)
+		verifier := mkVerifierParams(verifierAddr, allowance)
 		verifier.Allowance = big.Sum(c1.Allowance, c2.Allowance)
 		ac.addVerifier(rt, verifier.Address, verifier.Allowance)
 
 		// verifier 2 should have enough allowance for both clients
-		verifier2 := ac.mkVerifierParams(verifierAddr2, allowance)
+		verifier2 := mkVerifierParams(verifierAddr2, allowance)
 		verifier2.Allowance = big.Sum(c3.Allowance, c4.Allowance)
 		ac.addVerifier(rt, verifier2.Address, verifier2.Allowance)
 
@@ -268,23 +263,24 @@ func TestAddVerifiedClient(t *testing.T) {
 		ac.addVerifiedClient(rt, verifier2.Address, c4.Address, c4.Allowance)
 
 		// all clients should exist and verifiers should have no more allowance left
-		require.EqualValues(t, c1.Allowance, ac.getClientCap(rt, c1.Address))
-		require.EqualValues(t, c2.Allowance, ac.getClientCap(rt, c2.Address))
-		require.EqualValues(t, c3.Allowance, ac.getClientCap(rt, c3.Address))
-		require.EqualValues(t, c4.Allowance, ac.getClientCap(rt, c4.Address))
+		assert.EqualValues(t, c1.Allowance, ac.getClientCap(rt, c1.Address))
+		assert.EqualValues(t, c2.Allowance, ac.getClientCap(rt, c2.Address))
+		assert.EqualValues(t, c3.Allowance, ac.getClientCap(rt, c3.Address))
+		assert.EqualValues(t, c4.Allowance, ac.getClientCap(rt, c4.Address))
 
-		require.EqualValues(t, big.Zero(), ac.getVerifierCap(rt, verifierAddr))
-		require.EqualValues(t, big.Zero(), ac.getVerifierCap(rt, verifierAddr2))
+		assert.EqualValues(t, big.Zero(), ac.getVerifierCap(rt, verifierAddr))
+		assert.EqualValues(t, big.Zero(), ac.getVerifierCap(rt, verifierAddr2))
+		ac.checkState(rt)
 	})
 
 	t.Run("verifier successfully adds a verified client and then fails on adding another verified client because of low allowance", func(t *testing.T) {
 		rt, ac := basicVerifRegSetup(t, root)
 
-		c1 := ac.mkClientParams(clientAddr, clientAllowance)
-		c2 := ac.mkClientParams(clientAddr2, clientAllowance)
+		c1 := mkClientParams(clientAddr, clientAllowance)
+		c2 := mkClientParams(clientAddr2, clientAllowance)
 
 		// verifier only has enough balance for one client
-		verifier := ac.mkVerifierParams(verifierAddr, allowance)
+		verifier := mkVerifierParams(verifierAddr, allowance)
 		verifier.Allowance = c1.Allowance
 		ac.addVerifier(rt, verifier.Address, verifier.Allowance)
 
@@ -300,8 +296,9 @@ func TestAddVerifiedClient(t *testing.T) {
 		rt.Verify()
 
 		// one client should exist and verifier should have no more allowance left
-		require.EqualValues(t, c1.Allowance, ac.getClientCap(rt, c1.Address))
-		require.EqualValues(t, big.Zero(), ac.getVerifierCap(rt, verifierAddr))
+		assert.EqualValues(t, c1.Allowance, ac.getClientCap(rt, c1.Address))
+		assert.EqualValues(t, big.Zero(), ac.getVerifierCap(rt, verifierAddr))
+		ac.checkState(rt)
 	})
 
 	t.Run("successfully add a verified client after resolving it's given non ID address to it's ID address", func(t *testing.T) {
@@ -311,44 +308,46 @@ func TestAddVerifiedClient(t *testing.T) {
 		clientNonIdAddr := tutil.NewBLSAddr(t, 1)
 		rt.AddIDAddress(clientNonIdAddr, clientIdAddr)
 
-		c1 := ac.mkClientParams(clientNonIdAddr, clientAllowance)
+		c1 := mkClientParams(clientNonIdAddr, clientAllowance)
 
-		verifier := ac.mkVerifierParams(verifierAddr, allowance)
+		verifier := mkVerifierParams(verifierAddr, allowance)
 		ac.addVerifier(rt, verifier.Address, verifier.Allowance)
 		ac.addVerifiedClient(rt, verifier.Address, c1.Address, c1.Allowance)
 
-		require.EqualValues(t, clientAllowance, ac.getClientCap(rt, clientIdAddr))
+		assert.EqualValues(t, clientAllowance, ac.getClientCap(rt, clientIdAddr))
 
 		// adding another verified client with the same ID address now fails
-		c2 := ac.mkClientParams(clientIdAddr, clientAllowance)
-		verifier = ac.mkVerifierParams(verifierAddr, allowance)
+		c2 := mkClientParams(clientIdAddr, clientAllowance)
+		verifier = mkVerifierParams(verifierAddr, allowance)
 		ac.addVerifier(rt, verifier.Address, verifier.Allowance)
 
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			ac.addVerifiedClient(rt, verifier.Address, c2.Address, c2.Allowance)
 		})
+		ac.checkState(rt)
 	})
 
 	t.Run("success when allowance is equal to MinVerifiedDealSize", func(t *testing.T) {
 		rt, ac := basicVerifRegSetup(t, root)
 
-		c1 := ac.mkClientParams(clientAddr, verifreg.MinVerifiedDealSize)
+		c1 := mkClientParams(clientAddr, verifreg.MinVerifiedDealSize)
 
 		// verifier only has enough balance for one client
-		verifier := ac.mkVerifierParams(verifierAddr, verifreg.MinVerifiedDealSize)
+		verifier := mkVerifierParams(verifierAddr, verifreg.MinVerifiedDealSize)
 		ac.addVerifier(rt, verifier.Address, verifier.Allowance)
 
 		// add client works
 		ac.addVerifiedClient(rt, verifier.Address, c1.Address, c1.Allowance)
+		ac.checkState(rt)
 	})
 
 	t.Run("fails to add verified client if address is not resolvable to ID address", func(t *testing.T) {
 		rt, ac := basicVerifRegSetup(t, root)
 
 		clientNonIdAddr := tutil.NewBLSAddr(t, 1)
-		c1 := ac.mkClientParams(clientNonIdAddr, clientAllowance)
+		c1 := mkClientParams(clientNonIdAddr, clientAllowance)
 
-		verifier := ac.mkVerifierParams(verifierAddr, allowance)
+		verifier := mkVerifierParams(verifierAddr, allowance)
 		ac.addVerifier(rt, verifier.Address, verifier.Allowance)
 
 		rt.ExpectSend(clientNonIdAddr, builtin.MethodSend, nil, abi.NewTokenAmount(0), nil, exitcode.Ok)
@@ -356,6 +355,7 @@ func TestAddVerifiedClient(t *testing.T) {
 		rt.ExpectAbort(exitcode.ErrIllegalState, func() {
 			ac.addVerifiedClient(rt, verifier.Address, c1.Address, c1.Allowance)
 		})
+		ac.checkState(rt)
 	})
 
 	t.Run("fails when allowance is less than MinVerifiedDealSize", func(t *testing.T) {
@@ -368,12 +368,12 @@ func TestAddVerifiedClient(t *testing.T) {
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			rt.Call(ac.AddVerifiedClient, p)
 		})
-		rt.Verify()
+		ac.checkState(rt)
 	})
 
 	t.Run("fails when caller is not a verifier", func(t *testing.T) {
 		rt, ac := basicVerifRegSetup(t, root)
-		client := ac.mkClientParams(clientAddr, clientAllowance)
+		client := mkClientParams(clientAddr, clientAllowance)
 		ac.addNewVerifier(rt, verifierAddr, allowance)
 
 		nc := tutil.NewIDAddr(t, 209)
@@ -383,7 +383,7 @@ func TestAddVerifiedClient(t *testing.T) {
 		rt.ExpectAbort(exitcode.ErrNotFound, func() {
 			rt.Call(ac.AddVerifiedClient, client)
 		})
-		rt.Verify()
+		ac.checkState(rt)
 	})
 
 	t.Run("fails when verifier cap is less than client allowance", func(t *testing.T) {
@@ -393,12 +393,12 @@ func TestAddVerifiedClient(t *testing.T) {
 		rt.SetCaller(verifier.Address, builtin.VerifiedRegistryActorCodeID)
 		rt.ExpectValidateCallerAny()
 
-		client := ac.mkClientParams(clientAddr, clientAllowance)
+		client := mkClientParams(clientAddr, clientAllowance)
 		client.Allowance = big.Add(verifier.Allowance, big.NewInt(1))
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			rt.Call(ac.AddVerifiedClient, client)
 		})
-		rt.Verify()
+		ac.checkState(rt)
 	})
 
 	t.Run("fails when verified client already exists", func(t *testing.T) {
@@ -406,7 +406,7 @@ func TestAddVerifiedClient(t *testing.T) {
 
 		// add verified client with caller 1
 		verifier := ac.addNewVerifier(rt, verifierAddr, allowance)
-		client := ac.mkClientParams(clientAddr, clientAllowance)
+		client := mkClientParams(clientAddr, clientAllowance)
 		ac.addVerifiedClient(rt, verifier.Address, client.Address, client.Allowance)
 
 		// add verified client with caller 2
@@ -416,18 +416,19 @@ func TestAddVerifiedClient(t *testing.T) {
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			rt.Call(ac.AddVerifiedClient, client)
 		})
-		rt.Verify()
+		ac.checkState(rt)
 	})
 
 	t.Run("fails when root is added as a verified client", func(t *testing.T) {
 		rt, ac := basicVerifRegSetup(t, root)
 
 		verifier := ac.addNewVerifier(rt, verifierAddr, allowance)
-		client := ac.mkClientParams(root, clientAllowance)
+		client := mkClientParams(root, clientAllowance)
 
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			ac.addVerifiedClient(rt, verifier.Address, client.Address, client.Allowance)
 		})
+		ac.checkState(rt)
 	})
 
 	t.Run("fails when verifier is added as a verified client", func(t *testing.T) {
@@ -435,13 +436,13 @@ func TestAddVerifiedClient(t *testing.T) {
 
 		// add verified client with caller 1
 		verifier := ac.addNewVerifier(rt, verifierAddr, allowance)
-		client := ac.mkClientParams(verifierAddr, clientAllowance)
+		client := mkClientParams(verifierAddr, clientAllowance)
 		rt.SetCaller(verifier.Address, builtin.VerifiedRegistryActorCodeID)
 		rt.ExpectValidateCallerAny()
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			rt.Call(ac.AddVerifiedClient, client)
 		})
-		rt.Verify()
+		ac.checkState(rt)
 	})
 }
 
@@ -477,8 +478,8 @@ func TestUseBytes(t *testing.T) {
 		ac.useBytes(rt, clientAddr3, dSize, &capExpectation{removed: true})
 
 		// verify
-		require.EqualValues(t, bal1, ac.getClientCap(rt, clientAddr))
-		require.EqualValues(t, bal2, ac.getClientCap(rt, clientAddr2))
+		assert.EqualValues(t, bal1, ac.getClientCap(rt, clientAddr))
+		assert.EqualValues(t, bal2, ac.getClientCap(rt, clientAddr2))
 		ac.assertClientRemoved(rt, clientAddr3)
 
 		// client 1 adds a deal and it works
@@ -488,8 +489,9 @@ func TestUseBytes(t *testing.T) {
 		ac.useBytes(rt, clientAddr2, dSize, &capExpectation{removed: true})
 
 		// verify
-		require.EqualValues(t, bal1, ac.getClientCap(rt, clientAddr))
+		assert.EqualValues(t, bal1, ac.getClientCap(rt, clientAddr))
 		ac.assertClientRemoved(rt, clientAddr2)
+		ac.checkState(rt)
 	})
 
 	t.Run("successfully consume deal bytes for verified client and then fail on next attempt because it does NOT have enough allowance", func(t *testing.T) {
@@ -510,8 +512,7 @@ func TestUseBytes(t *testing.T) {
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			ac.useBytes(rt, param.Address, param.DealSize, nil)
 		})
-
-		rt.Verify()
+		ac.checkState(rt)
 	})
 
 	t.Run("successfully consume deal bytes after resolving verified client address", func(t *testing.T) {
@@ -528,6 +529,7 @@ func TestUseBytes(t *testing.T) {
 		// use bytes
 		dSize1 := verifreg.MinVerifiedDealSize
 		ac.useBytes(rt, clientNonIdAddr, dSize1, &capExpectation{expectedCap: big.Sub(clientAllowance, dSize1)})
+		ac.checkState(rt)
 	})
 
 	t.Run("successfully consume deal for verified client and then fail on next attempt because it has been removed", func(t *testing.T) {
@@ -549,8 +551,7 @@ func TestUseBytes(t *testing.T) {
 			ac.useBytes(rt, param.Address, param.DealSize, nil)
 
 		})
-
-		rt.Verify()
+		ac.checkState(rt)
 	})
 
 	t.Run("fail if caller is not storage market actor", func(t *testing.T) {
@@ -562,8 +563,7 @@ func TestUseBytes(t *testing.T) {
 		rt.ExpectAbort(exitcode.ErrForbidden, func() {
 			rt.Call(ac.UseBytes, param)
 		})
-
-		rt.Verify()
+		ac.checkState(rt)
 	})
 
 	t.Run("fail if deal size is less than min verified deal size", func(t *testing.T) {
@@ -574,8 +574,7 @@ func TestUseBytes(t *testing.T) {
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			ac.useBytes(rt, param.Address, param.DealSize, nil)
 		})
-
-		rt.Verify()
+		ac.checkState(rt)
 	})
 
 	t.Run("fail if verified client does not exist", func(t *testing.T) {
@@ -587,8 +586,7 @@ func TestUseBytes(t *testing.T) {
 			ac.useBytes(rt, param.Address, param.DealSize, nil)
 
 		})
-
-		rt.Verify()
+		ac.checkState(rt)
 	})
 
 	t.Run("fail if deal size is greater than verified client cap", func(t *testing.T) {
@@ -605,8 +603,7 @@ func TestUseBytes(t *testing.T) {
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			ac.useBytes(rt, param.Address, param.DealSize, nil)
 		})
-
-		rt.Verify()
+		ac.checkState(rt)
 	})
 }
 
@@ -643,9 +640,9 @@ func TestRestoreBytes(t *testing.T) {
 		ac.restoreBytes(rt, clientAddr3, dSize, &capExpectation{expectedCap: bal3})
 
 		// verify cap for all three clients
-		require.EqualValues(t, bal1, ac.getClientCap(rt, clientAddr))
-		require.EqualValues(t, bal2, ac.getClientCap(rt, clientAddr2))
-		require.EqualValues(t, bal3, ac.getClientCap(rt, clientAddr3))
+		assert.EqualValues(t, bal1, ac.getClientCap(rt, clientAddr))
+		assert.EqualValues(t, bal2, ac.getClientCap(rt, clientAddr2))
+		assert.EqualValues(t, bal3, ac.getClientCap(rt, clientAddr3))
 
 		bal1 = big.Sub(bal1, dSize)
 		bal2 = big.Sub(bal2, dSize)
@@ -653,9 +650,9 @@ func TestRestoreBytes(t *testing.T) {
 		ac.useBytes(rt, clientAddr, dSize, &capExpectation{expectedCap: bal1})
 		ac.useBytes(rt, clientAddr2, dSize, &capExpectation{expectedCap: bal2})
 
-		require.EqualValues(t, bal1, ac.getClientCap(rt, clientAddr))
-		require.EqualValues(t, bal2, ac.getClientCap(rt, clientAddr2))
-		require.EqualValues(t, bal3, ac.getClientCap(rt, clientAddr3))
+		assert.EqualValues(t, bal1, ac.getClientCap(rt, clientAddr))
+		assert.EqualValues(t, bal2, ac.getClientCap(rt, clientAddr2))
+		assert.EqualValues(t, bal3, ac.getClientCap(rt, clientAddr3))
 
 		bal1 = big.Add(bal1, dSize)
 		bal2 = big.Add(bal2, dSize)
@@ -664,9 +661,10 @@ func TestRestoreBytes(t *testing.T) {
 		ac.restoreBytes(rt, clientAddr, dSize, &capExpectation{expectedCap: bal1})
 		ac.restoreBytes(rt, clientAddr2, dSize, &capExpectation{expectedCap: bal2})
 		ac.restoreBytes(rt, clientAddr3, dSize, &capExpectation{expectedCap: bal3})
-		require.EqualValues(t, bal1, ac.getClientCap(rt, clientAddr))
-		require.EqualValues(t, bal2, ac.getClientCap(rt, clientAddr2))
-		require.EqualValues(t, bal3, ac.getClientCap(rt, clientAddr3))
+		assert.EqualValues(t, bal1, ac.getClientCap(rt, clientAddr))
+		assert.EqualValues(t, bal2, ac.getClientCap(rt, clientAddr2))
+		assert.EqualValues(t, bal3, ac.getClientCap(rt, clientAddr3))
+		ac.checkState(rt)
 	})
 
 	t.Run("successfully restore bytes after using bytes reduces a client's cap", func(t *testing.T) {
@@ -681,6 +679,7 @@ func TestRestoreBytes(t *testing.T) {
 
 		sz := verifreg.MinVerifiedDealSize
 		ac.restoreBytes(rt, clientAddr, sz, &capExpectation{expectedCap: big.Add(bal, sz)})
+		ac.checkState(rt)
 	})
 
 	t.Run("successfully restore deal bytes after resolving client address", func(t *testing.T) {
@@ -701,7 +700,8 @@ func TestRestoreBytes(t *testing.T) {
 		sz := verifreg.MinVerifiedDealSize
 		ac.restoreBytes(rt, clientNonIdAddr, sz, &capExpectation{expectedCap: big.Add(bal, sz)})
 
-		require.EqualValues(t, big.Add(bal, sz), ac.getClientCap(rt, clientIdAddr))
+		assert.EqualValues(t, big.Add(bal, sz), ac.getClientCap(rt, clientIdAddr))
+		ac.checkState(rt)
 	})
 
 	t.Run("successfully restore bytes after using bytes removes a client", func(t *testing.T) {
@@ -715,6 +715,7 @@ func TestRestoreBytes(t *testing.T) {
 
 		sz := verifreg.MinVerifiedDealSize
 		ac.restoreBytes(rt, clientAddr, sz, &capExpectation{expectedCap: sz})
+		ac.checkState(rt)
 	})
 
 	t.Run("fail if caller is not storage market actor", func(t *testing.T) {
@@ -726,8 +727,7 @@ func TestRestoreBytes(t *testing.T) {
 		rt.ExpectAbort(exitcode.ErrForbidden, func() {
 			rt.Call(ac.RestoreBytes, param)
 		})
-
-		rt.Verify()
+		ac.checkState(rt)
 	})
 
 	t.Run("fail if deal size is less than min verified deal size", func(t *testing.T) {
@@ -740,8 +740,7 @@ func TestRestoreBytes(t *testing.T) {
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			rt.Call(ac.RestoreBytes, param)
 		})
-
-		rt.Verify()
+		ac.checkState(rt)
 	})
 
 	t.Run("fails if attempt to restore bytes for root", func(t *testing.T) {
@@ -753,8 +752,7 @@ func TestRestoreBytes(t *testing.T) {
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			rt.Call(ac.RestoreBytes, param)
 		})
-
-		rt.Verify()
+		ac.checkState(rt)
 	})
 
 	t.Run("fails if attempt to restore bytes for verifier", func(t *testing.T) {
@@ -769,8 +767,7 @@ func TestRestoreBytes(t *testing.T) {
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			rt.Call(ac.RestoreBytes, param)
 		})
-
-		rt.Verify()
+		ac.checkState(rt)
 	})
 }
 
@@ -800,16 +797,21 @@ func (h *verifRegActorTestHarness) constructAndVerify(rt *mock.Runtime) {
 	rt.Verify()
 }
 
-func (h *verifRegActorTestHarness) mkVerifierParams(a address.Address, allowance verifreg.DataCap) *verifreg.AddVerifierParams {
-	return &verifreg.AddVerifierParams{Address: a, Allowance: allowance}
+func (h *verifRegActorTestHarness) state(rt *mock.Runtime) *verifreg.State {
+	var st verifreg.State
+	rt.GetState(&st)
+	return &st
 }
 
-func (h *verifRegActorTestHarness) mkClientParams(a address.Address, cap verifreg.DataCap) *verifreg.AddVerifiedClientParams {
-	return &verifreg.AddVerifiedClientParams{Address: a, Allowance: cap}
+func (h *verifRegActorTestHarness) checkState(rt *mock.Runtime) {
+	st := h.state(rt)
+	_, msgs, err := verifreg.CheckStateInvariants(st, rt.AdtStore())
+	assert.NoError(h.t, err)
+	assert.True(h.t, msgs.IsEmpty())
 }
 
 func (h *verifRegActorTestHarness) addNewVerifier(rt *mock.Runtime, a address.Address, allowance verifreg.DataCap) *verifreg.AddVerifierParams {
-	v := h.mkVerifierParams(a, allowance)
+	v := mkVerifierParams(a, allowance)
 	h.addVerifier(rt, v.Address, v.Allowance)
 	return v
 }
@@ -818,12 +820,12 @@ func (h *verifRegActorTestHarness) generateAndAddVerifierAndVerifiedClient(rt *m
 	verifierAllowance verifreg.DataCap, clientAllowance verifreg.DataCap) {
 
 	// add verifier with greater allowance than client
-	verifier := h.mkVerifierParams(verifierAddr, verifierAllowance)
+	verifier := mkVerifierParams(verifierAddr, verifierAllowance)
 	verifier.Allowance = big.Add(verifier.Allowance, clientAllowance)
 	h.addVerifier(rt, verifier.Address, verifier.Allowance)
 
 	// add client
-	client := h.mkClientParams(clientAddr, clientAllowance)
+	client := mkClientParams(clientAddr, clientAllowance)
 	client.Allowance = clientAllowance
 	h.addVerifiedClient(rt, verifier.Address, client.Address, client.Allowance)
 }
@@ -838,8 +840,7 @@ func (h *verifRegActorTestHarness) addVerifiedClient(rt *mock.Runtime, verifier,
 
 	clientIdAddr, found := rt.GetIdAddr(client)
 	require.True(h.t, found)
-
-	require.EqualValues(h.t, allowance, h.getClientCap(rt, clientIdAddr))
+	assert.EqualValues(h.t, allowance, h.getClientCap(rt, clientIdAddr))
 }
 
 func (h *verifRegActorTestHarness) addVerifier(rt *mock.Runtime, verifier address.Address, datacap verifreg.DataCap) {
@@ -853,9 +854,8 @@ func (h *verifRegActorTestHarness) addVerifier(rt *mock.Runtime, verifier addres
 
 	verifierIdAddr, found := rt.GetIdAddr(verifier)
 	require.True(h.t, found)
-
-	require.Nil(h.t, ret)
-	require.EqualValues(h.t, datacap, h.getVerifierCap(rt, verifierIdAddr))
+	assert.Nil(h.t, ret)
+	assert.EqualValues(h.t, datacap, h.getVerifierCap(rt, verifierIdAddr))
 }
 
 func (h *verifRegActorTestHarness) removeVerifier(rt *mock.Runtime, verifier address.Address) {
@@ -882,7 +882,7 @@ func (h *verifRegActorTestHarness) useBytes(rt *mock.Runtime, a address.Address,
 
 	ret := rt.Call(h.UseBytes, param)
 	rt.Verify()
-	require.Nil(h.t, ret)
+	assert.Nil(h.t, ret)
 
 	clientIdAddr, found := rt.GetIdAddr(a)
 	require.True(h.t, found)
@@ -891,7 +891,7 @@ func (h *verifRegActorTestHarness) useBytes(rt *mock.Runtime, a address.Address,
 	if expectedCap.removed {
 		h.assertClientRemoved(rt, clientIdAddr)
 	} else {
-		require.EqualValues(h.t, expectedCap.expectedCap, h.getClientCap(rt, clientIdAddr))
+		assert.EqualValues(h.t, expectedCap.expectedCap, h.getClientCap(rt, clientIdAddr))
 	}
 }
 
@@ -903,13 +903,13 @@ func (h *verifRegActorTestHarness) restoreBytes(rt *mock.Runtime, a address.Addr
 	param := &verifreg.RestoreBytesParams{Address: a, DealSize: dealSize}
 	ret := rt.Call(h.RestoreBytes, param)
 	rt.Verify()
-	require.Nil(h.t, ret)
+	assert.Nil(h.t, ret)
 
 	clientIdAddr, found := rt.GetIdAddr(a)
 	require.True(h.t, found)
 
 	// assert client cap now
-	require.EqualValues(h.t, expectedCap.expectedCap, h.getClientCap(rt, clientIdAddr))
+	assert.EqualValues(h.t, expectedCap.expectedCap, h.getClientCap(rt, clientIdAddr))
 }
 
 func (h *verifRegActorTestHarness) getVerifierCap(rt *mock.Runtime, a address.Address) verifreg.DataCap {
@@ -950,7 +950,7 @@ func (h *verifRegActorTestHarness) assertVerifierRemoved(rt *mock.Runtime, a add
 	var dc verifreg.DataCap
 	found, err := v.Get(abi.AddrKey(a), &dc)
 	require.NoError(h.t, err)
-	require.False(h.t, found)
+	assert.False(h.t, found)
 }
 
 func (h *verifRegActorTestHarness) assertClientRemoved(rt *mock.Runtime, a address.Address) {
@@ -963,5 +963,14 @@ func (h *verifRegActorTestHarness) assertClientRemoved(rt *mock.Runtime, a addre
 	var dc verifreg.DataCap
 	found, err := v.Get(abi.AddrKey(a), &dc)
 	require.NoError(h.t, err)
-	require.False(h.t, found)
+	assert.False(h.t, found)
 }
+
+func mkVerifierParams(a address.Address, allowance verifreg.DataCap) *verifreg.AddVerifierParams {
+	return &verifreg.AddVerifierParams{Address: a, Allowance: allowance}
+}
+
+func mkClientParams(a address.Address, cap verifreg.DataCap) *verifreg.AddVerifiedClientParams {
+	return &verifreg.AddVerifiedClientParams{Address: a, Allowance: cap}
+}
+

--- a/actors/states/check.go
+++ b/actors/states/check.go
@@ -1,0 +1,88 @@
+package states
+
+import (
+	addr "github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/specs-actors/actors/states"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
+	init_ "github.com/filecoin-project/specs-actors/v2/actors/builtin/init"
+	"github.com/filecoin-project/specs-actors/v2/actors/builtin/verifreg"
+)
+
+func CheckStateInvariants(tree states.Tree, expectedBalanceTotal abi.TokenAmount) (*builtin.MessageAccumulator, error) {
+	msgs := &builtin.MessageAccumulator{}
+	totalFIl := big.Zero()
+	var initSummary *init_.StateSummary
+	var verifregSummary *verifreg.StateSummary
+
+	if err := tree.ForEach(func(key addr.Address, actor *states.Actor) error {
+		if key.Protocol() != addr.ID {
+			msgs.Addf("unexpected address protocol in state tree root: %v", key)
+		}
+		totalFIl = big.Add(totalFIl, actor.Balance)
+
+		switch actor.Code {
+		case builtin.SystemActorCodeID:
+
+		case builtin.InitActorCodeID:
+			var st init_.State
+			if err := tree.Store.Get(tree.Store.Context(), actor.Head, &st); err != nil {
+				return err
+			}
+			if summary, msgs, err := init_.CheckStateInvariants(&st, tree.Store); err != nil {
+				return err
+			} else {
+				msgs.AddAll(msgs)
+				initSummary = summary
+			}
+		case builtin.CronActorCodeID:
+
+		case builtin.AccountActorCodeID:
+
+		case builtin.StoragePowerActorCodeID:
+
+		case builtin.StorageMinerActorCodeID:
+
+		case builtin.StorageMarketActorCodeID:
+
+		case builtin.PaymentChannelActorCodeID:
+
+		case builtin.MultisigActorCodeID:
+
+		case builtin.RewardActorCodeID:
+
+		case builtin.VerifiedRegistryActorCodeID:
+			var st verifreg.State
+			if err := tree.Store.Get(tree.Store.Context(), actor.Head, &st); err != nil {
+				return err
+			}
+			if summary, msgs, err := verifreg.CheckStateInvariants(&st, tree.Store); err != nil {
+				return err
+			} else {
+				msgs.AddAll(msgs)
+				verifregSummary = summary
+			}
+		default:
+			return xerrors.Errorf("unexpected actor code CID %v for address %v", actor.Code, key)
+
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	//
+	// Perform cross-actor checks from state summaries here.
+	//
+	_ = initSummary
+	_ = verifregSummary
+
+	if !totalFIl.Equals(expectedBalanceTotal) {
+		msgs.Addf("total token balance is %v, expected %v", totalFIl, expectedBalanceTotal)
+	}
+
+	return msgs, nil
+}


### PR DESCRIPTION
This is prototyping a pattern I think we can adopt for all actor states, with state checks we can invoke in every unit and scenario test, and as a post-migration check.

More work:
- Add checks for each actor (for miner, extract deadline/partition checks from existing unit tests)
- Add top-level state tree traversal to check all actors (blocked on top-level state tree)
- Add cross-actor and aggregate state checks, e.g. miners with power
- Invoke full-state check in scenario tests and migration

FYI @acruikshank 