### PR TITLE
Add miner ChangeOwnerAddress method

### DIFF
--- a/actors/builtin/methods.go
+++ b/actors/builtin/methods.go
@@ -98,7 +98,8 @@ var MethodsMiner = struct {
 	CompactSectorNumbers     abi.MethodNum
 	ConfirmUpdateWorkerKey   abi.MethodNum
 	RepayDebt                abi.MethodNum
-}{MethodConstructor, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22}
+	ChangeOwnerAddress       abi.MethodNum
+}{MethodConstructor, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23}
 
 var MethodsVerifiedRegistry = struct {
 	Constructor       abi.MethodNum

--- a/actors/builtin/miner/cbor_gen.go
+++ b/actors/builtin/miner/cbor_gen.go
@@ -303,7 +303,7 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
-var lengthBufMinerInfo = []byte{138}
+var lengthBufMinerInfo = []byte{139}
 
 func (t *MinerInfo) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -413,6 +413,11 @@ func (t *MinerInfo) MarshalCBOR(w io.Writer) error {
 			return err
 		}
 	}
+
+	// t.PendingOwnerAddress (address.Address) (struct)
+	if err := t.PendingOwnerAddress.MarshalCBOR(w); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -430,7 +435,7 @@ func (t *MinerInfo) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 10 {
+	if extra != 11 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -645,6 +650,25 @@ func (t *MinerInfo) UnmarshalCBOR(r io.Reader) error {
 		}
 
 		t.ConsensusFaultElapsed = abi.ChainEpoch(extraI)
+	}
+	// t.PendingOwnerAddress (address.Address) (struct)
+
+	{
+
+		b, err := br.ReadByte()
+		if err != nil {
+			return err
+		}
+		if b != cbg.CborNull[0] {
+			if err := br.UnreadByte(); err != nil {
+				return err
+			}
+			t.PendingOwnerAddress = new(address.Address)
+			if err := t.PendingOwnerAddress.UnmarshalCBOR(br); err != nil {
+				return xerrors.Errorf("unmarshaling t.PendingOwnerAddress pointer: %w", err)
+			}
+		}
+
 	}
 	return nil
 }

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -113,6 +113,10 @@ type MinerInfo struct {
 	// The next epoch this miner is eligible for certain permissioned actor methods
 	// and winning block elections as a result of being reported for a consensus fault.
 	ConsensusFaultElapsed abi.ChainEpoch
+
+	// A proposed new owner account for this miner.
+	// Must be confirmed by a message from the pending address itself.
+	PendingOwnerAddress *addr.Address
 }
 
 type WorkerKeyChange struct {
@@ -209,6 +213,7 @@ func ConstructMinerInfo(owner addr.Address, worker addr.Address, controlAddrs []
 		SectorSize:                 sectorSize,
 		WindowPoStPartitionSectors: partitionSectors,
 		ConsensusFaultElapsed:      abi.ChainEpoch(-1),
+		PendingOwnerAddress:        nil,
 	}, nil
 }
 


### PR DESCRIPTION
A miner operator may wish to change the owner address associated with a miner, e.g. due to compromise or for key rotation. 

This is a one-way operation that cannot be undone if the operator sets an address they do not actually control. To reduce risk of error, the method confirms effective ownership of the new address with a two-step process:
1. Existing owner proposes a new owner address
2. The new owner address confirms the proposal

The operator (or someone) must have access to the new address's private key in order to send the second message.

Closes #1176
FYI @magik6k @arajasek 