### PR TITLE
power actor invariant tests

### DIFF
--- a/actors/builtin/account/account_test.go
+++ b/actors/builtin/account/account_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/exitcode"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin/account"
@@ -80,9 +81,11 @@ func TestAccountactor(t *testing.T) {
 }
 
 func checkState(t *testing.T, rt *mock.Runtime) {
+	testAddress, err := address.NewIDAddress(1000)
+	require.NoError(t, err)
 	var st account.State
 	rt.GetState(&st)
-	_, msgs, err := account.CheckStateInvariants(&st, rt.AdtStore())
+	_, msgs, err := account.CheckStateInvariants(&st, testAddress)
 	assert.NoError(t, err)
 	assert.True(t, msgs.IsEmpty())
 }

--- a/actors/builtin/account/testing.go
+++ b/actors/builtin/account/testing.go
@@ -3,7 +3,6 @@ package account
 import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
-	"github.com/filecoin-project/specs-actors/v2/actors/util/adt"
 )
 
 type StateSummary struct {
@@ -11,11 +10,18 @@ type StateSummary struct {
 }
 
 // Checks internal invariants of account state.
-func CheckStateInvariants(st *State, store adt.Store) (*StateSummary, *builtin.MessageAccumulator, error) {
+func CheckStateInvariants(st *State, idAddr address.Address) (*StateSummary, *builtin.MessageAccumulator, error) {
 	acc := &builtin.MessageAccumulator{}
-	acc.Require(
-		st.Address.Protocol() == address.BLS || st.Address.Protocol() == address.SECP256K1,
-		"actor address %v must be BLS or SECP256K1 protocol", st.Address)
+
+	id, err := address.IDFromAddress(idAddr)
+	if err != nil {
+		return nil, acc, err
+	}
+	if id >= builtin.FirstNonSingletonActorId {
+		acc.Require(
+			st.Address.Protocol() == address.BLS || st.Address.Protocol() == address.SECP256K1,
+			"actor address %v must be BLS or SECP256K1 protocol", st.Address)
+	}
 
 	return &StateSummary{
 		PubKeyAddr: st.Address,

--- a/actors/builtin/miner/testing.go
+++ b/actors/builtin/miner/testing.go
@@ -12,9 +12,10 @@ import (
 )
 
 type StateSummary struct {
-	LivePower   PowerPair
-	ActivePower PowerPair
-	FaultyPower PowerPair
+	LivePower     PowerPair
+	ActivePower   PowerPair
+	FaultyPower   PowerPair
+	SealProofType abi.RegisteredSealProof
 }
 
 // Checks internal invariants of init state.
@@ -99,9 +100,10 @@ func CheckStateInvariants(st *State, store adt.Store, balance abi.TokenAmount) (
 	}
 
 	return &StateSummary{
-		LivePower:   livePower,
-		ActivePower: activePower,
-		FaultyPower: faultyPower,
+		LivePower:     livePower,
+		ActivePower:   activePower,
+		FaultyPower:   faultyPower,
+		SealProofType: info.SealProofType,
 	}, acc, nil
 }
 

--- a/actors/builtin/power/power_state.go
+++ b/actors/builtin/power/power_state.go
@@ -45,7 +45,7 @@ type State struct {
 	MinerAboveMinPowerCount int64
 
 	// A queue of events to be triggered by cron, indexed by epoch.
-	CronEventQueue cid.Cid // Multimap, (HAMT[ChainEpoch]AMT[CronEvent]
+	CronEventQueue cid.Cid // Multimap, (HAMT[ChainEpoch]AMT[CronEvent])
 
 	// First epoch in which a cron task may be stored.
 	// Cron will iterate every epoch between this and the current epoch inclusively to find tasks to execute.
@@ -54,7 +54,7 @@ type State struct {
 	// Claimed power for each miner.
 	Claims cid.Cid // Map, HAMT[address]Claim
 
-	ProofValidationBatch *cid.Cid // HAMT[Address]AMT[SealVerifyInfo]
+	ProofValidationBatch *cid.Cid // Multimap, (HAMT[Address]AMT[SealVerifyInfo])
 }
 
 type Claim struct {

--- a/actors/builtin/power/testing.go
+++ b/actors/builtin/power/testing.go
@@ -1,0 +1,201 @@
+package power
+
+import (
+	"bytes"
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
+	"github.com/filecoin-project/specs-actors/v2/actors/builtin/miner"
+	"github.com/filecoin-project/specs-actors/v2/actors/util/adt"
+)
+
+type CronEventsByAddress map[address.Address][]miner.CronEventPayload
+type ClaimsByAddress map[address.Address]Claim
+
+type StateSummary struct {
+	Crons  CronEventsByAddress
+	Claims ClaimsByAddress
+}
+
+/*
+TotalRawBytePower abi.StoragePower
+// TotalBytesCommitted includes claims from miners below min power threshold
+TotalBytesCommitted  abi.StoragePower
+TotalQualityAdjPower abi.StoragePower
+// TotalQABytesCommitted includes claims from miners below min power threshold
+TotalQABytesCommitted abi.StoragePower
+TotalPledgeCollateral abi.TokenAmount
+
+// These fields are set once per epoch in the previous cron tick and used
+// for consistent values across a single epoch's state transition.
+ThisEpochRawBytePower     abi.StoragePower
+ThisEpochQualityAdjPower  abi.StoragePower
+ThisEpochPledgeCollateral abi.TokenAmount
+ThisEpochQAPowerSmoothed  smoothing.FilterEstimate
+
+MinerCount int64
+// Number of miners having proven the minimum consensus power.
+MinerAboveMinPowerCount int64
+
+// A queue of events to be triggered by cron, indexed by epoch.
+CronEventQueue cid.Cid // Multimap, (HAMT[ChainEpoch]AMT[CronEvent])
+
+// First epoch in which a cron task may be stored.
+// Cron will iterate every epoch between this and the current epoch inclusively to find tasks to execute.
+FirstCronEpoch abi.ChainEpoch
+
+// Claimed power for each miner.
+Claims cid.Cid // Map, HAMT[address]Claim
+
+ProofValidationBatch *cid.Cid // Multimap, (HAMT[Address]AMT[SealVerifyInfo])
+*/
+
+// Checks internal invariants of power state.
+func CheckStateInvariants(st *State, store adt.Store) (*StateSummary, *builtin.MessageAccumulator, error) {
+	acc := &builtin.MessageAccumulator{}
+
+	// basic invariants around recorded power
+	acc.Require(st.TotalRawBytePower.GreaterThanEqual(big.Zero()), "total raw power is negative %v", st.TotalRawBytePower)
+	acc.Require(st.TotalQualityAdjPower.GreaterThanEqual(big.Zero()), "total qa power is negative %v", st.TotalQualityAdjPower)
+	acc.Require(st.TotalBytesCommitted.GreaterThanEqual(big.Zero()), "total raw power committed is negative %v", st.TotalBytesCommitted)
+	acc.Require(st.TotalQABytesCommitted.GreaterThanEqual(big.Zero()), "total qa power committed is negative %v", st.TotalQABytesCommitted)
+	acc.Require(st.TotalRawBytePower.GreaterThanEqual(big.Zero()), "total raw power is negative %v", st.TotalRawBytePower)
+	acc.Require(st.TotalRawBytePower.LessThanEqual(st.TotalQualityAdjPower),
+		"total raw power %v is greater than total quality adjusted power %v", st.TotalRawBytePower, st.TotalQualityAdjPower)
+	acc.Require(st.TotalBytesCommitted.LessThanEqual(st.TotalQABytesCommitted),
+		"committed raw power %v is greater than committed quality adjusted power %v", st.TotalBytesCommitted, st.TotalQABytesCommitted)
+	acc.Require(st.TotalRawBytePower.LessThanEqual(st.TotalBytesCommitted),
+		"total raw power %v is greater than raw power committed %v", st.TotalRawBytePower, st.TotalBytesCommitted)
+	acc.Require(st.TotalQualityAdjPower.LessThanEqual(st.TotalQABytesCommitted),
+		"total qua power %v is greater than qa power committed %v", st.TotalQualityAdjPower, st.TotalQABytesCommitted)
+
+	crons, msgs, err := CheckCronInvariants(st, store)
+	acc.AddAll(msgs)
+	if err != nil {
+		return nil, acc, err
+	}
+
+	claims, msgs, err := CheckClaimInvariants(st, store)
+
+	return &StateSummary{
+		Crons:  crons,
+		Claims: claims,
+	}, acc, nil
+}
+
+func CheckCronInvariants(st *State, store adt.Store) (CronEventsByAddress, *builtin.MessageAccumulator, error) {
+	acc := &builtin.MessageAccumulator{}
+
+	queue, err := adt.AsMultimap(store, st.CronEventQueue)
+	if err != nil {
+		return nil, acc, err
+	}
+
+	byAddress := make(CronEventsByAddress)
+	err = queue.ForAll(func(ekey string, arr *adt.Array) error {
+		epoch, err := abi.ParseIntKey(ekey)
+		acc.Require(err == nil, "non-int key in cron array")
+		if err != nil {
+			return nil // error noted above
+		}
+
+		acc.Require(abi.ChainEpoch(epoch) >= st.FirstCronEpoch, "cron event at epoch %d before FirstCronEpoch %d",
+			epoch, st.FirstCronEpoch)
+
+		var event CronEvent
+		return arr.ForEach(&event, func(i int64) error {
+
+			var payload miner.CronEventPayload
+			err := payload.UnmarshalCBOR(bytes.NewReader(event.CallbackPayload))
+			acc.Require(err == nil, "error unmarshalling miner cron event payload (might not be miner.CronEventPayload): %v", err)
+			if err != nil {
+				return nil // error noted above
+			}
+
+			existingPayloads, found := byAddress[event.MinerAddr]
+			if found && payload.EventType == miner.CronEventProvingDeadline {
+				for _, p := range existingPayloads {
+					acc.Require(p.EventType != miner.CronEventProvingDeadline, "found duplicate miner proving cron for miner %v", event.MinerAddr)
+				}
+			}
+			byAddress[event.MinerAddr] = append(existingPayloads, payload)
+
+			return nil
+		})
+	})
+	acc.Require(err != nil, "error attempting to read through power actor cron tasks: %v", err)
+
+	return byAddress, acc, nil
+}
+
+func CheckClaimInvariants(st *State, store adt.Store) (ClaimsByAddress, *builtin.MessageAccumulator, error) {
+	acc := &builtin.MessageAccumulator{}
+
+	claims, err := adt.AsMap(store, st.Claims)
+	if err != nil {
+		return nil, acc, err
+	}
+
+	committedRawPower := abi.NewStoragePower(0)
+	committedQAPower := abi.NewStoragePower(0)
+	rawPower := abi.NewStoragePower(0)
+	qaPower := abi.NewStoragePower(0)
+	claimCount := int64(0)
+	claimsWithSufficientPowerCount := int64(0)
+	byAddress := make(ClaimsByAddress)
+	var claim Claim
+	err = claims.ForEach(&claim, func(key string) error {
+		addr, err := address.NewFromBytes([]byte(key))
+		if err != nil {
+			return err
+		}
+		byAddress[addr] = claim
+		claimCount += 1
+		committedRawPower = big.Add(committedRawPower, claim.RawBytePower)
+		committedQAPower = big.Add(committedQAPower, claim.QualityAdjPower)
+
+		minPower, err := builtin.ConsensusMinerMinPower(claim.SealProofType)
+		acc.Require(err != nil, "could not get consensus miner min power for miner %v: %w", addr, err)
+		if err != nil {
+			return nil // noted above
+		}
+
+		if claim.RawBytePower.GreaterThanEqual(minPower) {
+			claimsWithSufficientPowerCount += 1
+			rawPower = big.Add(rawPower, claim.RawBytePower)
+			qaPower = big.Add(qaPower, claim.QualityAdjPower)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, acc, err
+	}
+
+	acc.Require(committedRawPower.Equals(st.TotalBytesCommitted),
+		"sum of raw power in claims %v does not match recorded bytes committed %v",
+		committedRawPower, st.TotalBytesCommitted)
+	acc.Require(committedQAPower.Equals(st.TotalQABytesCommitted),
+		"sum of qa power in claims %v does not match recorded qa power committed %v",
+		committedQAPower, st.TotalQABytesCommitted)
+
+	acc.Require(claimsWithSufficientPowerCount == st.MinerAboveMinPowerCount,
+		"claims with sufficient power %d does not match MinerAboveMinPowerCount %d",
+		claimsWithSufficientPowerCount, st.MinerAboveMinPowerCount)
+
+	if claimsWithSufficientPowerCount >= ConsensusMinerMinMiners {
+		acc.Require(st.TotalRawBytePower.Equals(rawPower),
+			"recorded raw power %v does not match raw power in claims %v", st.TotalRawBytePower, rawPower)
+		acc.Require(st.TotalQualityAdjPower.Equals(qaPower),
+			"recorded qa power %v does not match qa power in claims %v", st.TotalQualityAdjPower, qaPower)
+	} else {
+		acc.Require(st.TotalRawBytePower.Equals(st.TotalBytesCommitted),
+			"below consensus min recorded raw power %v does not match committed bytes %v",
+			st.TotalRawBytePower, st.TotalBytesCommitted)
+		acc.Require(st.TotalQualityAdjPower.Equals(st.TotalQABytesCommitted),
+			"below consensus min recorded qa power %v does not match qa committed bytes %v",
+			st.TotalQualityAdjPower, st.TotalQABytesCommitted)
+	}
+
+	return byAddress, acc, nil
+}

--- a/actors/builtin/power/testing.go
+++ b/actors/builtin/power/testing.go
@@ -125,7 +125,7 @@ func CheckCronInvariants(st *State, store adt.Store, acc *builtin.MessageAccumul
 			return nil
 		})
 	})
-	acc.Require(err != nil, "error attempting to read through power actor cron tasks: %v", err)
+	acc.Require(err == nil, "error attempting to read through power actor cron tasks: %v", err)
 
 	return byAddress, nil
 }
@@ -153,7 +153,7 @@ func CheckClaimInvariants(st *State, store adt.Store, acc *builtin.MessageAccumu
 		committedQAPower = big.Add(committedQAPower, claim.QualityAdjPower)
 
 		minPower, err := builtin.ConsensusMinerMinPower(claim.SealProofType)
-		acc.Require(err != nil, "could not get consensus miner min power for miner %v: %v", addr, err)
+		acc.Require(err == nil, "could not get consensus miner min power for miner %v: %v", addr, err)
 		if err != nil {
 			return nil // noted above
 		}
@@ -180,19 +180,10 @@ func CheckClaimInvariants(st *State, store adt.Store, acc *builtin.MessageAccumu
 		"claims with sufficient power %d does not match MinerAboveMinPowerCount %d",
 		claimsWithSufficientPowerCount, st.MinerAboveMinPowerCount)
 
-	if claimsWithSufficientPowerCount >= ConsensusMinerMinMiners {
-		acc.Require(st.TotalRawBytePower.Equals(rawPower),
-			"recorded raw power %v does not match raw power in claims %v", st.TotalRawBytePower, rawPower)
-		acc.Require(st.TotalQualityAdjPower.Equals(qaPower),
-			"recorded qa power %v does not match qa power in claims %v", st.TotalQualityAdjPower, qaPower)
-	} else {
-		acc.Require(st.TotalRawBytePower.Equals(st.TotalBytesCommitted),
-			"below consensus min recorded raw power %v does not match committed bytes %v",
-			st.TotalRawBytePower, st.TotalBytesCommitted)
-		acc.Require(st.TotalQualityAdjPower.Equals(st.TotalQABytesCommitted),
-			"below consensus min recorded qa power %v does not match qa committed bytes %v",
-			st.TotalQualityAdjPower, st.TotalQABytesCommitted)
-	}
+	acc.Require(st.TotalRawBytePower.Equals(rawPower),
+		"recorded raw power %v does not match raw power in claims %v", st.TotalRawBytePower, rawPower)
+	acc.Require(st.TotalQualityAdjPower.Equals(qaPower),
+		"recorded qa power %v does not match qa power in claims %v", st.TotalQualityAdjPower, qaPower)
 
 	return byAddress, nil
 }

--- a/actors/builtin/power/testing.go
+++ b/actors/builtin/power/testing.go
@@ -24,39 +24,6 @@ type StateSummary struct {
 	Proofs ProofsByAddress
 }
 
-/*
-TotalRawBytePower abi.StoragePower
-// TotalBytesCommitted includes claims from miners below min power threshold
-TotalBytesCommitted  abi.StoragePower
-TotalQualityAdjPower abi.StoragePower
-// TotalQABytesCommitted includes claims from miners below min power threshold
-TotalQABytesCommitted abi.StoragePower
-TotalPledgeCollateral abi.TokenAmount
-
-// These fields are set once per epoch in the previous cron tick and used
-// for consistent values across a single epoch's state transition.
-ThisEpochRawBytePower     abi.StoragePower
-ThisEpochQualityAdjPower  abi.StoragePower
-ThisEpochPledgeCollateral abi.TokenAmount
-ThisEpochQAPowerSmoothed  smoothing.FilterEstimate
-
-MinerCount int64
-// Number of miners having proven the minimum consensus power.
-MinerAboveMinPowerCount int64
-
-// A queue of events to be triggered by cron, indexed by epoch.
-CronEventQueue cid.Cid // Multimap, (HAMT[ChainEpoch]AMT[CronEvent])
-
-// First epoch in which a cron task may be stored.
-// Cron will iterate every epoch between this and the current epoch inclusively to find tasks to execute.
-FirstCronEpoch abi.ChainEpoch
-
-// Claimed power for each miner.
-Claims cid.Cid // Map, HAMT[address]Claim
-
-ProofValidationBatch *cid.Cid // Multimap, (HAMT[Address]AMT[SealVerifyInfo])
-*/
-
 // Checks internal invariants of power state.
 func CheckStateInvariants(st *State, store adt.Store) (*StateSummary, *builtin.MessageAccumulator, error) {
 	acc := &builtin.MessageAccumulator{}

--- a/actors/migration/power.go
+++ b/actors/migration/power.go
@@ -40,12 +40,12 @@ func (m powerMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, h
 		return nil, xerrors.Errorf("cron events: %w", err)
 	}
 
-	claimsRoot, err := m.updateClaims(ctx, store, inState.Claims, m.powerUpdates)
-	if err != nil {
+	// operates directly on inState
+	if err := m.updateClaims(ctx, store, inState.Claims, m.powerUpdates, &inState); err != nil {
 		return nil, xerrors.Errorf("claims: %w", err)
 	}
 
-	claimsRoot, err = m.migrateClaims(ctx, store, claimsRoot)
+	claimsRoot, err := m.migrateClaims(ctx, store, inState.Claims)
 	if err != nil {
 		return nil, xerrors.Errorf("claims: %w", err)
 	}
@@ -101,19 +101,33 @@ func (m *powerMigrator) migrateCronEvents(ctx context.Context, store cbor.IpldSt
 	return migrateHAMTRaw(ctx, store, root)
 }
 
-func (m *powerMigrator) updateClaims(ctx context.Context, store cbor.IpldStore, root cid.Cid, updates *PowerUpdates) (cid.Cid, error) {
+func (m *powerMigrator) updateClaims(ctx context.Context, store cbor.IpldStore, root cid.Cid, updates *PowerUpdates, st *power0.State) error {
 	claims, err := adt0.AsMap(adt0.WrapStore(ctx, store), root)
 	if err != nil {
-		return cid.Undef, err
+		return err
 	}
 
 	for addr, claim := range updates.claims { // nolint:nomaprange
-		if err := claims.Put(abi.AddrKey(addr), &claim); err != nil {
-			return cid.Undef, err
+		rawPower := claim.RawBytePower
+		qaPower := claim.QualityAdjPower
+
+		var oldClaim power0.Claim
+		found, err := claims.Get(abi.AddrKey(addr), &oldClaim)
+		if err != nil {
+			return nil
+		}
+
+		if found {
+			rawPower = big.Sub(rawPower, oldClaim.RawBytePower)
+			qaPower = big.Sub(qaPower, oldClaim.QualityAdjPower)
+		}
+
+		if err := st.AddToClaim(adt0.WrapStore(ctx, store), addr, rawPower, qaPower); err != nil {
+			return err
 		}
 	}
 
-	return claims.Root()
+	return nil
 }
 
 func (m *powerMigrator) migrateClaims(ctx context.Context, store cbor.IpldStore, root cid.Cid) (cid.Cid, error) {

--- a/actors/migration/test/correct_cc_upgrade_then_fault_scenario_test.go
+++ b/actors/migration/test/correct_cc_upgrade_then_fault_scenario_test.go
@@ -402,7 +402,12 @@ func TestMigrationCorrectsCCThenFaultIssue(t *testing.T) {
 	require.NoError(t, err)
 	acc, err = states.CheckStateInvariants(stateTree, totalBalance, v2.GetEpoch())
 	require.NoError(t, err)
-	assert.True(t, acc.IsEmpty(), strings.Join(acc.Messages(), "\n"))
+
+	// The v2 migration will not correctly update power totals. Expect 5 invariant violations all related to power
+	assert.Equal(t, 5, len(acc.Messages()))
+	for _, msg := range acc.Messages() {
+		assert.True(t, strings.Contains(msg, "t04 power:"))
+	}
 }
 
 func publishDeal(t *testing.T, v *vm0.VM, provider, dealClient, minerID addr.Address, dealLabel string,

--- a/actors/migration/test/correct_cc_upgrade_then_fault_scenario_test.go
+++ b/actors/migration/test/correct_cc_upgrade_then_fault_scenario_test.go
@@ -400,7 +400,7 @@ func TestMigrationCorrectsCCThenFaultIssue(t *testing.T) {
 	require.NoError(t, err)
 	totalBalance, err := v2.GetTotalActorBalance()
 	require.NoError(t, err)
-	acc, err = states.CheckStateInvariants(stateTree, totalBalance)
+	acc, err = states.CheckStateInvariants(stateTree, totalBalance, v2.GetEpoch())
 	require.NoError(t, err)
 	assert.True(t, acc.IsEmpty(), strings.Join(acc.Messages(), "\n"))
 }

--- a/actors/states/check.go
+++ b/actors/states/check.go
@@ -1,6 +1,7 @@
 package states
 
 import (
+	"bytes"
 	addr "github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
@@ -26,10 +27,10 @@ func CheckStateInvariants(tree *Tree, expectedBalanceTotal abi.TokenAmount, prio
 	var verifregSummary *verifreg.StateSummary
 	var marketSummary *market.StateSummary
 	var accountSummaries []*account.StateSummary
-	var minerSummaries []*miner.StateSummary
 	var powerSummary *power.StateSummary
 	var paychSummaries []*paych.StateSummary
 	var multisigSummaries []*multisig.StateSummary
+	minerSummaries := make(map[addr.Address]*miner.StateSummary)
 
 	if err := tree.ForEach(func(key addr.Address, actor *Actor) error {
 		acc := acc.WithPrefix("%v ", key) // Intentional shadow
@@ -95,7 +96,7 @@ func CheckStateInvariants(tree *Tree, expectedBalanceTotal abi.TokenAmount, prio
 				return err
 			} else {
 				acc.WithPrefix("miner: ").AddAll(msgs)
-				minerSummaries = append(minerSummaries, summary)
+				minerSummaries[key] = summary
 			}
 		case builtin.StorageMarketActorCodeID:
 			var st market.State
@@ -158,15 +159,55 @@ func CheckStateInvariants(tree *Tree, expectedBalanceTotal abi.TokenAmount, prio
 	//
 	// Perform cross-actor checks from state summaries here.
 	//
+
+	CheckMinersAgainstPower(acc, minerSummaries, powerSummary)
+
 	_ = initSummary
 	_ = verifregSummary
 	_ = cronSummary
 	_ = marketSummary
-	_ = powerSummary
 
 	if !totalFIl.Equals(expectedBalanceTotal) {
 		acc.Addf("total token balance is %v, expected %v", totalFIl, expectedBalanceTotal)
 	}
 
 	return acc, nil
+}
+
+func CheckMinersAgainstPower(acc *builtin.MessageAccumulator, minerSummaries map[addr.Address]*miner.StateSummary, powerSummary *power.StateSummary) {
+	for addr, minerSummary := range minerSummaries { // nolint:nomaprange
+
+		// check claim
+		claim, ok := powerSummary.Claims[addr]
+		acc.Require(ok, "miner %v has no power claim", addr)
+		if ok {
+			claimPower := miner.NewPowerPair(claim.RawBytePower, claim.QualityAdjPower)
+			acc.Require(minerSummary.ActivePower.Equals(claimPower),
+				"miner %v computed active power %v does not match claim %v", addr, minerSummary.ActivePower, claimPower)
+			acc.Require(minerSummary.SealProofType == claim.SealProofType,
+				"miner seal proof type %d does not match claim proof type %d", minerSummary.SealProofType, claim.SealProofType)
+		}
+
+		// check crons
+		crons, ok := powerSummary.Crons[addr]
+		if !ok {
+			continue
+		}
+
+		var payload miner.CronEventPayload
+		hasProvingPeriodCron := false
+		for _, event := range crons {
+			err := payload.UnmarshalCBOR(bytes.NewReader(event.Payload))
+			acc.Require(err == nil, "miner %v registered cron at epoch %d with wrong or corrupt payload",
+				addr, event.Epoch)
+
+			if payload.EventType == miner.CronEventProvingDeadline {
+				acc.Require(!hasProvingPeriodCron, "miner %v has duplicate proving period cron at epoch %d",
+					addr, event.Epoch)
+				hasProvingPeriodCron = true
+			}
+		}
+
+		acc.Require(hasProvingPeriodCron, "miner %v has no proving period cron", addr)
+	}
 }

--- a/actors/states/check.go
+++ b/actors/states/check.go
@@ -70,7 +70,7 @@ func CheckStateInvariants(tree *Tree, expectedBalanceTotal abi.TokenAmount, prio
 			if err := tree.Store.Get(tree.Store.Context(), actor.Head, &st); err != nil {
 				return err
 			}
-			if summary, msgs, err := account.CheckStateInvariants(&st, tree.Store); err != nil {
+			if summary, msgs, err := account.CheckStateInvariants(&st, key); err != nil {
 				return err
 			} else {
 				acc.WithPrefix("account: ").AddAll(msgs)

--- a/actors/test/commit_post_test.go
+++ b/actors/test/commit_post_test.go
@@ -253,7 +253,7 @@ func TestCommitPoStFlow(t *testing.T) {
 		require.NoError(t, err)
 		totalBalance, err := tv.GetTotalActorBalance()
 		require.NoError(t, err)
-		acc, err := states.CheckStateInvariants(stateTree, totalBalance)
+		acc, err := states.CheckStateInvariants(stateTree, totalBalance, tv.GetEpoch())
 		require.NoError(t, err)
 		assert.True(t, acc.IsEmpty(), strings.Join(acc.Messages(), "\n"))
 	})


### PR DESCRIPTION
work towards #1165 and #1166 

### Motivation

We would like to be able to check the internal consistency of the storage power actor's state. This PR adds `CheckStateInvariants` for power state and calls it for all unit tests that are not expected to fail. 

### Proposed Changes

1. Add `CheckStateInvariants`
2. Add test harness `checkState` and call it in all relevant unit tests.
3. Add a call to `CheckStateInvariants` to `states.CheckStateInvariants`.
4. Add `CheckMinersAgainstPower` to check cross actor state
5. Run `CheckStateInvariants` in scenario tests including correct_cc_upgrade migration test.
6. Fix issue with power migration where a miner's corrected claim would not update power state in a consistent way.
7. Change account invariant check to only require a public key if actor is non-singleton. (when I rebased in the inclusion of account to the main state check, it wasn't working in scenario tests without this fix).