### PR TITLE
migration fix to maintain state

### DIFF
--- a/actors/migration/power.go
+++ b/actors/migration/power.go
@@ -40,12 +40,12 @@ func (m *powerMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, 
 		return nil, xerrors.Errorf("cron events: %w", err)
 	}
 
-	claimsRoot, err := m.updateClaims(ctx, store, inState.Claims, m.powerUpdates)
-	if err != nil {
+	// operates directly on inState
+	if err := m.updateClaims(ctx, store, inState.Claims, m.powerUpdates, &inState); err != nil {
 		return nil, xerrors.Errorf("claims: %w", err)
 	}
 
-	claimsRoot, err = m.migrateClaims(ctx, store, claimsRoot)
+	claimsRoot, err := m.migrateClaims(ctx, store, inState.Claims)
 	if err != nil {
 		return nil, xerrors.Errorf("claims: %w", err)
 	}
@@ -101,19 +101,33 @@ func (m *powerMigrator) migrateCronEvents(ctx context.Context, store cbor.IpldSt
 	return migrateHAMTRaw(ctx, store, root)
 }
 
-func (m *powerMigrator) updateClaims(ctx context.Context, store cbor.IpldStore, root cid.Cid, updates *PowerUpdates) (cid.Cid, error) {
+func (m *powerMigrator) updateClaims(ctx context.Context, store cbor.IpldStore, root cid.Cid, updates *PowerUpdates, st *power0.State) error {
 	claims, err := adt0.AsMap(adt0.WrapStore(ctx, store), root)
 	if err != nil {
-		return cid.Undef, err
+		return err
 	}
 
 	for addr, claim := range updates.claims { // nolint:nomaprange
-		if err := claims.Put(abi.AddrKey(addr), &claim); err != nil {
-			return cid.Undef, err
+		rawPower := claim.RawBytePower
+		qaPower := claim.QualityAdjPower
+
+		var oldClaim power0.Claim
+		found, err := claims.Get(abi.AddrKey(addr), &oldClaim)
+		if err != nil {
+			return nil
+		}
+
+		if found {
+			rawPower = big.Sub(rawPower, oldClaim.RawBytePower)
+			qaPower = big.Sub(qaPower, oldClaim.QualityAdjPower)
+		}
+
+		if err := st.AddToClaim(adt0.WrapStore(ctx, store), addr, rawPower, qaPower); err != nil {
+			return err
 		}
 	}
 
-	return claims.Root()
+	return nil
 }
 
 func (m *powerMigrator) migrateClaims(ctx context.Context, store cbor.IpldStore, root cid.Cid) (cid.Cid, error) {

--- a/actors/migration/power.go
+++ b/actors/migration/power.go
@@ -120,10 +120,10 @@ func (m *powerMigrator) updateClaims(ctx context.Context, store cbor.IpldStore, 
 		if found {
 			rawPower = big.Sub(rawPower, oldClaim.RawBytePower)
 			qaPower = big.Sub(qaPower, oldClaim.QualityAdjPower)
-		}
 
-		if err := st.AddToClaim(adt0.WrapStore(ctx, store), addr, rawPower, qaPower); err != nil {
-			return err
+			if err := st.AddToClaim(adt0.WrapStore(ctx, store), addr, rawPower, qaPower); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
### Motivation

It's a bad idea to update the Claims HAMT without also updating power.State variables. This PR uses `AddToClaim` to ensure all state is kept up to date.