### PR TITLE
prevent multisig from decreasing approvals below 1

### DIFF
--- a/actors/builtin/multisig/multisig_actor.go
+++ b/actors/builtin/multisig/multisig_actor.go
@@ -355,6 +355,9 @@ func (a Actor) RemoveSigner(rt runtime.Runtime, params *RemoveSignerParams) *abi
 		}
 
 		if params.Decrease {
+			if st.NumApprovalsThreshold < 2 {
+				rt.Abortf(exitcode.ErrIllegalArgument, "can't decrease approvals from %d to %d", st.NumApprovalsThreshold, st.NumApprovalsThreshold-1)
+			}
 			st.NumApprovalsThreshold = st.NumApprovalsThreshold - 1
 		}
 		st.Signers = newSigners

--- a/actors/builtin/multisig/multisig_test.go
+++ b/actors/builtin/multisig/multisig_test.go
@@ -1479,6 +1479,19 @@ func TestRemoveSigner(t *testing.T) {
 			expectApprovals: uint64(2),
 			code:            exitcode.ErrForbidden,
 		},
+		{
+			desc: "fail to remove a signer and decrease approvals below 1",
+
+			initialSigners:   []addr.Address{anne, bob, chuck},
+			initialApprovals: uint64(1),
+
+			removeSigner: anne,
+			decrease:     true,
+
+			expectSigners:   []addr.Address{anne, bob, chuck},
+			expectApprovals: uint64(1),
+			code:            exitcode.ErrIllegalArgument,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
closes #1047

### Motivation

A multisig actor should always require at least 1 approval. By starting with more than one signer and then removing signers while decreasing approvals, it is possible to drop the number of approvals to zero or even negative. The PR makes dropping approvals below 1 an illegal argument exception (for the `Decrease` parameter.

### Proposed Changes
 
1. Raise error when attempting to drop approval count below 1.
2. Test error check.