### PR TITLE
Remove PARAM_FINISH tags

### DIFF
--- a/actors/builtin/market/policy.go
+++ b/actors/builtin/market/policy.go
@@ -28,11 +28,11 @@ const DealMaxLabelSize = 256
 
 // Bounds (inclusive) on deal duration
 func DealDurationBounds(_ abi.PaddedPieceSize) (min abi.ChainEpoch, max abi.ChainEpoch) {
-	return DealMinDuration, DealMaxDuration // PARAM_FINISH
+	return DealMinDuration, DealMaxDuration
 }
 
 func DealPricePerEpochBounds(_ abi.PaddedPieceSize, _ abi.ChainEpoch) (min abi.TokenAmount, max abi.TokenAmount) {
-	return abi.NewTokenAmount(0), builtin.TotalFilecoin // PARAM_FINISH
+	return abi.NewTokenAmount(0), builtin.TotalFilecoin
 }
 
 func DealProviderCollateralBounds(pieceSize abi.PaddedPieceSize, verified bool, networkRawPower, networkQAPower, baselinePower abi.StoragePower,
@@ -49,16 +49,16 @@ func DealProviderCollateralBounds(pieceSize abi.PaddedPieceSize, verified bool, 
 	num := big.Mul(lockTargetNum, powerShareNum)
 	denom := big.Mul(lockTargetDenom, powerShareDenom)
 	minCollateral := big.Div(num, denom)
-	return minCollateral, builtin.TotalFilecoin // PARAM_FINISH
+	return minCollateral, builtin.TotalFilecoin
 }
 
 func DealClientCollateralBounds(_ abi.PaddedPieceSize, _ abi.ChainEpoch) (min abi.TokenAmount, max abi.TokenAmount) {
-	return abi.NewTokenAmount(0), builtin.TotalFilecoin // PARAM_FINISH
+	return abi.NewTokenAmount(0), builtin.TotalFilecoin
 }
 
 // Penalty to provider deal collateral if the deadline expires before sector commitment.
 func CollateralPenaltyForDealActivationMissed(providerCollateral abi.TokenAmount) abi.TokenAmount {
-	return providerCollateral // PARAM_FINISH
+	return providerCollateral
 }
 
 // Computes the weight for a deal proposal, which is a function of its size and duration.

--- a/actors/builtin/miner/monies.go
+++ b/actors/builtin/miner/monies.go
@@ -12,12 +12,12 @@ import (
 
 // Projection period of expected sector block reward for deposit required to pre-commit a sector.
 // This deposit is lost if the pre-commitment is not timely followed up by a commitment proof.
-var PreCommitDepositFactor = 20 // PARAM_SPEC PARAM_FINISH
+var PreCommitDepositFactor = 20 // PARAM_SPEC
 var PreCommitDepositProjectionPeriod = abi.ChainEpoch(PreCommitDepositFactor) * builtin.EpochsInDay
 
 // Projection period of expected sector block rewards for storage pledge required to commit a sector.
 // This pledge is lost if a sector is terminated before its full committed lifetime.
-var InitialPledgeFactor = 20 // PARAM_SPEC PARAM_FINISH
+var InitialPledgeFactor = 20 // PARAM_SPEC
 var InitialPledgeProjectionPeriod = abi.ChainEpoch(InitialPledgeFactor) * builtin.EpochsInDay
 
 // Cap on initial pledge requirement for sectors.
@@ -28,7 +28,7 @@ var InitialPledgeMaxPerByte = big.Div(big.NewInt(1e18), big.NewInt(32 << 30))
 // Multiplier of share of circulating money supply for consensus pledge required to commit a sector.
 // This pledge is lost if a sector is terminated before its full committed lifetime.
 var InitialPledgeLockTarget = builtin.BigFrac{
-	Numerator:   big.NewInt(3), // PARAM_SPEC PARAM_FINISH
+	Numerator:   big.NewInt(3), // PARAM_SPEC
 	Denominator: big.NewInt(10),
 }
 

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -99,7 +99,7 @@ var SupportedProofTypes = map[abi.RegisteredSealProof]struct{}{
 // Maximum delay to allow between sector pre-commit and subsequent proof.
 // The allowable delay depends on seal proof algorithm.
 var MaxProveCommitDuration = map[abi.RegisteredSealProof]abi.ChainEpoch{
-	abi.RegisteredSealProof_StackedDrg32GiBV1:  builtin.EpochsInDay + PreCommitChallengeDelay, // PARAM_SPEC PARAM_FINISH
+	abi.RegisteredSealProof_StackedDrg32GiBV1:  builtin.EpochsInDay + PreCommitChallengeDelay, // PARAM_SPEC
 	abi.RegisteredSealProof_StackedDrg2KiBV1:   builtin.EpochsInDay + PreCommitChallengeDelay,
 	abi.RegisteredSealProof_StackedDrg8MiBV1:   builtin.EpochsInDay + PreCommitChallengeDelay,
 	abi.RegisteredSealProof_StackedDrg512MiBV1: builtin.EpochsInDay + PreCommitChallengeDelay,
@@ -204,7 +204,7 @@ func SectorDealsMax(size abi.SectorSize) uint64 {
 
 // Initial share of consensus fault penalty allocated as reward to the reporter.
 var consensusFaultReporterInitialShare = builtin.BigFrac{
-	Numerator:   big.NewInt(1), // PARAM_FINISH PARAM_SPEC
+	Numerator:   big.NewInt(1), // PARAM_SPEC
 	Denominator: big.NewInt(1000),
 }
 
@@ -212,7 +212,7 @@ var consensusFaultReporterInitialShare = builtin.BigFrac{
 // consensusFaultReporterInitialShare*consensusFaultReporterShareGrowthRate^consensusFaultGrowthDuration ~= consensusFaultReporterMaxShare
 // consensusFaultGrowthDuration = 500 epochs
 var consensusFaultReporterShareGrowthRate = builtin.BigFrac{
-	Numerator:   big.NewInt(100785473384), // PARAM_FINISH PARAM_SPEC
+	Numerator:   big.NewInt(100785473384), // PARAM_SPEC
 	Denominator: big.NewInt(100000000000),
 }
 
@@ -232,10 +232,10 @@ type VestSpec struct {
 
 // The vesting schedule for block rewards earned by a block producer.
 var RewardVestingSpec = VestSpec{ // PARAM_SPEC
-	InitialDelay: abi.ChainEpoch(0),                         // PARAM_FINISH
-	VestPeriod:   abi.ChainEpoch(180 * builtin.EpochsInDay), // PARAM_FINISH
-	StepDuration: abi.ChainEpoch(1 * builtin.EpochsInDay),   // PARAM_FINISH
-	Quantization: 12 * builtin.EpochsInHour,                 // PARAM_FINISH
+	InitialDelay: abi.ChainEpoch(0),
+	VestPeriod:   abi.ChainEpoch(180 * builtin.EpochsInDay),
+	StepDuration: abi.ChainEpoch(1 * builtin.EpochsInDay),
+	Quantization: 12 * builtin.EpochsInHour,
 }
 
 // When an actor reports a consensus fault, they earn a share of the penalty paid by the miner.

--- a/actors/builtin/miner/vesting_state.go
+++ b/actors/builtin/miner/vesting_state.go
@@ -53,7 +53,7 @@ func (v *VestingFunds) addLockedFunds(currEpoch abi.ChainEpoch, vestingSum abi.T
 
 		targetVest := big.Zero() //nolint:ineffassign
 		if elapsed < spec.VestPeriod {
-			// Linear vesting, PARAM_FINISH
+			// Linear vesting
 			targetVest = big.Div(big.Mul(vestingSum, big.NewInt(int64(elapsed))), vestPeriod)
 		} else {
 			targetVest = vestingSum

--- a/actors/builtin/reward/reward_logic.go
+++ b/actors/builtin/reward/reward_logic.go
@@ -46,8 +46,8 @@ func BaselinePowerFromPrev(prevEpochBaselinePower abi.StoragePower) abi.StorageP
 }
 
 // These numbers are placeholders, but should be in units of attoFIL, 10^-18 FIL
-var SimpleTotal = big.Mul(big.NewInt(330e6), big.NewInt(1e18))   // 330M for testnet, PARAM_FINISH
-var BaselineTotal = big.Mul(big.NewInt(770e6), big.NewInt(1e18)) // 770M for testnet, PARAM_FINISH
+var SimpleTotal = big.Mul(big.NewInt(330e6), big.NewInt(1e18))   // 330M
+var BaselineTotal = big.Mul(big.NewInt(770e6), big.NewInt(1e18)) // 770M
 
 // Computes RewardTheta which is is precise fractional value of effectiveNetworkTime.
 // The effectiveNetworkTime is defined by CumsumBaselinePower(theta) == CumsumRealizedPower

--- a/actors/builtin/verifreg/verified_registry_state.go
+++ b/actors/builtin/verifreg/verified_registry_state.go
@@ -3,7 +3,6 @@ package verifreg
 import (
 	addr "github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
-	"github.com/filecoin-project/go-state-types/big"
 	cid "github.com/ipfs/go-cid"
 )
 
@@ -24,7 +23,7 @@ type State struct {
 	VerifiedClients cid.Cid // HAMT[addr.Address]DataCap
 }
 
-var MinVerifiedDealSize abi.StoragePower = big.NewInt(1 << 20) // PARAM_FINISH
+var MinVerifiedDealSize = abi.NewStoragePower(1 << 20)
 
 // rootKeyAddress comes from genesis.
 func ConstructState(emptyMapCid cid.Cid, rootKeyAddress addr.Address) *State {


### PR DESCRIPTION
The `PARAM_FINISH` tags are no longer serving a useful purpose. The tagged parameters are no more or less likely to change than other parameters. Significant changes will likely come through FIPs, and trivial ones will be low impact.

Consider this PR a final check that the values are appropriate.
