### PR TITLE
make migrations threadsafe

### DIFF
--- a/actors/migration/account.go
+++ b/actors/migration/account.go
@@ -14,7 +14,7 @@ import (
 type accountMigrator struct {
 }
 
-func (m *accountMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, head cid.Cid, _ MigrationInfo) (*StateMigrationResult, error) {
+func (m accountMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, head cid.Cid, _ MigrationInfo) (*StateMigrationResult, error) {
 	var inState account0.State
 	if err := store.Get(ctx, head, &inState); err != nil {
 		return nil, err

--- a/actors/migration/cron.go
+++ b/actors/migration/cron.go
@@ -14,7 +14,7 @@ import (
 type cronMigrator struct {
 }
 
-func (m *cronMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, head cid.Cid, _ MigrationInfo) (*StateMigrationResult, error) {
+func (m cronMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, head cid.Cid, _ MigrationInfo) (*StateMigrationResult, error) {
 	var inState cron0.State
 	if err := store.Get(ctx, head, &inState); err != nil {
 		return nil, err

--- a/actors/migration/init.go
+++ b/actors/migration/init.go
@@ -15,7 +15,7 @@ import (
 type initMigrator struct {
 }
 
-func (m *initMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, head cid.Cid, _ MigrationInfo) (*StateMigrationResult, error) {
+func (m initMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, head cid.Cid, _ MigrationInfo) (*StateMigrationResult, error) {
 	var inState init0.State
 	if err := store.Get(ctx, head, &inState); err != nil {
 		return nil, err

--- a/actors/migration/market.go
+++ b/actors/migration/market.go
@@ -15,7 +15,7 @@ import (
 type marketMigrator struct {
 }
 
-func (m *marketMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, head cid.Cid, _ MigrationInfo) (*StateMigrationResult, error) {
+func (m marketMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, head cid.Cid, _ MigrationInfo) (*StateMigrationResult, error) {
 	var inState market0.State
 	if err := store.Get(ctx, head, &inState); err != nil {
 		return nil, err

--- a/actors/migration/miner.go
+++ b/actors/migration/miner.go
@@ -18,7 +18,7 @@ import (
 type minerMigrator struct {
 }
 
-func (m *minerMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, head cid.Cid, info MigrationInfo) (*StateMigrationResult, error) {
+func (m minerMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, head cid.Cid, info MigrationInfo) (*StateMigrationResult, error) {
 	// first correct issues with miners due problems in old code
 	result, err := m.CorrectState(ctx, store, head, info.priorEpoch, info.address)
 	if err != nil {

--- a/actors/migration/multisig.go
+++ b/actors/migration/multisig.go
@@ -16,7 +16,7 @@ import (
 type multisigMigrator struct {
 }
 
-func (m *multisigMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, head cid.Cid, _ MigrationInfo) (*StateMigrationResult, error) {
+func (m multisigMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, head cid.Cid, _ MigrationInfo) (*StateMigrationResult, error) {
 	var inState multisig0.State
 	if err := store.Get(ctx, head, &inState); err != nil {
 		return nil, err

--- a/actors/migration/paych.go
+++ b/actors/migration/paych.go
@@ -16,7 +16,7 @@ import (
 type paychMigrator struct {
 }
 
-func (m *paychMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, head cid.Cid, _ MigrationInfo) (*StateMigrationResult, error) {
+func (m paychMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, head cid.Cid, _ MigrationInfo) (*StateMigrationResult, error) {
 	var inState paych0.State
 	if err := store.Get(ctx, head, &inState); err != nil {
 		return nil, err

--- a/actors/migration/power.go
+++ b/actors/migration/power.go
@@ -24,7 +24,7 @@ type powerMigrator struct {
 	powerUpdates *PowerUpdates
 }
 
-func (m *powerMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, head cid.Cid, info MigrationInfo) (*StateMigrationResult, error) {
+func (m powerMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, head cid.Cid, info MigrationInfo) (*StateMigrationResult, error) {
 	var inState power0.State
 	if err := store.Get(ctx, head, &inState); err != nil {
 		return nil, err

--- a/actors/migration/reward.go
+++ b/actors/migration/reward.go
@@ -40,7 +40,7 @@ type rewardMigrator struct {
 	actorsOut *states.Tree
 }
 
-func (m *rewardMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, head cid.Cid, migInfo MigrationInfo) (*StateMigrationResult, error) {
+func (m rewardMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, head cid.Cid, migInfo MigrationInfo) (*StateMigrationResult, error) {
 	var inState reward0.State
 	if err := store.Get(ctx, head, &inState); err != nil {
 		return nil, err

--- a/actors/migration/system.go
+++ b/actors/migration/system.go
@@ -14,7 +14,7 @@ import (
 type systemMigrator struct {
 }
 
-func (m *systemMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, head cid.Cid, _ MigrationInfo) (*StateMigrationResult, error) {
+func (m systemMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, head cid.Cid, _ MigrationInfo) (*StateMigrationResult, error) {
 	// No change
 	var _ = system2.State(system0.State{})
 	return &StateMigrationResult{

--- a/actors/migration/top.go
+++ b/actors/migration/top.go
@@ -101,47 +101,47 @@ func MigrateStateTree(ctx context.Context, store cbor.IpldStore, stateRootIn cid
 	var migrations = map[cid.Cid]ActorMigration{ // nolint:varcheck,deadcode,unused
 		builtin0.AccountActorCodeID: ActorMigration{
 			OutCodeCID:     builtin.AccountActorCodeID,
-			StateMigration: &accountMigrator{},
+			StateMigration: accountMigrator{},
 		},
 		builtin0.CronActorCodeID: ActorMigration{
 			OutCodeCID:     builtin.CronActorCodeID,
-			StateMigration: &cronMigrator{},
+			StateMigration: cronMigrator{},
 		},
 		builtin0.InitActorCodeID: ActorMigration{
 			OutCodeCID:     builtin.InitActorCodeID,
-			StateMigration: &initMigrator{},
+			StateMigration: initMigrator{},
 		},
 		builtin0.StorageMarketActorCodeID: ActorMigration{
 			OutCodeCID:     builtin.StorageMarketActorCodeID,
-			StateMigration: &marketMigrator{},
+			StateMigration: marketMigrator{},
 		},
 		builtin0.MultisigActorCodeID: ActorMigration{
 			OutCodeCID:     builtin.MultisigActorCodeID,
-			StateMigration: &multisigMigrator{},
+			StateMigration: multisigMigrator{},
 		},
 		builtin0.PaymentChannelActorCodeID: ActorMigration{
 			OutCodeCID:     builtin.PaymentChannelActorCodeID,
-			StateMigration: &paychMigrator{},
+			StateMigration: paychMigrator{},
 		},
 		builtin0.StoragePowerActorCodeID: ActorMigration{
 			OutCodeCID:     builtin.StoragePowerActorCodeID,
-			StateMigration: &powerMigrator{},
+			StateMigration: powerMigrator{},
 		},
 		builtin0.RewardActorCodeID: ActorMigration{
 			OutCodeCID:     builtin.RewardActorCodeID,
-			StateMigration: &rewardMigrator{},
+			StateMigration: rewardMigrator{},
 		},
 		builtin0.SystemActorCodeID: ActorMigration{
 			OutCodeCID:     builtin.SystemActorCodeID,
-			StateMigration: &systemMigrator{},
+			StateMigration: systemMigrator{},
 		},
 		builtin0.VerifiedRegistryActorCodeID: ActorMigration{
 			OutCodeCID:     builtin.VerifiedRegistryActorCodeID,
-			StateMigration: &verifregMigrator{},
+			StateMigration: verifregMigrator{},
 		},
 		builtin0.StorageMinerActorCodeID: ActorMigration{
 			OutCodeCID:     builtin.StorageMinerActorCodeID,
-			StateMigration: &minerMigrator{},
+			StateMigration: minerMigrator{},
 		},
 	}
 
@@ -241,7 +241,7 @@ func MigrateStateTree(ctx context.Context, store cbor.IpldStore, stateRootIn cid
 	}
 
 	// Migrate Power actor
-	pm := migrations[builtin0.StoragePowerActorCodeID].StateMigration.(*powerMigrator)
+	pm := migrations[builtin0.StoragePowerActorCodeID].StateMigration.(powerMigrator)
 	pm.actorsIn = actorsIn
 	pm.powerUpdates = powerUpdates
 	powerActorIn, found, err := actorsIn.GetActor(builtin0.StoragePowerActorAddr)
@@ -271,7 +271,7 @@ func MigrateStateTree(ctx context.Context, store cbor.IpldStore, stateRootIn cid
 	}
 
 	// Migrate reward actor
-	rm := migrations[builtin0.RewardActorCodeID].StateMigration.(*rewardMigrator)
+	rm := migrations[builtin0.RewardActorCodeID].StateMigration.(rewardMigrator)
 	rm.actorsOut = actorsOut
 	rewardActorIn, found, err := actorsIn.GetActor(builtin0.RewardActorAddr)
 	if err != nil {
@@ -300,7 +300,7 @@ func MigrateStateTree(ctx context.Context, store cbor.IpldStore, stateRootIn cid
 	}
 
 	// Migrate verified registry
-	vm := migrations[builtin0.VerifiedRegistryActorCodeID].StateMigration.(*verifregMigrator)
+	vm := migrations[builtin0.VerifiedRegistryActorCodeID].StateMigration.(verifregMigrator)
 	vm.actorsOut = actorsOut
 	verifRegActorIn, found, err := actorsIn.GetActor(builtin0.VerifiedRegistryActorAddr)
 	if err != nil {

--- a/actors/migration/verifreg.go
+++ b/actors/migration/verifreg.go
@@ -24,7 +24,7 @@ type verifregMigrator struct {
 	actorsOut *states.Tree
 }
 
-func (m *verifregMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, head cid.Cid, _ MigrationInfo) (*StateMigrationResult, error) {
+func (m verifregMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, head cid.Cid, _ MigrationInfo) (*StateMigrationResult, error) {
 	var inState verifreg0.State
 	if err := store.Get(ctx, head, &inState); err != nil {
 		return nil, err


### PR DESCRIPTION
Ideally, these would just be pure functions. But this, at least, forces a copy which prevents us from sharing state across invocations.