### PR TITLE
add invariant checks to partitions

### DIFF
--- a/actors/builtin/miner/partition_state.go
+++ b/actors/builtin/miner/partition_state.go
@@ -921,13 +921,13 @@ func (p *Partition) ValidatePowerState() error {
 
 // Test that invariants about sector bitfields hold
 func (p *Partition) ValidateBFState() error {
-	// Merge unproven, recoveries, and faults for checks
-	merge, err := bitfield.MultiMerge(p.Unproven, p.Recoveries, p.Faults)
+	// Merge unproven and faults for checks
+	merge, err := bitfield.MultiMerge(p.Unproven, p.Faults)
 	if err != nil {
 		return err
 	}
 
-	// Unproven, recovering, or faulty sectors should not be in terminated
+	// Unproven or faulty sectors should not be in terminated
 	if containsAny, err := util.BitFieldContainsAny(p.Terminated, merge); err != nil {
 		return err
 	} else if containsAny {


### PR DESCRIPTION
closes #1068

### Motivation

If we miscalculate a partition, we would like to know that as soon as possible. Partitions have several invariants we can check to detect problems in the actor code. This PR adds that validation and uses it in all Partition methods that alter state.

### Proposed changes

1. Add `Partition.ValidatePowerState`, `Partition.ValidateBFState`, and `Partition.ValidateState` that calls the first two.
2. Call `ValidateState` in every partition method that alters state and error out if invalid.

cc @wadeAlexC