### PR TITLE
terminate sectors scenario test

### DIFF
--- a/actors/test/committed_capacity_scenario_test.go
+++ b/actors/test/committed_capacity_scenario_test.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"testing"
 
-	addr "github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-bitfield"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
-	"github.com/filecoin-project/go-state-types/crypto"
 	"github.com/filecoin-project/go-state-types/exitcode"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -415,53 +413,4 @@ func TestReplaceCommittedCapacitySectorWithDealLadenSector(t *testing.T) {
 	assert.Equal(t, upgradeSectorPower.QA, minerPower.QA)
 	assert.Equal(t, upgradeSectorPower.Raw, networkStats.TotalBytesCommitted)
 	assert.Equal(t, upgradeSectorPower.QA, networkStats.TotalQABytesCommitted)
-}
-
-func publishDeal(t *testing.T, v *vm.VM, provider, dealClient, minerID addr.Address, dealLabel string,
-	pieceSize abi.PaddedPieceSize, verifiedDeal bool, dealStart abi.ChainEpoch, dealLifetime abi.ChainEpoch,
-) *market.PublishStorageDealsReturn {
-	deal := market.DealProposal{
-		PieceCID:             tutil.MakeCID(dealLabel, &market.PieceCIDPrefix),
-		PieceSize:            pieceSize,
-		VerifiedDeal:         verifiedDeal,
-		Client:               dealClient,
-		Provider:             minerID,
-		Label:                dealLabel,
-		StartEpoch:           dealStart,
-		EndEpoch:             dealStart + dealLifetime,
-		StoragePricePerEpoch: abi.NewTokenAmount(1 << 20),
-		ProviderCollateral:   big.Mul(big.NewInt(2), vm.FIL),
-		ClientCollateral:     big.Mul(big.NewInt(1), vm.FIL),
-	}
-
-	publishDealParams := market.PublishStorageDealsParams{
-		Deals: []market.ClientDealProposal{{
-			Proposal:        deal,
-			ClientSignature: crypto.Signature{},
-		}},
-	}
-	ret, code := v.ApplyMessage(provider, builtin.StorageMarketActorAddr, big.Zero(), builtin.MethodsMarket.PublishStorageDeals, &publishDealParams)
-	require.Equal(t, exitcode.Ok, code)
-
-	expectedPublishSubinvocations := []vm.ExpectInvocation{
-		{To: minerID, Method: builtin.MethodsMiner.ControlAddresses, SubInvocations: []vm.ExpectInvocation{}},
-		{To: builtin.RewardActorAddr, Method: builtin.MethodsReward.ThisEpochReward, SubInvocations: []vm.ExpectInvocation{}},
-		{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.CurrentTotalPower, SubInvocations: []vm.ExpectInvocation{}},
-	}
-
-	if verifiedDeal {
-		expectedPublishSubinvocations = append(expectedPublishSubinvocations, vm.ExpectInvocation{
-			To:             builtin.VerifiedRegistryActorAddr,
-			Method:         builtin.MethodsVerifiedRegistry.UseBytes,
-			SubInvocations: []vm.ExpectInvocation{},
-		})
-	}
-
-	vm.ExpectInvocation{
-		To:             builtin.StorageMarketActorAddr,
-		Method:         builtin.MethodsMarket.PublishStorageDeals,
-		SubInvocations: expectedPublishSubinvocations,
-	}.Matches(t, v.LastInvocation())
-
-	return ret.(*market.PublishStorageDealsReturn)
 }

--- a/actors/test/common_test.go
+++ b/actors/test/common_test.go
@@ -1,0 +1,66 @@
+package test_test
+
+import (
+	"testing"
+
+	addr "github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/crypto"
+	"github.com/filecoin-project/go-state-types/exitcode"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
+	"github.com/filecoin-project/specs-actors/v2/actors/builtin/market"
+	tutil "github.com/filecoin-project/specs-actors/v2/support/testing"
+	vm "github.com/filecoin-project/specs-actors/v2/support/vm"
+)
+
+func publishDeal(t *testing.T, v *vm.VM, provider, dealClient, minerID addr.Address, dealLabel string,
+	pieceSize abi.PaddedPieceSize, verifiedDeal bool, dealStart abi.ChainEpoch, dealLifetime abi.ChainEpoch,
+) *market.PublishStorageDealsReturn {
+	deal := market.DealProposal{
+		PieceCID:             tutil.MakeCID(dealLabel, &market.PieceCIDPrefix),
+		PieceSize:            pieceSize,
+		VerifiedDeal:         verifiedDeal,
+		Client:               dealClient,
+		Provider:             minerID,
+		Label:                dealLabel,
+		StartEpoch:           dealStart,
+		EndEpoch:             dealStart + dealLifetime,
+		StoragePricePerEpoch: abi.NewTokenAmount(1 << 20),
+		ProviderCollateral:   big.Mul(big.NewInt(2), vm.FIL),
+		ClientCollateral:     big.Mul(big.NewInt(1), vm.FIL),
+	}
+
+	publishDealParams := market.PublishStorageDealsParams{
+		Deals: []market.ClientDealProposal{{
+			Proposal:        deal,
+			ClientSignature: crypto.Signature{},
+		}},
+	}
+	ret, code := v.ApplyMessage(provider, builtin.StorageMarketActorAddr, big.Zero(), builtin.MethodsMarket.PublishStorageDeals, &publishDealParams)
+	require.Equal(t, exitcode.Ok, code)
+
+	expectedPublishSubinvocations := []vm.ExpectInvocation{
+		{To: minerID, Method: builtin.MethodsMiner.ControlAddresses, SubInvocations: []vm.ExpectInvocation{}},
+		{To: builtin.RewardActorAddr, Method: builtin.MethodsReward.ThisEpochReward, SubInvocations: []vm.ExpectInvocation{}},
+		{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.CurrentTotalPower, SubInvocations: []vm.ExpectInvocation{}},
+	}
+
+	if verifiedDeal {
+		expectedPublishSubinvocations = append(expectedPublishSubinvocations, vm.ExpectInvocation{
+			To:             builtin.VerifiedRegistryActorAddr,
+			Method:         builtin.MethodsVerifiedRegistry.UseBytes,
+			SubInvocations: []vm.ExpectInvocation{},
+		})
+	}
+
+	vm.ExpectInvocation{
+		To:             builtin.StorageMarketActorAddr,
+		Method:         builtin.MethodsMarket.PublishStorageDeals,
+		SubInvocations: expectedPublishSubinvocations,
+	}.Matches(t, v.LastInvocation())
+
+	return ret.(*market.PublishStorageDealsReturn)
+}

--- a/actors/test/market_withdrawal_test.go
+++ b/actors/test/market_withdrawal_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/filecoin-project/go-state-types/big"
-	"github.com/filecoin-project/go-state-types/exitcode"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -23,8 +22,7 @@ func TestMarketWithdraw(t *testing.T) {
 
 	// add market collateral for clients and miner
 	collateral := big.Mul(big.NewInt(3), vm.FIL)
-	_, code := v.ApplyMessage(caller, builtin.StorageMarketActorAddr, collateral, builtin.MethodsMarket.AddBalance, &caller)
-	require.Equal(t, exitcode.Ok, code)
+	vm.ApplyOk(t, v, caller, builtin.StorageMarketActorAddr, collateral, builtin.MethodsMarket.AddBalance, &caller)
 
 	a, found, err := v.GetActor(caller)
 	require.NoError(t, err)
@@ -36,8 +34,7 @@ func TestMarketWithdraw(t *testing.T) {
 		ProviderOrClientAddress: caller,
 		Amount:                  collateral,
 	}
-	_, code = v.ApplyMessage(caller, builtin.StorageMarketActorAddr, big.Zero(), builtin.MethodsMarket.WithdrawBalance, params)
-	require.Equal(t, exitcode.Ok, code)
+	vm.ApplyOk(t, v, caller, builtin.StorageMarketActorAddr, big.Zero(), builtin.MethodsMarket.WithdrawBalance, params)
 
 	a, found, err = v.GetActor(caller)
 	require.NoError(t, err)

--- a/actors/test/power_scenario_test.go
+++ b/actors/test/power_scenario_test.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
-	"github.com/filecoin-project/go-state-types/exitcode"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
@@ -27,8 +25,7 @@ func TestCreateMiner(t *testing.T) {
 		SealProofType: abi.RegisteredSealProof_StackedDrg32GiBV1,
 		Peer:          abi.PeerID("not really a peer id"),
 	}
-	ret, code := v.ApplyMessage(addrs[0], builtin.StoragePowerActorAddr, big.NewInt(1e10), builtin.MethodsPower.CreateMiner, &params)
-	assert.Equal(t, exitcode.Ok, code)
+	ret := vm.ApplyOk(t, v, addrs[0], builtin.StoragePowerActorAddr, big.NewInt(1e10), builtin.MethodsPower.CreateMiner, &params)
 
 	minerAddrs, ok := ret.(*power.CreateMinerReturn)
 	require.True(t, ok)
@@ -75,8 +72,7 @@ func TestOnEpochTickEnd(t *testing.T) {
 
 	// create a miner
 	params := power.CreateMinerParams{Owner: addrs[0], Worker: addrs[0], SealProofType: abi.RegisteredSealProof_StackedDrg32GiBV1, Peer: abi.PeerID("pid")}
-	ret, code := v.ApplyMessage(addrs[0], builtin.StoragePowerActorAddr, big.NewInt(1e10), builtin.MethodsPower.CreateMiner, &params)
-	assert.Equal(t, exitcode.Ok, code)
+	ret := vm.ApplyOk(t, v, addrs[0], builtin.StoragePowerActorAddr, big.NewInt(1e10), builtin.MethodsPower.CreateMiner, &params)
 
 	ret, ok := ret.(*power.CreateMinerReturn)
 	require.True(t, ok)
@@ -94,8 +90,7 @@ func TestOnEpochTickEnd(t *testing.T) {
 	require.NoError(t, err)
 
 	// run cron and expect a call to miner and a call to update reward actor parameters
-	_, code = v.ApplyMessage(builtin.CronActorAddr, builtin.StoragePowerActorAddr, big.Zero(), builtin.MethodsPower.OnEpochTickEnd, abi.Empty)
-	assert.Equal(t, exitcode.Ok, code)
+	vm.ApplyOk(t, v, builtin.CronActorAddr, builtin.StoragePowerActorAddr, big.Zero(), builtin.MethodsPower.OnEpochTickEnd, abi.Empty)
 
 	// expect miner call to be missing
 	vm.ExpectInvocation{
@@ -115,8 +110,7 @@ func TestOnEpochTickEnd(t *testing.T) {
 	require.NoError(t, err)
 
 	// run cron and expect a call to miner and a call to update reward actor parameters
-	_, code = v.ApplyMessage(builtin.CronActorAddr, builtin.StoragePowerActorAddr, big.Zero(), builtin.MethodsPower.OnEpochTickEnd, abi.Empty)
-	assert.Equal(t, exitcode.Ok, code)
+	vm.ApplyOk(t, v, builtin.CronActorAddr, builtin.StoragePowerActorAddr, big.Zero(), builtin.MethodsPower.OnEpochTickEnd, abi.Empty)
 
 	// expect call to miner
 	vm.ExpectInvocation{

--- a/actors/test/terminate_sectors_scenario_test.go
+++ b/actors/test/terminate_sectors_scenario_test.go
@@ -1,0 +1,198 @@
+package test_test
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"testing"
+
+	"github.com/filecoin-project/go-bitfield"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/exitcode"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
+	"github.com/filecoin-project/specs-actors/v2/actors/builtin/miner"
+	"github.com/filecoin-project/specs-actors/v2/actors/builtin/power"
+	"github.com/filecoin-project/specs-actors/v2/actors/builtin/verifreg"
+	"github.com/filecoin-project/specs-actors/v2/actors/runtime/proof"
+	tutil "github.com/filecoin-project/specs-actors/v2/support/testing"
+	vm "github.com/filecoin-project/specs-actors/v2/support/vm"
+)
+
+func TestTerminateSectors(t *testing.T) {
+	ctx := context.Background()
+	v := vm.NewVMWithSingletons(ctx, t)
+	addrs := vm.CreateAccounts(ctx, t, v, 4, big.Mul(big.NewInt(10_000), vm.FIL), 93837778)
+	worker, verifier, unverifiedClient, verifiedClient := addrs[0], addrs[1], addrs[2], addrs[3]
+
+	minerBalance := big.Mul(big.NewInt(1_000), vm.FIL)
+	sectorNumber := abi.SectorNumber(100)
+	sealedCid := tutil.MakeCID("100", &miner.SealedCIDPrefix)
+	sealProof := abi.RegisteredSealProof_StackedDrg32GiBV1
+
+	// create miner
+	params := power.CreateMinerParams{
+		Owner:         worker,
+		Worker:        worker,
+		SealProofType: sealProof,
+		Peer:          abi.PeerID("not really a peer id"),
+	}
+	ret, code := v.ApplyMessage(addrs[0], builtin.StoragePowerActorAddr, minerBalance, builtin.MethodsPower.CreateMiner, &params)
+	require.Equal(t, exitcode.Ok, code)
+
+	minerAddrs, ok := ret.(*power.CreateMinerReturn)
+	require.True(t, ok)
+
+	//
+	// publish verified and unverified deals
+	//
+
+	// register verifier then verified client
+	addVerifierParams := verifreg.AddVerifierParams{
+		Address:   verifier,
+		Allowance: abi.NewStoragePower(32 << 40),
+	}
+	_, code = v.ApplyMessage(vm.VerifregRoot, builtin.VerifiedRegistryActorAddr, big.Zero(), builtin.MethodsVerifiedRegistry.AddVerifier, &addVerifierParams)
+	require.Equal(t, exitcode.Ok, code)
+
+	addClientParams := verifreg.AddVerifiedClientParams{
+		Address:   verifiedClient,
+		Allowance: abi.NewStoragePower(32 << 40),
+	}
+	_, code = v.ApplyMessage(verifier, builtin.VerifiedRegistryActorAddr, big.Zero(), builtin.MethodsVerifiedRegistry.AddVerifiedClient, &addClientParams)
+	require.Equal(t, exitcode.Ok, code)
+
+	// add market collateral for clients and miner
+	collateral := big.Mul(big.NewInt(3), vm.FIL)
+	_, code = v.ApplyMessage(unverifiedClient, builtin.StorageMarketActorAddr, collateral, builtin.MethodsMarket.AddBalance, &unverifiedClient)
+	require.Equal(t, exitcode.Ok, code)
+	_, code = v.ApplyMessage(verifiedClient, builtin.StorageMarketActorAddr, collateral, builtin.MethodsMarket.AddBalance, &verifiedClient)
+	require.Equal(t, exitcode.Ok, code)
+	collateral = big.Mul(big.NewInt(64), vm.FIL)
+	_, code = v.ApplyMessage(worker, builtin.StorageMarketActorAddr, collateral, builtin.MethodsMarket.AddBalance, &minerAddrs.IDAddress)
+	require.Equal(t, exitcode.Ok, code)
+
+	// create 3 deals, some verified and some not
+	dealIDs := []abi.DealID{}
+	dealStart := v.GetEpoch() + miner.MaxProveCommitDuration[sealProof]
+	deals := publishDeal(t, v, worker, verifiedClient, minerAddrs.IDAddress, "deal1", 1<<30, true, dealStart, 181*builtin.EpochsInDay)
+	dealIDs = append(dealIDs, deals.IDs...)
+	deals = publishDeal(t, v, worker, verifiedClient, minerAddrs.IDAddress, "deal2", 1<<32, true, dealStart, 200*builtin.EpochsInDay)
+	dealIDs = append(dealIDs, deals.IDs...)
+	deals = publishDeal(t, v, worker, unverifiedClient, minerAddrs.IDAddress, "deal3", 1<<34, false, dealStart, 210*builtin.EpochsInDay)
+	dealIDs = append(dealIDs, deals.IDs...)
+
+	stats := vm.GetNetworkStats(t, v)
+	assert.Equal(t, int64(0), stats.MinerAboveMinPowerCount)
+	assert.Equal(t, big.Zero(), stats.TotalRawBytePower)
+	assert.Equal(t, big.Zero(), stats.TotalQualityAdjPower)
+	assert.Equal(t, big.Zero(), stats.TotalBytesCommitted)
+	assert.Equal(t, big.Zero(), stats.TotalQABytesCommitted)
+	assert.Equal(t, big.Zero(), stats.TotalPledgeCollateral)
+	assert.Equal(t, big.Zero(), stats.TotalClientLockedCollateral)
+	assert.Equal(t, big.Zero(), stats.TotalProviderLockedCollateral)
+	assert.Equal(t, big.Zero(), stats.TotalClientStorageFee)
+
+	//
+	// Precommit, Prove, Verify and PoSt sector with deals
+	//
+
+	// precommit sector with deals
+	preCommitParams := miner.PreCommitSectorParams{
+		SealProof:       sealProof,
+		SectorNumber:    sectorNumber,
+		SealedCID:       sealedCid,
+		SealRandEpoch:   v.GetEpoch() - 1,
+		DealIDs:         dealIDs,
+		Expiration:      v.GetEpoch() + 220*builtin.EpochsInDay,
+		ReplaceCapacity: false,
+	}
+	_, code = v.ApplyMessage(addrs[0], minerAddrs.RobustAddress, big.Zero(), builtin.MethodsMiner.PreCommitSector, &preCommitParams)
+	require.Equal(t, exitcode.Ok, code)
+
+	// advance time to min seal duration
+	proveTime := v.GetEpoch() + miner.PreCommitChallengeDelay + 1
+	v, _ = vm.AdvanceByDeadlineTillEpoch(t, v, minerAddrs.IDAddress, proveTime)
+
+	// Prove commit sector after max seal duration
+	v, err := v.WithEpoch(proveTime)
+	require.NoError(t, err)
+	proveCommitParams := miner.ProveCommitSectorParams{
+		SectorNumber: sectorNumber,
+	}
+	_, code = v.ApplyMessage(worker, minerAddrs.RobustAddress, big.Zero(), builtin.MethodsMiner.ProveCommitSector, &proveCommitParams)
+	require.Equal(t, exitcode.Ok, code)
+
+	// In the same epoch, trigger cron to validate prove commit
+	_, code = v.ApplyMessage(builtin.SystemActorAddr, builtin.CronActorAddr, big.Zero(), builtin.MethodsCron.EpochTick, nil)
+	require.Equal(t, exitcode.Ok, code)
+
+	// advance to proving period and submit post
+	dlInfo, pIdx, v := vm.AdvanceTillProvingDeadline(t, v, minerAddrs.IDAddress, sectorNumber)
+	submitParams := miner.SubmitWindowedPoStParams{
+		Deadline: dlInfo.Index,
+		Partitions: []miner.PoStPartition{{
+			Index:   pIdx,
+			Skipped: bitfield.New(),
+		}},
+		Proofs: []proof.PoStProof{{
+			PoStProof: abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
+		}},
+		ChainCommitEpoch: dlInfo.Challenge,
+		ChainCommitRand:  []byte("not really random"),
+	}
+	_, code = v.ApplyMessage(worker, minerAddrs.RobustAddress, big.Zero(), builtin.MethodsMiner.SubmitWindowedPoSt, &submitParams)
+	require.Equal(t, exitcode.Ok, code)
+
+	// proving period cron adds miner power
+	v, err = v.WithEpoch(dlInfo.Last())
+	require.NoError(t, err)
+	_, code = v.ApplyMessage(builtin.SystemActorAddr, builtin.CronActorAddr, big.Zero(), builtin.MethodsCron.EpochTick, nil)
+	require.Equal(t, exitcode.Ok, code)
+
+	//
+	// Terminate Sector
+	//
+
+	terminateParams := miner.TerminateSectorsParams{
+		Terminations: []miner.TerminationDeclaration{{
+			Deadline:  dlInfo.Index,
+			Partition: pIdx,
+			Sectors:   bitfield.NewFromSet([]uint64{uint64(sectorNumber)}),
+		}},
+	}
+
+	_, code = v.ApplyMessage(worker, minerAddrs.RobustAddress, big.Zero(), builtin.MethodsMiner.TerminateSectors, &terminateParams)
+	require.Equal(t, exitcode.Ok, code)
+
+	noSubinvocations := []vm.ExpectInvocation{}
+	vm.ExpectInvocation{
+		To:     minerAddrs.IDAddress,
+		Method: builtin.MethodsMiner.TerminateSectors,
+		SubInvocations: []vm.ExpectInvocation{
+			{To: builtin.RewardActorAddr, Method: builtin.MethodsReward.ThisEpochReward, SubInvocations: noSubinvocations},
+			{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.CurrentTotalPower, SubInvocations: noSubinvocations},
+			{To: builtin.BurntFundsActorAddr, Method: builtin.MethodSend, SubInvocations: noSubinvocations},
+			{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.UpdatePledgeTotal, SubInvocations: noSubinvocations},
+			{To: builtin.StorageMarketActorAddr, Method: builtin.MethodsMarket.OnMinerSectorsTerminate, SubInvocations: noSubinvocations},
+			{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.UpdateClaimedPower, SubInvocations: noSubinvocations},
+		},
+	}.Matches(t, v.LastInvocation())
+
+	// expect power, market and miner to be in base state
+	minerBalances := vm.GetMinerBalances(t, v, minerAddrs.IDAddress)
+	assert.Equal(t, big.Zero(), minerBalances.InitialPledge)
+	assert.Equal(t, big.Zero(), minerBalances.PreCommitDeposit)
+
+	stats = vm.GetNetworkStats(t, v)
+	assert.Equal(t, int64(0), stats.MinerAboveMinPowerCount)
+	assert.Equal(t, big.Zero(), stats.TotalRawBytePower)
+	assert.Equal(t, big.Zero(), stats.TotalQualityAdjPower)
+	assert.Equal(t, big.Zero(), stats.TotalBytesCommitted)
+	assert.Equal(t, big.Zero(), stats.TotalQABytesCommitted)
+	assert.Equal(t, big.Zero(), stats.TotalPledgeCollateral)
+	assert.Equal(t, big.Zero(), stats.TotalClientLockedCollateral)
+	assert.Equal(t, big.Zero(), stats.TotalProviderLockedCollateral)
+	assert.Equal(t, big.Zero(), stats.TotalClientStorageFee)
+}

--- a/support/vm/testing.go
+++ b/support/vm/testing.go
@@ -334,7 +334,7 @@ func SectorDeadline(t *testing.T, v *VM, minerIDAddress address.Address, sectorN
 	return dlIdx, pIdx
 }
 
-//
+///
 // state abstraction
 //
 
@@ -455,6 +455,16 @@ func GetDealState(t *testing.T, vm *VM, dealID abi.DealID) (*market.DealState, b
 	require.NoError(t, err)
 
 	return state, found
+}
+
+//
+// Misc. helpers
+//
+
+func ApplyOk(t *testing.T, v *VM, from, to address.Address, value abi.TokenAmount, method abi.MethodNum, params interface{}) cbor.Marshaler {
+	ret, code := v.ApplyMessage(from, to, value, method, params)
+	require.Equal(t, exitcode.Ok, code)
+	return ret
 }
 
 //

--- a/support/vm/testing.go
+++ b/support/vm/testing.go
@@ -263,6 +263,18 @@ func ParamsForInvocation(t *testing.T, vm *VM, idxs ...int) interface{} {
 	return invocation.Msg.params
 }
 
+func ValueForInvocation(t *testing.T, vm *VM, idxs ...int) abi.TokenAmount {
+	invocations := vm.Invocations()
+	var invocation *Invocation
+	for _, idx := range idxs {
+		require.Greater(t, len(invocations), idx)
+		invocation = invocations[idx]
+		invocations = invocation.SubInvocations
+	}
+	require.NotNil(t, invocation)
+	return invocation.Msg.value
+}
+
 //
 // Advancing Time while updating state
 //

--- a/support/vm/testing.go
+++ b/support/vm/testing.go
@@ -443,6 +443,20 @@ func GetNetworkStats(t *testing.T, vm *VM) NetworkStats {
 	}
 }
 
+func GetDealState(t *testing.T, vm *VM, dealID abi.DealID) (*market.DealState, bool) {
+	var marketState market.State
+	err := vm.GetState(builtin.StorageMarketActorAddr, &marketState)
+	require.NoError(t, err)
+
+	states, err := market.AsDealStateArray(vm.store, marketState.States)
+	require.NoError(t, err)
+
+	state, found, err := states.Get(dealID)
+	require.NoError(t, err)
+
+	return state, found
+}
+
 //
 //  internal stuff
 //

--- a/support/vm/testing.go
+++ b/support/vm/testing.go
@@ -390,20 +390,23 @@ func MinerPower(t *testing.T, vm *VM, minerIdAddr address.Address) miner.PowerPa
 
 type NetworkStats struct {
 	power.State
-	TotalRawBytePower         abi.StoragePower
-	TotalBytesCommitted       abi.StoragePower
-	TotalQualityAdjPower      abi.StoragePower
-	TotalQABytesCommitted     abi.StoragePower
-	TotalPledgeCollateral     abi.TokenAmount
-	ThisEpochRawBytePower     abi.StoragePower
-	ThisEpochQualityAdjPower  abi.StoragePower
-	ThisEpochPledgeCollateral abi.TokenAmount
-	MinerCount                int64
-	MinerAboveMinPowerCount   int64
-	ThisEpochReward           abi.TokenAmount
-	ThisEpochRewardSmoothed   smoothing.FilterEstimate
-	ThisEpochBaselinePower    abi.StoragePower
-	TotalMined                abi.TokenAmount
+	TotalRawBytePower             abi.StoragePower
+	TotalBytesCommitted           abi.StoragePower
+	TotalQualityAdjPower          abi.StoragePower
+	TotalQABytesCommitted         abi.StoragePower
+	TotalPledgeCollateral         abi.TokenAmount
+	ThisEpochRawBytePower         abi.StoragePower
+	ThisEpochQualityAdjPower      abi.StoragePower
+	ThisEpochPledgeCollateral     abi.TokenAmount
+	MinerCount                    int64
+	MinerAboveMinPowerCount       int64
+	ThisEpochReward               abi.TokenAmount
+	ThisEpochRewardSmoothed       smoothing.FilterEstimate
+	ThisEpochBaselinePower        abi.StoragePower
+	TotalMined                    abi.TokenAmount
+	TotalClientLockedCollateral   abi.TokenAmount
+	TotalProviderLockedCollateral abi.TokenAmount
+	TotalClientStorageFee         abi.TokenAmount
 }
 
 func GetNetworkStats(t *testing.T, vm *VM) NetworkStats {
@@ -415,21 +418,28 @@ func GetNetworkStats(t *testing.T, vm *VM) NetworkStats {
 	err = vm.GetState(builtin.RewardActorAddr, &rewardState)
 	require.NoError(t, err)
 
+	var marketState market.State
+	err = vm.GetState(builtin.StorageMarketActorAddr, &marketState)
+	require.NoError(t, err)
+
 	return NetworkStats{
-		TotalRawBytePower:         powerState.TotalRawBytePower,
-		TotalBytesCommitted:       powerState.TotalBytesCommitted,
-		TotalQualityAdjPower:      powerState.TotalQualityAdjPower,
-		TotalQABytesCommitted:     powerState.TotalQABytesCommitted,
-		TotalPledgeCollateral:     powerState.TotalPledgeCollateral,
-		ThisEpochRawBytePower:     powerState.ThisEpochRawBytePower,
-		ThisEpochQualityAdjPower:  powerState.ThisEpochQualityAdjPower,
-		ThisEpochPledgeCollateral: powerState.ThisEpochPledgeCollateral,
-		MinerCount:                powerState.MinerCount,
-		MinerAboveMinPowerCount:   powerState.MinerAboveMinPowerCount,
-		ThisEpochReward:           rewardState.ThisEpochReward,
-		ThisEpochRewardSmoothed:   rewardState.ThisEpochRewardSmoothed,
-		ThisEpochBaselinePower:    rewardState.ThisEpochBaselinePower,
-		TotalMined:                rewardState.TotalMined,
+		TotalRawBytePower:             powerState.TotalRawBytePower,
+		TotalBytesCommitted:           powerState.TotalBytesCommitted,
+		TotalQualityAdjPower:          powerState.TotalQualityAdjPower,
+		TotalQABytesCommitted:         powerState.TotalQABytesCommitted,
+		TotalPledgeCollateral:         powerState.TotalPledgeCollateral,
+		ThisEpochRawBytePower:         powerState.ThisEpochRawBytePower,
+		ThisEpochQualityAdjPower:      powerState.ThisEpochQualityAdjPower,
+		ThisEpochPledgeCollateral:     powerState.ThisEpochPledgeCollateral,
+		MinerCount:                    powerState.MinerCount,
+		MinerAboveMinPowerCount:       powerState.MinerAboveMinPowerCount,
+		ThisEpochReward:               rewardState.ThisEpochReward,
+		ThisEpochRewardSmoothed:       rewardState.ThisEpochRewardSmoothed,
+		ThisEpochBaselinePower:        rewardState.ThisEpochBaselinePower,
+		TotalMined:                    rewardState.TotalMined,
+		TotalClientLockedCollateral:   marketState.TotalClientLockedCollateral,
+		TotalProviderLockedCollateral: marketState.TotalProviderLockedCollateral,
+		TotalClientStorageFee:         marketState.TotalClientStorageFee,
 	}
 }
 


### PR DESCRIPTION
closes #810

### Motivation

We want to scenario test market actor methods. It turns out that a scenario involving adding deals then terminating them all is one stop shopping for all the market methods. Specifically this test hits:

* `market.AddBalance`
* `market.WithdrawBalance`
* `market.PublishStorageDeals`
* `market.VerifyDealsForActivation`
* `market.ActivateDeals`
* `market.OnMinerSectorsTerminate`
* `market.ComputeDataCommitment`
* `market.CronTick`

### Proposed Changes

1. Add `terminate_sectors_secnario_test.go`.
2. Various test helper functionality to support this test.