### PR TITLE
add miner info invariant checks

### DIFF
--- a/actors/builtin/miner/testing.go
+++ b/actors/builtin/miner/testing.go
@@ -591,6 +591,8 @@ func CheckMinerInfo(info *MinerInfo) (*builtin.MessageAccumulator, error) {
 	}
 
 	if info.PendingOwnerAddress != nil {
+		acc.Require(info.PendingOwnerAddress.Protocol() == addr.ID,
+			"pending owner address %v is not an ID address", info.PendingOwnerAddress)
 		acc.Require(*info.PendingOwnerAddress != info.Owner,
 			"pending owner address %v is same as existing owner %v", info.PendingOwnerAddress, info.Owner)
 	}
@@ -600,10 +602,9 @@ func CheckMinerInfo(info *MinerInfo) (*builtin.MessageAccumulator, error) {
 	if found {
 		acc.Require(sealProofInfo.SectorSize == info.SectorSize,
 			"sector size %d is wrong for seal proof type %d: %d", info.SectorSize, info.SealProofType, sealProofInfo.SectorSize)
-		acc.Require(sealProofInfo.SectorSize == info.SectorSize,
-			"sector size %d is wrong for seal proof type %d: %d", info.SectorSize, info.SealProofType, sealProofInfo.SectorSize)
 	}
 	sealProofPolicy, found := builtin.SealProofPolicies[info.SealProofType]
+	acc.Require(found, "no seal proof policy exists for proof type %d", info.SealProofType)
 	if found {
 		acc.Require(sealProofPolicy.WindowPoStPartitionSectors == info.WindowPoStPartitionSectors,
 			"miner partition sectors %d does not match partition sectors %d for seal proof type %d",


### PR DESCRIPTION
further work towards #1165

### Motivation

We want to run invariant checks on miner state after tests that we couldn't run on chain for performance reasons. This PR adds tests invariants hold for miner info.

### Proposed Changes

1 Add `CheckMinerInfo`.
2. Call it from `CheckStateInvariants` so it will be invoked on almost all the miner tests.
