### PR TITLE
fix: mock runtime validate caller exit code

### DIFF
--- a/actors/builtin/market/market_test.go
+++ b/actors/builtin/market/market_test.go
@@ -140,7 +140,7 @@ func TestMarketActor(t *testing.T) {
 			rt.ExpectValidateCallerType(builtin.CallerTypesSignable...)
 
 			rt.SetCaller(provider, builtin.StorageMinerActorCodeID)
-			rt.ExpectAbort(exitcode.ErrForbidden, func() {
+			rt.ExpectAbort(exitcode.SysErrForbidden, func() {
 				rt.Call(actor.AddBalance, &provider)
 			})
 
@@ -224,7 +224,7 @@ func TestMarketActor(t *testing.T) {
 
 			// caller is not the recipient
 			rt.SetCaller(tutil.NewIDAddr(t, 909), builtin.AccountActorCodeID)
-			rt.ExpectAbort(exitcode.ErrForbidden, func() {
+			rt.ExpectAbort(exitcode.SysErrForbidden, func() {
 				rt.Call(actor.WithdrawBalance, &params)
 			})
 			rt.Verify()
@@ -252,7 +252,7 @@ func TestMarketActor(t *testing.T) {
 			rt.SetCaller(tutil.NewIDAddr(t, 909), builtin.AccountActorCodeID)
 			actor.expectProviderControlAddresses(rt, provider, owner, worker)
 
-			rt.ExpectAbort(exitcode.ErrForbidden, func() {
+			rt.ExpectAbort(exitcode.SysErrForbidden, func() {
 				rt.Call(actor.WithdrawBalance, &params)
 			})
 			rt.Verify()
@@ -865,7 +865,7 @@ func TestPublishStorageDealsFailures(t *testing.T) {
 			w := tutil.NewIDAddr(t, 1000)
 			rt.SetCaller(w, builtin.StorageMinerActorCodeID)
 			rt.ExpectValidateCallerType(builtin.AccountActorCodeID, builtin.MultisigActorCodeID)
-			rt.ExpectAbort(exitcode.ErrForbidden, func() {
+			rt.ExpectAbort(exitcode.SysErrForbidden, func() {
 				rt.Call(actor.PublishStorageDeals, params)
 			})
 		})
@@ -1006,7 +1006,7 @@ func TestActivateDealFailures(t *testing.T) {
 			rt, actor := basicMarketSetup(t, owner, provider, worker, client)
 			rt.ExpectValidateCallerType(builtin.StorageMinerActorCodeID)
 			rt.SetCaller(provider, builtin.AccountActorCodeID)
-			rt.ExpectAbort(exitcode.ErrForbidden, func() {
+			rt.ExpectAbort(exitcode.SysErrForbidden, func() {
 				rt.Call(actor.ActivateDeals, &market.ActivateDealsParams{})
 			})
 
@@ -1263,7 +1263,7 @@ func TestOnMinerSectorsTerminate(t *testing.T) {
 		rt, actor := basicMarketSetup(t, owner, provider, worker, client)
 		rt.ExpectValidateCallerType(builtin.StorageMinerActorCodeID)
 		rt.SetCaller(provider, builtin.AccountActorCodeID)
-		rt.ExpectAbort(exitcode.ErrForbidden, func() {
+		rt.ExpectAbort(exitcode.SysErrForbidden, func() {
 			rt.Call(actor.OnMinerSectorsTerminate, &market.OnMinerSectorsTerminateParams{})
 		})
 
@@ -2438,7 +2438,7 @@ func TestVerifyDealsForActivation(t *testing.T) {
 		param := &market.VerifyDealsForActivationParams{DealIDs: []abi.DealID{dealId}, SectorStart: sectorStart, SectorExpiry: sectorExpiry}
 		rt.SetCaller(worker, builtin.AccountActorCodeID)
 		rt.ExpectValidateCallerType(builtin.StorageMinerActorCodeID)
-		rt.ExpectAbort(exitcode.ErrForbidden, func() {
+		rt.ExpectAbort(exitcode.SysErrForbidden, func() {
 			rt.Call(actor.VerifyDealsForActivation, param)
 		})
 	})

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -3514,7 +3514,7 @@ func TestChangeWorkerAddress(t *testing.T) {
 
 		rt.SetCaller(actor.worker, builtin.AccountActorCodeID)
 		param := &miner.ChangeWorkerAddressParams{NewWorker: newWorker}
-		rt.ExpectAbort(exitcode.ErrForbidden, func() {
+		rt.ExpectAbort(exitcode.SysErrForbidden, func() {
 			rt.Call(actor.a.ChangeWorkerAddress, param)
 		})
 		rt.Verify()
@@ -3886,7 +3886,7 @@ func TestCompactSectorNumbers(t *testing.T) {
 		rt.SetCaller(rAddr, builtin.AccountActorCodeID)
 		rt.ExpectValidateCallerAddr(append(actor.controlAddrs, actor.owner, actor.worker)...)
 
-		rt.ExpectAbort(exitcode.ErrForbidden, func() {
+		rt.ExpectAbort(exitcode.SysErrForbidden, func() {
 			rt.Call(actor.a.CompactSectorNumbers, &miner.CompactSectorNumbersParams{
 				MaskSectorNumbers: bf(uint64(targetSno), uint64(targetSno)+1),
 			})

--- a/actors/builtin/multisig/multisig_test.go
+++ b/actors/builtin/multisig/multisig_test.go
@@ -1878,7 +1878,7 @@ func TestLockBalance(t *testing.T) {
 
 		// Can't change vest start
 		rt.ExpectValidateCallerAddr(receiver)
-		rt.ExpectAbort(exitcode.ErrForbidden, func() {
+		rt.ExpectAbort(exitcode.SysErrForbidden, func() {
 			actor.lockBalance(rt, startEpoch-1, abi.ChainEpoch(unlockDuration), big.Zero())
 		})
 		rt.Reset()

--- a/actors/builtin/power/power_test.go
+++ b/actors/builtin/power/power_test.go
@@ -83,7 +83,7 @@ func TestCreateMinerFailures(t *testing.T) {
 
 		rt.SetCaller(owner, builtin.StorageMinerActorCodeID)
 		rt.ExpectValidateCallerType(builtin.CallerTypesSignable...)
-		rt.ExpectAbort(exitcode.ErrForbidden, func() {
+		rt.ExpectAbort(exitcode.SysErrForbidden, func() {
 			rt.Call(ac.CreateMiner, &power.CreateMinerParams{})
 		})
 		rt.Verify()
@@ -137,7 +137,7 @@ func TestUpdateClaimedPowerFailures(t *testing.T) {
 		rt.SetCaller(miner, builtin.SystemActorCodeID)
 		rt.ExpectValidateCallerType(builtin.StorageMinerActorCodeID)
 
-		rt.ExpectAbort(exitcode.ErrForbidden, func() {
+		rt.ExpectAbort(exitcode.SysErrForbidden, func() {
 			rt.Call(ac.UpdateClaimedPower, &params)
 		})
 

--- a/actors/builtin/verifreg/verified_registry_test.go
+++ b/actors/builtin/verifreg/verified_registry_test.go
@@ -104,7 +104,7 @@ func TestAddVerifier(t *testing.T) {
 		rt.ExpectValidateCallerAddr(ac.rootkey)
 
 		rt.SetCaller(tutil.NewIDAddr(t, 501), builtin.VerifiedRegistryActorCodeID)
-		rt.ExpectAbort(exitcode.ErrForbidden, func() {
+		rt.ExpectAbort(exitcode.SysErrForbidden, func() {
 			rt.Call(ac.AddVerifier, verifier)
 		})
 		rt.Verify()
@@ -187,7 +187,7 @@ func TestRemoveVerifier(t *testing.T) {
 		rt.ExpectValidateCallerAddr(ac.rootkey)
 
 		rt.SetCaller(tutil.NewIDAddr(t, 501), builtin.VerifiedRegistryActorCodeID)
-		rt.ExpectAbort(exitcode.ErrForbidden, func() {
+		rt.ExpectAbort(exitcode.SysErrForbidden, func() {
 			rt.Call(ac.RemoveVerifier, &v.Address)
 		})
 		rt.Verify()
@@ -559,7 +559,7 @@ func TestUseBytes(t *testing.T) {
 		rt.SetCaller(builtin.StoragePowerActorAddr, builtin.StoragePowerActorCodeID)
 		param := &verifreg.UseBytesParams{Address: clientAddr, DealSize: verifreg.MinVerifiedDealSize}
 
-		rt.ExpectAbort(exitcode.ErrForbidden, func() {
+		rt.ExpectAbort(exitcode.SysErrForbidden, func() {
 			rt.Call(ac.UseBytes, param)
 		})
 
@@ -723,7 +723,7 @@ func TestRestoreBytes(t *testing.T) {
 		rt.SetCaller(builtin.StoragePowerActorAddr, builtin.StoragePowerActorCodeID)
 		param := &verifreg.RestoreBytesParams{Address: clientAddr, DealSize: verifreg.MinVerifiedDealSize}
 
-		rt.ExpectAbort(exitcode.ErrForbidden, func() {
+		rt.ExpectAbort(exitcode.SysErrForbidden, func() {
 			rt.Call(ac.RestoreBytes, param)
 		})
 

--- a/support/mock/mockrt.go
+++ b/support/mock/mockrt.go
@@ -213,7 +213,7 @@ func (rt *Runtime) ValidateImmediateCallerIs(addrs ...addr.Address) {
 			return
 		}
 	}
-	rt.Abortf(exitcode.ErrForbidden, "caller address %v forbidden, allowed: %v", rt.caller, addrs)
+	rt.Abortf(exitcode.SysErrForbidden, "caller address %v forbidden, allowed: %v", rt.caller, addrs)
 }
 
 func (rt *Runtime) ValidateImmediateCallerType(types ...cid.Cid) {
@@ -237,7 +237,7 @@ func (rt *Runtime) ValidateImmediateCallerType(types ...cid.Cid) {
 			return
 		}
 	}
-	rt.Abortf(exitcode.ErrForbidden, "caller type %v forbidden, allowed: %v", rt.callerType, types)
+	rt.Abortf(exitcode.SysErrForbidden, "caller type %v forbidden, allowed: %v", rt.callerType, types)
 }
 
 func (rt *Runtime) CurrentBalance() abi.TokenAmount {


### PR DESCRIPTION
This PR changes the exit code for caller validation failures in the MOCK runtime from `ErrForbidden` to `SysErrForbidden`, which is the [documented exit code](https://github.com/filecoin-project/go-state-types/blob/964d6c679cfcddaaf01e56ae4b6093f76ad071e0/exitcode/reserved.go#L39-L40) and code in use in lotus currently.

