### PR TITLE
fix AssertMsg panic with exit code

### DIFF
--- a/actors/util/assert.go
+++ b/actors/util/assert.go
@@ -1,12 +1,20 @@
 package util
 
-import "fmt"
+import (
+	"fmt"
+	"github.com/filecoin-project/go-state-types/exitcode"
+)
+
+type abort struct {
+	code exitcode.ExitCode
+	msg  string
+}
 
 // Indicates a condition that should never happen. If encountered, execution will halt and the
 // resulting state is undefined.
 func AssertMsg(b bool, format string, a ...interface{}) {
 	if !b {
-		panic(fmt.Sprintf(format, a...))
+		panic(abort{exitcode.ErrForbidden, fmt.Sprintf(format, a...)})
 	}
 }
 
@@ -16,6 +24,6 @@ func Assert(b bool) {
 
 func AssertNoError(e error) {
 	if e != nil {
-		panic(e.Error())
+		panic(abort{exitcode.ErrForbidden, e.Error()})
 	}
 }


### PR DESCRIPTION
proof validation failed, sector not found in sector set after cron.
This error occurred when I was testing in the 2k environment.

The problem is that `st.AddInitialPledgeRequirement(totalPledge)` in `miner_actor.go:ConfirmSectorProofsValid` panics in `AssertMsg`, but the message execution result is `Exit Code: 0`.
**The AssertMsg operation in specs-actor seems to cause the message not to execute correctly, but ExitCode returns 0. This does not capture the correct results on the outside.**

Whether need to consider returning the correct ExitCode in AssertMsg, along with the correct error message.
