### PR TITLE
Migration Fixes

### DIFF
--- a/actors/migration/miner_corrections.go
+++ b/actors/migration/miner_corrections.go
@@ -10,7 +10,6 @@ import (
 	"github.com/filecoin-project/go-state-types/big"
 	cid "github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
-	xerrors "golang.org/x/xerrors"
 
 	miner "github.com/filecoin-project/specs-actors/actors/builtin/miner"
 	power0 "github.com/filecoin-project/specs-actors/actors/builtin/power"
@@ -76,17 +75,6 @@ func (m *minerMigrator) correctForCCUpgradeThenFaultIssue(
 	if expectedDeadlline != st.CurrentDeadline {
 		st.CurrentDeadline = expectedDeadlline
 		missedProvingPeriodCron = true
-	}
-
-	// assert ranges for new proving period and deadline
-	if st.ProvingPeriodStart <= epoch-miner.WPoStProvingPeriod || st.ProvingPeriodStart > epoch {
-		return false, xerrors.Errorf("miner proving period start, %d, is out of range (%d, %d]",
-			st.ProvingPeriodStart, epoch-miner.WPoStProvingPeriod, epoch)
-	}
-	dlInfo := st.DeadlineInfo(epoch)
-	if dlInfo.Open > epoch || dlInfo.Close <= epoch {
-		return false, xerrors.Errorf("priorEpoch is out of expected range of miner deadline [%d, %d) ∌ %d",
-			dlInfo.Open, dlInfo.Close, epoch)
 	}
 
 	deadlinesModified := false

--- a/actors/migration/miner_corrections.go
+++ b/actors/migration/miner_corrections.go
@@ -118,6 +118,7 @@ func (m *minerMigrator) correctForCCUpgradeThenFaultIssue(
 			}
 			if missedProvingPeriodCron {
 				part.Recoveries = bitfield.New()
+				part.RecoveringPower = miner.NewPowerPairZero()
 				alteredPartitions[uint64(partIdx)] = part
 			}
 			allFaultyPower = allFaultyPower.Add(part.FaultyPower)


### PR DESCRIPTION
1. The proving period invariant being asserted is not actually an invariant because when we create miners their proving period starts are in the future.  We can add back the deadline invariant assertion here upon request since they should still always hold but would prefer if we test for them in the invariant checks instead.

2. Validation checks uncovered that we are not zeroing out recovering power.

