### PR TITLE
Skip miner for miners who's proving periods haven't started

### DIFF
--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -1018,6 +1018,25 @@ func (st *State) AdvanceDeadline(store adt.Store, currEpoch abi.ChainEpoch) (*Ad
 	// we still use dlInfo.Last().
 	dlInfo := st.DeadlineInfo(currEpoch)
 
+	// Return early if the proving period hasn't started. While actors v2
+	// sets the proving period start into the past so this case can never
+	// happen, v1:
+	//
+	// 1. Sets the proving period in the future.
+	// 2. Schedules the first cron event one epoch _before_ the proving
+	//    period start.
+	//
+	// At this point, no proofs have been submitted so we can't check them.
+	if !dlInfo.PeriodStarted() {
+		return &AdvanceDeadlineResult{
+			pledgeDelta,
+			powerDelta,
+			NewPowerPairZero(),
+			NewPowerPairZero(),
+			NewPowerPairZero(),
+		}, nil
+	}
+
 	// Advance to the next deadline (in case we short-circuit below).
 	st.CurrentDeadline = (st.CurrentDeadline + 1) % WPoStPeriodDeadlines
 	if st.CurrentDeadline == 0 {

--- a/actors/migration/miner_corrections.go
+++ b/actors/migration/miner_corrections.go
@@ -26,6 +26,16 @@ func (m *minerMigrator) CorrectState(ctx context.Context, store cbor.IpldStore, 
 		return cid.Undef, err
 	}
 
+	// If the miner's proving period hasn't started yet, it's a new v0
+	// miner.
+	//
+	// 1. There's no need to fix any state.
+	// 2. We definitely don't want to reschedule the proving period
+	//    start/deadlines.
+	if st.ProvingPeriodStart > epoch {
+		return head, nil
+	}
+
 	adtStore := adt.WrapStore(ctx, store)
 
 	sectors, err := miner.LoadSectors(adtStore, st.Sectors)


### PR DESCRIPTION
The migration logic assumes that proving periods are never set in the future, and miners that haven't started their first proving period will not have experienced any faults that need correcting.