### PR TITLE
Multiply miner penalty by 3x

### DIFF
--- a/actors/builtin/reward/reward_actor.go
+++ b/actors/builtin/reward/reward_actor.go
@@ -15,6 +15,9 @@ import (
 	"github.com/filecoin-project/specs-actors/v2/actors/util/smoothing"
 )
 
+// PenaltyMultiplier is the factor miner penaltys are scaled up by
+const PenaltyMultiplier = 3
+
 type Actor struct{}
 
 func (a Actor) Exports() []interface{} {
@@ -91,8 +94,8 @@ func (a Actor) AwardBlockReward(rt runtime.Runtime, params *AwardBlockRewardPara
 	if !ok {
 		rt.Abortf(exitcode.ErrNotFound, "failed to resolve given owner address")
 	}
-
-	penalty := params.Penalty
+	// The miner penalty is scaled up by a factor of PenaltyMultiplier
+	penalty := big.Mul(big.NewInt(PenaltyMultiplier), params.Penalty)
 	totalReward := big.Zero()
 	var st State
 	rt.StateTransaction(&st, func() {

--- a/actors/builtin/reward/reward_test.go
+++ b/actors/builtin/reward/reward_test.go
@@ -149,7 +149,8 @@ func TestAwardBlockReward(t *testing.T) {
 		rt.SetBalance(smallReward)
 		rt.ExpectValidateCallerAddr(builtin.SystemActorAddr)
 
-		expectedParams := builtin.ApplyRewardParams{Reward: smallReward, Penalty: penalty}
+		minerPenalty := big.Mul(big.NewInt(reward.PenaltyMultiplier), penalty)
+		expectedParams := builtin.ApplyRewardParams{Reward: smallReward, Penalty: minerPenalty}
 		rt.ExpectSend(winner, builtin.MethodsMiner.ApplyRewards, &expectedParams, smallReward, nil, 0)
 		rt.Call(actor.AwardBlockReward, &reward.AwardBlockRewardParams{
 			Miner:     winner,
@@ -275,7 +276,9 @@ func (h *rewardHarness) updateNetworkKPI(rt *mock.Runtime, currRawPower *abi.Sto
 
 func (h *rewardHarness) awardBlockReward(rt *mock.Runtime, miner address.Address, penalty, gasReward abi.TokenAmount, winCount int64, expectedPayment abi.TokenAmount) {
 	rt.ExpectValidateCallerAddr(builtin.SystemActorAddr)
-	expectedParams := builtin.ApplyRewardParams{Reward: expectedPayment, Penalty: penalty}
+	// expect penalty multiplier
+	minerPenalty := big.Mul(big.NewInt(reward.PenaltyMultiplier), penalty)
+	expectedParams := builtin.ApplyRewardParams{Reward: expectedPayment, Penalty: minerPenalty}
 	rt.ExpectSend(miner, builtin.MethodsMiner.ApplyRewards, &expectedParams, expectedPayment, nil, 0)
 
 	rt.Call(h.AwardBlockReward, &reward.AwardBlockRewardParams{


### PR DESCRIPTION
As part of red team / cryptoecon requirements for upcoming upgrade the miner penalty as computed in the node and passed on to the reward actor is scaled up by a factor of three before being passed on to the miner actor for deduction.