### PR TITLE
Feat/parallel work

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,5 +20,6 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/whyrusleeping/cbor-gen v0.0.0-20200812213548-958ddffe352c
 	github.com/xorcare/golden v0.6.0
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 )

--- a/go.sum
+++ b/go.sum
@@ -163,6 +163,7 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 h1:0GoQqolDA55aaLxZyTzK/Y2ePZzZTUrRacwib7cNsYQ=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190219092855-153ac476189d/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
This aims to parallelize state migrations to make use of time spent waiting for datastore reads and writes as well and to leverage the multiple CPUs of miners' machines.  The idea is to run each actor migration in a different worker goroutine.  goroutines are bounded to a fixed size set (arbitrarily 16 here, need to empirically set it and it should be configurable for miners migrating).

@anorth this is still rough.  Apart from one clear bug it should work but hasn't been tested out yet so there might be other things wrong with it.
- We use a single shared miner migrator and set its balance and transfer state.  This is not threadsafe and is just broken.  I think we should differentiate the miner migration to have a different function signature to get rid of this problem simply.
- Concurrency pattern seems sound but there are likely much simpler approaches.  Maybe we could use a standard wait group instead of a fancy semaphore?  There should be some way we could do the semaphore release as a ~require~ defer instead of explicitly before every return statement.  The separate goroutine for accumulating transfers can probably go away with another approach. Etc.  Ideas welcome here.
- Global var semaphore is maybe a problem for multiple invocations
- Haven't separated out the synchronization code from the actors traversal so its getting crowded


