### PR TITLE
state invariant tests for account, cron and market

### DIFF
--- a/actors/builtin/account/account_test.go
+++ b/actors/builtin/account/account_test.go
@@ -82,7 +82,7 @@ func TestAccountactor(t *testing.T) {
 func checkState(t *testing.T, rt *mock.Runtime) {
 	var st account.State
 	rt.GetState(&st)
-	_, msgs, err := account.CheckStateInvariants(&st)
+	_, msgs, err := account.CheckStateInvariants(&st, rt.AdtStore())
 	assert.NoError(t, err)
 	assert.True(t, msgs.IsEmpty())
 }

--- a/actors/builtin/account/account_test.go
+++ b/actors/builtin/account/account_test.go
@@ -67,6 +67,8 @@ func TestAccountactor(t *testing.T) {
 				rt.ExpectValidateCallerAny()
 				pubkeyAddress := rt.Call(actor.PubkeyAddress, nil).(*address.Address)
 				assert.Equal(t, &tc.addr, pubkeyAddress)
+
+				checkState(t, rt)
 			} else {
 				rt.ExpectAbort(tc.exitCode, func() {
 					rt.Call(actor.Constructor, &tc.addr)
@@ -75,4 +77,12 @@ func TestAccountactor(t *testing.T) {
 			rt.Verify()
 		})
 	}
+}
+
+func checkState(t *testing.T, rt *mock.Runtime) {
+	var st account.State
+	rt.GetState(&st)
+	_, msgs, err := account.CheckStateInvariants(&st)
+	assert.NoError(t, err)
+	assert.True(t, msgs.IsEmpty())
 }

--- a/actors/builtin/account/testing.go
+++ b/actors/builtin/account/testing.go
@@ -1,0 +1,22 @@
+package account
+
+import (
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
+)
+
+type StateSummary struct {
+	PubKeyAddr address.Address
+}
+
+// Checks internal invariants of verified registry state.
+func CheckStateInvariants(st *State) (*StateSummary, *builtin.MessageAccumulator, error) {
+	acc := &builtin.MessageAccumulator{}
+	acc.Require(
+		st.Address.Protocol() == address.BLS || st.Address.Protocol() == address.SECP256K1,
+		"actor address %v must be BLS or SECP256K1 protocol", st.Address)
+
+	return &StateSummary{
+		PubKeyAddr: st.Address,
+	}, acc, nil
+}

--- a/actors/builtin/cron/testing.go
+++ b/actors/builtin/cron/testing.go
@@ -1,4 +1,4 @@
-package account
+package cron
 
 import (
 	"github.com/filecoin-project/go-address"
@@ -7,17 +7,17 @@ import (
 )
 
 type StateSummary struct {
-	PubKeyAddr address.Address
+	EntryCount int
 }
 
-// Checks internal invariants of account state.
+// Checks internal invariants of cron state.
 func CheckStateInvariants(st *State, store adt.Store) (*StateSummary, *builtin.MessageAccumulator, error) {
 	acc := &builtin.MessageAccumulator{}
-	acc.Require(
-		st.Address.Protocol() == address.BLS || st.Address.Protocol() == address.SECP256K1,
-		"actor address %v must be BLS or SECP256K1 protocol", st.Address)
+	for i, e := range st.Entries {
+		acc.Require(e.Receiver.Protocol() == address.ID, "entry %d receiver address %v must be ID protocol", i, e.Receiver)
+	}
 
 	return &StateSummary{
-		PubKeyAddr: st.Address,
+		EntryCount: len(st.Entries),
 	}, acc, nil
 }

--- a/actors/builtin/cron/testing.go
+++ b/actors/builtin/cron/testing.go
@@ -15,6 +15,7 @@ func CheckStateInvariants(st *State, store adt.Store) (*StateSummary, *builtin.M
 	acc := &builtin.MessageAccumulator{}
 	for i, e := range st.Entries {
 		acc.Require(e.Receiver.Protocol() == address.ID, "entry %d receiver address %v must be ID protocol", i, e.Receiver)
+		acc.Require(e.MethodNum > 0, "entry %d has invalid method number %d", i, e.MethodNum)
 	}
 
 	return &StateSummary{

--- a/actors/builtin/market/market_test.go
+++ b/actors/builtin/market/market_test.go
@@ -3152,7 +3152,7 @@ func (h *marketActorTestHarness) generateDealWithCollateralAndAddFunds(rt *mock.
 func (h *marketActorTestHarness) checkState(rt *mock.Runtime) {
 	var st market.State
 	rt.GetState(&st)
-	_, msgs, err := market.CheckStateInvariants(&st, rt.AdtStore())
+	_, msgs, err := market.CheckStateInvariants(&st, rt.AdtStore(), rt.Balance())
 	assert.NoError(h.t, err)
 	for _, msg := range msgs.Messages() {
 		assert.Fail(h.t, msg)
@@ -3178,6 +3178,7 @@ func generateDealProposal(client, provider address.Address, startEpoch, endEpoch
 func basicMarketSetup(t *testing.T, owner, provider, worker, client address.Address) (*mock.Runtime, *marketActorTestHarness) {
 	builder := mock.NewBuilder(context.Background(), builtin.StorageMarketActorAddr).
 		WithCaller(builtin.SystemActorAddr, builtin.InitActorCodeID).
+		WithBalance(big.Mul(big.NewInt(10), big.NewInt(1e18)), big.Zero()).
 		WithActorType(owner, builtin.AccountActorCodeID).
 		WithActorType(worker, builtin.AccountActorCodeID).
 		WithActorType(provider, builtin.StorageMinerActorCodeID).

--- a/actors/builtin/market/market_test.go
+++ b/actors/builtin/market/market_test.go
@@ -147,6 +147,8 @@ func TestMarketActor(t *testing.T) {
 			})
 
 			rt.Verify()
+
+			actor.checkState(rt)
 		})
 
 		t.Run("adds to non-provider escrow funds", func(t *testing.T) {
@@ -190,6 +192,8 @@ func TestMarketActor(t *testing.T) {
 				rt.Call(actor.AddBalance, &provider)
 			})
 			rt.Verify()
+
+			actor.checkState(rt)
 		})
 	})
 
@@ -211,6 +215,7 @@ func TestMarketActor(t *testing.T) {
 			})
 
 			rt.Verify()
+			actor.checkState(rt)
 		})
 
 		t.Run("fails if withdraw from non provider funds is not initiated by the recipient", func(t *testing.T) {
@@ -236,6 +241,8 @@ func TestMarketActor(t *testing.T) {
 			// verify there was no withdrawal
 			rt.GetState(&st)
 			assert.Equal(t, abi.NewTokenAmount(20), actor.getEscrowBalance(rt, client))
+
+			actor.checkState(rt)
 		})
 
 		t.Run("fails if withdraw from provider funds is not initiated by the owner or worker", func(t *testing.T) {
@@ -264,6 +271,8 @@ func TestMarketActor(t *testing.T) {
 			// verify there was no withdrawal
 			rt.GetState(&st)
 			assert.Equal(t, abi.NewTokenAmount(20), actor.getEscrowBalance(rt, provider))
+
+			actor.checkState(rt)
 		})
 
 		t.Run("withdraws from provider escrow funds and sends to owner", func(t *testing.T) {
@@ -805,6 +814,7 @@ func TestPublishStorageDealsFailures(t *testing.T) {
 				})
 
 				rt.Verify()
+				actor.checkState(rt)
 			})
 		}
 	}
@@ -831,6 +841,7 @@ func TestPublishStorageDealsFailures(t *testing.T) {
 			})
 
 			rt.Verify()
+			actor.checkState(rt)
 		})
 
 		t.Run("fail when provider has some funds but not enough for a deal", func(t *testing.T) {
@@ -852,6 +863,7 @@ func TestPublishStorageDealsFailures(t *testing.T) {
 			})
 
 			rt.Verify()
+			actor.checkState(rt)
 		})
 	}
 
@@ -880,6 +892,7 @@ func TestPublishStorageDealsFailures(t *testing.T) {
 			})
 
 			rt.Verify()
+			actor.checkState(rt)
 		})
 
 		//  failures because of incorrect call params
@@ -892,6 +905,7 @@ func TestPublishStorageDealsFailures(t *testing.T) {
 			rt.ExpectAbort(exitcode.SysErrForbidden, func() {
 				rt.Call(actor.PublishStorageDeals, params)
 			})
+			actor.checkState(rt)
 		})
 
 		t.Run("fail when no deals in params", func(t *testing.T) {
@@ -902,6 +916,7 @@ func TestPublishStorageDealsFailures(t *testing.T) {
 			rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 				rt.Call(actor.PublishStorageDeals, params)
 			})
+			actor.checkState(rt)
 		})
 
 		t.Run("fail to resolve provider address", func(t *testing.T) {
@@ -915,6 +930,7 @@ func TestPublishStorageDealsFailures(t *testing.T) {
 			rt.ExpectAbort(exitcode.ErrNotFound, func() {
 				rt.Call(actor.PublishStorageDeals, params)
 			})
+			actor.checkState(rt)
 		})
 
 		t.Run("caller is not the same as the worker address for miner", func(t *testing.T) {
@@ -929,6 +945,7 @@ func TestPublishStorageDealsFailures(t *testing.T) {
 			})
 
 			rt.Verify()
+			actor.checkState(rt)
 		})
 	}
 
@@ -948,6 +965,7 @@ func TestPublishStorageDealsFailures(t *testing.T) {
 		})
 
 		rt.Verify()
+		actor.checkState(rt)
 	})
 }
 
@@ -1023,6 +1041,7 @@ func TestActivateDealFailures(t *testing.T) {
 			})
 
 			rt.Verify()
+			actor.checkState(rt)
 		})
 	}
 
@@ -1037,6 +1056,7 @@ func TestActivateDealFailures(t *testing.T) {
 			})
 
 			rt.Verify()
+			actor.checkState(rt)
 		})
 	}
 
@@ -1053,6 +1073,7 @@ func TestActivateDealFailures(t *testing.T) {
 			})
 
 			rt.Verify()
+			actor.checkState(rt)
 		})
 	}
 
@@ -1070,6 +1091,7 @@ func TestActivateDealFailures(t *testing.T) {
 			})
 
 			rt.Verify()
+			actor.checkState(rt)
 		})
 	}
 
@@ -1087,6 +1109,7 @@ func TestActivateDealFailures(t *testing.T) {
 			})
 
 			rt.Verify()
+			actor.checkState(rt)
 		})
 
 		t.Run("fail when end epoch of deal greater than sector expiry", func(t *testing.T) {
@@ -1100,6 +1123,7 @@ func TestActivateDealFailures(t *testing.T) {
 			})
 
 			rt.Verify()
+			actor.checkState(rt)
 		})
 	}
 
@@ -1131,6 +1155,9 @@ func TestActivateDealFailures(t *testing.T) {
 			_, found, err := states.Get(dealId2)
 			require.NoError(t, err)
 			require.False(t, found)
+
+			actor.checkState(rt)
+
 		})
 	}
 
@@ -1305,6 +1332,8 @@ func TestOnMinerSectorsTerminate(t *testing.T) {
 		})
 
 		rt.Verify()
+		actor.checkState(rt)
+
 	})
 
 	t.Run("fail when caller is not the provider of the deal", func(t *testing.T) {
@@ -1324,6 +1353,8 @@ func TestOnMinerSectorsTerminate(t *testing.T) {
 		})
 
 		rt.Verify()
+		actor.checkState(rt)
+
 	})
 
 	t.Run("fail when deal has been published but not activated", func(t *testing.T) {
@@ -1340,6 +1371,8 @@ func TestOnMinerSectorsTerminate(t *testing.T) {
 		})
 
 		rt.Verify()
+		actor.checkState(rt)
+
 	})
 
 	t.Run("termination of all deals should fail when one deal fails", func(t *testing.T) {
@@ -1362,6 +1395,8 @@ func TestOnMinerSectorsTerminate(t *testing.T) {
 
 		// verify deal1 has not been terminated
 		actor.assertDeaslNotTerminated(rt, dealId1)
+
+		actor.checkState(rt)
 	})
 }
 
@@ -1380,7 +1415,7 @@ func TestCronTick(t *testing.T) {
 		rt, actor := basicMarketSetup(t, owner, provider, worker, client)
 		dealId := actor.publishAndActivateDeal(rt, client, mAddrs, startEpoch, endEpoch, 0, sectorExpiry, startEpoch)
 
-		// delete the deal proposal
+		// delete the deal proposal (this breaks state invariants)
 		actor.deleteDealProposal(rt, dealId)
 
 		// move the current epoch to the start epoch of the deal
@@ -1408,6 +1443,8 @@ func TestCronTick(t *testing.T) {
 		rt.ExpectAssertionFailure("assertion failed", func() {
 			actor.cronTick(rt)
 		})
+
+		actor.checkState(rt)
 	})
 
 	t.Run("crontick for a deal at it's start epoch results in zero payment and no slashing", func(t *testing.T) {
@@ -1479,6 +1516,8 @@ func TestCronTick(t *testing.T) {
 		rt.SetEpoch(d1.StartEpoch)
 		actor.cronTick(rt)
 		actor.publishDeals(rt, mAddrs, publishDealReq{deal: d2})
+
+		actor.checkState(rt)
 	})
 }
 
@@ -1584,6 +1623,8 @@ func TestRandomCronEpochDuringPublish(t *testing.T) {
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			actor.activateDeals(rt, sectorExpiry, provider, startEpoch+1, dealId)
 		})
+
+		actor.checkState(rt)
 	})
 
 	t.Run("cron processing of deal after missed activation should fail and slash", func(t *testing.T) {
@@ -1759,6 +1800,8 @@ func TestCronTickTimedoutDeals(t *testing.T) {
 
 		// now publishing should work
 		actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch, startEpoch)
+
+		actor.checkState(rt)
 	})
 
 	t.Run("timed out and verified deals are slashed, deleted AND sent to the Registry actor", func(t *testing.T) {
@@ -2089,8 +2132,6 @@ func TestCronTickDealSlashing(t *testing.T) {
 						// running cron tick again dosen't do anything
 						actor.cronTickNoChange(rt, client, provider)
 					}
-
-					actor.checkState(rt)
 				} else {
 					rt.ExpectAssertionFailure(tc.assertionMsg, func() {
 						rt.ExpectValidateCallerAddr(builtin.CronActorAddr)
@@ -2100,6 +2141,7 @@ func TestCronTickDealSlashing(t *testing.T) {
 						rt.Verify()
 					})
 				}
+				actor.checkState(rt)
 			})
 		}
 	}
@@ -2346,6 +2388,7 @@ func TestMarketActorDeals(t *testing.T) {
 	{
 		actor.publishDeals(rt, minerAddrs, publishDealReq{deal: dealProposal})
 	}
+	actor.checkState(rt)
 }
 
 func TestMaxDealLabelSize(t *testing.T) {
@@ -2389,6 +2432,7 @@ func TestMaxDealLabelSize(t *testing.T) {
 
 		rt.Verify()
 	}
+	actor.checkState(rt)
 }
 
 func TestComputeDataCommitment(t *testing.T) {
@@ -2436,6 +2480,7 @@ func TestComputeDataCommitment(t *testing.T) {
 		rt.ExpectAbort(exitcode.ErrNotFound, func() {
 			rt.Call(actor.ComputeDataCommitment, param)
 		})
+		actor.checkState(rt)
 	})
 
 	t.Run("fail when syscall returns an error", func(t *testing.T) {
@@ -2452,6 +2497,7 @@ func TestComputeDataCommitment(t *testing.T) {
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			rt.Call(actor.ComputeDataCommitment, param)
 		})
+		actor.checkState(rt)
 	})
 }
 
@@ -2526,6 +2572,7 @@ func TestVerifyDealsForActivation(t *testing.T) {
 		rt.ExpectAbort(exitcode.SysErrForbidden, func() {
 			rt.Call(actor.VerifyDealsForActivation, param)
 		})
+		actor.checkState(rt)
 	})
 
 	t.Run("fail when deal proposal is not found", func(t *testing.T) {
@@ -2536,6 +2583,7 @@ func TestVerifyDealsForActivation(t *testing.T) {
 		rt.ExpectAbort(exitcode.ErrNotFound, func() {
 			rt.Call(actor.VerifyDealsForActivation, param)
 		})
+		actor.checkState(rt)
 	})
 
 	t.Run("fail when caller is not the provider", func(t *testing.T) {
@@ -2550,6 +2598,7 @@ func TestVerifyDealsForActivation(t *testing.T) {
 		rt.ExpectAbort(exitcode.ErrForbidden, func() {
 			rt.Call(actor.VerifyDealsForActivation, param)
 		})
+		actor.checkState(rt)
 	})
 
 	t.Run("fail when sector start epoch is greater than proposal start epoch", func(t *testing.T) {
@@ -2562,6 +2611,7 @@ func TestVerifyDealsForActivation(t *testing.T) {
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			rt.Call(actor.VerifyDealsForActivation, param)
 		})
+		actor.checkState(rt)
 	})
 
 	t.Run("fail when deal end epoch is greater than sector expiration", func(t *testing.T) {
@@ -2574,6 +2624,7 @@ func TestVerifyDealsForActivation(t *testing.T) {
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			rt.Call(actor.VerifyDealsForActivation, param)
 		})
+		actor.checkState(rt)
 	})
 
 	t.Run("fail when the same deal ID is passed multiple times", func(t *testing.T) {
@@ -2586,6 +2637,7 @@ func TestVerifyDealsForActivation(t *testing.T) {
 		rt.ExpectAbortContainsMessage(exitcode.ErrIllegalArgument, "multiple times", func() {
 			rt.Call(actor.VerifyDealsForActivation, param)
 		})
+		actor.checkState(rt)
 	})
 }
 

--- a/actors/builtin/market/market_test.go
+++ b/actors/builtin/market/market_test.go
@@ -1443,8 +1443,6 @@ func TestCronTick(t *testing.T) {
 		rt.ExpectAssertionFailure("assertion failed", func() {
 			actor.cronTick(rt)
 		})
-
-		actor.checkState(rt)
 	})
 
 	t.Run("crontick for a deal at it's start epoch results in zero payment and no slashing", func(t *testing.T) {

--- a/actors/builtin/market/market_test.go
+++ b/actors/builtin/market/market_test.go
@@ -3152,7 +3152,7 @@ func (h *marketActorTestHarness) generateDealWithCollateralAndAddFunds(rt *mock.
 func (h *marketActorTestHarness) checkState(rt *mock.Runtime) {
 	var st market.State
 	rt.GetState(&st)
-	_, msgs, err := market.CheckStateInvariants(&st, rt.AdtStore(), rt.Balance())
+	_, msgs, err := market.CheckStateInvariants(&st, rt.AdtStore(), rt.Balance(), rt.Epoch())
 	assert.NoError(h.t, err)
 	for _, msg := range msgs.Messages() {
 		assert.Fail(h.t, msg)

--- a/actors/builtin/market/testing.go
+++ b/actors/builtin/market/testing.go
@@ -1,0 +1,226 @@
+package market
+
+import (
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
+	"github.com/filecoin-project/specs-actors/v2/actors/util/adt"
+	"github.com/ipfs/go-cid"
+	cbg "github.com/whyrusleeping/cbor-gen"
+	"strconv"
+)
+
+type StateSummary struct {
+	ProposalCount        uint64
+	PendingProposalCount uint64
+	DealStateCount       uint64
+	LockTableCount       uint64
+	DealOpEpochCount     uint64
+	DealOpCount          uint64
+}
+
+// Checks internal invariants of market state.
+func CheckStateInvariants(st *State, store adt.Store) (*StateSummary, *builtin.MessageAccumulator, error) {
+	acc := &builtin.MessageAccumulator{}
+
+	acc.Require(
+		st.TotalClientLockedCollateral.GreaterThanEqual(big.Zero()),
+		"negative total client locked collateral: %v", st.TotalClientLockedCollateral)
+
+	acc.Require(
+		st.TotalProviderLockedCollateral.GreaterThanEqual(big.Zero()),
+		"negative total provider locked collateral: %v", st.TotalClientLockedCollateral)
+
+	acc.Require(
+		st.TotalClientStorageFee.GreaterThanEqual(big.Zero()),
+		"negative total client storage fee: %v", st.TotalClientLockedCollateral)
+
+	//
+	// Proposals
+	//
+
+	allIDs := make(map[abi.DealID]struct{})
+	proposalCids := make(map[cid.Cid]struct{})
+	maxDealID := int64(-1)
+	proposalCount := uint64(0)
+
+	proposals, err := adt.AsArray(store, st.Proposals)
+	if err != nil {
+		return nil, acc, err
+	}
+	var proposal DealProposal
+	err = proposals.ForEach(&proposal, func(dealID int64) error {
+		allIDs[abi.DealID(dealID)] = struct{}{}
+
+		pcid, err := proposal.Cid()
+		if err != nil {
+			return err
+		}
+
+		_, found := proposalCids[pcid]
+		acc.Require(!found, "duplicate DealProposal %d found in proposals", dealID)
+
+		// keep some state
+		proposalCids[pcid] = struct{}{}
+		if dealID > maxDealID {
+			maxDealID = dealID
+		}
+		proposalCount++
+
+		return nil
+	})
+	if err != nil {
+		return nil, acc, err
+	}
+
+	// next id should be higher than any existing deal
+	acc.Require(int64(st.NextID) > maxDealID, "next id, %d, is not greater than highest id in proposals, %d", st.NextID, maxDealID)
+
+	//
+	// Deal States
+	//
+
+	dealStateCount := uint64(0)
+	dealStates, err := adt.AsArray(store, st.States)
+	if err != nil {
+		return nil, acc, err
+	}
+	var dealState DealState
+	err = dealStates.ForEach(&dealState, func(dealID int64) error {
+		acc.Require(
+			dealState.SectorStartEpoch >= 0,
+			"deal state start epoch undefined %d: %v", dealID, dealState)
+
+		acc.Require(
+			dealState.LastUpdatedEpoch == epochUndefined || dealState.LastUpdatedEpoch >= dealState.SectorStartEpoch,
+			"deal state last updated before sector start %d: %v", dealID, dealState)
+
+		acc.Require(
+			dealState.SlashEpoch == epochUndefined || dealState.SlashEpoch >= dealState.SectorStartEpoch,
+			"deal state slashed before sector start %d: %v", dealID, dealState)
+
+		_, found := allIDs[abi.DealID(dealID)]
+		acc.Require(found, "deal state references deal %d not found in proposals", dealID)
+
+		dealStateCount++
+		return nil
+	})
+	if err != nil {
+		return nil, acc, err
+	}
+
+	//
+	// Pending Proposals
+	//
+
+	pendingProposalCount := uint64(0)
+	pendingProposals, err := adt.AsMap(store, st.PendingProposals)
+	if err != nil {
+		return nil, nil, err
+	}
+	var pendingProposal DealProposal
+	err = pendingProposals.ForEach(&pendingProposal, func(key string) error {
+		proposalCID, err := cid.Parse([]byte(key))
+		if err != nil {
+			return err
+		}
+
+		pcid, err := pendingProposal.Cid()
+		if err != nil {
+			return err
+		}
+		acc.Require(pcid.Equals(proposalCID), "pending proposal's key does not match its CID %v != %v", pcid, proposalCID)
+
+		_, found := proposalCids[pcid]
+		acc.Require(found, "pending proposal with cid %v not fond within proposals %v", pcid, pendingProposals)
+
+		pendingProposalCount++
+		return nil
+	})
+	if err != nil {
+		return nil, acc, err
+	}
+
+	//
+	// Escrow Table and Locked Table
+	//
+
+	escrowTable, err := adt.AsBalanceTable(store, st.EscrowTable)
+	if err != nil {
+		return nil, acc, err
+	}
+
+	lockTableCount := uint64(0)
+	lockTable, err := adt.AsBalanceTable(store, st.LockedTable)
+	if err != nil {
+		return nil, acc, err
+	}
+	var lockedAmount abi.TokenAmount
+	lockedTotal := abi.NewTokenAmount(0)
+	err = (*adt.Map)(lockTable).ForEach(&lockedAmount, func(key string) error {
+		addr, err := address.NewFromBytes([]byte(key))
+		if err != nil {
+			return err
+		}
+		lockedTotal = big.Add(lockedTotal, lockedAmount)
+
+		// every entry in locked table should have a corresponding entry in escrow table that is at least as high
+		escrowAmount, err := escrowTable.Get(addr)
+		if err != nil {
+			return err
+		}
+		acc.Require(escrowAmount.GreaterThanEqual(lockedAmount),
+			"locked funds for %s, %s, greater than escrow amount, %s", addr, lockedAmount, escrowAmount)
+
+		lockTableCount++
+		return nil
+	})
+	if err != nil {
+		return nil, acc, err
+	}
+
+	// lockTable total should be sum of client and provider locked plus client storage fee
+	expectedLockTotal := big.Sum(st.TotalProviderLockedCollateral, st.TotalClientLockedCollateral, st.TotalClientStorageFee)
+	acc.Require(lockedTotal.Equals(expectedLockTotal),
+		"locked total, %s, does not sum to provider locked, %s, client locked, %s, and client storage fee, %s",
+		lockedTotal, st.TotalProviderLockedCollateral, st.TotalClientLockedCollateral, st.TotalClientStorageFee)
+
+	//
+	// Deal Ops by Epoch
+	//
+
+	dealOpEpochCount := uint64(0)
+	dealOpCount := uint64(0)
+	dealOps, err := AsSetMultimap(store, st.DealOpsByEpoch)
+	if err != nil {
+		return nil, acc, err
+	}
+
+	// get into internals just to iterate through full data structure
+	var setRoot cbg.CborCid
+	err = dealOps.mp.ForEach(&setRoot, func(key string) error {
+		epoch, err := strconv.ParseInt(key, 10, 64)
+		acc.Require(err != nil, "deal ops has key that is not a natural number: %s", key)
+
+		dealOpEpochCount++
+		return dealOps.ForEach(abi.ChainEpoch(epoch), func(id abi.DealID) error {
+			_, found := allIDs[id]
+			acc.Require(found, "deal op found for deal id %d with missing proposal at epoch %d", id, epoch)
+			dealOpCount++
+			return nil
+		})
+	})
+	if err != nil {
+		return nil, acc, err
+	}
+
+	return &StateSummary{
+		ProposalCount:        proposalCount,
+		PendingProposalCount: pendingProposalCount,
+		DealStateCount:       dealStateCount,
+		LockTableCount:       lockTableCount,
+		DealOpEpochCount:     dealOpEpochCount,
+		DealOpCount:          dealOpCount,
+	}, acc, nil
+}

--- a/actors/builtin/market/testing.go
+++ b/actors/builtin/market/testing.go
@@ -16,7 +16,7 @@ import (
 )
 
 type StateSummary struct {
-	ProposalCount        uint64
+	ProposalIDs          []abi.DealID
 	PendingProposalCount uint64
 	DealStateCount       uint64
 	LockTableCount       uint64
@@ -47,7 +47,7 @@ func CheckStateInvariants(st *State, store adt.Store) (*StateSummary, *builtin.M
 	allIDs := make(map[abi.DealID]struct{})
 	proposalCids := make(map[cid.Cid]struct{})
 	maxDealID := int64(-1)
-	proposalCount := uint64(0)
+	var proposalIDs []abi.DealID
 
 	proposals, err := adt.AsArray(store, st.Proposals)
 	if err != nil {
@@ -67,7 +67,7 @@ func CheckStateInvariants(st *State, store adt.Store) (*StateSummary, *builtin.M
 		if dealID > maxDealID {
 			maxDealID = dealID
 		}
-		proposalCount++
+		proposalIDs = append(proposalIDs, dealID)
 
 		return nil
 	})
@@ -219,7 +219,7 @@ func CheckStateInvariants(st *State, store adt.Store) (*StateSummary, *builtin.M
 	}
 
 	return &StateSummary{
-		ProposalCount:        proposalCount,
+		ProposalIDs:          proposalIDs,
 		PendingProposalCount: pendingProposalCount,
 		DealStateCount:       dealStateCount,
 		LockTableCount:       lockTableCount,

--- a/actors/builtin/market/testing.go
+++ b/actors/builtin/market/testing.go
@@ -109,8 +109,16 @@ func CheckStateInvariants(st *State, store adt.Store, balance abi.TokenAmount, c
 			"deal state last updated before sector start %d: %v", dealID, dealState)
 
 		acc.Require(
+			dealState.LastUpdatedEpoch == epochUndefined || dealState.LastUpdatedEpoch <= currEpoch,
+			"last updated epoch after current epoch %d: %v > %v", dealID, dealState.LastUpdatedEpoch, currEpoch)
+
+		acc.Require(
 			dealState.SlashEpoch == epochUndefined || dealState.SlashEpoch >= dealState.SectorStartEpoch,
 			"deal state slashed before sector start %d: %v", dealID, dealState)
+
+		acc.Require(
+			dealState.SlashEpoch == epochUndefined || dealState.SlashEpoch <= currEpoch,
+			"deal state slashed after current epoch %d: %v", dealID, currEpoch)
 
 		_, found := allIDs[abi.DealID(dealID)]
 		acc.Require(found, "deal state references deal %d not found in proposals", dealID)


### PR DESCRIPTION
work towards #1165

### Motivation

For performance reasons, our actor state is represented over multiple data structures and values. We need to ensure these many views on state always stay consistent. This PR adds checks for the Account, Cron, and Market actors that traverse these data structures ensuring consistency and uses them to check the state after every successful unit test.

### Proposed Changes

1. Create `CheckStateInvariants` function for `Account`, `Cron` and `Market` actors.
2. Add a call to this at the end of every actor test function that succeeds that fails the test if there is an inconsistency.

