### PR TITLE
Change reward actor baseline parameters to 2.5EiB/100% as in-place upgrade.

### DIFF
--- a/actors/builtin/reward/reward_actor.go
+++ b/actors/builtin/reward/reward_actor.go
@@ -154,6 +154,7 @@ func (a Actor) UpdateNetworkKPI(rt runtime.Runtime, currRealizedPower *abi.Stora
 	if currRealizedPower == nil {
 		rt.Abortf(exitcode.ErrIllegalArgument, "arugment should not be nil")
 	}
+	networkVersion := rt.NetworkVersion()
 
 	var st State
 	rt.StateTransaction(&st, func() {
@@ -162,10 +163,10 @@ func (a Actor) UpdateNetworkKPI(rt runtime.Runtime, currRealizedPower *abi.Stora
 		// st.Epoch == rt.CurrEpoch()
 		for st.Epoch < rt.CurrEpoch() {
 			// Update to next epoch to process null rounds
-			st.updateToNextEpoch(*currRealizedPower)
+			st.updateToNextEpoch(*currRealizedPower, networkVersion)
 		}
 
-		st.updateToNextEpochWithReward(*currRealizedPower)
+		st.updateToNextEpochWithReward(*currRealizedPower, networkVersion)
 		// only update smoothed estimates after updating reward and epoch
 		st.updateSmoothedEstimates(st.Epoch - prev)
 	})

--- a/actors/builtin/reward/reward_logic_test.go
+++ b/actors/builtin/reward/reward_logic_test.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/filecoin-project/go-state-types/abi"
 	big "github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/network"
 	"github.com/stretchr/testify/assert"
 	"github.com/xorcare/golden"
 
@@ -83,7 +84,7 @@ func TestBaselineRewardGrowth(t *testing.T) {
 	baselineInYears := func(start StoragePower, x ChainEpoch) StoragePower {
 		baseline := start
 		for i := ChainEpoch(0); i < x*epochsInYear; i++ {
-			baseline = BaselinePowerFromPrev(baseline)
+			baseline = BaselinePowerFromPrev(baseline, network.Version0)
 		}
 		return baseline
 	}
@@ -123,7 +124,7 @@ func TestBaselineRewardGrowth(t *testing.T) {
 		},
 		// EiB
 		{
-			BaselineInitialValue,
+			BaselineInitialValueV0,
 			1e-8,
 		},
 		// ZiB

--- a/actors/builtin/reward/reward_test.go
+++ b/actors/builtin/reward/reward_test.go
@@ -35,9 +35,9 @@ func TestConstructor(t *testing.T) {
 		assert.Equal(t, abi.ChainEpoch(0), st.Epoch)
 		assert.Equal(t, abi.NewStoragePower(0), st.CumsumRealized)
 		assert.Equal(t, big.MustFromString(EpochZeroReward), st.ThisEpochReward)
-		epochZeroBaseline := big.Sub(reward.BaselineInitialValue, big.NewInt(1)) // account for rounding error of one byte during construction
+		epochZeroBaseline := big.Sub(reward.BaselineInitialValueV0, big.NewInt(1)) // account for rounding error of one byte during construction
 		assert.Equal(t, epochZeroBaseline, st.ThisEpochBaselinePower)
-		assert.Equal(t, reward.BaselineInitialValue, st.EffectiveBaselinePower)
+		assert.Equal(t, reward.BaselineInitialValueV0, st.EffectiveBaselinePower)
 	})
 	t.Run("construct with less power than baseline", func(t *testing.T) {
 		rt := mock.NewBuilder(context.Background(), builtin.RewardActorAddr).

--- a/actors/migration/nv3/reward.go
+++ b/actors/migration/nv3/reward.go
@@ -5,11 +5,36 @@ import (
 
 	cid "github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/specs-actors/actors/builtin/reward"
 )
 
 type rewardMigrator struct {
 }
 
 func (m *rewardMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, head cid.Cid) (cid.Cid, error) {
-	return head, nil
+	var st reward.State
+	if err := store.Get(ctx, head, &st); err != nil {
+		return cid.Undef, err
+	}
+
+	// The baseline function initial value and growth rate are changed.
+	// As an approximation to working out what the baseline value would be at the migration epoch
+	// had the baseline parameters been this way all along, this just sets the immediately value to the
+	// new (higher) initial value, essentially restarting its calculation.
+	// The baseline and realized cumsums, and effective network time, are not changed.
+	// This boils down to a step change in the baseline function, as if it had been defined piecewise.
+	// This will be a bit annoying for external analytical calculations of the baseline function.
+	newBaselineInitialValue := reward.BaselineInitialValueV3
+
+	if st.ThisEpochBaselinePower.GreaterThan(newBaselineInitialValue) {
+		return cid.Undef, xerrors.Errorf("unexpected baseline power %v higher than new initial value %v",
+			st.ThisEpochBaselinePower, newBaselineInitialValue)
+	}
+
+	st.ThisEpochBaselinePower = newBaselineInitialValue
+
+	newHead, err := store.Put(ctx, &st)
+	return newHead, err
 }

--- a/actors/migration/nv3/reward.go
+++ b/actors/migration/nv3/reward.go
@@ -5,7 +5,6 @@ import (
 
 	cid "github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
-	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/specs-actors/actors/builtin/reward"
 )
@@ -21,19 +20,12 @@ func (m *rewardMigrator) MigrateState(ctx context.Context, store cbor.IpldStore,
 
 	// The baseline function initial value and growth rate are changed.
 	// As an approximation to working out what the baseline value would be at the migration epoch
-	// had the baseline parameters been this way all along, this just sets the immediately value to the
+	// had the baseline parameters been this way all along, this just sets the immediate value to the
 	// new (higher) initial value, essentially restarting its calculation.
 	// The baseline and realized cumsums, and effective network time, are not changed.
 	// This boils down to a step change in the baseline function, as if it had been defined piecewise.
 	// This will be a bit annoying for external analytical calculations of the baseline function.
-	newBaselineInitialValue := reward.BaselineInitialValueV3
-
-	if st.ThisEpochBaselinePower.GreaterThan(newBaselineInitialValue) {
-		return cid.Undef, xerrors.Errorf("unexpected baseline power %v higher than new initial value %v",
-			st.ThisEpochBaselinePower, newBaselineInitialValue)
-	}
-
-	st.ThisEpochBaselinePower = newBaselineInitialValue
+	st.ThisEpochBaselinePower = reward.BaselineInitialValueV3
 
 	newHead, err := store.Put(ctx, &st)
 	return newHead, err


### PR DESCRIPTION
This was previously implemented in #1135 for actors v2 (please cross-check compatibility). We're now planning a smaller migration to come ahead of that, involving a small state migration but no state schema changes, so we can bring this forward.

- [x] Land #1178 and rebase onto `release/v0.9`

After merge:
- [ ] Revert re-setting the baseline initial value in the v2 upgrade migration.

FYI @zixuanzh 