### PR TITLE
Finish miner state checks

### DIFF
--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -138,7 +138,7 @@ func TestConstruction(t *testing.T) {
 
 		assertEmptyBitfield(t, st.EarlyTerminations)
 
-		_, msgs, err := miner.CheckStateInvariants(&st, rt.AdtStore())
+		_, msgs, err := miner.CheckStateInvariants(&st, rt.AdtStore(), rt.Balance())
 		require.NoError(t, err)
 		assert.True(t, msgs.IsEmpty(), strings.Join(msgs.Messages(), "\n"))
 	})
@@ -4317,7 +4317,7 @@ func (h *actorHarness) getLockedFunds(rt *mock.Runtime) abi.TokenAmount {
 
 func (h *actorHarness) checkState(rt *mock.Runtime) {
 	st := getState(rt)
-	_, msgs, err := miner.CheckStateInvariants(st, rt.AdtStore())
+	_, msgs, err := miner.CheckStateInvariants(st, rt.AdtStore(), rt.Balance())
 	assert.NoError(h.t, err)
 	assert.True(h.t, msgs.IsEmpty(), strings.Join(msgs.Messages(), "\n"))
 }

--- a/actors/migration/test/correct_cc_upgrade_then_fault_scenario_test.go
+++ b/actors/migration/test/correct_cc_upgrade_then_fault_scenario_test.go
@@ -321,7 +321,11 @@ func TestMigrationCorrectsCCThenFaultIssue(t *testing.T) {
 	err = v2.GetState(minerAddrs.IDAddress, &st1)
 	require.NoError(t, err)
 
-	_, acc, err := miner2.CheckStateInvariants(&st1, v2.Store())
+	act, found, err := v2.GetActor(minerAddrs.IDAddress)
+	require.NoError(t, err)
+	require.True(t, found)
+
+	_, acc, err := miner2.CheckStateInvariants(&st1, v2.Store(), act.Balance)
 	require.NoError(t, err)
 
 	assert.True(t, acc.IsEmpty())
@@ -390,7 +394,11 @@ func TestMigrationCorrectsCCThenFaultIssue(t *testing.T) {
 	err = v2.GetState(minerAddrs.IDAddress, &st2)
 	require.NoError(t, err)
 
-	_, acc, err = miner2.CheckStateInvariants(&st2, v2.Store())
+	act, found, err = v2.GetActor(minerAddrs.IDAddress)
+	require.NoError(t, err)
+	require.True(t, found)
+
+	_, acc, err = miner2.CheckStateInvariants(&st2, v2.Store(), act.Balance)
 	require.NoError(t, err)
 
 	assert.True(t, acc.IsEmpty())

--- a/actors/states/check.go
+++ b/actors/states/check.go
@@ -51,7 +51,7 @@ func CheckStateInvariants(tree *Tree, expectedBalanceTotal abi.TokenAmount) (*bu
 			if err := tree.Store.Get(tree.Store.Context(), actor.Head, &st); err != nil {
 				return err
 			}
-			if summary, msgs, err := miner.CheckStateInvariants(&st, tree.Store); err != nil {
+			if summary, msgs, err := miner.CheckStateInvariants(&st, tree.Store, actor.Balance); err != nil {
 				return err
 			} else {
 				acc.WithPrefix("miner: ").AddAll(msgs)


### PR DESCRIPTION
continued work on #1166

### Motivation

Many invariants of miner state remain untested by our slow checks. This PR adds several more, and should complete coverage.

### Proposed Changes

1. Check miner balances (balance, locked funds, precommit deposit, initial pledge, fee debt) for consistency.
2. Assert sum of vesting table is locked funds and ensure locked fund entries are quantized.
3. Check precommit data structure for consistency.
4. Check that sector numbers of all on chain sectors have been allocated.
5. Check that deadline index is less than 48.
6. Modify test calls to pass in actor balance.