### PR TITLE
Check if the proving period has started before advancing the deadline

### DIFF
--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -1018,6 +1018,25 @@ func (st *State) AdvanceDeadline(store adt.Store, currEpoch abi.ChainEpoch) (*Ad
 	// we still use dlInfo.Last().
 	dlInfo := st.DeadlineInfo(currEpoch)
 
+	// Return early if the proving period hasn't started. While actors v2
+	// sets the proving period start into the past so this case can never
+	// happen, v1:
+	//
+	// 1. Sets the proving period in the future.
+	// 2. Schedules the first cron event one epoch _before_ the proving
+	//    period start.
+	//
+	// At this point, no proofs have been submitted so we can't check them.
+	if !dlInfo.PeriodStarted() {
+		return &AdvanceDeadlineResult{
+			pledgeDelta,
+			powerDelta,
+			NewPowerPairZero(),
+			NewPowerPairZero(),
+			NewPowerPairZero(),
+		}, nil
+	}
+
 	// Advance to the next deadline (in case we short-circuit below).
 	st.CurrentDeadline = (st.CurrentDeadline + 1) % WPoStPeriodDeadlines
 	if st.CurrentDeadline == 0 {


### PR DESCRIPTION
While V2 actors always starts the proving period in the past, v1 set it into the future and scheduled the first cron callback one epoch before the proving period start.

Without this change, if a miner is created less than one proving period before the upgrade epoch, the miner will fail to prove their deadline 0 after the upgrade.

Alternatively, we could move the proving period start and attempt to re-schedule the initial cron callback, but some miners could end up with no time to actually submit a proof.