### PR TITLE
add test vm to 0.9 to be used to test future migrations

### DIFF
--- a/support/vm/invocation_context.go
+++ b/support/vm/invocation_context.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/filecoin-project/specs-actors/actors/builtin"
-	"github.com/filecoin-project/specs-actors/actors/builtin/exported"
 	init_ "github.com/filecoin-project/specs-actors/actors/builtin/init"
 	"github.com/filecoin-project/specs-actors/actors/runtime"
 	"github.com/filecoin-project/specs-actors/actors/runtime/proof"
@@ -326,11 +325,12 @@ func (ic *invocationContext) Send(toAddr address.Address, methodNum abi.MethodNu
 
 // CreateActor implements runtime.ExtendedInvocationContext.
 func (ic *invocationContext) CreateActor(codeID cid.Cid, addr address.Address) {
-	if !builtin.IsBuiltinActor(codeID) {
+	act, ok := ic.rt.actorImpls[codeID]
+	if !ok {
 		ic.Abortf(exitcode.SysErrorIllegalArgument, "Can only create built-in actors.")
 	}
 
-	if builtin.IsSingletonActor(codeID) {
+	if rt.IsSingletonActor(act) {
 		ic.Abortf(exitcode.SysErrorIllegalArgument, "Can only have one instance of singleton actors.")
 	}
 
@@ -599,7 +599,7 @@ func (ic *invocationContext) invoke() (ret returnWrapper, errcode exitcode.ExitC
 	return ret, exitcode.Ok
 }
 
-func (ic *invocationContext) dispatch(actor exported.BuiltinActor, method abi.MethodNum, arg interface{}) (interface{}, error) {
+func (ic *invocationContext) dispatch(actor runtime.VMActor, method abi.MethodNum, arg interface{}) (interface{}, error) {
 	// get method signature
 	exports := actor.Exports()
 

--- a/support/vm/invocation_context.go
+++ b/support/vm/invocation_context.go
@@ -1,0 +1,789 @@
+package vm_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"github.com/filecoin-project/specs-actors/actors/states"
+	"reflect"
+	"runtime/debug"
+
+	"github.com/filecoin-project/go-state-types/cbor"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/crypto"
+	"github.com/filecoin-project/go-state-types/exitcode"
+	"github.com/filecoin-project/go-state-types/network"
+	"github.com/filecoin-project/go-state-types/rt"
+	"github.com/ipfs/go-cid"
+	"github.com/pkg/errors"
+
+	"github.com/filecoin-project/specs-actors/actors/builtin"
+	"github.com/filecoin-project/specs-actors/actors/builtin/exported"
+	init_ "github.com/filecoin-project/specs-actors/actors/builtin/init"
+	"github.com/filecoin-project/specs-actors/actors/runtime"
+	"github.com/filecoin-project/specs-actors/actors/runtime/proof"
+	"github.com/filecoin-project/specs-actors/actors/util/adt"
+	"github.com/filecoin-project/specs-actors/support/testing"
+)
+
+var EmptyObjectCid cid.Cid
+
+// Context for an individual message invocation, including inter-actor sends.
+type invocationContext struct {
+	rt                *VM
+	topLevel          *topLevelContext
+	msg               InternalMessage // The message being processed
+	fromActor         *states.Actor   // The immediate calling actor
+	toActor           *states.Actor   // The actor to which message is addressed
+	emptyObject       cid.Cid
+	isCallerValidated bool
+	allowSideEffects  bool
+	callerValidated   bool
+}
+
+// Context for a top-level invocation sequence
+type topLevelContext struct {
+	originatorStableAddress address.Address // Stable (public key) address of the top-level message sender.
+	originatorCallSeq       uint64          // Call sequence number of the top-level message.
+	newActorAddressCount    uint64          // Count of calls to NewActorAddress (mutable).
+}
+
+func newInvocationContext(rt *VM, topLevel *topLevelContext, msg InternalMessage, fromActor *states.Actor, emptyObject cid.Cid) invocationContext {
+	// Note: the toActor and stateHandle are loaded during the `invoke()`
+	return invocationContext{
+		rt:                rt,
+		topLevel:          topLevel,
+		msg:               msg,
+		fromActor:         fromActor,
+		emptyObject:       emptyObject,
+		isCallerValidated: false,
+		allowSideEffects:  true,
+		toActor:           nil,
+	}
+}
+
+var _ runtime.StateHandle = (*invocationContext)(nil)
+
+func (ic *invocationContext) loadState(obj cbor.Unmarshaler) cid.Cid {
+	// The actor must be loaded from store every time since the state may have changed via a different state handle
+	// (e.g. in a recursive call).
+	actr := ic.loadActor()
+	c := actr.Head
+	if !c.Defined() {
+		ic.Abortf(exitcode.SysErrorIllegalActor, "failed to load undefined state, must construct first")
+	}
+	err := ic.rt.store.Get(ic.rt.ctx, c, obj)
+	if err != nil {
+		panic(errors.Wrapf(err, "failed to load state for actor %s, CID %s", ic.msg.to, c))
+	}
+	return c
+}
+
+func (ic *invocationContext) loadActor() *states.Actor {
+	actr, found, err := ic.rt.GetActor(ic.msg.to)
+	if err != nil {
+		panic(err)
+	}
+	if !found {
+		panic(fmt.Errorf("failed to find actor %s for state", ic.msg.to))
+	}
+	return actr
+}
+
+func (ic *invocationContext) storeActor(actr *states.Actor) {
+	err := ic.rt.setActor(ic.rt.ctx, ic.msg.to, actr)
+	if err != nil {
+		panic(err)
+	}
+}
+
+/////////////////////////////////////////////
+//          Runtime methods
+/////////////////////////////////////////////
+
+var _ runtime.Runtime = (*invocationContext)(nil)
+
+// Store implements runtime.Runtime.
+func (ic *invocationContext) StoreGet(c cid.Cid, o cbor.Unmarshaler) bool {
+	sw := &storeWrapper{s: ic.rt.store, rt: ic.rt}
+	return sw.StoreGet(c, o)
+}
+
+func (ic *invocationContext) StorePut(x cbor.Marshaler) cid.Cid {
+	sw := &storeWrapper{s: ic.rt.store, rt: ic.rt}
+	return sw.StorePut(x)
+}
+
+// These methods implement
+// ValueReceived implements runtime.Message
+func (ic *invocationContext) ValueReceived() abi.TokenAmount {
+	return ic.msg.ValueReceived()
+}
+
+// Caller implements runtime.Message
+func (ic *invocationContext) Caller() address.Address {
+	return ic.msg.Caller()
+}
+
+// Receiver implements runtime.Message
+func (ic *invocationContext) Receiver() address.Address {
+	return ic.msg.Receiver()
+}
+
+func (ic *invocationContext) StateCreate(obj cbor.Marshaler) {
+	actr := ic.loadActor()
+	if actr.Head.Defined() && !ic.emptyObject.Equals(actr.Head) {
+		ic.Abortf(exitcode.SysErrorIllegalActor, "failed to construct actor state: already initialized")
+	}
+	c, err := ic.rt.store.Put(ic.rt.ctx, obj)
+	if err != nil {
+		ic.Abortf(exitcode.ErrIllegalState, "failed to create actor state")
+	}
+	actr.Head = c
+	ic.storeActor(actr)
+}
+
+// Readonly is the implementation of the ActorStateHandle interface.
+func (ic *invocationContext) StateReadonly(obj cbor.Unmarshaler) {
+	// Load state to obj.
+	ic.loadState(obj)
+}
+
+// Transaction is the implementation of the ActorStateHandle interface.
+func (ic *invocationContext) StateTransaction(obj cbor.Er, f func()) {
+	if obj == nil {
+		ic.Abortf(exitcode.SysErrorIllegalActor, "Must not pass nil to Transaction()")
+	}
+
+	// Load state to obj.
+	ic.loadState(obj)
+
+	// Call user code allowing mutation but not side-effects
+	ic.allowSideEffects = false
+	f()
+	ic.allowSideEffects = true
+
+	ic.replace(obj)
+}
+
+func (ic *invocationContext) VerifySignature(signature crypto.Signature, signer address.Address, plaintext []byte) error {
+	return ic.Syscalls().VerifySignature(signature, signer, plaintext)
+}
+
+func (ic *invocationContext) HashBlake2b(data []byte) [32]byte {
+	return ic.Syscalls().HashBlake2b(data)
+}
+
+func (ic *invocationContext) ComputeUnsealedSectorCID(reg abi.RegisteredSealProof, pieces []abi.PieceInfo) (cid.Cid, error) {
+	return ic.Syscalls().ComputeUnsealedSectorCID(reg, pieces)
+}
+
+func (ic *invocationContext) VerifySeal(vi proof.SealVerifyInfo) error {
+	return ic.Syscalls().VerifySeal(vi)
+}
+
+func (ic *invocationContext) BatchVerifySeals(vis map[address.Address][]proof.SealVerifyInfo) (map[address.Address][]bool, error) {
+	return ic.Syscalls().BatchVerifySeals(vis)
+}
+
+func (ic *invocationContext) VerifyPoSt(vi proof.WindowPoStVerifyInfo) error {
+	return ic.Syscalls().VerifyPoSt(vi)
+}
+
+func (ic *invocationContext) VerifyConsensusFault(h1, h2, extra []byte) (*runtime.ConsensusFault, error) {
+	return ic.Syscalls().VerifyConsensusFault(h1, h2, extra)
+}
+
+func (ic *invocationContext) NetworkVersion() network.Version {
+	return ic.rt.networkVersion
+}
+
+func (ic *invocationContext) CurrEpoch() abi.ChainEpoch {
+	return ic.rt.currentEpoch
+}
+
+func (ic *invocationContext) CurrentBalance() abi.TokenAmount {
+	return ic.toActor.Balance
+}
+
+func (ic *invocationContext) GetActorCodeCID(a address.Address) (cid.Cid, bool) {
+	entry, found, err := ic.rt.GetActor(a)
+	if !found {
+		return cid.Undef, false
+	}
+	if err != nil {
+		panic(err)
+	}
+	return entry.Code, true
+}
+
+func (ic *invocationContext) GetRandomnessFromBeacon(_ crypto.DomainSeparationTag, _ abi.ChainEpoch, _ []byte) abi.Randomness {
+	return []byte("not really random")
+}
+
+func (ic *invocationContext) GetRandomnessFromTickets(_ crypto.DomainSeparationTag, _ abi.ChainEpoch, _ []byte) abi.Randomness {
+	return []byte("not really random")
+}
+
+func (ic *invocationContext) ValidateImmediateCallerAcceptAny() {
+	ic.assertf(!ic.callerValidated, "caller has been double validated")
+	ic.callerValidated = true
+}
+
+func (ic *invocationContext) ValidateImmediateCallerIs(addrs ...address.Address) {
+	ic.assertf(!ic.callerValidated, "caller has been double validated")
+	ic.callerValidated = true
+	for _, addr := range addrs {
+		if ic.msg.from == addr {
+			return
+		}
+	}
+	ic.Abortf(exitcode.ErrForbidden, "caller address %v forbidden, allowed: %v", ic.msg.from, addrs)
+}
+
+func (ic *invocationContext) ValidateImmediateCallerType(types ...cid.Cid) {
+	ic.assertf(!ic.callerValidated, "caller has been double validated")
+	ic.callerValidated = true
+	for _, t := range types {
+		if t.Equals(ic.fromActor.Code) {
+			return
+		}
+	}
+	ic.Abortf(exitcode.ErrForbidden, "caller type %v forbidden, allowed: %v", ic.fromActor.Code, types)
+}
+
+func (ic *invocationContext) Abortf(errExitCode exitcode.ExitCode, msg string, args ...interface{}) {
+	ic.rt.Abortf(errExitCode, msg, args...)
+}
+
+func (ic *invocationContext) assertf(condition bool, msg string, args ...interface{}) {
+	if !condition {
+		panic(fmt.Errorf(msg, args...))
+	}
+}
+
+func (ic *invocationContext) ResolveAddress(address address.Address) (address.Address, bool) {
+	return ic.rt.NormalizeAddress(address)
+}
+
+func (ic *invocationContext) NewActorAddress() address.Address {
+	var buf bytes.Buffer
+
+	b1, err := ic.topLevel.originatorStableAddress.Marshal()
+	if err != nil {
+		panic(err)
+	}
+	_, err = buf.Write(b1)
+	if err != nil {
+		panic(err)
+	}
+
+	err = binary.Write(&buf, binary.BigEndian, ic.topLevel.originatorCallSeq)
+	if err != nil {
+		panic(err)
+	}
+
+	err = binary.Write(&buf, binary.BigEndian, ic.topLevel.newActorAddressCount)
+	if err != nil {
+		panic(err)
+	}
+
+	actorAddress, err := address.NewActorAddress(buf.Bytes())
+	if err != nil {
+		panic(err)
+	}
+	return actorAddress
+}
+
+// Send implements runtime.InvocationContext.
+func (ic *invocationContext) Send(toAddr address.Address, methodNum abi.MethodNum, params cbor.Marshaler, value abi.TokenAmount, out cbor.Er) (errcode exitcode.ExitCode) {
+	// check if side-effects are allowed
+	if !ic.allowSideEffects {
+		ic.Abortf(exitcode.SysErrorIllegalActor, "Calling Send() is not allowed during side-effect lock")
+	}
+	from := ic.msg.to
+	fromActor := ic.toActor
+	newMsg := InternalMessage{
+		from:   from,
+		to:     toAddr,
+		value:  value,
+		method: methodNum,
+		params: params,
+	}
+
+	newCtx := newInvocationContext(ic.rt, ic.topLevel, newMsg, fromActor, ic.emptyObject)
+	ret, code := newCtx.invoke()
+	err := ret.Into(out)
+	if err != nil {
+		ic.Abortf(exitcode.ErrSerialization, "failed to serialize send return value into output parameter")
+	}
+	return code
+}
+
+// CreateActor implements runtime.ExtendedInvocationContext.
+func (ic *invocationContext) CreateActor(codeID cid.Cid, addr address.Address) {
+	if !builtin.IsBuiltinActor(codeID) {
+		ic.Abortf(exitcode.SysErrorIllegalArgument, "Can only create built-in actors.")
+	}
+
+	if builtin.IsSingletonActor(codeID) {
+		ic.Abortf(exitcode.SysErrorIllegalArgument, "Can only have one instance of singleton actors.")
+	}
+
+	ic.rt.Log(rt.DEBUG, "creating actor, friendly-name: %s, Exitcode: %s, addr: %s\n", builtin.ActorNameByCode(codeID), codeID, addr)
+
+	// Check existing address. If nothing there, create empty actor.
+	//
+	// Note: we are storing the actors by ActorID *address*
+	_, found, err := ic.rt.GetActor(addr)
+	if err != nil {
+		panic(err)
+	}
+	if found {
+		ic.Abortf(exitcode.SysErrorIllegalArgument, "Actor address already exists")
+	}
+
+	newActor := &states.Actor{
+		Head:    ic.emptyObject,
+		Code:    codeID,
+		Balance: abi.NewTokenAmount(0),
+	}
+	if err := ic.rt.setActor(ic.rt.ctx, addr, newActor); err != nil {
+		panic(err)
+	}
+}
+
+// deleteActor implements runtime.ExtendedInvocationContext.
+func (ic *invocationContext) DeleteActor(beneficiary address.Address) {
+	receiver := ic.msg.to
+	receiverActor, found, err := ic.rt.GetActor(receiver)
+	if err != nil {
+		panic(err)
+	}
+	if !found {
+		ic.Abortf(exitcode.SysErrorIllegalActor, "delete non-existent actor %v", receiverActor)
+	}
+
+	// Transfer any remaining balance to the beneficiary.
+	// This looks like it could cause a problem with gas refund going to a non-existent actor, but the gas payer
+	// is always an account actor, which cannot be the receiver of this message.
+	if receiverActor.Balance.GreaterThan(big.Zero()) {
+		ic.rt.transfer(receiver, beneficiary, receiverActor.Balance)
+	}
+
+	if err := ic.rt.deleteActor(ic.rt.ctx, receiver); err != nil {
+		panic(err)
+	}
+}
+
+func (ic *invocationContext) TotalFilCircSupply() abi.TokenAmount {
+	return big.Mul(big.NewInt(1e9), big.NewInt(1e18))
+}
+
+func (ic *invocationContext) Context() context.Context {
+	return ic.rt.ctx
+}
+
+func (ic *invocationContext) ChargeGas(_ string, _ int64, _ int64) {
+	// no-op
+}
+
+// Starts a new tracing span. The span must be End()ed explicitly, typically with a deferred invocation.
+func (ic *invocationContext) StartSpan(_ string) func() {
+	return fakeTraceSpanEnd
+}
+
+// Provides the system call interface.
+func (ic *invocationContext) Syscalls() runtime.Syscalls {
+	return fakeSyscalls{receiver: ic.msg.to, epoch: ic.rt.currentEpoch}
+}
+
+// Note events that may make debugging easier
+func (ic *invocationContext) Log(level rt.LogLevel, msg string, args ...interface{}) {
+	ic.rt.Log(level, msg, args...)
+}
+
+type returnWrapper struct {
+	inner cbor.Marshaler
+}
+
+func (r returnWrapper) Into(o cbor.Unmarshaler) error {
+	if r.inner == nil {
+		return fmt.Errorf("failed to unmarshal nil return (did you mean abi.Empty?)")
+	}
+	b := bytes.Buffer{}
+	if err := r.inner.MarshalCBOR(&b); err != nil {
+		return err
+	}
+	return o.UnmarshalCBOR(&b)
+}
+
+/////////////////////////////////////////////
+//          Fake syscalls
+/////////////////////////////////////////////
+
+type fakeSyscalls struct {
+	receiver address.Address
+	epoch    abi.ChainEpoch
+}
+
+func (s fakeSyscalls) VerifySignature(_ crypto.Signature, _ address.Address, _ []byte) error {
+	return nil
+}
+
+func (s fakeSyscalls) HashBlake2b(_ []byte) [32]byte {
+	return [32]byte{}
+}
+
+func (s fakeSyscalls) ComputeUnsealedSectorCID(_ abi.RegisteredSealProof, _ []abi.PieceInfo) (cid.Cid, error) {
+	return testing.MakeCID("presealedSectorCID", nil), nil
+}
+
+func (s fakeSyscalls) VerifySeal(_ proof.SealVerifyInfo) error {
+	return nil
+}
+
+func (s fakeSyscalls) BatchVerifySeals(vi map[address.Address][]proof.SealVerifyInfo) (map[address.Address][]bool, error) {
+	res := map[address.Address][]bool{}
+	for addr, infos := range vi { //nolint:nomaprange
+		verified := make([]bool, len(infos))
+		for i := range infos {
+			// everyone wins
+			verified[i] = true
+		}
+		res[addr] = verified
+	}
+	return res, nil
+}
+
+func (s fakeSyscalls) VerifyPoSt(_ proof.WindowPoStVerifyInfo) error {
+	return nil
+}
+
+func (s fakeSyscalls) VerifyConsensusFault(_, _, _ []byte) (*runtime.ConsensusFault, error) {
+	return &runtime.ConsensusFault{
+		Target: s.receiver,
+		Epoch:  s.epoch - 1,
+		Type:   runtime.ConsensusFaultDoubleForkMining,
+	}, nil
+}
+
+/////////////////////////////////////////////
+//          Fake trace span
+/////////////////////////////////////////////
+
+func fakeTraceSpanEnd() {
+}
+
+/////////////////////////////////////////////
+//          storeWrapper
+/////////////////////////////////////////////
+
+type storeWrapper struct {
+	s  adt.Store
+	rt *VM
+}
+
+func (s storeWrapper) StoreGet(c cid.Cid, o cbor.Unmarshaler) bool {
+	err := s.s.Get(s.rt.ctx, c, o)
+	// assume all errors are not found errors (bad assumption, but ok for testing)
+	return err == nil
+}
+
+func (s storeWrapper) StorePut(x cbor.Marshaler) cid.Cid {
+	c, err := s.s.Put(s.rt.ctx, x)
+	if err != nil {
+		s.rt.Abortf(exitcode.ErrIllegalState, "could not put object in store")
+	}
+	return c
+}
+
+/////////////////////////////////////////////
+//          invocation
+/////////////////////////////////////////////
+
+// runtime aborts are trapped by invoke, it will always return an exit code.
+func (ic *invocationContext) invoke() (ret returnWrapper, errcode exitcode.ExitCode) {
+	// Checkpoint state, for restoration on rollback
+	// Note that changes prior to invocation (sequence number bump and gas prepayment) persist even if invocation fails.
+	priorRoot, err := ic.rt.checkpoint()
+	if err != nil {
+		panic(err)
+	}
+
+	ic.rt.startInvocation(&ic.msg)
+
+	// Install handler for abort, which rolls back all state changes from this and any nested invocations.
+	// This is the only path by which a non-OK exit code may be returned.
+	defer func() {
+		if r := recover(); r != nil {
+			if err := ic.rt.rollback(priorRoot); err != nil {
+				panic(err)
+			}
+			switch r := r.(type) {
+			case abort:
+				ic.rt.Log(rt.WARN, "Abort during actor execution. errMsg: %v exitCode: %d sender: %v receiver; %v method: %d value %v",
+					r, r.code, ic.msg.from, ic.msg.to, ic.msg.method, ic.msg.value)
+				ic.rt.endInvocation(r.code, abi.Empty)
+				ret = returnWrapper{abi.Empty} // The Empty here should never be used, but slightly safer than zero value.
+				errcode = r.code
+				return
+			default:
+				// do not trap unknown panics
+				debug.PrintStack()
+				panic(r)
+			}
+		}
+	}()
+
+	// pre-dispatch
+	// 1. load target actor
+	// 2. transfer optional funds
+	// 3. short-circuit _Send_ method
+	// 4. load target actor code
+	// 5. create target state handle
+	// assert from address is an ID address.
+	if ic.msg.from.Protocol() != address.ID {
+		panic("bad Exitcode: sender address MUST be an ID address at invocation time")
+	}
+
+	// 2. load target actor
+	// Note: we replace the "to" address with the normalized version
+	ic.toActor, ic.msg.to = ic.resolveTarget(ic.msg.to)
+
+	// 3. transfer funds carried by the msg
+	if !ic.msg.value.NilOrZero() {
+		if ic.msg.value.LessThan(big.Zero()) {
+			ic.Abortf(exitcode.SysErrForbidden, "attempt to transfer negative value %s from %s to %s",
+				ic.msg.value, ic.msg.from, ic.msg.to)
+		}
+		if ic.fromActor.Balance.LessThan(ic.msg.value) {
+			ic.Abortf(exitcode.SysErrInsufficientFunds, "sender %s insufficient balance %s to transfer %s to %s",
+				ic.msg.from, ic.fromActor.Balance, ic.msg.value, ic.msg.to)
+		}
+		ic.toActor, ic.fromActor = ic.rt.transfer(ic.msg.from, ic.msg.to, ic.msg.value)
+	}
+
+	// 4. if we are just sending funds, there is nothing else to do.
+	if ic.msg.method == builtin.MethodSend {
+		ic.rt.endInvocation(exitcode.Ok, abi.Empty)
+		return returnWrapper{abi.Empty}, exitcode.Ok
+	}
+
+	// 5. load target actor code
+	actorImpl := ic.rt.getActorImpl(ic.toActor.Code)
+
+	// dispatch
+	out, err := ic.dispatch(actorImpl, ic.msg.method, ic.msg.params)
+	if err != nil {
+		ic.Abortf(exitcode.SysErrInvalidMethod, "could not dispatch method")
+	}
+
+	// assert output implements expected interface
+	var marsh cbor.Marshaler = abi.Empty
+	if out != nil {
+		var ok bool
+		marsh, ok = out.(cbor.Marshaler)
+		if !ok {
+			ic.Abortf(exitcode.SysErrorIllegalActor, "Returned value is not a CBORMarshaler")
+		}
+	}
+	ret = returnWrapper{inner: marsh}
+
+	// 3. success!
+	ic.rt.endInvocation(exitcode.Ok, marsh)
+	return ret, exitcode.Ok
+}
+
+func (ic *invocationContext) dispatch(actor exported.BuiltinActor, method abi.MethodNum, arg interface{}) (interface{}, error) {
+	// get method signature
+	exports := actor.Exports()
+
+	// get method entry
+	methodIdx := (uint64)(method)
+	if len(exports) < (int)(methodIdx) {
+		return nil, fmt.Errorf("method undefined. method: %d, Exitcode: %s", method, actor.Code())
+	}
+	entry := exports[methodIdx]
+	if entry == nil {
+		return nil, fmt.Errorf("method undefined. method: %d, Exitcode: %s", method, actor.Code())
+	}
+
+	ventry := reflect.ValueOf(entry)
+
+	// build args to pass to the method
+	args := []reflect.Value{
+		// the ctx will be automatically coerced
+		reflect.ValueOf(ic),
+	}
+
+	t := ventry.Type().In(1)
+	if arg == nil {
+		args = append(args, reflect.New(t).Elem())
+	} else if raw, ok := arg.([]byte); ok {
+		obj, err := decodeBytes(t, raw)
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, reflect.ValueOf(obj))
+	} else if raw, ok := arg.(runtime.CBORBytes); ok {
+		obj, err := decodeBytes(t, raw)
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, reflect.ValueOf(obj))
+	} else {
+		args = append(args, reflect.ValueOf(arg))
+	}
+
+	// invoke the method
+	out := ventry.Call(args)
+
+	// Note: we only support single objects being returned
+	if len(out) > 1 {
+		return nil, fmt.Errorf("actor method returned more than one object. method: %d, Exitcode: %s", method, actor.Code())
+	}
+
+	// method returns unit
+	// Note: we need to check for `IsNill()` here because Go doesnt work if you do `== nil` on the interface
+	if len(out) == 0 || (out[0].Kind() != reflect.Struct && out[0].IsNil()) {
+		return nil, nil
+	}
+
+	// forward return
+	return out[0].Interface(), nil
+}
+
+// resolveTarget loads and actor and returns its ActorID address.
+//
+// If the target actor does not exist, and the target address is a pub-key address,
+// a new account actor will be created.
+// Otherwise, this method will abort execution.
+func (ic *invocationContext) resolveTarget(target address.Address) (*states.Actor, address.Address) {
+	// resolve the target address via the InitActor, and attempt to load state.
+	initActorEntry, found, err := ic.rt.GetActor(builtin.InitActorAddr)
+	if err != nil {
+		panic(err)
+	}
+	if !found {
+		ic.Abortf(exitcode.SysErrSenderInvalid, "init actor not found")
+	}
+
+	if target == builtin.InitActorAddr {
+		return initActorEntry, target
+	}
+
+	// get a view into the actor state
+	var state init_.State
+	if err := ic.rt.store.Get(ic.rt.ctx, initActorEntry.Head, &state); err != nil {
+		panic(err)
+	}
+
+	// lookup the ActorID based on the address
+	targetIDAddr, found, err := state.ResolveAddress(ic.rt.store, target)
+	created := false
+	if err != nil {
+		panic(err)
+	} else if !found {
+		if target.Protocol() != address.SECP256K1 && target.Protocol() != address.BLS {
+			// Don't implicitly create an account actor for an address without an associated key.
+			ic.Abortf(exitcode.SysErrInvalidReceiver, "cannot create account for address type")
+		}
+
+		targetIDAddr, err = state.MapAddressToNewID(ic.rt.store, target)
+		if err != nil {
+			panic(err)
+		}
+		// store new state
+		initHead, err := ic.rt.store.Put(ic.rt.ctx, &state)
+		if err != nil {
+			panic(err)
+		}
+		// update init actor
+		initActorEntry.Head = initHead
+		if err := ic.rt.setActor(ic.rt.ctx, builtin.InitActorAddr, initActorEntry); err != nil {
+			panic(err)
+		}
+
+		ic.CreateActor(builtin.AccountActorCodeID, targetIDAddr)
+
+		// call constructor on account
+		newMsg := InternalMessage{
+			from:   builtin.SystemActorAddr,
+			to:     targetIDAddr,
+			value:  big.Zero(),
+			method: builtin.MethodsAccount.Constructor,
+			// use original address as constructor params
+			// Note: constructor takes a pointer
+			params: &target,
+		}
+
+		newCtx := newInvocationContext(ic.rt, ic.topLevel, newMsg, nil, ic.emptyObject)
+		_, code := newCtx.invoke()
+		if code.IsError() {
+			// we failed to construct an account actor..
+			ic.Abortf(code, "failed to construct account actor")
+		}
+
+		created = true
+	}
+
+	// load actor
+	targetActor, found, err := ic.rt.GetActor(targetIDAddr)
+	if err != nil {
+		panic(err)
+	}
+	if !found && created {
+		panic(fmt.Errorf("unreachable: actor is supposed to exist but it does not. addr: %s, idAddr: %s", target, targetIDAddr))
+	}
+	if !found {
+		ic.Abortf(exitcode.SysErrInvalidReceiver, "actor at address %s registered but not found", targetIDAddr.String())
+	}
+
+	return targetActor, targetIDAddr
+}
+
+func (ic *invocationContext) replace(obj cbor.Marshaler) cid.Cid {
+	actr, found, err := ic.rt.GetActor(ic.msg.to)
+	if err != nil {
+		panic(err)
+	}
+	if !found {
+		ic.rt.Abortf(exitcode.ErrIllegalState, "failed to find actor %s for state", ic.msg.to)
+	}
+	c, err := ic.rt.store.Put(ic.rt.ctx, obj)
+	if err != nil {
+		ic.rt.Abortf(exitcode.ErrIllegalState, "could not save new state")
+	}
+	actr.Head = c
+	err = ic.rt.setActor(ic.rt.ctx, ic.msg.to, actr)
+	if err != nil {
+		ic.rt.Abortf(exitcode.ErrIllegalState, "could not save actor %s", ic.msg.to)
+	}
+	return c
+}
+
+func decodeBytes(t reflect.Type, argBytes []byte) (interface{}, error) {
+	// decode arg1 (this is the payload for the actor method)
+	v := reflect.New(t)
+
+	// This would be better fixed in then encoding library.
+	obj := v.Elem().Interface()
+	if _, ok := obj.(cbor.Unmarshaler); !ok {
+		return nil, errors.New("method argument cannot be decoded")
+	}
+
+	buf := bytes.NewBuffer(argBytes)
+	auxv := reflect.New(t.Elem())
+	obj = auxv.Interface()
+
+	unmarsh := obj.(cbor.Unmarshaler)
+	if err := unmarsh.UnmarshalCBOR(buf); err != nil {
+		return nil, err
+	}
+	return unmarsh, nil
+}

--- a/support/vm/testing.go
+++ b/support/vm/testing.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/filecoin-project/specs-actors/actors/runtime"
 	"github.com/filecoin-project/specs-actors/actors/states"
 	"testing"
 
@@ -53,7 +54,7 @@ func init() {
 func NewVMWithSingletons(ctx context.Context, t *testing.T) *VM {
 	store := ipld.NewADTStore(ctx)
 
-	lookup := map[cid.Cid]exported.BuiltinActor{}
+	lookup := map[cid.Cid]runtime.VMActor{}
 	for _, ba := range exported.BuiltinActors() {
 		lookup[ba.Code()] = ba
 	}

--- a/support/vm/testing.go
+++ b/support/vm/testing.go
@@ -1,0 +1,501 @@
+package vm_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"github.com/filecoin-project/specs-actors/actors/states"
+	"testing"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/cbor"
+	"github.com/filecoin-project/go-state-types/dline"
+	"github.com/filecoin-project/go-state-types/exitcode"
+	"github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/specs-actors/actors/builtin"
+	"github.com/filecoin-project/specs-actors/actors/builtin/account"
+	"github.com/filecoin-project/specs-actors/actors/builtin/cron"
+	"github.com/filecoin-project/specs-actors/actors/builtin/exported"
+	initactor "github.com/filecoin-project/specs-actors/actors/builtin/init"
+	"github.com/filecoin-project/specs-actors/actors/builtin/market"
+	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
+	"github.com/filecoin-project/specs-actors/actors/builtin/power"
+	"github.com/filecoin-project/specs-actors/actors/builtin/reward"
+	"github.com/filecoin-project/specs-actors/actors/builtin/system"
+	"github.com/filecoin-project/specs-actors/actors/builtin/verifreg"
+	"github.com/filecoin-project/specs-actors/actors/util/adt"
+	"github.com/filecoin-project/specs-actors/actors/util/smoothing"
+	"github.com/filecoin-project/specs-actors/support/ipld"
+	actor_testing "github.com/filecoin-project/specs-actors/support/testing"
+)
+
+var FIL = big.NewInt(1e18)
+var VerifregRoot address.Address
+
+func init() {
+	var err error
+	VerifregRoot, err = address.NewIDAddress(80)
+	if err != nil {
+		panic("could not create id address 80")
+	}
+}
+
+//
+// Genesis like setup
+//
+
+// Creates a new VM and initializes all singleton actors plus a root verifier account.
+func NewVMWithSingletons(ctx context.Context, t *testing.T) *VM {
+	store := ipld.NewADTStore(ctx)
+
+	lookup := map[cid.Cid]exported.BuiltinActor{}
+	for _, ba := range exported.BuiltinActors() {
+		lookup[ba.Code()] = ba
+	}
+
+	vm := NewVM(ctx, lookup, store)
+
+	emptyMapCID, err := adt.MakeEmptyMap(vm.store).Root()
+	require.NoError(t, err)
+	emptyArrayCID, err := adt.MakeEmptyArray(vm.store).Root()
+	require.NoError(t, err)
+	emptyMultimapCID, err := adt.MakeEmptyMultimap(vm.store).Root()
+	require.NoError(t, err)
+
+	initializeActor(ctx, t, vm, &system.State{}, builtin.SystemActorCodeID, builtin.SystemActorAddr, big.Zero())
+
+	initState := initactor.ConstructState(emptyMapCID, "scenarios")
+	initializeActor(ctx, t, vm, initState, builtin.InitActorCodeID, builtin.InitActorAddr, big.Zero())
+
+	rewardState := reward.ConstructState(abi.NewStoragePower(0))
+	initializeActor(ctx, t, vm, rewardState, builtin.RewardActorCodeID, builtin.RewardActorAddr, big.Max(big.NewInt(14e8), FIL))
+
+	cronState := cron.ConstructState(cron.BuiltInEntries())
+	initializeActor(ctx, t, vm, cronState, builtin.CronActorCodeID, builtin.CronActorAddr, big.Zero())
+
+	powerState := power.ConstructState(emptyMapCID, emptyMultimapCID)
+	initializeActor(ctx, t, vm, powerState, builtin.StoragePowerActorCodeID, builtin.StoragePowerActorAddr, big.Zero())
+
+	marketState := market.ConstructState(emptyArrayCID, emptyMapCID, emptyMultimapCID)
+	initializeActor(ctx, t, vm, marketState, builtin.StorageMarketActorCodeID, builtin.StorageMarketActorAddr, big.Zero())
+
+	// this will need to be replaced with the address of a multisig actor for the verified registry to be tested accurately
+	initializeActor(ctx, t, vm, &account.State{Address: VerifregRoot}, builtin.AccountActorCodeID, VerifregRoot, big.Zero())
+	vrState := verifreg.ConstructState(emptyMapCID, VerifregRoot)
+	initializeActor(ctx, t, vm, vrState, builtin.VerifiedRegistryActorCodeID, builtin.VerifiedRegistryActorAddr, big.Zero())
+
+	// burnt funds
+	initializeActor(ctx, t, vm, &account.State{Address: builtin.BurntFundsActorAddr}, builtin.AccountActorCodeID, builtin.BurntFundsActorAddr, big.Zero())
+
+	_, err = vm.checkpoint()
+	require.NoError(t, err)
+
+	return vm
+}
+
+// Creates n account actors in the VM with the given balance
+func CreateAccounts(ctx context.Context, t *testing.T, vm *VM, n int, balance abi.TokenAmount, seed int64) []address.Address {
+	var initState initactor.State
+	err := vm.GetState(builtin.InitActorAddr, &initState)
+	require.NoError(t, err)
+
+	addrPairs := make([]addrPair, n)
+	for i := range addrPairs {
+		addr := actor_testing.NewBLSAddr(t, seed+int64(i))
+		idAddr, err := initState.MapAddressToNewID(vm.store, addr)
+		require.NoError(t, err)
+
+		addrPairs[i] = addrPair{
+			pubAddr: addr,
+			idAddr:  idAddr,
+		}
+	}
+	err = vm.setActorState(ctx, builtin.InitActorAddr, &initState)
+	require.NoError(t, err)
+
+	pubAddrs := make([]address.Address, len(addrPairs))
+	for i, addrPair := range addrPairs {
+		st := &account.State{Address: addrPair.pubAddr}
+		initializeActor(ctx, t, vm, st, builtin.AccountActorCodeID, addrPair.idAddr, balance)
+		pubAddrs[i] = addrPair.pubAddr
+	}
+	return pubAddrs
+}
+
+//
+// Invocation expectations
+//
+
+// ExpectInvocation is a pattern for a message invocation within the VM.
+// The To and Method fields must be supplied. Exitcode defaults to exitcode.Ok.
+// All other field are optional, where a nil or Undef value indicates that any value will match.
+// SubInvocations will be matched recursively.
+type ExpectInvocation struct {
+	To     address.Address
+	Method abi.MethodNum
+
+	// optional
+	Exitcode       exitcode.ExitCode
+	From           address.Address
+	Value          *abi.TokenAmount
+	Params         *objectExpectation
+	Ret            *objectExpectation
+	SubInvocations []ExpectInvocation
+}
+
+func (ei ExpectInvocation) Matches(t *testing.T, invocations *Invocation) {
+	ei.matches(t, "", invocations)
+}
+
+func (ei ExpectInvocation) matches(t *testing.T, breadcrumb string, invocation *Invocation) {
+	identifier := fmt.Sprintf("%s[%s:%d]", breadcrumb, invocation.Msg.to, invocation.Msg.method)
+
+	// mismatch of to or method probably indicates skipped message or messages out of order. halt.
+	require.Equal(t, ei.To, invocation.Msg.to, "%s unexpected 'to' address", identifier)
+	require.Equal(t, ei.Method, invocation.Msg.method, "%s unexpected method", identifier)
+
+	// other expectations are optional
+	if address.Undef != ei.From {
+		assert.Equal(t, ei.From, invocation.Msg.from, "%s unexpected from address", identifier)
+	}
+	if ei.Value != nil {
+		assert.Equal(t, *ei.Value, invocation.Msg.value, "%s unexpected value", identifier)
+	}
+	if ei.Params != nil {
+		assert.True(t, ei.Params.matches(invocation.Msg.params), "%s params aren't equal (%v != %v)", identifier, ei.Params.val, invocation.Msg.params)
+	}
+	if ei.SubInvocations != nil {
+		for i, invk := range invocation.SubInvocations {
+			subidentifier := fmt.Sprintf("%s%d:", identifier, i)
+			// attempt match only if methods match
+			require.True(t, len(ei.SubInvocations) > i && ei.SubInvocations[i].To == invk.Msg.to && ei.SubInvocations[i].Method == invk.Msg.method,
+				"%s unexpected subinvocation [%s:%d]\nexpected:\n%s\nactual:\n%s",
+				subidentifier, invk.Msg.to, invk.Msg.method, ei.listSubinvocations(), listInvocations(invocation.SubInvocations))
+			ei.SubInvocations[i].matches(t, subidentifier, invk)
+		}
+		missingInvocations := len(ei.SubInvocations) - len(invocation.SubInvocations)
+		if missingInvocations > 0 {
+			missingIndex := len(invocation.SubInvocations)
+			missingExpect := ei.SubInvocations[missingIndex]
+			require.Failf(t, "missing expected invocations", "%s%d: expected invocation [%s:%d]\nexpected:\n%s\nactual:\n%s",
+				identifier, missingIndex, missingExpect.To, missingExpect.Method, ei.listSubinvocations(), listInvocations(invocation.SubInvocations))
+		}
+	}
+
+	// expect results
+	assert.Equal(t, ei.Exitcode, invocation.Exitcode, "%s unexpected exitcode", identifier)
+	if ei.Ret != nil {
+		assert.True(t, ei.Ret.matches(invocation.Ret), "%s unexpected return value (%v != %v)", identifier, ei.Ret, invocation.Ret)
+	}
+}
+
+func (ei ExpectInvocation) listSubinvocations() string {
+	if len(ei.SubInvocations) == 0 {
+		return "[no invocations]\n"
+	}
+	list := ""
+	for i, si := range ei.SubInvocations {
+		list = fmt.Sprintf("%s%2d: [%s:%d]\n", list, i, si.To, si.Method)
+	}
+	return list
+}
+
+func listInvocations(invocations []*Invocation) string {
+	if len(invocations) == 0 {
+		return "[no invocations]\n"
+	}
+	list := ""
+	for i, si := range invocations {
+		list = fmt.Sprintf("%s%2d: [%s:%d]\n", list, i, si.Msg.to, si.Msg.method)
+	}
+	return list
+}
+
+// helpers to simplify pointer creation
+func ExpectAttoFil(amount big.Int) *big.Int                    { return &amount }
+func ExpectExitCode(code exitcode.ExitCode) *exitcode.ExitCode { return &code }
+
+func ExpectObject(v cbor.Marshaler) *objectExpectation {
+	return &objectExpectation{v}
+}
+
+// distinguishes a non-expectation from an expectation of nil
+type objectExpectation struct {
+	val cbor.Marshaler
+}
+
+// match by cbor encoding to avoid inconsistencies in internal representations of effectively equal objects
+func (oe objectExpectation) matches(obj interface{}) bool {
+	if oe.val == nil || obj == nil {
+		return oe.val == nil && obj == nil
+	}
+
+	paramBuf1 := new(bytes.Buffer)
+	oe.val.MarshalCBOR(paramBuf1) // nolint: errcheck
+	marshaller, ok := obj.(cbor.Marshaler)
+	if !ok {
+		return false
+	}
+	paramBuf2 := new(bytes.Buffer)
+	if marshaller != nil {
+		marshaller.MarshalCBOR(paramBuf2) // nolint: errcheck
+	}
+	return bytes.Equal(paramBuf1.Bytes(), paramBuf2.Bytes())
+}
+
+var okExitCode = exitcode.Ok
+var ExpectOK = &okExitCode
+
+func ParamsForInvocation(t *testing.T, vm *VM, idxs ...int) interface{} {
+	invocations := vm.Invocations()
+	var invocation *Invocation
+	for _, idx := range idxs {
+		require.Greater(t, len(invocations), idx)
+		invocation = invocations[idx]
+		invocations = invocation.SubInvocations
+	}
+	require.NotNil(t, invocation)
+	return invocation.Msg.params
+}
+
+func ValueForInvocation(t *testing.T, vm *VM, idxs ...int) abi.TokenAmount {
+	invocations := vm.Invocations()
+	var invocation *Invocation
+	for _, idx := range idxs {
+		require.Greater(t, len(invocations), idx)
+		invocation = invocations[idx]
+		invocations = invocation.SubInvocations
+	}
+	require.NotNil(t, invocation)
+	return invocation.Msg.value
+}
+
+//
+// Advancing Time while updating state
+//
+
+type advanceDeadlinePredicate func(dlInfo *dline.Info) bool
+
+func MinerDLInfo(t *testing.T, v *VM, minerIDAddr address.Address) *dline.Info {
+	var minerState miner.State
+	err := v.GetState(minerIDAddr, &minerState)
+	require.NoError(t, err)
+
+	return minerState.DeadlineInfo(v.GetEpoch())
+}
+
+// AdvanceByDeadline creates a new VM advanced to an epoch specified by the predicate while keeping the
+// miner state upu-to-date by running a cron at the end of each deadline period.
+func AdvanceByDeadline(t *testing.T, v *VM, minerIDAddr address.Address, predicate advanceDeadlinePredicate) (*VM, *dline.Info) {
+	dlInfo := MinerDLInfo(t, v, minerIDAddr)
+	var err error
+	for predicate(dlInfo) {
+		v, err = v.WithEpoch(dlInfo.Last())
+		require.NoError(t, err)
+
+		_, code := v.ApplyMessage(builtin.SystemActorAddr, builtin.CronActorAddr, big.Zero(), builtin.MethodsCron.EpochTick, nil)
+		require.Equal(t, exitcode.Ok, code)
+
+		dlInfo = MinerDLInfo(t, v, minerIDAddr)
+	}
+	return v, dlInfo
+}
+
+// Advances by deadline until e is contained within the deadline period represented by the returned deadline info.
+// The VM returned will be set to the last deadline close, not at e.
+func AdvanceByDeadlineTillEpoch(t *testing.T, v *VM, minerIDAddr address.Address, e abi.ChainEpoch) (*VM, *dline.Info) {
+	return AdvanceByDeadline(t, v, minerIDAddr, func(dlInfo *dline.Info) bool {
+		return dlInfo.Close <= e
+	})
+}
+
+// Advances by deadline until the deadline index matches the given index.
+// The vm returned will be set to the close epoch of the previous deadline.
+func AdvanceByDeadlineTillIndex(t *testing.T, v *VM, minerIDAddr address.Address, i uint64) (*VM, *dline.Info) {
+	return AdvanceByDeadline(t, v, minerIDAddr, func(dlInfo *dline.Info) bool {
+		return dlInfo.Index != i
+	})
+}
+
+// Advance to the epoch when the sector is due to be proven.
+// Returns the deadline info for proving deadline for sector, partition index of sector, and a VM at the opening of
+// the deadline (ready for SubmitWindowedPoSt).
+func AdvanceTillProvingDeadline(t *testing.T, v *VM, minerIDAddress address.Address, sectorNumber abi.SectorNumber) (*dline.Info, uint64, *VM) {
+	dlIdx, pIdx := SectorDeadline(t, v, minerIDAddress, sectorNumber)
+
+	// advance time to next proving period
+	v, dlInfo := AdvanceByDeadlineTillIndex(t, v, minerIDAddress, dlIdx)
+	v, err := v.WithEpoch(dlInfo.Open)
+	require.NoError(t, err)
+	return dlInfo, pIdx, v
+}
+
+// find the proving deadline and partition index of a miner's sector
+func SectorDeadline(t *testing.T, v *VM, minerIDAddress address.Address, sectorNumber abi.SectorNumber) (uint64, uint64) {
+	var minerState miner.State
+	err := v.GetState(minerIDAddress, &minerState)
+	require.NoError(t, err)
+
+	dlIdx, pIdx, err := minerState.FindSector(v.Store(), sectorNumber)
+	require.NoError(t, err)
+	return dlIdx, pIdx
+}
+
+///
+// state abstraction
+//
+
+type MinerBalances struct {
+	AvailableBalance abi.TokenAmount
+	VestingBalance   abi.TokenAmount
+	PreCommitDeposit abi.TokenAmount
+}
+
+func GetMinerBalances(t *testing.T, vm *VM, minerIdAddr address.Address) MinerBalances {
+	var state miner.State
+	a, found, err := vm.GetActor(minerIdAddr)
+	require.NoError(t, err)
+	require.True(t, found)
+
+	err = vm.GetState(minerIdAddr, &state)
+	require.NoError(t, err)
+
+	return MinerBalances{
+		AvailableBalance: big.Subtract(a.Balance, state.PreCommitDeposits, state.LockedFunds),
+		PreCommitDeposit: state.PreCommitDeposits,
+		VestingBalance:   state.LockedFunds,
+	}
+}
+
+func PowerForMinerSector(t *testing.T, vm *VM, minerIdAddr address.Address, sectorNumber abi.SectorNumber) miner.PowerPair {
+	var state miner.State
+	err := vm.GetState(minerIdAddr, &state)
+	require.NoError(t, err)
+
+	sector, found, err := state.GetSector(vm.store, sectorNumber)
+	require.NoError(t, err)
+	require.True(t, found)
+
+	sectorSize, err := sector.SealProof.SectorSize()
+	require.NoError(t, err)
+	return miner.PowerForSector(sectorSize, sector)
+}
+
+func MinerPower(t *testing.T, vm *VM, minerIdAddr address.Address) miner.PowerPair {
+	var state power.State
+	err := vm.GetState(builtin.StoragePowerActorAddr, &state)
+	require.NoError(t, err)
+
+	claims, err := adt.AsMap(vm.store, state.Claims)
+	require.NoError(t, err)
+
+	var claim power.Claim
+	found, err := claims.Get(abi.AddrKey(minerIdAddr), &claim)
+	require.NoError(t, err)
+	require.True(t, found)
+
+	return miner.NewPowerPair(claim.RawBytePower, claim.QualityAdjPower)
+}
+
+type NetworkStats struct {
+	power.State
+	TotalRawBytePower             abi.StoragePower
+	TotalBytesCommitted           abi.StoragePower
+	TotalQualityAdjPower          abi.StoragePower
+	TotalQABytesCommitted         abi.StoragePower
+	TotalPledgeCollateral         abi.TokenAmount
+	ThisEpochRawBytePower         abi.StoragePower
+	ThisEpochQualityAdjPower      abi.StoragePower
+	ThisEpochPledgeCollateral     abi.TokenAmount
+	MinerCount                    int64
+	MinerAboveMinPowerCount       int64
+	ThisEpochReward               abi.TokenAmount
+	ThisEpochRewardSmoothed       *smoothing.FilterEstimate
+	ThisEpochBaselinePower        abi.StoragePower
+	TotalClientLockedCollateral   abi.TokenAmount
+	TotalProviderLockedCollateral abi.TokenAmount
+	TotalClientStorageFee         abi.TokenAmount
+}
+
+func GetNetworkStats(t *testing.T, vm *VM) NetworkStats {
+	var powerState power.State
+	err := vm.GetState(builtin.StoragePowerActorAddr, &powerState)
+	require.NoError(t, err)
+
+	var rewardState reward.State
+	err = vm.GetState(builtin.RewardActorAddr, &rewardState)
+	require.NoError(t, err)
+
+	var marketState market.State
+	err = vm.GetState(builtin.StorageMarketActorAddr, &marketState)
+	require.NoError(t, err)
+
+	return NetworkStats{
+		TotalRawBytePower:             powerState.TotalRawBytePower,
+		TotalBytesCommitted:           powerState.TotalBytesCommitted,
+		TotalQualityAdjPower:          powerState.TotalQualityAdjPower,
+		TotalQABytesCommitted:         powerState.TotalQABytesCommitted,
+		TotalPledgeCollateral:         powerState.TotalPledgeCollateral,
+		ThisEpochRawBytePower:         powerState.ThisEpochRawBytePower,
+		ThisEpochQualityAdjPower:      powerState.ThisEpochQualityAdjPower,
+		ThisEpochPledgeCollateral:     powerState.ThisEpochPledgeCollateral,
+		MinerCount:                    powerState.MinerCount,
+		MinerAboveMinPowerCount:       powerState.MinerAboveMinPowerCount,
+		ThisEpochReward:               rewardState.ThisEpochReward,
+		ThisEpochRewardSmoothed:       rewardState.ThisEpochRewardSmoothed,
+		ThisEpochBaselinePower:        rewardState.ThisEpochBaselinePower,
+		TotalClientLockedCollateral:   marketState.TotalClientLockedCollateral,
+		TotalProviderLockedCollateral: marketState.TotalProviderLockedCollateral,
+		TotalClientStorageFee:         marketState.TotalClientStorageFee,
+	}
+}
+
+func GetDealState(t *testing.T, vm *VM, dealID abi.DealID) (*market.DealState, bool) {
+	var marketState market.State
+	err := vm.GetState(builtin.StorageMarketActorAddr, &marketState)
+	require.NoError(t, err)
+
+	states, err := market.AsDealStateArray(vm.store, marketState.States)
+	require.NoError(t, err)
+
+	state, found, err := states.Get(dealID)
+	require.NoError(t, err)
+
+	return state, found
+}
+
+//
+// Misc. helpers
+//
+
+func ApplyOk(t *testing.T, v *VM, from, to address.Address, value abi.TokenAmount, method abi.MethodNum, params interface{}) cbor.Marshaler {
+	ret, code := v.ApplyMessage(from, to, value, method, params)
+	require.Equal(t, exitcode.Ok, code)
+	return ret
+}
+
+//
+//  internal stuff
+//
+
+func initializeActor(ctx context.Context, t *testing.T, vm *VM, state cbor.Marshaler, code cid.Cid, a address.Address, balance abi.TokenAmount) {
+	stateCID, err := vm.store.Put(ctx, state)
+	require.NoError(t, err)
+	actor := &states.Actor{
+		Head:    stateCID,
+		Code:    code,
+		Balance: balance,
+	}
+	err = vm.setActor(ctx, a, actor)
+	require.NoError(t, err)
+}
+
+type addrPair struct {
+	pubAddr address.Address
+	idAddr  address.Address
+}

--- a/support/vm/vm.go
+++ b/support/vm/vm.go
@@ -1,0 +1,470 @@
+package vm_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/filecoin-project/specs-actors/actors/states"
+
+	"github.com/filecoin-project/go-address"
+	hamt "github.com/filecoin-project/go-hamt-ipld"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/cbor"
+	"github.com/filecoin-project/go-state-types/exitcode"
+	"github.com/filecoin-project/go-state-types/network"
+	"github.com/filecoin-project/go-state-types/rt"
+	"github.com/ipfs/go-cid"
+	"github.com/pkg/errors"
+
+	"github.com/filecoin-project/specs-actors/actors/builtin"
+	"github.com/filecoin-project/specs-actors/actors/builtin/exported"
+	init_ "github.com/filecoin-project/specs-actors/actors/builtin/init"
+	"github.com/filecoin-project/specs-actors/actors/runtime"
+	"github.com/filecoin-project/specs-actors/actors/util/adt"
+)
+
+// VM is a simplified message execution framework for the purposes of testing inter-actor communication.
+// The VM maintains actor state and can be used to simulate message validation for a single block or tipset.
+// The VM does not track gas charges, provide working syscalls, validate message nonces and many other things
+// that a compliant VM needs to do.
+type VM struct {
+	ctx   context.Context
+	store adt.Store
+
+	currentEpoch   abi.ChainEpoch
+	networkVersion network.Version
+
+	actorImpls  ActorImplLookup
+	stateRoot   cid.Cid  // The last committed root.
+	actors      *adt.Map // The current (not necessarily committed) root node.
+	actorsDirty bool
+
+	emptyObject cid.Cid
+
+	logs            []string
+	invocationStack []*Invocation
+	invocations     []*Invocation
+}
+
+// VM types
+
+// Simplifed actor implementation that does not contain message nonce.
+type TestActor struct {
+	Head    cid.Cid
+	Code    cid.Cid
+	Balance abi.TokenAmount
+}
+
+type ActorImplLookup map[cid.Cid]exported.BuiltinActor
+
+type InternalMessage struct {
+	from   address.Address
+	to     address.Address
+	value  abi.TokenAmount
+	method abi.MethodNum
+	params interface{}
+}
+
+type Invocation struct {
+	Msg            *InternalMessage
+	Exitcode       exitcode.ExitCode
+	Ret            cbor.Marshaler
+	SubInvocations []*Invocation
+}
+
+// NewVM creates a new runtime for executing messages.
+func NewVM(ctx context.Context, actorImpls ActorImplLookup, store adt.Store) *VM {
+	// Note: this uses the most recent HAMT implementation.
+	// To test across chain state upgrades, factor out this initial state tree construction.
+	actors := adt.MakeEmptyMap(store)
+	actorRoot, err := actors.Root()
+	if err != nil {
+		panic(err)
+	}
+
+	emptyObject, err := store.Put(context.TODO(), []struct{}{})
+	if err != nil {
+		panic(err)
+	}
+
+	return &VM{
+		ctx:            ctx,
+		actorImpls:     actorImpls,
+		store:          store,
+		actors:         actors,
+		stateRoot:      actorRoot,
+		actorsDirty:    false,
+		emptyObject:    emptyObject,
+		networkVersion: network.VersionMax,
+	}
+}
+
+func (vm *VM) WithEpoch(epoch abi.ChainEpoch) (*VM, error) {
+	_, err := vm.checkpoint()
+	if err != nil {
+		return nil, err
+	}
+
+	actors, err := adt.AsMap(vm.store, vm.stateRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	return &VM{
+		ctx:            vm.ctx,
+		actorImpls:     vm.actorImpls,
+		store:          vm.store,
+		actors:         actors,
+		stateRoot:      vm.stateRoot,
+		actorsDirty:    false,
+		emptyObject:    vm.emptyObject,
+		currentEpoch:   epoch,
+		networkVersion: vm.networkVersion,
+	}, nil
+}
+
+func (vm *VM) WithRoot(root cid.Cid) (*VM, error) {
+	newVM := &VM{
+		ctx:            vm.ctx,
+		actorImpls:     vm.actorImpls,
+		store:          vm.store,
+		stateRoot:      root,
+		actorsDirty:    false,
+		emptyObject:    vm.emptyObject,
+		currentEpoch:   vm.currentEpoch,
+		networkVersion: vm.networkVersion,
+	}
+
+	actors, err := adt.AsMap(newVM.store, newVM.stateRoot)
+	if err != nil {
+		return nil, err
+	}
+	newVM.actors = actors
+
+	return newVM, nil
+}
+
+func (vm *VM) rollback(root cid.Cid) error {
+	var err error
+	vm.actors, err = adt.AsMap(vm.store, root)
+	if err != nil {
+		return errors.Wrapf(err, "failed to load node for %s", root)
+	}
+
+	// reset the root node
+	vm.stateRoot = root
+	vm.actorsDirty = false
+	return nil
+}
+
+func (vm *VM) GetActor(a address.Address) (*states.Actor, bool, error) {
+	na, found := vm.NormalizeAddress(a)
+	if !found {
+		return nil, false, nil
+	}
+	var act states.Actor
+	found, err := vm.actors.Get(abi.AddrKey(na), &act)
+	return &act, found, err
+}
+
+// SetActor sets the the actor to the given value whether it previously existed or not.
+//
+// This method will not check if the actor previously existed, it will blindly overwrite it.
+func (vm *VM) setActor(ctx context.Context, key address.Address, a *states.Actor) error {
+	if err := vm.actors.Put(abi.AddrKey(key), a); err != nil {
+		return errors.Wrap(err, "setting actor in state tree failed")
+	}
+	vm.actorsDirty = true
+	return nil
+}
+
+// setActorState stores the state and updates the addressed actor
+func (vm *VM) setActorState(ctx context.Context, key address.Address, state cbor.Marshaler) error {
+	stateCid, err := vm.store.Put(ctx, state)
+	if err != nil {
+		return err
+	}
+	a, found, err := vm.GetActor(key)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return errors.Errorf("could not find actor %s to set state", key)
+	}
+	a.Head = stateCid
+	return vm.setActor(ctx, key, a)
+}
+
+// deleteActor remove the actor from the storage.
+//
+// This method will NOT return an error if the actor was not found.
+// This behaviour is based on a principle that some store implementations might not be able to determine
+// whether something exists before deleting it.
+func (vm *VM) deleteActor(ctx context.Context, key address.Address) error {
+	err := vm.actors.Delete(abi.AddrKey(key))
+	vm.actorsDirty = true
+	if err == hamt.ErrNotFound {
+		return nil
+	}
+	return err
+}
+
+func (vm *VM) checkpoint() (cid.Cid, error) {
+	// commit the vm state
+	root, err := vm.actors.Root()
+	if err != nil {
+		return cid.Undef, err
+	}
+	vm.stateRoot = root
+	vm.actorsDirty = false
+
+	return root, nil
+}
+
+func (vm *VM) NormalizeAddress(addr address.Address) (address.Address, bool) {
+	// short-circuit if the address is already an ID address
+	if addr.Protocol() == address.ID {
+		return addr, true
+	}
+
+	// resolve the target address via the InitActor, and attempt to load state.
+	initActorEntry, found, err := vm.GetActor(builtin.InitActorAddr)
+	if err != nil {
+		panic(errors.Wrapf(err, "failed to load init actor"))
+	}
+	if !found {
+		panic(errors.Wrapf(err, "no init actor"))
+	}
+
+	// get a view into the actor state
+	var state init_.State
+	if err := vm.store.Get(vm.ctx, initActorEntry.Head, &state); err != nil {
+		panic(err)
+	}
+
+	idAddr, found, err := state.ResolveAddress(vm.store, addr)
+	if err != nil {
+		panic(err)
+	}
+	return idAddr, found
+}
+
+// ApplyMessage applies the message to the current state.
+func (vm *VM) ApplyMessage(from, to address.Address, value abi.TokenAmount, method abi.MethodNum, params interface{}) (cbor.Marshaler, exitcode.ExitCode) {
+	// This method does not actually execute the message itself,
+	// but rather deals with the pre/post processing of a message.
+	// (see: `invocationContext.invoke()` for the dispatch and execution)
+
+	// load actor from global state
+	var ok bool
+	if from, ok = vm.NormalizeAddress(from); !ok {
+		return nil, exitcode.SysErrSenderInvalid
+	}
+
+	fromActor, found, err := vm.GetActor(from)
+	if err != nil {
+		panic(err)
+	}
+	if !found {
+		// Execution error; sender does not exist at time of message execution.
+		return nil, exitcode.SysErrSenderInvalid
+	}
+
+	// checkpoint state
+	// Even if the message fails, the following accumulated changes will be applied:
+	// - CallSeqNumber increment
+	// - sender balance withheld
+	priorRoot, err := vm.checkpoint()
+	if err != nil {
+		panic(err)
+	}
+
+	// send
+	// 1. build internal message
+	// 2. build invocation context
+	// 3. process the msg
+
+	topLevel := topLevelContext{
+		newActorAddressCount: 0,
+	}
+
+	// build internal msg
+	imsg := InternalMessage{
+		from:   from,
+		to:     to,
+		value:  value,
+		method: method,
+		params: params,
+	}
+
+	// build invocation context
+	ctx := newInvocationContext(vm, &topLevel, imsg, fromActor, vm.emptyObject)
+
+	// 3. invoke
+	ret, exitCode := ctx.invoke()
+
+	// Roll back all state if the receipt's exit code is not ok.
+	// This is required in addition to rollback within the invocation context since top level messages can fail for
+	// more reasons than internal ones. Invocation context still needs its own rollback so actors can recover and
+	// proceed from a nested call failure.
+	if exitCode != exitcode.Ok {
+		if err := vm.rollback(priorRoot); err != nil {
+			panic(err)
+		}
+	}
+
+	return ret.inner, exitCode
+}
+
+func (vm *VM) StateRoot() cid.Cid {
+	return vm.stateRoot
+}
+
+func (vm *VM) GetState(addr address.Address, out cbor.Unmarshaler) error {
+	act, found, err := vm.GetActor(addr)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return errors.Errorf("actor %v not found", addr)
+	}
+	return vm.store.Get(vm.ctx, act.Head, out)
+}
+
+func (vm *VM) Store() adt.Store {
+	return vm.store
+}
+
+// Get the chain epoch for this vm
+func (vm *VM) GetEpoch() abi.ChainEpoch {
+	return vm.currentEpoch
+}
+
+// transfer debits money from one account and credits it to another.
+// avoid calling this method with a zero amount else it will perform unnecessary actor loading.
+//
+// WARNING: this method will panic if the the amount is negative, accounts dont exist, or have inssuficient funds.
+//
+// Note: this is not idiomatic, it follows the Spec expectations for this method.
+func (vm *VM) transfer(debitFrom address.Address, creditTo address.Address, amount abi.TokenAmount) (*states.Actor, *states.Actor) {
+	// allow only for positive amounts
+	if amount.LessThan(abi.NewTokenAmount(0)) {
+		panic("unreachable: negative funds transfer not allowed")
+	}
+
+	ctx := context.Background()
+
+	// retrieve debit account
+	fromActor, found, err := vm.GetActor(debitFrom)
+	if err != nil {
+		panic(err)
+	}
+	if !found {
+		panic(fmt.Errorf("unreachable: debit account not found. %s", err))
+	}
+
+	// check that account has enough balance for transfer
+	if fromActor.Balance.LessThan(amount) {
+		panic("unreachable: insufficient balance on debit account")
+	}
+
+	// debit funds
+	fromActor.Balance = big.Sub(fromActor.Balance, amount)
+	if err := vm.setActor(ctx, debitFrom, fromActor); err != nil {
+		panic(err)
+	}
+
+	// retrieve credit account
+	toActor, found, err := vm.GetActor(creditTo)
+	if err != nil {
+		panic(err)
+	}
+	if !found {
+		panic(fmt.Errorf("unreachable: credit account not found. %s", err))
+	}
+
+	// credit funds
+	toActor.Balance = big.Add(toActor.Balance, amount)
+	if err := vm.setActor(ctx, creditTo, toActor); err != nil {
+		panic(err)
+	}
+	return toActor, fromActor
+}
+
+func (vm *VM) getActorImpl(code cid.Cid) exported.BuiltinActor {
+	actorImpl, ok := vm.actorImpls[code]
+	if !ok {
+		vm.Abortf(exitcode.SysErrInvalidReceiver, "actor implementation not found for Exitcode %v", code)
+	}
+	return actorImpl
+}
+
+//
+// invocation tracking
+//
+
+func (vm *VM) startInvocation(msg *InternalMessage) {
+	invocation := Invocation{Msg: msg}
+	if len(vm.invocationStack) > 0 {
+		parent := vm.invocationStack[len(vm.invocationStack)-1]
+		parent.SubInvocations = append(parent.SubInvocations, &invocation)
+	} else {
+		vm.invocations = append(vm.invocations, &invocation)
+	}
+	vm.invocationStack = append(vm.invocationStack, &invocation)
+}
+
+func (vm *VM) endInvocation(code exitcode.ExitCode, ret cbor.Marshaler) {
+	curIndex := len(vm.invocationStack) - 1
+	current := vm.invocationStack[curIndex]
+	current.Exitcode = code
+	current.Ret = ret
+
+	vm.invocationStack = vm.invocationStack[:curIndex]
+}
+
+func (vm *VM) Invocations() []*Invocation {
+	return vm.invocations
+}
+
+func (vm *VM) LastInvocation() *Invocation {
+	return vm.invocations[len(vm.invocations)-1]
+}
+
+//
+// implement runtime.Runtime for VM
+//
+
+func (vm *VM) Log(level rt.LogLevel, msg string, args ...interface{}) {
+	vm.logs = append(vm.logs, fmt.Sprintf(msg, args...))
+}
+
+type abort struct {
+	code exitcode.ExitCode
+	msg  string
+}
+
+func (vm *VM) Abortf(errExitCode exitcode.ExitCode, msg string, args ...interface{}) {
+	panic(abort{errExitCode, fmt.Sprintf(msg, args...)})
+}
+
+//
+// implement runtime.MessageInfo for InternalMessage
+//
+
+var _ runtime.Message = (*InternalMessage)(nil)
+
+// ValueReceived implements runtime.MessageInfo.
+func (msg InternalMessage) ValueReceived() abi.TokenAmount {
+	return msg.value
+}
+
+// Caller implements runtime.MessageInfo.
+func (msg InternalMessage) Caller() address.Address {
+	return msg.from
+}
+
+// Receiver implements runtime.MessageInfo.
+func (msg InternalMessage) Receiver() address.Address {
+	return msg.to
+}

--- a/support/vm/vm.go
+++ b/support/vm/vm.go
@@ -17,7 +17,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/filecoin-project/specs-actors/actors/builtin"
-	"github.com/filecoin-project/specs-actors/actors/builtin/exported"
 	init_ "github.com/filecoin-project/specs-actors/actors/builtin/init"
 	"github.com/filecoin-project/specs-actors/actors/runtime"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
@@ -55,7 +54,7 @@ type TestActor struct {
 	Balance abi.TokenAmount
 }
 
-type ActorImplLookup map[cid.Cid]exported.BuiltinActor
+type ActorImplLookup map[cid.Cid]runtime.VMActor
 
 type InternalMessage struct {
 	from   address.Address
@@ -391,7 +390,7 @@ func (vm *VM) transfer(debitFrom address.Address, creditTo address.Address, amou
 	return toActor, fromActor
 }
 
-func (vm *VM) getActorImpl(code cid.Cid) exported.BuiltinActor {
+func (vm *VM) getActorImpl(code cid.Cid) runtime.VMActor {
 	actorImpl, ok := vm.actorImpls[code]
 	if !ok {
 		vm.Abortf(exitcode.SysErrInvalidReceiver, "actor implementation not found for Exitcode %v", code)


### PR DESCRIPTION
### Motivation

We would like to have a test vm that works with v0.9 actors embedded in the v0.9 branch. This will allow us to run scenario tests that build state with 0.9 actors, migrate and then run with future actors. This PR will have no effect on the actor code itself.

### Proposed Changes

1. Add test vm (`VM`, `InvocationContext` and some setup code).