### PR TITLE
[v0.9] Tests for baseline function migration

### DIFF
--- a/actors/builtin/reward/reward_actor.go
+++ b/actors/builtin/reward/reward_actor.go
@@ -163,10 +163,10 @@ func (a Actor) UpdateNetworkKPI(rt runtime.Runtime, currRealizedPower *abi.Stora
 		// st.Epoch == rt.CurrEpoch()
 		for st.Epoch < rt.CurrEpoch() {
 			// Update to next epoch to process null rounds
-			st.updateToNextEpoch(*currRealizedPower, networkVersion)
+			st.UpdateToNextEpoch(*currRealizedPower, networkVersion)
 		}
 
-		st.updateToNextEpochWithReward(*currRealizedPower, networkVersion)
+		st.UpdateToNextEpochWithReward(*currRealizedPower, networkVersion)
 		// only update smoothed estimates after updating reward and epoch
 		st.updateSmoothedEstimates(st.Epoch - prev)
 	})

--- a/actors/builtin/reward/reward_state.go
+++ b/actors/builtin/reward/reward_state.go
@@ -70,14 +70,14 @@ func ConstructState(currRealizedPower abi.StoragePower) *State {
 		TotalMined:              big.Zero(),
 	}
 
-	st.updateToNextEpochWithReward(currRealizedPower, network.Version0)
+	st.UpdateToNextEpochWithReward(currRealizedPower, network.Version0)
 
 	return st
 }
 
 // Takes in current realized power and updates internal state
 // Used for update of internal state during null rounds
-func (st *State) updateToNextEpoch(currRealizedPower abi.StoragePower, nv network.Version) {
+func (st *State) UpdateToNextEpoch(currRealizedPower abi.StoragePower, nv network.Version) {
 	st.Epoch++
 	st.ThisEpochBaselinePower = BaselinePowerFromPrev(st.ThisEpochBaselinePower, nv)
 	cappedRealizedPower := big.Min(st.ThisEpochBaselinePower, currRealizedPower)
@@ -92,9 +92,9 @@ func (st *State) updateToNextEpoch(currRealizedPower abi.StoragePower, nv networ
 
 // Takes in a current realized power for a reward epoch and computes
 // and updates reward state to track reward for the next epoch
-func (st *State) updateToNextEpochWithReward(currRealizedPower abi.StoragePower, nv network.Version) {
+func (st *State) UpdateToNextEpochWithReward(currRealizedPower abi.StoragePower, nv network.Version) {
 	prevRewardTheta := computeRTheta(st.EffectiveNetworkTime, st.EffectiveBaselinePower, st.CumsumRealized, st.CumsumBaseline)
-	st.updateToNextEpoch(currRealizedPower, nv)
+	st.UpdateToNextEpoch(currRealizedPower, nv)
 	currRewardTheta := computeRTheta(st.EffectiveNetworkTime, st.EffectiveBaselinePower, st.CumsumRealized, st.CumsumBaseline)
 
 	st.ThisEpochReward = computeReward(st.Epoch, prevRewardTheta, currRewardTheta)

--- a/actors/migration/nv3/reward_test.go
+++ b/actors/migration/nv3/reward_test.go
@@ -1,0 +1,70 @@
+package nv3
+
+import (
+	"context"
+	gbig "math/big"
+	"testing"
+
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/network"
+	assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/specs-actors/actors/builtin"
+	"github.com/filecoin-project/specs-actors/actors/builtin/reward"
+	"github.com/filecoin-project/specs-actors/support/ipld"
+)
+
+func TestRewardMigrator(t *testing.T) {
+	ctx := context.Background()
+	store := ipld.NewADTStore(ctx)
+
+	power := abi.NewStoragePower(1 << 50)
+	st := reward.ConstructState(power)
+	_, err := store.Put(ctx, st)
+	require.NoError(t, err)
+
+	// Simulate some time passing and baseline growth.
+	epochsInYear := abi.ChainEpoch(365 * builtin.EpochsInDay)
+	epoch := abi.ChainEpoch(0)
+	for ; epoch < epochsInYear; epoch++ {
+		st.UpdateToNextEpochWithReward(power, network.Version0)
+	}
+	head, err := store.Put(ctx, st)
+	require.NoError(t, err)
+
+	{
+		// With network version 0, after 1 year expect value to be 200% higher (allowing for small error).
+		multiplier := big.NewInt(3)
+		expectedValue := big.Mul(reward.BaselineInitialValueV0, multiplier)
+		diff := big.Sub(expectedValue, st.ThisEpochBaselinePower)
+		perrFrac := gbig.NewRat(1, 1).SetFrac(diff.Int, expectedValue.Int)
+		perr, _ := perrFrac.Float64()
+		assert.Less(t, perr, 1e-8)
+	}
+
+	// Upgrade to network version 1.
+	rw := rewardMigrator{}
+	newHead, err := rw.MigrateState(ctx, store, head, epoch, builtin.RewardActorAddr, nil)
+	require.NoError(t, err)
+
+	// Expect the baseline value to be reset.
+	require.NoError(t, store.Get(ctx, newHead, st))
+	assert.True(t, reward.BaselineInitialValueV3.Equals(st.ThisEpochBaselinePower))
+
+	// Simulate another year
+	for ; epoch < 2*epochsInYear; epoch++ {
+		st.UpdateToNextEpochWithReward(power, network.Version3)
+	}
+
+	{
+		// After 1 more year expect value to be 100% higher than the reset initial value (allowing for small error).
+		multiplier := big.NewInt(2)
+		expectedValue := big.Mul(reward.BaselineInitialValueV3, multiplier)
+		diff := big.Sub(expectedValue, st.ThisEpochBaselinePower)
+		perrFrac := gbig.NewRat(1, 1).SetFrac(diff.Int, expectedValue.Int)
+		perr, _ := perrFrac.Float64()
+		assert.Less(t, perr, 1e-8)
+	}
+}


### PR DESCRIPTION
I wrote some tests for the migration of the baseline function. They pass. 

I don't think we should actually land this as-is, due to:
- code duplication
- very slow (>= 20s)
- not valuable after the migration happens

We can discuss adjustments that would make them better, but since I demonstrated what I set out to, I don't think it's urgent or important.

FYI @zixuanzh 