### PR TITLE
Separate input and output stores

### DIFF
--- a/actors/migration/account.go
+++ b/actors/migration/account.go
@@ -13,12 +13,12 @@ import (
 type accountMigrator struct {
 }
 
-func (m *accountMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, head cid.Cid) (cid.Cid, error) {
+func (m *accountMigrator) MigrateState(ctx context.Context, storeIn, storeOut cbor.IpldStore, head cid.Cid) (cid.Cid, error) {
 	var inState account0.State
-	if err := store.Get(ctx, head, &inState); err != nil {
+	if err := storeIn.Get(ctx, head, &inState); err != nil {
 		return cid.Undef, err
 	}
 
 	outState := account2.State(inState) // Identical
-	return store.Put(ctx, &outState)
+	return storeOut.Put(ctx, &outState)
 }

--- a/actors/migration/cron.go
+++ b/actors/migration/cron.go
@@ -13,9 +13,9 @@ import (
 type cronMigrator struct {
 }
 
-func (m *cronMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, head cid.Cid) (cid.Cid, error) {
+func (m *cronMigrator) MigrateState(ctx context.Context, storeIn, storeOut cbor.IpldStore, head cid.Cid) (cid.Cid, error) {
 	var inState cron0.State
-	if err := store.Get(ctx, head, &inState); err != nil {
+	if err := storeIn.Get(ctx, head, &inState); err != nil {
 		return cid.Undef, err
 	}
 
@@ -23,5 +23,5 @@ func (m *cronMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, h
 	for i, e := range inState.Entries {
 		outState.Entries[i] = cron2.Entry(e) // Identical
 	}
-	return store.Put(ctx, &outState)
+	return storeOut.Put(ctx, &outState)
 }

--- a/actors/migration/power.go
+++ b/actors/migration/power.go
@@ -21,18 +21,18 @@ type powerMigrator struct {
 	actorsIn *states0.Tree
 }
 
-func (m *powerMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, head cid.Cid) (cid.Cid, error) {
+func (m *powerMigrator) MigrateState(ctx context.Context, storeIn, storeOut cbor.IpldStore, head cid.Cid) (cid.Cid, error) {
 	var inState power0.State
-	if err := store.Get(ctx, head, &inState); err != nil {
+	if err := storeIn.Get(ctx, head, &inState); err != nil {
 		return cid.Undef, err
 	}
 
-	cronEventsRoot, err := m.migrateCronEvents(ctx, store, inState.CronEventQueue)
+	cronEventsRoot, err := m.migrateCronEvents(ctx, storeIn, storeOut, inState.CronEventQueue)
 	if err != nil {
 		return cid.Undef, xerrors.Errorf("cron events: %w", err)
 	}
 
-	claimsRoot, err := m.migrateClaims(ctx, store, inState.Claims)
+	claimsRoot, err := m.migrateClaims(ctx, storeIn, storeOut, inState.Claims)
 	if err != nil {
 		return cid.Undef, xerrors.Errorf("claims: %w", err)
 	}
@@ -55,24 +55,24 @@ func (m *powerMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, 
 		ProofValidationBatch:      nil, // Set nil at the end of every epoch in cron handler
 	}
 
-	return store.Put(ctx, &outState)
+	return storeOut.Put(ctx, &outState)
 }
 
-func (m *powerMigrator) migrateCronEvents(ctx context.Context, store cbor.IpldStore, root cid.Cid) (cid.Cid, error) {
+func (m *powerMigrator) migrateCronEvents(ctx context.Context, storeIn, storeOut cbor.IpldStore, root cid.Cid) (cid.Cid, error) {
 	// The HAMT has changed, but the value (an AMT[CronEvent] root) is identical.
 	// The AMT queues may contain miner0.CronEventWorkerKeyChange, but these will be ignored by the miner
 	// actor so are safe to leave behind.
 	var _ = power0.CronEvent(power2.CronEvent{})
 
-	return migrateHAMTRaw(ctx, store, root)
+	return migrateHAMTRaw(ctx, storeIn, storeOut, root)
 }
 
-func (m *powerMigrator) migrateClaims(ctx context.Context, store cbor.IpldStore, root cid.Cid) (cid.Cid, error) {
-	inMap, err := adt0.AsMap(adt0.WrapStore(ctx, store), root)
+func (m *powerMigrator) migrateClaims(ctx context.Context, storeIn, storeOut cbor.IpldStore, root cid.Cid) (cid.Cid, error) {
+	inMap, err := adt0.AsMap(adt0.WrapStore(ctx, storeIn), root)
 	if err != nil {
 		return cid.Undef, err
 	}
-	outMap := adt2.MakeEmptyMap(adt2.WrapStore(ctx, store))
+	outMap := adt2.MakeEmptyMap(adt2.WrapStore(ctx, storeOut))
 
 	var inClaim power0.Claim
 	if err = inMap.ForEach(&inClaim, func(key string) error {
@@ -89,10 +89,10 @@ func (m *powerMigrator) migrateClaims(ctx context.Context, store cbor.IpldStore,
 			return xerrors.Errorf("claim exists for miner %s but miner not in state tree", a)
 		}
 		var minerState miner0.State
-		if err := store.Get(ctx, minerActor.Head, &minerState); err != nil {
+		if err := storeIn.Get(ctx, minerActor.Head, &minerState); err != nil {
 			return err
 		}
-		info, err := minerState.GetInfo(adt0.WrapStore(ctx, store))
+		info, err := minerState.GetInfo(adt0.WrapStore(ctx, storeIn))
 		if err != nil {
 			return err
 		}

--- a/actors/migration/reward.go
+++ b/actors/migration/reward.go
@@ -15,9 +15,9 @@ import (
 type rewardMigrator struct {
 }
 
-func (m *rewardMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, head cid.Cid) (cid.Cid, error) {
+func (m *rewardMigrator) MigrateState(ctx context.Context, storeIn, storeOut cbor.IpldStore, head cid.Cid) (cid.Cid, error) {
 	var inState reward0.State
-	if err := store.Get(ctx, head, &inState); err != nil {
+	if err := storeIn.Get(ctx, head, &inState); err != nil {
 		return cid.Undef, err
 	}
 
@@ -45,6 +45,5 @@ func (m *rewardMigrator) MigrateState(ctx context.Context, store cbor.IpldStore,
 		Epoch:                   inState.Epoch,
 		TotalMined:              inState.TotalMined,
 	}
-	return store.Put(ctx, &outState)
+	return storeOut.Put(ctx, &outState)
 }
-

--- a/actors/migration/system.go
+++ b/actors/migration/system.go
@@ -13,7 +13,7 @@ import (
 type systemMigrator struct {
 }
 
-func (m *systemMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, head cid.Cid) (cid.Cid, error) {
+func (m *systemMigrator) MigrateState(ctx context.Context, storeIn, storeOut cbor.IpldStore, head cid.Cid) (cid.Cid, error) {
 	// No change
 	var _ = system2.State(system0.State{})
 	return head, nil


### PR DESCRIPTION
Separate input and output stores.

The actual migration will most likely pass the same store to both arguments.

The motivation is testing.  I would like to migrate 10s of gigabytes of old state without persisting 10s of gigs of new state in the same datastore.  I want to put new state in a temporary datastore so that it can be deleted without deleting chain data along with it.