### PR TITLE
[v2] Remove penalties on recovery and on missed PoSt

### DIFF
--- a/actors/builtin/miner/deadline_state.go
+++ b/actors/builtin/miner/deadline_state.go
@@ -773,7 +773,7 @@ func (dl *Deadline) DeclareFaultsRecovered(
 
 // ProcessDeadlineEnd processes all PoSt submissions, marking unproven sectors as
 // faulty and clearing failed recoveries. It returns the power delta, and any
-// power that should be penalized.
+// power that should be penalized (new faults and failed recoveries).
 func (dl *Deadline) ProcessDeadlineEnd(store adt.Store, quant QuantSpec, faultExpirationEpoch abi.ChainEpoch) (
 	powerDelta, penalizedPower PowerPair, err error,
 ) {

--- a/actors/builtin/miner/miner_internal_test.go
+++ b/actors/builtin/miner/miner_internal_test.go
@@ -104,14 +104,6 @@ func TestFaultFeeInvariants(t *testing.T) {
 	networkPower := abi.NewStoragePower(100 << 50)
 	powerEstimate := smoothing.TestingConstantEstimate(networkPower)
 
-	t.Run("Undeclared faults are more expensive than declared faults", func(t *testing.T) {
-		faultySectorPower := abi.NewStoragePower(1 << 50)
-
-		ff := PledgePenaltyForDeclaredFault(rewardEstimate, powerEstimate, faultySectorPower)
-		sp := PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, faultySectorPower)
-		assert.True(t, sp.GreaterThan(ff))
-	})
-
 	// constant filter estimate cumsum ratio is just multiplication and division
 	// test that internal precision of BR calculation does not cost accuracy
 	// compared to simple multiplication in this case.
@@ -162,11 +154,11 @@ func TestFaultFeeInvariants(t *testing.T) {
 		totalFaultPower := big.Add(big.Add(faultySectorAPower, faultySectorBPower), faultySectorCPower)
 
 		// Declared faults
-		ffA := PledgePenaltyForDeclaredFault(rewardEstimate, powerEstimate, faultySectorAPower)
-		ffB := PledgePenaltyForDeclaredFault(rewardEstimate, powerEstimate, faultySectorBPower)
-		ffC := PledgePenaltyForDeclaredFault(rewardEstimate, powerEstimate, faultySectorCPower)
+		ffA := PledgePenaltyForContinuedFault(rewardEstimate, powerEstimate, faultySectorAPower)
+		ffB := PledgePenaltyForContinuedFault(rewardEstimate, powerEstimate, faultySectorBPower)
+		ffC := PledgePenaltyForContinuedFault(rewardEstimate, powerEstimate, faultySectorCPower)
 
-		ffAll := PledgePenaltyForDeclaredFault(rewardEstimate, powerEstimate, totalFaultPower)
+		ffAll := PledgePenaltyForContinuedFault(rewardEstimate, powerEstimate, totalFaultPower)
 
 		// Because we can introduce rounding error between 1 and zero for every penalty calculation
 		// we can at best expect n calculations of 1 power to be within n of 1 calculation of n powers.
@@ -175,11 +167,11 @@ func TestFaultFeeInvariants(t *testing.T) {
 		assert.True(t, diff.LessThan(big.NewInt(3)))
 
 		// Undeclared faults
-		spA := PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, faultySectorAPower)
-		spB := PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, faultySectorBPower)
-		spC := PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, faultySectorCPower)
+		spA := PledgePenaltyForTerminationLowerBound(rewardEstimate, powerEstimate, faultySectorAPower)
+		spB := PledgePenaltyForTerminationLowerBound(rewardEstimate, powerEstimate, faultySectorBPower)
+		spC := PledgePenaltyForTerminationLowerBound(rewardEstimate, powerEstimate, faultySectorCPower)
 
-		spAll := PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, totalFaultPower)
+		spAll := PledgePenaltyForTerminationLowerBound(rewardEstimate, powerEstimate, totalFaultPower)
 
 		// Because we can introduce rounding error between 1 and zero for every penalty calculation
 		// we can at best expect n calculations of 1 power to be within n of 1 calculation of n powers.

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -997,6 +997,8 @@ type AdvanceDeadlineResult struct {
 	PreviouslyFaultyPower PowerPair // Power that was faulty before this advance (including recovering)
 	DetectedFaultyPower   PowerPair // Power of new faults and failed recoveries
 	TotalFaultyPower      PowerPair // Total faulty power after detecting faults (before expiring sectors)
+	// Note that failed recovery power is included in both PreviouslyFaultyPower and DetectedFaultyPower,
+	// so TotalFaultyPower is not simply their sum.
 }
 
 // AdvanceDeadline advances the deadline. It:
@@ -1102,11 +1104,11 @@ func (st *State) AdvanceDeadline(store adt.Store, currEpoch abi.ChainEpoch) (*Ad
 	// Compute penalties all together.
 	// Be very careful when changing these as any changes can affect rounding.
 	return &AdvanceDeadlineResult{
-		pledgeDelta,
-		powerDelta,
-		previouslyFaultyPower,
-		detectedFaultyPower,
-		totalFaultyPower,
+		PledgeDelta:           pledgeDelta,
+		PowerDelta:            powerDelta,
+		PreviouslyFaultyPower: previouslyFaultyPower,
+		DetectedFaultyPower:   detectedFaultyPower,
+		TotalFaultyPower:      totalFaultyPower,
 	}, nil
 }
 

--- a/actors/builtin/miner/monies_test.go
+++ b/actors/builtin/miner/monies_test.go
@@ -21,7 +21,7 @@ func TestPledgePenaltyForTermination(t *testing.T) {
 	rewardEstimate := smoothing.TestingConstantEstimate(epochTargetReward)
 	powerEstimate := smoothing.TestingConstantEstimate(networkQAPower)
 
-	undeclaredPenalty := miner.PledgePenaltyForUndeclaredFault(rewardEstimate, powerEstimate, qaSectorPower)
+	undeclaredPenalty := miner.PledgePenaltyForTerminationLowerBound(rewardEstimate, powerEstimate, qaSectorPower)
 	bigInitialPledgeFactor := big.NewInt(int64(miner.InitialPledgeFactor))
 	bigLifetimeCap := big.NewInt(int64(miner.TerminationLifetimeCap))
 

--- a/actors/builtin/miner/partition_state.go
+++ b/actors/builtin/miner/partition_state.go
@@ -683,7 +683,7 @@ func (p *Partition) PopExpiredSectors(store adt.Store, until abi.ChainEpoch, qua
 
 // Marks all non-faulty sectors in the partition as faulty and clears recoveries, updating power memos appropriately.
 // All sectors' expirations are rescheduled to the fault expiration, as "early" (if not expiring earlier)
-// Returns the power delta, power that should be penalized, and newly faulty power.
+// Returns the power delta, power that should be penalized (new faults + failed recoveries), and newly faulty power.
 func (p *Partition) RecordMissedPost(
 	store adt.Store, faultExpiration abi.ChainEpoch, quant QuantSpec,
 ) (powerDelta, penalizedPower, newFaultyPower PowerPair, err error) {

--- a/actors/test/committed_capacity_scenario_test.go
+++ b/actors/test/committed_capacity_scenario_test.go
@@ -282,7 +282,6 @@ func TestReplaceCommittedCapacitySectorWithDealLadenSector(t *testing.T) {
 						{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.CurrentTotalPower},
 						// power is removed for old sector and pledge is burnt
 						{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.UpdateClaimedPower},
-						{To: builtin.BurntFundsActorAddr, Method: builtin.MethodSend},
 						{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.UpdatePledgeTotal},
 						{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.EnrollCronEvent},
 					}},
@@ -327,12 +326,6 @@ func TestReplaceCommittedCapacitySectorWithDealLadenSector(t *testing.T) {
 			To:     minerAddrs.IDAddress,
 			Method: builtin.MethodsMiner.SubmitWindowedPoSt,
 			Params: vm.ExpectObject(&submitParams),
-			SubInvocations: []vm.ExpectInvocation{
-				{To: builtin.RewardActorAddr, Method: builtin.MethodsReward.ThisEpochReward},
-				{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.CurrentTotalPower},
-				// Skipped sector is penalized as undeclared fault
-				{To: builtin.BurntFundsActorAddr, Method: builtin.MethodSend},
-			},
 		}.Matches(t, tv.LastInvocation())
 
 		// old sector power remains (until its proving deadline)
@@ -363,8 +356,6 @@ func TestReplaceCommittedCapacitySectorWithDealLadenSector(t *testing.T) {
 		Method: builtin.MethodsMiner.SubmitWindowedPoSt,
 		Params: vm.ExpectObject(&submitParams),
 		SubInvocations: []vm.ExpectInvocation{
-			{To: builtin.RewardActorAddr, Method: builtin.MethodsReward.ThisEpochReward},
-			{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.CurrentTotalPower},
 			// This call to the power actor indicates power has been added for the replaced sector
 			{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.UpdateClaimedPower},
 		},


### PR DESCRIPTION
This is #1181 adapted to the v2 code on master.

Honest miners are sometimes disproportionately penalized for operational failures and network congestion by the high undeclared-fault penalty (aka SP) for missed Window PoSts. This change reduces those costs without sacrificing much of the incentive to maintain reliable storage.

Summary:
* Remove fee incurred when a sector is successfully recovered.
* Remove fee incurred by sectors faulted when a Window PoSt is missed.
* Update Sector Fault Fee (FF) to 3.51 days of expected block reward, for ongoing faults.

As a result of this:
- Declaring faults in advance is irrational compared with skipping them at Window PoSt. The DeclareFaults method remains, but miners should avoid calling it. The rationality may change in the future. 
- There are no penalties charged at all during SubmitWindowPoSt, so a bunch of code was deleted.
- Submitting a PoSt with all sectors skipped is now actively bad, rather than just pointless, so is now rejected.

This change is a demonstration of upcoming FIP-0008, which will describe more background and rationale.

FYI @Stebalien @magik6k @whyrusleeping @zixuanzh @nicola