### PR TITLE
Introduce VMActor abstraction

### DIFF
--- a/actors/builtin/account/account_actor.go
+++ b/actors/builtin/account/account_actor.go
@@ -3,7 +3,9 @@ package account
 import (
 	addr "github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/cbor"
 	"github.com/filecoin-project/go-state-types/exitcode"
+	"github.com/ipfs/go-cid"
 
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/runtime"
@@ -18,7 +20,15 @@ func (a Actor) Exports() []interface{} {
 	}
 }
 
-var _ runtime.Invokee = Actor{}
+func (a Actor) Code() cid.Cid {
+	return builtin.AccountActorCodeID
+}
+
+func (a Actor) State() cbor.Er {
+	return new(State)
+}
+
+var _ runtime.VMActor = Actor{}
 
 type State struct {
 	Address addr.Address

--- a/actors/builtin/cron/cron_actor.go
+++ b/actors/builtin/cron/cron_actor.go
@@ -2,6 +2,8 @@ package cron
 
 import (
 	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/cbor"
+	"github.com/ipfs/go-cid"
 
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/runtime"
@@ -17,7 +19,19 @@ func (a Actor) Exports() []interface{} {
 	}
 }
 
-var _ runtime.Invokee = Actor{}
+func (a Actor) Code() cid.Cid {
+	return builtin.CronActorCodeID
+}
+
+func (a Actor) IsSingleton() bool {
+	return true
+}
+
+func (a Actor) State() cbor.Er {
+	return new(State)
+}
+
+var _ runtime.VMActor = Actor{}
 
 type ConstructorParams struct {
 	Entries []Entry

--- a/actors/builtin/exported/actors.go
+++ b/actors/builtin/exported/actors.go
@@ -1,9 +1,6 @@
 package exported
 
 import (
-	cid "github.com/ipfs/go-cid"
-
-	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/builtin/account"
 	"github.com/filecoin-project/specs-actors/actors/builtin/cron"
 	init_ "github.com/filecoin-project/specs-actors/actors/builtin/init"
@@ -18,68 +15,18 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/runtime"
 )
 
-var _ runtime.Invokee = BuiltinActor{}
-
-type BuiltinActor struct {
-	actor runtime.Invokee
-	code  cid.Cid
-}
-
-// Code is the CodeID (cid) of the actor.
-func (b BuiltinActor) Code() cid.Cid {
-	return b.code
-}
-
-// Exports returns a slice of callable Actor methods.
-func (b BuiltinActor) Exports() []interface{} {
-	return b.actor.Exports()
-}
-
-func BuiltinActors() []BuiltinActor {
-	return []BuiltinActor{
-		{
-			actor: account.Actor{},
-			code:  builtin.AccountActorCodeID,
-		},
-		{
-			actor: cron.Actor{},
-			code:  builtin.CronActorCodeID,
-		},
-		{
-			actor: init_.Actor{},
-			code:  builtin.InitActorCodeID,
-		},
-		{
-			actor: market.Actor{},
-			code:  builtin.StorageMarketActorCodeID,
-		},
-		{
-			actor: miner.Actor{},
-			code:  builtin.StorageMinerActorCodeID,
-		},
-		{
-			actor: multisig.Actor{},
-			code:  builtin.MultisigActorCodeID,
-		},
-		{
-			actor: paych.Actor{},
-			code:  builtin.PaymentChannelActorCodeID,
-		},
-		{
-			actor: power.Actor{},
-			code:  builtin.StoragePowerActorCodeID,
-		},
-		{
-			actor: reward.Actor{},
-			code:  builtin.RewardActorCodeID,
-		},
-		{
-			actor: system.Actor{},
-			code:  builtin.SystemActorCodeID,
-		},
-		{
-			actor: verifreg.Actor{},
-			code:  builtin.VerifiedRegistryActorCodeID,
-		},
+func BuiltinActors() []runtime.VMActor {
+	return []runtime.VMActor{
+		account.Actor{},
+		cron.Actor{},
+		init_.Actor{},
+		market.Actor{},
+		miner.Actor{},
+		multisig.Actor{},
+		paych.Actor{},
+		power.Actor{},
+		reward.Actor{},
+		system.Actor{},
+		verifreg.Actor{},
 	}
 }

--- a/actors/builtin/exported/actors_test.go
+++ b/actors/builtin/exported/actors_test.go
@@ -1,0 +1,94 @@
+package exported
+
+import (
+	"reflect"
+	goruntime "runtime"
+	"strings"
+	"testing"
+
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/specs-actors/actors/builtin"
+	"github.com/filecoin-project/specs-actors/actors/builtin/account"
+	"github.com/filecoin-project/specs-actors/actors/builtin/cron"
+	init_ "github.com/filecoin-project/specs-actors/actors/builtin/init"
+	"github.com/filecoin-project/specs-actors/actors/builtin/market"
+	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
+	"github.com/filecoin-project/specs-actors/actors/builtin/multisig"
+	"github.com/filecoin-project/specs-actors/actors/builtin/paych"
+	"github.com/filecoin-project/specs-actors/actors/builtin/power"
+	"github.com/filecoin-project/specs-actors/actors/builtin/reward"
+	"github.com/filecoin-project/specs-actors/actors/builtin/system"
+	"github.com/filecoin-project/specs-actors/actors/builtin/verifreg"
+	"github.com/filecoin-project/specs-actors/actors/runtime"
+	"github.com/ipfs/go-cid"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestKnownActors(t *testing.T) {
+	// Test all known actors. This ensures we:
+	// * Export all the right actors.
+	// * Don't get any method mismatches.
+
+	// We can't test this in the builtin package due to cyclic imports, so
+	// we test it here.
+	builtins := BuiltinActors()
+	actorInfos := []struct {
+		actor   runtime.VMActor
+		code    cid.Cid
+		methods interface{}
+	}{
+		{account.Actor{}, builtin.AccountActorCodeID, builtin.MethodsAccount},
+		{cron.Actor{}, builtin.CronActorCodeID, builtin.MethodsCron},
+		{init_.Actor{}, builtin.InitActorCodeID, builtin.MethodsInit},
+		{market.Actor{}, builtin.StorageMarketActorCodeID, builtin.MethodsMarket},
+		{miner.Actor{}, builtin.StorageMinerActorCodeID, builtin.MethodsMiner},
+		{multisig.Actor{}, builtin.MultisigActorCodeID, builtin.MethodsMultisig},
+		{paych.Actor{}, builtin.PaymentChannelActorCodeID, builtin.MethodsPaych},
+		{power.Actor{}, builtin.StoragePowerActorCodeID, builtin.MethodsPower},
+		{reward.Actor{}, builtin.RewardActorCodeID, builtin.MethodsReward},
+		{system.Actor{}, builtin.SystemActorCodeID, nil},
+		{verifreg.Actor{}, builtin.VerifiedRegistryActorCodeID, builtin.MethodsVerifiedRegistry},
+	}
+	require.Equal(t, len(builtins), len(actorInfos))
+	for i, info := range actorInfos {
+		// check exported actors.
+		require.Equal(t, info.actor, builtins[i])
+
+		// check codes.
+		require.Equal(t, info.code, info.actor.Code())
+
+		// check methods.
+		exports := info.actor.Exports()
+		if info.methods == nil {
+			continue
+		}
+		methodsVal := reflect.ValueOf(info.methods)
+		methodsTyp := methodsVal.Type()
+		require.Equal(t, len(exports)-1, methodsVal.NumField())
+		require.Nil(t, exports[0]) // send.
+		for i, m := range exports {
+			if i == 0 {
+				// send
+				require.Nil(t, m)
+				continue
+			}
+			expectedVal := methodsVal.Field(i - 1)
+			expectedName := methodsTyp.Field(i - 1).Name
+
+			require.Equal(t, expectedVal.Interface().(abi.MethodNum), abi.MethodNum(i))
+
+			if m == nil {
+				// not send, must be deprecated.
+				require.True(t, strings.HasPrefix(expectedName, "Deprecated"))
+				continue
+			}
+
+			name := goruntime.FuncForPC(reflect.ValueOf(m).Pointer()).Name()
+			name = strings.TrimSuffix(name, "-fm")
+			lastDot := strings.LastIndexByte(name, '.')
+			name = name[lastDot+1:]
+			require.Equal(t, expectedName, name)
+		}
+	}
+}

--- a/actors/builtin/init/init_actor.go
+++ b/actors/builtin/init/init_actor.go
@@ -3,6 +3,7 @@ package init
 import (
 	addr "github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/cbor"
 	"github.com/filecoin-project/go-state-types/exitcode"
 	cid "github.com/ipfs/go-cid"
 
@@ -23,7 +24,17 @@ func (a Actor) Exports() []interface{} {
 	}
 }
 
-var _ runtime.Invokee = Actor{}
+func (a Actor) Code() cid.Cid {
+	return builtin.InitActorCodeID
+}
+
+func (a Actor) IsSingleton() bool {
+	return true
+}
+
+func (a Actor) State() cbor.Er { return new(State) }
+
+var _ runtime.VMActor = Actor{}
 
 type ConstructorParams struct {
 	NetworkName string

--- a/actors/builtin/market/market_actor.go
+++ b/actors/builtin/market/market_actor.go
@@ -8,9 +8,11 @@ import (
 	addr "github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/cbor"
 	"github.com/filecoin-project/go-state-types/crypto"
 	"github.com/filecoin-project/go-state-types/exitcode"
 	rtt "github.com/filecoin-project/go-state-types/rt"
+	"github.com/ipfs/go-cid"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	"golang.org/x/xerrors"
 
@@ -41,7 +43,19 @@ func (a Actor) Exports() []interface{} {
 	}
 }
 
-var _ runtime.Invokee = Actor{}
+func (a Actor) Code() cid.Cid {
+	return builtin.StorageMarketActorCodeID
+}
+
+func (a Actor) IsSingleton() bool {
+	return true
+}
+
+func (a Actor) State() cbor.Er {
+	return new(State)
+}
+
+var _ runtime.VMActor = Actor{}
 
 ////////////////////////////////////////////////////////////////////////////////
 // Actor methods

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -10,6 +10,7 @@ import (
 	"github.com/filecoin-project/go-bitfield"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/cbor"
 	"github.com/filecoin-project/go-state-types/crypto"
 	"github.com/filecoin-project/go-state-types/dline"
 	"github.com/filecoin-project/go-state-types/exitcode"
@@ -77,7 +78,15 @@ func (a Actor) Exports() []interface{} {
 	}
 }
 
-var _ runtime.Invokee = Actor{}
+func (a Actor) Code() cid.Cid {
+	return builtin.StorageMinerActorCodeID
+}
+
+func (a Actor) State() cbor.Er {
+	return new(State)
+}
+
+var _ runtime.VMActor = Actor{}
 
 /////////////////
 // Constructor //

--- a/actors/builtin/multisig/multisig_actor.go
+++ b/actors/builtin/multisig/multisig_actor.go
@@ -7,7 +7,9 @@ import (
 
 	addr "github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/cbor"
 	"github.com/filecoin-project/go-state-types/exitcode"
+	"github.com/ipfs/go-cid"
 
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/runtime"
@@ -64,7 +66,15 @@ func (a Actor) Exports() []interface{} {
 	}
 }
 
-var _ runtime.Invokee = Actor{}
+func (a Actor) Code() cid.Cid {
+	return builtin.MultisigActorCodeID
+}
+
+func (a Actor) State() cbor.Er {
+	return new(State)
+}
+
+var _ runtime.VMActor = Actor{}
 
 type ConstructorParams struct {
 	Signers               []addr.Address

--- a/actors/builtin/paych/paych_actor.go
+++ b/actors/builtin/paych/paych_actor.go
@@ -7,8 +7,10 @@ import (
 	addr "github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/cbor"
 	"github.com/filecoin-project/go-state-types/crypto"
 	"github.com/filecoin-project/go-state-types/exitcode"
+	"github.com/ipfs/go-cid"
 
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/runtime"
@@ -31,7 +33,15 @@ func (a Actor) Exports() []interface{} {
 	}
 }
 
-var _ runtime.Invokee = Actor{}
+func (a Actor) Code() cid.Cid {
+	return builtin.PaymentChannelActorCodeID
+}
+
+func (a Actor) State() cbor.Er {
+	return new(State)
+}
+
+var _ runtime.VMActor = Actor{}
 
 type ConstructorParams struct {
 	From addr.Address // Payer

--- a/actors/builtin/power/power_actor.go
+++ b/actors/builtin/power/power_actor.go
@@ -7,9 +7,10 @@ import (
 	addr "github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/cbor"
 	"github.com/filecoin-project/go-state-types/exitcode"
 	rtt "github.com/filecoin-project/go-state-types/rt"
-
+	"github.com/ipfs/go-cid"
 
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	initact "github.com/filecoin-project/specs-actors/actors/builtin/init"
@@ -44,7 +45,19 @@ func (a Actor) Exports() []interface{} {
 	}
 }
 
-var _ runtime.Invokee = Actor{}
+func (a Actor) Code() cid.Cid {
+	return builtin.StoragePowerActorCodeID
+}
+
+func (a Actor) IsSingleton() bool {
+	return true
+}
+
+func (a Actor) State() cbor.Er {
+	return new(State)
+}
+
+var _ runtime.VMActor = Actor{}
 
 // Storage miner actor constructor params are defined here so the power actor can send them to the init actor
 // to instantiate miners.

--- a/actors/builtin/reward/reward_actor.go
+++ b/actors/builtin/reward/reward_actor.go
@@ -5,8 +5,10 @@ import (
 
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/cbor"
 	"github.com/filecoin-project/go-state-types/exitcode"
 	rtt "github.com/filecoin-project/go-state-types/rt"
+	"github.com/ipfs/go-cid"
 
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/runtime"
@@ -25,7 +27,19 @@ func (a Actor) Exports() []interface{} {
 	}
 }
 
-var _ runtime.Invokee = Actor{}
+func (a Actor) Code() cid.Cid {
+	return builtin.RewardActorCodeID
+}
+
+func (a Actor) IsSingleton() bool {
+	return true
+}
+
+func (a Actor) State() cbor.Er {
+	return new(State)
+}
+
+var _ runtime.VMActor = Actor{}
 
 func (a Actor) Constructor(rt runtime.Runtime, currRealizedPower *abi.StoragePower) *abi.EmptyValue {
 	rt.ValidateImmediateCallerIs(builtin.SystemActorAddr)

--- a/actors/builtin/singletons.go
+++ b/actors/builtin/singletons.go
@@ -2,7 +2,6 @@ package builtin
 
 import (
 	addr "github.com/filecoin-project/go-address"
-	"github.com/ipfs/go-cid"
 
 	autil "github.com/filecoin-project/specs-actors/actors/util"
 )
@@ -27,15 +26,4 @@ func mustMakeAddress(id uint64) addr.Address {
 	address, err := addr.NewIDAddress(id)
 	autil.AssertNoError(err)
 	return address
-}
-
-// IsSingletonActor returns true if the code belongs to a singleton actor.
-func IsSingletonActor(code cid.Cid) bool {
-	return code.Equals(SystemActorCodeID) ||
-		code.Equals(InitActorCodeID) ||
-		code.Equals(RewardActorCodeID) ||
-		code.Equals(CronActorCodeID) ||
-		code.Equals(StoragePowerActorCodeID) ||
-		code.Equals(StorageMarketActorCodeID) ||
-		code.Equals(VerifiedRegistryActorCodeID)
 }

--- a/actors/builtin/system/system_actor.go
+++ b/actors/builtin/system/system_actor.go
@@ -2,6 +2,8 @@ package system
 
 import (
 	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/cbor"
+	"github.com/ipfs/go-cid"
 
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/runtime"
@@ -15,7 +17,19 @@ func (a Actor) Exports() []interface{} {
 	}
 }
 
-var _ runtime.Invokee = Actor{}
+func (a Actor) Code() cid.Cid {
+	return builtin.SystemActorCodeID
+}
+
+func (a Actor) IsSingleton() bool {
+	return true
+}
+
+func (a Actor) State() cbor.Er {
+	return new(State)
+}
+
+var _ runtime.VMActor = Actor{}
 
 func (a Actor) Constructor(rt runtime.Runtime, _ *abi.EmptyValue) *abi.EmptyValue {
 	rt.ValidateImmediateCallerIs(builtin.SystemActorAddr)

--- a/actors/builtin/verifreg/verified_registry_actor.go
+++ b/actors/builtin/verifreg/verified_registry_actor.go
@@ -2,10 +2,11 @@ package verifreg
 
 import (
 	addr "github.com/filecoin-project/go-address"
-
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/cbor"
 	"github.com/filecoin-project/go-state-types/exitcode"
+	"github.com/ipfs/go-cid"
 
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/runtime"
@@ -26,7 +27,19 @@ func (a Actor) Exports() []interface{} {
 	}
 }
 
-var _ runtime.Invokee = Actor{}
+func (a Actor) Code() cid.Cid {
+	return builtin.VerifiedRegistryActorCodeID
+}
+
+func (a Actor) IsSingleton() bool {
+	return true
+}
+
+func (a Actor) State() cbor.Er {
+	return new(State)
+}
+
+var _ runtime.VMActor = Actor{}
 
 ////////////////////////////////////////////////////////////////////////////////
 // Actor methods

--- a/actors/runtime/invokee.go
+++ b/actors/runtime/invokee.go
@@ -1,5 +1,0 @@
-package runtime
-
-type Invokee interface {
-	Exports() []interface{}
-}

--- a/actors/runtime/runtime.go
+++ b/actors/runtime/runtime.go
@@ -262,3 +262,5 @@ func (b *CBORBytes) UnmarshalCBOR(r io.Reader) error {
 	*b = c.Bytes()
 	return err
 }
+
+type VMActor = rt.VMActor

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/filecoin-project/go-amt-ipld/v2 v2.1.0
 	github.com/filecoin-project/go-bitfield v0.2.0
 	github.com/filecoin-project/go-hamt-ipld v0.1.5
-	github.com/filecoin-project/go-state-types v0.0.0-20200911004822-964d6c679cfc
+	github.com/filecoin-project/go-state-types v0.0.0-20200928172055-2df22083d8ab
 	github.com/gopherjs/gopherjs v0.0.0-20190812055157-5d271430af9f // indirect
 	github.com/ipfs/go-block-format v0.0.2
 	github.com/ipfs/go-cid v0.0.7

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03 h1:2pMX
 github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03/go.mod h1:+viYnvGtUTgJRdy6oaeF4MTFKAfatX071MPDPBL11EQ=
 github.com/filecoin-project/go-hamt-ipld v0.1.5 h1:uoXrKbCQZ49OHpsTCkrThPNelC4W3LPEk0OrS/ytIBM=
 github.com/filecoin-project/go-hamt-ipld v0.1.5/go.mod h1:6Is+ONR5Cd5R6XZoCse1CWaXZc0Hdb/JeX+EQCQzX24=
-github.com/filecoin-project/go-state-types v0.0.0-20200911004822-964d6c679cfc h1:1vr/LoqGq5m5g37Q3sNSAjfwF1uJY0zmiHcvnxY6hik=
-github.com/filecoin-project/go-state-types v0.0.0-20200911004822-964d6c679cfc/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
+github.com/filecoin-project/go-state-types v0.0.0-20200928172055-2df22083d8ab h1:cEDC5Ei8UuT99hPWhCjA72SM9AuRtnpvdSTIYbnzN8I=
+github.com/filecoin-project/go-state-types v0.0.0-20200928172055-2df22083d8ab/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=


### PR DESCRIPTION
This simplifies supporting multiple versions of actors in lotus.

* We can now determine if an actor is a "singleton" actor, without having to call `builtin.IsSingleton` for all imported versions of the actors module.
* We can now introduce a `Register(actors ...exports.BuiltinActors())` to register all actors in the lotus vm. Previously, the per-actors-version `BuiltinActor` concrete type prevented this.

Implements https://github.com/filecoin-project/go-state-types/pull/13
Backport of https://github.com/filecoin-project/specs-actors/pull/1191