### PR TITLE
multisig invariant tests

### DIFF
--- a/actors/builtin/multisig/multisig_state.go
+++ b/actors/builtin/multisig/multisig_state.go
@@ -25,7 +25,7 @@ type State struct {
 	StartEpoch     abi.ChainEpoch
 	UnlockDuration abi.ChainEpoch
 
-	PendingTxns cid.Cid
+	PendingTxns cid.Cid // HAMT[TxnID]Transaction
 }
 
 func (st *State) SetLocked(startEpoch abi.ChainEpoch, unlockDuration abi.ChainEpoch, lockedAmount abi.TokenAmount) {
@@ -67,7 +67,7 @@ func (st *State) PurgeApprovals(store adt.Store, addr address.Address) error {
 	}
 
 	// Identify the transactions that need updating.
-	var txnIdsToPurge []string // For stable iteration
+	var txnIdsToPurge []string              // For stable iteration
 	txnsToPurge := map[string]Transaction{} // Values are not pointers, we need copies
 	var txn Transaction
 	if err = txns.ForEach(&txn, func(txid string) error {

--- a/actors/builtin/multisig/testing.go
+++ b/actors/builtin/multisig/testing.go
@@ -8,31 +8,6 @@ import (
 	"github.com/filecoin-project/specs-actors/v2/actors/util/adt"
 )
 
-/*
-len(Signers) > 0
-NumApprovals >= len(Signers)
-NextTxnID > max(key(PendingTxns))
-
-//
-InitialBalance >= 0
-UnlockDuration >= 0
-
-type Transaction struct {
-	To     addr.Address
-	Value  abi.TokenAmount
-	Method abi.MethodNum
-	Params []byte
-
-	// This address at index 0 is the transaction proposer, order of this slice must be preserved.
-	Approved []addr.Address
-}
-
-To is ID address? NOPE
-Value is non-negative? NOPE
-len(approved) <= numapprovalsthreshold ??? (do we send transactions when we lower threshold?) NOPE
-approved subset of signers (because we purge)
-*/
-
 type StateSummary struct {
 	PendingTxns  uint64
 	NumApprovals uint64

--- a/actors/builtin/multisig/testing.go
+++ b/actors/builtin/multisig/testing.go
@@ -1,0 +1,98 @@
+package multisig
+
+import (
+	"bytes"
+	"encoding/binary"
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
+	"github.com/filecoin-project/specs-actors/v2/actors/util/adt"
+)
+
+/*
+len(Signers) > 0
+NumApprovals >= len(Signers)
+NextTxnID > max(key(PendingTxns))
+
+//
+InitialBalance >= 0
+UnlockDuration >= 0
+
+type Transaction struct {
+	To     addr.Address
+	Value  abi.TokenAmount
+	Method abi.MethodNum
+	Params []byte
+
+	// This address at index 0 is the transaction proposer, order of this slice must be preserved.
+	Approved []addr.Address
+}
+
+To is ID address? NOPE
+Value is non-negative? NOPE
+len(approved) <= numapprovalsthreshold ??? (do we send transactions when we lower threshold?) NOPE
+approved subset of signers (because we purge)
+*/
+
+type StateSummary struct {
+	PendingTxns  uint64
+	NumApprovals uint64
+	Signers      int
+}
+
+// Checks internal invariants of multisig state.
+func CheckStateInvariants(st *State, store adt.Store) (*StateSummary, *builtin.MessageAccumulator, error) {
+	acc := &builtin.MessageAccumulator{}
+
+	// assert invariants involving signers
+	acc.Require(len(st.Signers) <= SignersMax, "multisig has too many signers: %d", len(st.Signers))
+	acc.Require(uint64(len(st.Signers)) >= st.NumApprovalsThreshold,
+		"multisig has insufficient signers to meet threshold (%d < %d)", len(st.Signers), st.NumApprovalsThreshold)
+
+	// create lookup to test transaction approvals are multisig signers.
+	signers := make(map[address.Address]struct{})
+	for _, a := range st.Signers {
+		signers[a] = struct{}{}
+	}
+
+	// test pending transactions
+	transactions, err := adt.AsMap(store, st.PendingTxns)
+	if err != nil {
+		return nil, acc, err
+	}
+
+	maxTxnID := TxnID(-1)
+	numPending := uint64(0)
+	var txn Transaction
+	err = transactions.ForEach(&txn, func(txnIDStr string) error {
+		txnID, err := ParseTxnIDKey(txnIDStr)
+		if err != nil {
+			return err
+		}
+		if txnID > maxTxnID {
+			maxTxnID = txnID
+		}
+
+		for _, approval := range txn.Approved {
+			_, found := signers[approval]
+			acc.Require(found, "approval %v for transaction %d is not in signers list", approval, txnID)
+		}
+
+		numPending++
+		return nil
+	})
+	if err != nil {
+		return nil, acc, err
+	}
+
+	acc.Require(st.NextTxnID > maxTxnID, "next transaction id %d is not greater than pending ids", st.NextTxnID)
+	return &StateSummary{
+		PendingTxns:  numPending,
+		NumApprovals: st.NumApprovalsThreshold,
+		Signers:      len(st.Signers),
+	}, acc, nil
+}
+
+func ParseTxnIDKey(key string) (TxnID, error) {
+	id, err := binary.ReadVarint(bytes.NewReader([]byte(key)))
+	return TxnID(id), err
+}

--- a/actors/builtin/multisig/testing.go
+++ b/actors/builtin/multisig/testing.go
@@ -9,9 +9,9 @@ import (
 )
 
 type StateSummary struct {
-	PendingTxns  uint64
-	NumApprovals uint64
-	Signers      int
+	PendingTxnCount  uint64
+	NumApprovalsThreshold uint64
+	SignerCount      int
 }
 
 // Checks internal invariants of multisig state.


### PR DESCRIPTION
work towards #1165

### Motivation

We want to have tests for all actor state invariants, and we have yet to do this for Multisig. This PR adds a check that multisig state is internally consistent and runs that check in all unit tests.

The invariants tested are:

* `len(st.Signers) <= SignersMax`
* `len(st.Signers) > 0`
* `NextTxnID > max(keys(PendingTxns))`
* `txn.Approved ⊆ st.Signers` for all txns.

Some almost-invariants that cannot be asserted:

* `st.InitialBalance >= 0`. see #1223
* `txn.To is ID`. The multisig actor does not enforce this. There might be good reason for this since a fork between the proposal and execution causing the txn to be sent to the wrong account.
* `txn.Value is non-negative`. The multisig does not enforce this. It will cause the send to be invalid though.
* `len(txn.Approved) < st.NumApprovalsThreshold`. Usually the transaction approvals hitting the threshold will cause it to be executed and removed, but reducing the threshold can put the actor in a state where txns are approved but not yet sent. This is noted in #71 and addressed in #524. This PR adds a test for #524.


### Proposed Changes

1. Add `multisig.CheckStateInvariants` that deep checks multisig state.
2. Add a call to the above in every multisig unit test that is expected to call a multisig message successfully.
3. Add a test for re-approving after lowering a threshold to eliminate a resolved TODO.