### PR TITLE
[v0.9] Remove penalties on recovery and on missed PoSt (FIP-0002)

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -299,6 +299,7 @@ type SubmitWindowedPoStParams struct {
 func (a Actor) SubmitWindowedPoSt(rt Runtime, params *SubmitWindowedPoStParams) *abi.EmptyValue {
 	currEpoch := rt.CurrEpoch()
 	store := adt.AsStore(rt)
+	networkVersion := rt.NetworkVersion()
 	var st State
 
 	if params.Deadline >= WPoStPeriodDeadlines {
@@ -394,23 +395,37 @@ func (a Actor) SubmitWindowedPoSt(rt Runtime, params *SubmitWindowedPoStParams) 
 		// Penalize new skipped faults and retracted recoveries as undeclared faults.
 		// These pay a higher fee than faults declared before the deadline challenge window opened.
 		undeclaredPenaltyPower := postResult.PenaltyPower()
-		undeclaredPenaltyTarget := PledgePenaltyForUndeclaredFault(
-			rewardStats.ThisEpochRewardSmoothed, pwrTotal.QualityAdjPowerSmoothed, undeclaredPenaltyPower.QA,
-			rt.NetworkVersion(),
-		)
-		// Subtract the "ongoing" fault fee from the amount charged now, since it will be charged at
-		// the end-of-deadline cron.
-		undeclaredPenaltyTarget = big.Sub(undeclaredPenaltyTarget, PledgePenaltyForDeclaredFault(
-			rewardStats.ThisEpochRewardSmoothed, pwrTotal.QualityAdjPowerSmoothed, undeclaredPenaltyPower.QA,
-		))
+		undeclaredPenaltyTarget := big.Zero()
+		if networkVersion >= network.Version3 {
+			// From version 3, skipped faults and retracted recoveries pay nothing at Window PoSt,
+			// but will incur the "ongoing" fault fee at deadline end.
+		} else {
+			undeclaredPenaltyTarget = PledgePenaltyForUndeclaredFault(
+				rewardStats.ThisEpochRewardSmoothed, pwrTotal.QualityAdjPowerSmoothed, undeclaredPenaltyPower.QA,
+				networkVersion,
+			)
+			// Subtract the "ongoing" fault fee from the amount charged now, since it will be charged at
+			// the end-of-deadline cron.
+			undeclaredPenaltyTarget = big.Sub(undeclaredPenaltyTarget, PledgePenaltyForDeclaredFault(
+				rewardStats.ThisEpochRewardSmoothed, pwrTotal.QualityAdjPowerSmoothed, undeclaredPenaltyPower.QA,
+				networkVersion,
+			))
+		}
 
 		// Penalize recoveries as declared faults (a lower fee than the undeclared, above).
 		// It sounds odd, but because faults are penalized in arrears, at the _end_ of the faulty period, we must
 		// penalize recovered sectors here because they won't be penalized by the end-of-deadline cron for the
 		// immediately-prior faulty period.
-		declaredPenaltyTarget := PledgePenaltyForDeclaredFault(
-			rewardStats.ThisEpochRewardSmoothed, pwrTotal.QualityAdjPowerSmoothed, postResult.RecoveredPower.QA,
-		)
+		declaredPenaltyTarget := big.Zero()
+		if networkVersion >= network.Version3 {
+			// From version 3, recovered sectors pay no penalty.
+			// They won't pay anything at deadline end either, since they'll no longer be faulty.
+		} else {
+			declaredPenaltyTarget = PledgePenaltyForDeclaredFault(
+				rewardStats.ThisEpochRewardSmoothed, pwrTotal.QualityAdjPowerSmoothed, postResult.RecoveredPower.QA,
+				networkVersion,
+			)
+		}
 
 		// Note: We could delay this charge until end of deadline, but that would require more accounting state.
 		totalPenaltyTarget := big.Add(undeclaredPenaltyTarget, declaredPenaltyTarget)
@@ -1570,6 +1585,7 @@ func processEarlyTerminations(rt Runtime) (more bool) {
 func handleProvingDeadline(rt Runtime) {
 	currEpoch := rt.CurrEpoch()
 	store := adt.AsStore(rt)
+	networkVersion := rt.NetworkVersion()
 
 	epochReward := requestCurrentEpochBlockReward(rt)
 	pwrTotal := requestCurrentTotalPower(rt)
@@ -1630,33 +1646,47 @@ func handleProvingDeadline(rt Runtime) {
 		quant := QuantSpecForDeadline(dlInfo)
 		unlockedBalance := st.GetUnlockedBalance(rt.CurrentBalance())
 
+		// Remember power that was faulty before processing any missed PoSts.
+		previouslyFaultyPower := deadline.FaultyPower.QA
+
 		{
 			// Detect and penalize missing proofs.
 			faultExpiration := dlInfo.Last() + FaultMaxAge
-			penalizePowerTotal := big.Zero()
 
 			newFaultyPower, failedRecoveryPower, err := deadline.ProcessDeadlineEnd(store, quant, faultExpiration)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to process end of deadline %d", dlInfo.Index)
 
 			powerDelta = powerDelta.Sub(newFaultyPower)
-			penalizePowerTotal = big.Sum(penalizePowerTotal, newFaultyPower.QA, failedRecoveryPower.QA)
 
-			// Unlock sector penalty for all undeclared faults.
-			penaltyTarget := PledgePenaltyForUndeclaredFault(epochReward.ThisEpochRewardSmoothed, pwrTotal.QualityAdjPowerSmoothed,
-				penalizePowerTotal, rt.NetworkVersion())
-			// Subtract the "ongoing" fault fee from the amount charged now, since it will be added on just below.
-			penaltyTarget = big.Sub(penaltyTarget, PledgePenaltyForDeclaredFault(epochReward.ThisEpochRewardSmoothed, pwrTotal.QualityAdjPowerSmoothed, penalizePowerTotal))
-			penaltyFromVesting, penaltyFromBalance, err := st.PenalizeFundsInPriorityOrder(store, currEpoch, penaltyTarget, unlockedBalance)
-			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to unlock penalty")
-			unlockedBalance = big.Sub(unlockedBalance, penaltyFromBalance)
-			penaltyTotal = big.Sum(penaltyTotal, penaltyFromVesting, penaltyFromBalance)
-			pledgeDelta = big.Sub(pledgeDelta, penaltyFromVesting)
+			if networkVersion >= network.Version3 {
+				// From network version 3, faults detected from a missed PoSt pay nothing.
+				// Failed recoveries pay nothing here, but will pay the ongoing fault fee in the subsequent block.
+			} else {
+				penalizePowerTotal := big.Add(newFaultyPower.QA, failedRecoveryPower.QA)
 
+				// Unlock sector penalty for all undeclared faults.
+				penaltyTarget := PledgePenaltyForUndeclaredFault(epochReward.ThisEpochRewardSmoothed, pwrTotal.QualityAdjPowerSmoothed,
+					penalizePowerTotal, rt.NetworkVersion())
+				// Subtract the "ongoing" fault fee from the amount charged now, since it will be added on just below.
+				penaltyTarget = big.Sub(penaltyTarget, PledgePenaltyForDeclaredFault(epochReward.ThisEpochRewardSmoothed,
+					pwrTotal.QualityAdjPowerSmoothed, penalizePowerTotal, networkVersion))
+				penaltyFromVesting, penaltyFromBalance, err := st.PenalizeFundsInPriorityOrder(store, currEpoch, penaltyTarget, unlockedBalance)
+				builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to unlock penalty")
+				unlockedBalance = big.Sub(unlockedBalance, penaltyFromBalance)
+				penaltyTotal = big.Sum(penaltyTotal, penaltyFromVesting, penaltyFromBalance)
+				pledgeDelta = big.Sub(pledgeDelta, penaltyFromVesting)
+			}
 		}
 		{
 			// Record faulty power for penalisation of ongoing faults, before popping expirations.
 			// This includes any power that was just faulted from missing a PoSt.
-			penaltyTarget := PledgePenaltyForDeclaredFault(epochReward.ThisEpochRewardSmoothed, pwrTotal.QualityAdjPowerSmoothed, deadline.FaultyPower.QA)
+			ongoingFaultyPower := deadline.FaultyPower.QA
+			if networkVersion >= network.Version3 {
+				// From network version 3, this *excludes* any power that was just faulted from missing a PoSt.
+				ongoingFaultyPower = previouslyFaultyPower
+			}
+			penaltyTarget := PledgePenaltyForDeclaredFault(epochReward.ThisEpochRewardSmoothed,
+				pwrTotal.QualityAdjPowerSmoothed, ongoingFaultyPower, networkVersion)
 			penaltyFromVesting, penaltyFromBalance, err := st.PenalizeFundsInPriorityOrder(store, currEpoch, penaltyTarget, unlockedBalance)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to unlock penalty")
 			unlockedBalance = big.Sub(unlockedBalance, penaltyFromBalance) //nolint:ineffassign

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -1683,6 +1683,8 @@ func handleProvingDeadline(rt Runtime) {
 			ongoingFaultyPower := deadline.FaultyPower.QA
 			if networkVersion >= network.Version3 {
 				// From network version 3, this *excludes* any power that was just faulted from missing a PoSt.
+				// It includes power that was previously declared, skipped, or detected faulty, whether or
+				// not it is also marked for recovery.
 				ongoingFaultyPower = previouslyFaultyPower
 			}
 			penaltyTarget := PledgePenaltyForDeclaredFault(epochReward.ThisEpochRewardSmoothed,

--- a/actors/builtin/miner/miner_internal_test.go
+++ b/actors/builtin/miner/miner_internal_test.go
@@ -108,7 +108,7 @@ func TestFaultFeeInvariants(t *testing.T) {
 	t.Run("Undeclared faults are more expensive than declared faults", func(t *testing.T) {
 		faultySectorPower := abi.NewStoragePower(1 << 50)
 
-		ff := PledgePenaltyForDeclaredFault(rewardEstimate, powerEstimate, faultySectorPower)
+		ff := PledgePenaltyForDeclaredFault(rewardEstimate, powerEstimate, faultySectorPower, nv)
 		sp := PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, faultySectorPower, nv)
 		assert.True(t, sp.GreaterThan(ff))
 	})
@@ -163,11 +163,11 @@ func TestFaultFeeInvariants(t *testing.T) {
 		totalFaultPower := big.Add(big.Add(faultySectorAPower, faultySectorBPower), faultySectorCPower)
 
 		// Declared faults
-		ffA := PledgePenaltyForDeclaredFault(rewardEstimate, powerEstimate, faultySectorAPower)
-		ffB := PledgePenaltyForDeclaredFault(rewardEstimate, powerEstimate, faultySectorBPower)
-		ffC := PledgePenaltyForDeclaredFault(rewardEstimate, powerEstimate, faultySectorCPower)
+		ffA := PledgePenaltyForDeclaredFault(rewardEstimate, powerEstimate, faultySectorAPower, nv)
+		ffB := PledgePenaltyForDeclaredFault(rewardEstimate, powerEstimate, faultySectorBPower, nv)
+		ffC := PledgePenaltyForDeclaredFault(rewardEstimate, powerEstimate, faultySectorCPower, nv)
 
-		ffAll := PledgePenaltyForDeclaredFault(rewardEstimate, powerEstimate, totalFaultPower)
+		ffAll := PledgePenaltyForDeclaredFault(rewardEstimate, powerEstimate, totalFaultPower, nv)
 
 		// Because we can introduce rounding error between 1 and zero for every penalty calculation
 		// we can at best expect n calculations of 1 power to be within n of 1 calculation of n powers.

--- a/actors/builtin/miner/monies.go
+++ b/actors/builtin/miner/monies.go
@@ -29,9 +29,11 @@ var SpaceRaceInitialPledgeMaxPerByte = big.Div(big.NewInt(1e18), big.NewInt(32 <
 
 // FF = BR(t, DeclaredFaultProjectionPeriod)
 // projection period of 2.14 days:  2880 * 2.14 = 6163.2.  Rounded to nearest epoch 6163
-var DeclaredFaultFactorNum = 214
+var DeclaredFaultFactorNumV0 = 214
+var DeclaredFaultFactorNumV3 = 351
 var DeclaredFaultFactorDenom = 100
-var DeclaredFaultProjectionPeriod = abi.ChainEpoch((builtin.EpochsInDay * DeclaredFaultFactorNum) / DeclaredFaultFactorDenom)
+var DeclaredFaultProjectionPeriodV0 = abi.ChainEpoch((builtin.EpochsInDay * DeclaredFaultFactorNumV0) / DeclaredFaultFactorDenom)
+var DeclaredFaultProjectionPeriodV3 = abi.ChainEpoch((builtin.EpochsInDay * DeclaredFaultFactorNumV3) / DeclaredFaultFactorDenom)
 
 // SP = BR(t, UndeclaredFaultProjectionPeriod)
 var UndeclaredFaultFactorNumV0 = 50
@@ -60,8 +62,13 @@ func ExpectedRewardForPower(rewardEstimate, networkQAPowerEstimate *smoothing.Fi
 // This is the FF(t) penalty for a sector expected to be in the fault state either because the fault was declared or because
 // it has been previously detected by the network.
 // FF(t) = DeclaredFaultFactor * BR(t)
-func PledgePenaltyForDeclaredFault(rewardEstimate, networkQAPowerEstimate *smoothing.FilterEstimate, qaSectorPower abi.StoragePower) abi.TokenAmount {
-	return ExpectedRewardForPower(rewardEstimate, networkQAPowerEstimate, qaSectorPower, DeclaredFaultProjectionPeriod)
+func PledgePenaltyForDeclaredFault(rewardEstimate, networkQAPowerEstimate *smoothing.FilterEstimate, qaSectorPower abi.StoragePower,
+	networkVersion network.Version) abi.TokenAmount {
+	projectionPeriod := DeclaredFaultProjectionPeriodV0
+	if networkVersion >= network.Version3 {
+		projectionPeriod = DeclaredFaultProjectionPeriodV3
+	}
+	return ExpectedRewardForPower(rewardEstimate, networkQAPowerEstimate, qaSectorPower, projectionPeriod)
 }
 
 // This is the SP(t) penalty for a newly faulty sector that has not been declared.


### PR DESCRIPTION
Honest miners are sometimes disproportionately penalized for operational failures and network congestion by the high undeclared-fault penalty (aka SP) for missed Window PoSts. This change reduces those costs without sacrificing much of the incentive to maintain reliable storage.

Summary:
* Remove fee incurred when a sector is successfully recovered.
* Remove fee incurred by sectors faulted when a Window PoSt is missed.
* Update Sector Fault Fee (FF) to 3.51 days of expected block reward, for ongoing faults.

As a result of this, declaring faults in advance confers no advantage compared with skipping them at Window PoSt. The DeclareFaults method remains, but may be removed in the future.

This change is a demonstration of upcoming [FIP-0002](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0002.md), which will describe more background and rationale.

Note that the new values are not directly tested in this PR. I intend to replicate on the `v2` line and change all the tests there. UPDATE: see #1183

FYI @Stebalien @magik6k @whyrusleeping @zixuanzh @nicola 