### PR TITLE
rename TotalMined to TotalStoragePowerReward

### DIFF
--- a/actors/builtin/reward/cbor_gen.go
+++ b/actors/builtin/reward/cbor_gen.go
@@ -78,8 +78,8 @@ func (t *State) MarshalCBOR(w io.Writer) error {
 		}
 	}
 
-	// t.TotalMined (big.Int) (struct)
-	if err := t.TotalMined.MarshalCBOR(w); err != nil {
+	// t.TotalStoragePowerReward (big.Int) (struct)
+	if err := t.TotalStoragePowerReward.MarshalCBOR(w); err != nil {
 		return err
 	}
 	return nil
@@ -207,12 +207,12 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 
 		t.Epoch = abi.ChainEpoch(extraI)
 	}
-	// t.TotalMined (big.Int) (struct)
+	// t.TotalStoragePowerReward (big.Int) (struct)
 
 	{
 
-		if err := t.TotalMined.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.TotalMined: %w", err)
+		if err := t.TotalStoragePowerReward.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.TotalStoragePowerReward: %w", err)
 		}
 
 	}

--- a/actors/builtin/reward/reward_actor.go
+++ b/actors/builtin/reward/reward_actor.go
@@ -94,7 +94,7 @@ func (a Actor) AwardBlockReward(rt runtime.Runtime, params *AwardBlockRewardPara
 			// Since we have already asserted the balance is greater than gas reward blockReward is >= 0
 			AssertMsg(blockReward.GreaterThanEqual(big.Zero()), "programming error, block reward is %v below zero", blockReward)
 		}
-		st.TotalMined = big.Add(st.TotalMined, blockReward)
+		st.TotalStoragePowerReward = big.Add(st.TotalStoragePowerReward, blockReward)
 	})
 
 	AssertMsg(totalReward.LessThanEqual(priorBalance), "reward %v exceeds balance %v", totalReward, priorBalance)

--- a/actors/builtin/reward/reward_state.go
+++ b/actors/builtin/reward/reward_state.go
@@ -52,8 +52,8 @@ type State struct {
 	// Epoch tracks for which epoch the Reward was computed
 	Epoch abi.ChainEpoch
 
-	// TotalMined tracks the total FIL awarded to block miners
-	TotalMined abi.TokenAmount
+	// TotalStoragePowerReward tracks the total FIL awarded to block miners
+	TotalStoragePowerReward abi.TokenAmount
 }
 
 func ConstructState(currRealizedPower abi.StoragePower) *State {
@@ -68,7 +68,7 @@ func ConstructState(currRealizedPower abi.StoragePower) *State {
 		Epoch:                  -1,
 
 		ThisEpochRewardSmoothed: smoothing.NewEstimate(InitialRewardPositionEstimate, InitialRewardVelocityEstimate),
-		TotalMined:              big.Zero(),
+		TotalStoragePowerReward: big.Zero(),
 	}
 
 	st.updateToNextEpochWithReward(currRealizedPower)

--- a/actors/builtin/reward/reward_test.go
+++ b/actors/builtin/reward/reward_test.go
@@ -160,14 +160,14 @@ func TestAwardBlockReward(t *testing.T) {
 		rt.Verify()
 	})
 
-	t.Run("TotalMined tracks correctly", func(t *testing.T) {
+	t.Run("TotalStoragePowerReward tracks correctly", func(t *testing.T) {
 		rt := builder.Build(t)
 		startRealizedPower := abi.NewStoragePower(1)
 		actor.constructAndVerify(rt, &startRealizedPower)
 		miner := tutil.NewIDAddr(t, 1000)
 
 		st := getState(rt)
-		assert.Equal(t, big.Zero(), st.TotalMined)
+		assert.Equal(t, big.Zero(), st.TotalStoragePowerReward)
 		st.ThisEpochReward = abi.NewTokenAmount(5000)
 		rt.ReplaceState(st)
 		// enough balance to pay 3 full rewards and one partial
@@ -181,7 +181,7 @@ func TestAwardBlockReward(t *testing.T) {
 		actor.awardBlockReward(rt, miner, big.Zero(), big.Zero(), 1, big.NewInt(500)) // partial payout when balance below reward
 
 		newState := getState(rt)
-		assert.Equal(t, totalPayout, newState.TotalMined)
+		assert.Equal(t, totalPayout, newState.TotalStoragePowerReward)
 
 	})
 
@@ -191,7 +191,7 @@ func TestAwardBlockReward(t *testing.T) {
 		actor.constructAndVerify(rt, &startRealizedPower)
 		miner := tutil.NewIDAddr(t, 1000)
 		st := getState(rt)
-		assert.Equal(t, big.Zero(), st.TotalMined)
+		assert.Equal(t, big.Zero(), st.TotalStoragePowerReward)
 		st.ThisEpochReward = abi.NewTokenAmount(5000)
 		rt.ReplaceState(st)
 		// enough balance to pay 3 full rewards and one partial

--- a/actors/migration/reward.go
+++ b/actors/migration/reward.go
@@ -43,8 +43,7 @@ func (m *rewardMigrator) MigrateState(ctx context.Context, store cbor.IpldStore,
 		ThisEpochRewardSmoothed: smoothing2.FilterEstimate(*inState.ThisEpochRewardSmoothed),
 		ThisEpochBaselinePower:  reward2.BaselineInitialValue,
 		Epoch:                   inState.Epoch,
-		TotalMined:              inState.TotalMined,
+		TotalStoragePowerReward: inState.TotalMined,
 	}
 	return store.Put(ctx, &outState)
 }
-

--- a/support/vm/testing.go
+++ b/support/vm/testing.go
@@ -415,7 +415,7 @@ type NetworkStats struct {
 	ThisEpochReward               abi.TokenAmount
 	ThisEpochRewardSmoothed       smoothing.FilterEstimate
 	ThisEpochBaselinePower        abi.StoragePower
-	TotalMined                    abi.TokenAmount
+	TotalStoragePowerReward       abi.TokenAmount
 	TotalClientLockedCollateral   abi.TokenAmount
 	TotalProviderLockedCollateral abi.TokenAmount
 	TotalClientStorageFee         abi.TokenAmount
@@ -448,7 +448,7 @@ func GetNetworkStats(t *testing.T, vm *VM) NetworkStats {
 		ThisEpochReward:               rewardState.ThisEpochReward,
 		ThisEpochRewardSmoothed:       rewardState.ThisEpochRewardSmoothed,
 		ThisEpochBaselinePower:        rewardState.ThisEpochBaselinePower,
-		TotalMined:                    rewardState.TotalMined,
+		TotalStoragePowerReward:       rewardState.TotalStoragePowerReward,
 		TotalClientLockedCollateral:   marketState.TotalClientLockedCollateral,
 		TotalProviderLockedCollateral: marketState.TotalProviderLockedCollateral,
 		TotalClientStorageFee:         marketState.TotalClientStorageFee,


### PR DESCRIPTION
closes #1048

### Motivation

We want to rename `Reward.State.TotalMined` to `Reward.State.TotalStoragePowerReward` to make more clear that the reward actor is distributing rewards for maintaining storage power.

### Proposed Changes

1. rename TotalMined to TotalStoragePowerReward