### PR TITLE
Feat/reward invariants

### DIFF
--- a/actors/builtin/reward/reward_logic_test.go
+++ b/actors/builtin/reward/reward_logic_test.go
@@ -151,3 +151,18 @@ func TestBaselineRewardGrowth(t *testing.T) {
 		assert.Less(t, perr, testCase.ErrBound)
 	}
 }
+
+func TestExpError(t *testing.T) {
+	// Multiplications linear in exponent
+	for j := 100; j < 10000; j += 100 {
+		acc1 := big.Lsh(big.NewInt(1), math.Precision128) // Q.128
+		for i := 0; i < j; i++ {
+			acc1 = big.Mul(BaselineExponent, acc1)  // Q.128 * Q.128 => Q.256
+			acc1 = big.Rsh(acc1, math.Precision128) // Q.256 => Q.128
+		}
+		// Multiplications log in exponent
+		acc2 := math.ExpBySquaring(BaselineExponent, int64(j))
+		fmt.Printf("%v\n", big.Sub(acc1, acc2))
+	}
+
+}

--- a/actors/builtin/reward/reward_logic_test.go
+++ b/actors/builtin/reward/reward_logic_test.go
@@ -151,18 +151,3 @@ func TestBaselineRewardGrowth(t *testing.T) {
 		assert.Less(t, perr, testCase.ErrBound)
 	}
 }
-
-func TestExpError(t *testing.T) {
-	// Multiplications linear in exponent
-	for j := 100; j < 10000; j += 100 {
-		acc1 := big.Lsh(big.NewInt(1), math.Precision128) // Q.128
-		for i := 0; i < j; i++ {
-			acc1 = big.Mul(BaselineExponent, acc1)  // Q.128 * Q.128 => Q.256
-			acc1 = big.Rsh(acc1, math.Precision128) // Q.256 => Q.128
-		}
-		// Multiplications log in exponent
-		acc2 := math.ExpBySquaring(BaselineExponent, int64(j))
-		fmt.Printf("%v\n", big.Sub(acc1, acc2))
-	}
-
-}

--- a/actors/builtin/reward/testing.go
+++ b/actors/builtin/reward/testing.go
@@ -1,0 +1,32 @@
+package reward
+
+import (
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
+	"github.com/filecoin-project/specs-actors/v2/actors/util/math"
+	"github.com/filecoin-project/specs-actors/v2/actors/util/adt"
+)
+
+type StateSummary struct{}
+
+var FIL = big.NewInt(1e18)
+var StorageMiningAllocationCheck = big.Mul(big.NewInt(1_100_000_000), FIL)
+
+func CheckStateInvariants(st *State, store adt.Store, priorEpoch abi.ChainEpoch, balance abi.TokenAmount) (*StateSummary, *builtin.MessageAccumulator, error) {
+	acc := &builtin.MessageAccumulator{}
+
+	acc.Require(big.Add(st.TotalStoragePowerReward, balance).Equals(StorageMiningAllocationCheck), "reward given + reward left != storage mining allocation")
+
+	acc.Require(st.Epoch == priorEpoch, "reward state epoch %d does not match priorEpoch %d", st.Epoch, priorEpoch)
+	acc.Require(st.EffectiveNetworkTime <= st.Epoch, "effective network time greater than state epoch")
+
+	acc.Require(st.CumsumRealized.LessThanEqual(st.CumsumBaseline), "cumsum realized > cumsum baseline")
+	acc.Require(st.CumsumRealized.GreaterThanEqual(big.Zero()), "cumsum realized < 0")
+	acc.Require(st.EffectiveBaselinePower.LessThanEqual(st.ThisEpochBaselinePower), "effective baseline power > baseline power")
+
+	computedBaseline := math.ExpBySquaring(BaselineExponent, int64(st.Epoch))
+	acc.Require(st.ThisEpochBaselinePower.Equals(computedBaseline), "state baseline power does not match computed")
+
+	return &StateSummary{}, acc, nil
+}

--- a/actors/builtin/reward/testing.go
+++ b/actors/builtin/reward/testing.go
@@ -1,6 +1,7 @@
 package reward
 
 import (
+	"fmt"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
@@ -18,7 +19,7 @@ func CheckStateInvariants(st *State, store adt.Store, priorEpoch abi.ChainEpoch,
 
 	acc.Require(big.Add(st.TotalStoragePowerReward, balance).Equals(StorageMiningAllocationCheck), "reward given %v + reward left %v != storage mining allocation %v", st.TotalStoragePowerReward, balance, StorageMiningAllocationCheck)
 
-	acc.Require(st.Epoch == priorEpoch, "reward state epoch %d does not match priorEpoch %d", st.Epoch, priorEpoch)
+	acc.Require(st.Epoch == priorEpoch+1, "reward state epoch %d does not match priorEpoch+1 %d", st.Epoch, priorEpoch+1)
 	acc.Require(st.EffectiveNetworkTime <= st.Epoch, "effective network time greater than state epoch")
 
 	acc.Require(st.CumsumRealized.LessThanEqual(st.CumsumBaseline), "cumsum realized > cumsum baseline")
@@ -28,6 +29,24 @@ func CheckStateInvariants(st *State, store adt.Store, priorEpoch abi.ChainEpoch,
 	computedBaseline := big.Mul(BaselineInitialValue, math.ExpBySquaring(BaselineExponent, int64(st.Epoch)))
 	computedBaseline = big.Rsh(computedBaseline, math.Precision128)
 	acc.Require(st.ThisEpochBaselinePower.Equals(computedBaseline), "state baseline power %v does not match computed %v", st.ThisEpochBaselinePower, computedBaseline)
+
+	fmt.Printf(`{
+		"CumsumBaseline": %v,
+		"CumsumRealized": %v,
+		"EffectiveBaselinePower": %v,
+		"EffectiveNetworkTime": %d,
+		"Epoch": %d,
+		"ThisEpochBaselinePower": %v,
+		"ThisEpochReward": %v,
+		"ThisEpochRewardSmoothed": {
+		  "PositionEstimate": %v,
+		  "VelocityEstimate": %v
+		},
+		"TotalMined": %v
+	}
+	`, st.CumsumBaseline, st.CumsumRealized, st.EffectiveBaselinePower, st.EffectiveNetworkTime,
+	st.Epoch, st.ThisEpochBaselinePower, st.ThisEpochReward, st.ThisEpochRewardSmoothed.PositionEstimate,
+	st.ThisEpochRewardSmoothed.VelocityEstimate, st.TotalStoragePowerReward)
 
 	return &StateSummary{}, acc, nil
 }

--- a/actors/builtin/reward/testing.go
+++ b/actors/builtin/reward/testing.go
@@ -1,11 +1,9 @@
 package reward
 
 import (
-	"fmt"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
-	"github.com/filecoin-project/specs-actors/v2/actors/util/math"
 	"github.com/filecoin-project/specs-actors/v2/actors/util/adt"
 )
 
@@ -17,7 +15,8 @@ var StorageMiningAllocationCheck = big.Mul(big.NewInt(1_100_000_000), FIL)
 func CheckStateInvariants(st *State, store adt.Store, priorEpoch abi.ChainEpoch, balance abi.TokenAmount) (*StateSummary, *builtin.MessageAccumulator, error) {
 	acc := &builtin.MessageAccumulator{}
 
-	acc.Require(big.Add(st.TotalStoragePowerReward, balance).Equals(StorageMiningAllocationCheck), "reward given %v + reward left %v != storage mining allocation %v", st.TotalStoragePowerReward, balance, StorageMiningAllocationCheck)
+	// Can't assert equality because anyone can send funds to reward actor (and already have on mainnet)
+	acc.Require(big.Add(st.TotalStoragePowerReward, balance).GreaterThanEqual(StorageMiningAllocationCheck), "reward given %v + reward left %v < storage mining allocation %v", st.TotalStoragePowerReward, balance, StorageMiningAllocationCheck)
 
 	acc.Require(st.Epoch == priorEpoch+1, "reward state epoch %d does not match priorEpoch+1 %d", st.Epoch, priorEpoch+1)
 	acc.Require(st.EffectiveNetworkTime <= st.Epoch, "effective network time greater than state epoch")
@@ -25,28 +24,6 @@ func CheckStateInvariants(st *State, store adt.Store, priorEpoch abi.ChainEpoch,
 	acc.Require(st.CumsumRealized.LessThanEqual(st.CumsumBaseline), "cumsum realized > cumsum baseline")
 	acc.Require(st.CumsumRealized.GreaterThanEqual(big.Zero()), "cumsum realized < 0")
 	acc.Require(st.EffectiveBaselinePower.LessThanEqual(st.ThisEpochBaselinePower), "effective baseline power > baseline power")
-
-	computedBaseline := big.Mul(BaselineInitialValue, math.ExpBySquaring(BaselineExponent, int64(st.Epoch)))
-	computedBaseline = big.Rsh(computedBaseline, math.Precision128)
-	acc.Require(st.ThisEpochBaselinePower.Equals(computedBaseline), "state baseline power %v does not match computed %v", st.ThisEpochBaselinePower, computedBaseline)
-
-	fmt.Printf(`{
-		"CumsumBaseline": %v,
-		"CumsumRealized": %v,
-		"EffectiveBaselinePower": %v,
-		"EffectiveNetworkTime": %d,
-		"Epoch": %d,
-		"ThisEpochBaselinePower": %v,
-		"ThisEpochReward": %v,
-		"ThisEpochRewardSmoothed": {
-		  "PositionEstimate": %v,
-		  "VelocityEstimate": %v
-		},
-		"TotalMined": %v
-	}
-	`, st.CumsumBaseline, st.CumsumRealized, st.EffectiveBaselinePower, st.EffectiveNetworkTime,
-	st.Epoch, st.ThisEpochBaselinePower, st.ThisEpochReward, st.ThisEpochRewardSmoothed.PositionEstimate,
-	st.ThisEpochRewardSmoothed.VelocityEstimate, st.TotalStoragePowerReward)
 
 	return &StateSummary{}, acc, nil
 }

--- a/actors/test/commit_post_test.go
+++ b/actors/test/commit_post_test.go
@@ -2,9 +2,10 @@ package test_test
 
 import (
 	"context"
-	"github.com/filecoin-project/specs-actors/v2/actors/states"
 	"strings"
 	"testing"
+
+	"github.com/filecoin-project/specs-actors/v2/actors/states"
 
 	"github.com/filecoin-project/go-bitfield"
 	"github.com/filecoin-project/go-state-types/abi"
@@ -248,6 +249,9 @@ func TestCommitPoStFlow(t *testing.T) {
 		networkStats := vm.GetNetworkStats(t, tv)
 		assert.Equal(t, big.NewInt(int64(sectorSize)), networkStats.TotalBytesCommitted)
 		assert.True(t, networkStats.TotalPledgeCollateral.GreaterThan(big.Zero()))
+
+		// Trigger cron to keep reward accounting correct
+		vm.ApplyOk(t, tv, builtin.SystemActorAddr, builtin.CronActorAddr, big.Zero(), builtin.MethodsCron.EpochTick, nil)
 
 		stateTree, err := tv.GetStateTree()
 		require.NoError(t, err)

--- a/support/vm/testing.go
+++ b/support/vm/testing.go
@@ -74,7 +74,7 @@ func NewVMWithSingletons(ctx context.Context, t *testing.T) *VM {
 	initializeActor(ctx, t, vm, initState, builtin.InitActorCodeID, builtin.InitActorAddr, big.Zero())
 
 	rewardState := reward.ConstructState(abi.NewStoragePower(0))
-	initializeActor(ctx, t, vm, rewardState, builtin.RewardActorCodeID, builtin.RewardActorAddr, big.Max(big.NewInt(14e8), FIL))
+	initializeActor(ctx, t, vm, rewardState, builtin.RewardActorCodeID, builtin.RewardActorAddr, reward.StorageMiningAllocationCheck)
 
 	cronState := cron.ConstructState(cron.BuiltInEntries())
 	initializeActor(ctx, t, vm, cronState, builtin.CronActorCodeID, builtin.CronActorAddr, big.Zero())


### PR DESCRIPTION
Adding a few simple reward actor invariants

@zixuanzh @davidad let me know if any of these are not actually invariants.  Also if you have other invariants that should hold over the reward actor's state fields please let me know and I will add them.  The more obscure and paranoid the better.  Also efficiency isn't a big concern since these checks should never be running on the critical path.  One specific question @acruikshank and I have been wondering about since we started looking at power actor state: are there any useful invariants we can check between the latest value of the alpha beta filter and the latest observation?