### PR TITLE
Entry point and stubs for state migration in v0.9.

### DIFF
--- a/actors/migration/nv3/migrators.go
+++ b/actors/migration/nv3/migrators.go
@@ -1,0 +1,31 @@
+package nv3
+
+import (
+	"context"
+
+	"github.com/ipfs/go-cid"
+	cbor "github.com/ipfs/go-ipld-cbor"
+
+	"github.com/filecoin-project/specs-actors/actors/builtin"
+)
+
+type StateMigration interface {
+	// Loads an actor's state from an input store and writes new state to an output store.
+	// Returns the new state head CID.
+	MigrateState(ctx context.Context, store cbor.IpldStore, head cid.Cid) (newHead cid.Cid, err error)
+}
+
+var migrators = map[cid.Cid]StateMigration{ // nolint:varcheck,deadcode,unused
+	builtin.RewardActorCodeID: &rewardMigrator{},
+	builtin.StorageMinerActorCodeID: &minerMigrator{},
+	//builtin.AccountActorCodeID: nil,
+	//builtin.CronActorCodeID: nil,
+	//builtin.InitActorCodeID: nil,
+	//builtin.MultisigActorCodeID:nil,
+	//builtin.PaymentChannelActorCodeID: nil,
+	//builtin.StorageMarketActorCodeID: nil,
+	//builtin.StoragePowerActorCodeID: nil,
+	//builtin.SystemActorCodeID: nil,
+	//builtin.VerifiedRegistryActorCodeID: nil,
+}
+

--- a/actors/migration/nv3/miner.go
+++ b/actors/migration/nv3/miner.go
@@ -1,0 +1,27 @@
+package nv3
+
+import (
+	"context"
+
+	cid "github.com/ipfs/go-cid"
+	cbor "github.com/ipfs/go-ipld-cbor"
+
+	miner "github.com/filecoin-project/specs-actors/actors/builtin/miner"
+)
+
+type minerMigrator struct {
+}
+
+func (m *minerMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, head cid.Cid) (cid.Cid, error) {
+	var st miner.State
+	if err := store.Get(ctx, head, &st); err != nil {
+		return cid.Undef, err
+	}
+
+	// TODO: https://github.com/filecoin-project/specs-actors/issues/1177
+	//  - repair broken partitions, deadline info:
+	//  - fix power actor claim with any power delta
+
+	newHead, err := store.Put(ctx, &st)
+	return newHead, err
+}

--- a/actors/migration/nv3/reward.go
+++ b/actors/migration/nv3/reward.go
@@ -1,0 +1,15 @@
+package nv3
+
+import (
+	"context"
+
+	cid "github.com/ipfs/go-cid"
+	cbor "github.com/ipfs/go-ipld-cbor"
+)
+
+type rewardMigrator struct {
+}
+
+func (m *rewardMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, head cid.Cid) (cid.Cid, error) {
+	return head, nil
+}

--- a/actors/migration/nv3/top.go
+++ b/actors/migration/nv3/top.go
@@ -1,0 +1,78 @@
+package nv3
+
+import (
+	"context"
+
+	address "github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/ipfs/go-cid"
+	cbor "github.com/ipfs/go-ipld-cbor"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/specs-actors/actors/builtin"
+	"github.com/filecoin-project/specs-actors/actors/states"
+	"github.com/filecoin-project/specs-actors/actors/util/adt"
+)
+
+//
+// State migration for network version 3.
+// This is an in-place upgrade that makes functionality changes guarded by checks on the network version,
+// and migrates some state.
+//
+
+// Loads and migrates the Filecoin state tree from a root, writing the new state tree blocks into the
+// same store.
+// Returns the new root of the state tree.
+func MigrateStateTree(ctx context.Context, store cbor.IpldStore, root cid.Cid) (cid.Cid, error) {
+	// Setup input and output state tree helpers
+	adtStore := adt.WrapStore(ctx, store)
+	tree, err := states.LoadTree(adtStore, root)
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	// Iterate all actors in old state root, set new actor states as we go.
+	if err = tree.ForEach(func(addr address.Address, actorIn *states.Actor) error {
+		migration, found := migrators[actorIn.Code]
+		if !found {
+			return nil // No migration for this actor type
+		}
+
+		headOut, err := migration.MigrateState(ctx, store, actorIn.Head)
+		if err != nil {
+			return xerrors.Errorf("state migration error on %s actor at addr %s: %w", builtin.ActorNameByCode(actorIn.Code), addr, err)
+		}
+
+		// Write new state root with the migrated state.
+		actorOut := states.Actor{
+			Code:       actorIn.Code,
+			Head:       headOut,
+			CallSeqNum: actorIn.CallSeqNum,
+			Balance:    actorIn.Balance,
+		}
+
+		return tree.SetActor(addr, &actorOut)
+	}); err != nil {
+		return cid.Undef, err
+	}
+
+	return tree.Flush()
+}
+
+// Checks that a state tree is internally consistent.
+// This performs only very basic checks. Versions in v2 will be much more thorough.
+func CheckStateTree(tree states.Tree, expectedBalanceTotal abi.TokenAmount) error {
+	balanceTotal := big.Zero()
+	if err := tree.ForEach(func(addr address.Address, actor *states.Actor) error {
+		balanceTotal = big.Add(balanceTotal, actor.Balance)
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	if !balanceTotal.Equals(expectedBalanceTotal) {
+		return xerrors.Errorf("balance total %v doesn't match expected %v", balanceTotal, expectedBalanceTotal)
+	}
+	return nil
+}


### PR DESCRIPTION
We are considering performing another small upgrade on the release/v0.9 branch, ahead of the larger upgrade/migration to v2. We're still working out exactly what we can/should include, but probably:
- repair miners broken by #1100 
- reduce some Window PoSt penalties (spec coming in another issue)
- update reward baseline parameters (previously implemented in /v2)

This PR adds the entry point and stubs for the state migration part.

FYI @acruikshank we'll probably put the code for #1177 here.