### PR TITLE
Multisig purges approvals from removed signers

### DIFF
--- a/actors/builtin/multisig/multisig_state.go
+++ b/actors/builtin/multisig/multisig_state.go
@@ -58,6 +58,62 @@ func (st *State) AmountLocked(elapsedEpoch abi.ChainEpoch) abi.TokenAmount {
 	return locked
 }
 
+// Iterates all pending transactions and removes an address from each list of approvals, if present.
+// If an approval list becomes empty, the pending transaction is deleted.
+func (st *State) PurgeApprovals(store adt.Store, addr address.Address) error {
+	txns, err := adt.AsMap(store, st.PendingTxns)
+	if err != nil {
+		return xerrors.Errorf("failed to load transactions: %w", err)
+	}
+
+	// Identify the transactions that need updating.
+	var txnIdsToPurge []string // For stable iteration
+	txnsToPurge := map[string]Transaction{} // Values are not pointers, we need copies
+	var txn Transaction
+	if err = txns.ForEach(&txn, func(txid string) error {
+		for _, approver := range txn.Approved {
+			if approver == addr {
+				txnIdsToPurge = append(txnIdsToPurge, txid)
+				txnsToPurge[txid] = txn
+				break
+			}
+		}
+		return nil
+	}); err != nil {
+		return xerrors.Errorf("failed to traverse transactions: %w", err)
+	}
+
+	// Update or remove those transactions.
+	for _, txid := range txnIdsToPurge {
+		txn := txnsToPurge[txid]
+		// The right length is almost certainly len-1, but let's not be too clever.
+		newApprovers := make([]address.Address, 0, len(txn.Approved))
+		for _, approver := range txn.Approved {
+			if approver != addr {
+				newApprovers = append(newApprovers, approver)
+			}
+		}
+
+		if len(newApprovers) > 0 {
+			txn.Approved = newApprovers
+			if err := txns.Put(StringKey(txid), &txn); err != nil {
+				return xerrors.Errorf("failed to update transaction approvers: %w", err)
+			}
+		} else {
+			if err := txns.Delete(StringKey(txid)); err != nil {
+				return xerrors.Errorf("failed to delete transaction with no approvers: %w", err)
+			}
+		}
+	}
+
+	if newTxns, err := txns.Root(); err != nil {
+		return xerrors.Errorf("failed to persist transactions: %w", err)
+	} else {
+		st.PendingTxns = newTxns
+	}
+	return nil
+}
+
 // return nil if MultiSig maintains required locked balance after spending the amount, else return an error.
 func (st *State) assertAvailable(currBalance abi.TokenAmount, amountToSpend abi.TokenAmount, currEpoch abi.ChainEpoch) error {
 	if amountToSpend.LessThan(big.Zero()) {
@@ -91,4 +147,11 @@ func getPendingTransaction(ptx *adt.Map, txnID TxnID) (Transaction, error) {
 		return Transaction{}, exitcode.ErrNotFound.Wrapf("failed to find transaction %v", txnID)
 	}
 	return out, nil
+}
+
+// An adt.Map key that just preserves the underlying string.
+type StringKey string
+
+func (k StringKey) Key() string {
+	return string(k)
 }


### PR DESCRIPTION
### Motivation
When a multisig's signers are changed, especially through `SwapSigner`, if both a removed and added address are controlled by the same external entity, that entity might get to approve a pending transaction twice: once with a removed address and once with a new one. Whether or not this is a problem depends whether the desired behaviour treats the addresses as entities themselves, or as a handle to (possibly shared) other entities.

### Change
To avoid potential mis-use, this PR purges all approvals of pending transactions by removed signers.
- If a transaction's only approval (by its proposer) is removed, the transaction is deleted.
- If a transaction's proposer is removed but another signer has approved, the next approving signer becomes the "proposer", meaning they have the ability to cancel the transaction.

This cleans up an odd case in the old semantics where a pending transaction could be left un-cancellable if its proposer was removed as a signer.

Promoting the second approver to proposer was an arbitrary policy choice. We could just as easily delete all pending transactions proposed by a removed signer, regardless of other approvals, if desired.

Closes #1041.