### PR TITLE
Make miner state checks robust to errors.

### DIFF
--- a/actors/builtin/miner/deadline_state_test.go
+++ b/actors/builtin/miner/deadline_state_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin/miner"
 	"github.com/filecoin-project/specs-actors/v2/actors/util/adt"
 	"github.com/filecoin-project/specs-actors/v2/support/ipld"
@@ -976,8 +977,8 @@ func checkDeadlineInvariants(
 	allTerminations bitfield.BitField,
 	allUnproven bitfield.BitField,
 ) {
-	summary, msgs, err := miner.CheckDeadlineStateInvariants(dl, store, quant, ssize, sectorsAsMap(sectors))
-	require.NoError(t, err)
+	msgs := &builtin.MessageAccumulator{}
+	summary := miner.CheckDeadlineStateInvariants(dl, store, quant, ssize, sectorsAsMap(sectors), msgs)
 	assert.True(t, msgs.IsEmpty(), strings.Join(msgs.Messages(), "\n"))
 
 	allSectors = summary.AllSectors

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -1499,7 +1499,15 @@ func TestCCUpgrade(t *testing.T) {
 		actor.onDeadlineCron(rt, &cronConfig{
 			expectedEnrollment: rt.Epoch() + miner.WPoStChallengeWindow,
 		})
-		actor.checkState(rt)
+
+		//actor.checkState(rt)
+		// ExtendSectorExpiration fails to update the deadline expiration queue.
+		st = getState(rt)
+		_, msgs := miner.CheckStateInvariants(st, rt.AdtStore(), rt.Balance())
+		assert.Equal(t, 2, len(msgs.Messages()), strings.Join(msgs.Messages(), "\n"))
+		for _, msg := range msgs.Messages() {
+			assert.True(t, strings.Contains(msg, "at epoch 725919"))
+		}
 	})
 
 	t.Run("fault and recover a replaced sector", func(t *testing.T) {
@@ -2636,7 +2644,15 @@ func TestExtendSectorExpiration(t *testing.T) {
 		rt.ExpectAbortContainsMessage(exitcode.ErrIllegalArgument, "total sector lifetime", func() {
 			actor.extendSectors(rt, params)
 		})
-		actor.checkState(rt)
+
+		// actor.checkState(rt)
+		// ExtendSectorExpiration fails to update the deadline expiration queue.
+		st = getState(rt)
+		_, msgs := miner.CheckStateInvariants(st, rt.AdtStore(), rt.Balance())
+		assert.Equal(t, 2, len(msgs.Messages()), strings.Join(msgs.Messages(), "\n"))
+		for _, msg := range msgs.Messages() {
+			assert.True(t, strings.Contains(msg, "at epoch 5213079"))
+		}
 	})
 
 	t.Run("updates expiration with valid params", func(t *testing.T) {
@@ -2680,7 +2696,15 @@ func TestExtendSectorExpiration(t *testing.T) {
 		empty, err = expirationSet.IsEmpty()
 		require.NoError(t, err)
 		assert.False(t, empty)
-		actor.checkState(rt)
+
+		//actor.checkState(rt)
+		// ExtendSectorExpiration fails to update the deadline expiration queue.
+		st = getState(rt)
+		_, msgs := miner.CheckStateInvariants(st, rt.AdtStore(), rt.Balance())
+		assert.Equal(t, 2, len(msgs.Messages()), strings.Join(msgs.Messages(), "\n"))
+		for _, msg := range msgs.Messages() {
+			assert.True(t, strings.Contains(msg, "at epoch 668439"))
+		}
 	})
 
 	t.Run("updates many sectors", func(t *testing.T) {
@@ -2768,7 +2792,18 @@ func TestExtendSectorExpiration(t *testing.T) {
 			}))
 			assert.EqualValues(t, sectorCount/2, extendedTotal)
 		}
-		actor.checkState(rt)
+
+		//actor.checkState(rt)
+		// ExtendSectorExpiration fails to update the deadline expiration queue.
+		st := getState(rt)
+		_, msgs := miner.CheckStateInvariants(st, rt.AdtStore(), rt.Balance())
+		assert.Equal(t, 4, len(msgs.Messages()), strings.Join(msgs.Messages(), "\n"))
+		for _, msg := range msgs.Messages()[:2] {
+			assert.True(t, strings.Contains(msg, "at epoch 668439")) // deadline 2
+		}
+		for _, msg := range msgs.Messages()[2:] {
+			assert.True(t, strings.Contains(msg, "at epoch 668499")) // deadline 3
+		}
 	})
 
 	t.Run("supports extensions off deadline boundary", func(t *testing.T) {

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -139,8 +139,7 @@ func TestConstruction(t *testing.T) {
 
 		assertEmptyBitfield(t, st.EarlyTerminations)
 
-		_, msgs, err := miner.CheckStateInvariants(&st, rt.AdtStore(), rt.Balance())
-		require.NoError(t, err)
+		_, msgs := miner.CheckStateInvariants(&st, rt.AdtStore(), rt.Balance())
 		assert.True(t, msgs.IsEmpty(), strings.Join(msgs.Messages(), "\n"))
 	})
 
@@ -4330,8 +4329,7 @@ func (h *actorHarness) getLockedFunds(rt *mock.Runtime) abi.TokenAmount {
 
 func (h *actorHarness) checkState(rt *mock.Runtime) {
 	st := getState(rt)
-	_, msgs, err := miner.CheckStateInvariants(st, rt.AdtStore(), rt.Balance())
-	assert.NoError(h.t, err)
+	_, msgs := miner.CheckStateInvariants(st, rt.AdtStore(), rt.Balance())
 	assert.True(h.t, msgs.IsEmpty(), strings.Join(msgs.Messages(), "\n"))
 }
 

--- a/actors/builtin/miner/partition_state_test.go
+++ b/actors/builtin/miner/partition_state_test.go
@@ -894,9 +894,9 @@ func assertPartitionState(t *testing.T,
 	assertBitfieldsEqual(t, unproven, partition.Unproven)
 	assertBitfieldsEqual(t, allSectorIds, partition.Sectors)
 
-	_, acc, err := miner.CheckPartitionStateInvariants(partition, store, quant, sectorSize, sectorsAsMap(sectors))
-	require.NoError(t, err)
-	assert.True(t, acc.IsEmpty(), strings.Join(acc.Messages(), "\n"))
+	msgs := &builtin.MessageAccumulator{}
+	_ = miner.CheckPartitionStateInvariants(partition, store, quant, sectorSize, sectorsAsMap(sectors), msgs)
+	assert.True(t, msgs.IsEmpty(), strings.Join(msgs.Messages(), "\n"))
 }
 
 func bf(secNos ...uint64) bitfield.BitField {

--- a/actors/builtin/testing.go
+++ b/actors/builtin/testing.go
@@ -63,6 +63,14 @@ func (ma *MessageAccumulator) Require(predicate bool, msg string, args ...interf
 	}
 }
 
+func (ma *MessageAccumulator) RequireNoError(err error, msg string, args ...interface{}) {
+	if err != nil {
+		msg = msg + ": %v"
+		args = append(args, err)
+		ma.Addf(msg, args...)
+	}
+}
+
 func (ma *MessageAccumulator) initialize() {
 	if ma.msgs == nil {
 		ma.msgs = &[]string{}

--- a/actors/states/check.go
+++ b/actors/states/check.go
@@ -19,6 +19,9 @@ import (
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin/verifreg"
 )
 
+// Within this code, Go errors are not expected, but are often converted to messages so that execution
+// can continue to find more errors rather than fail with no insight.
+// Only errors thar are particularly troublesome to recover from should propagate as Go errors.
 func CheckStateInvariants(tree *Tree, expectedBalanceTotal abi.TokenAmount, priorEpoch abi.ChainEpoch) (*builtin.MessageAccumulator, error) {
 	acc := &builtin.MessageAccumulator{}
 	totalFIl := big.Zero()
@@ -92,12 +95,9 @@ func CheckStateInvariants(tree *Tree, expectedBalanceTotal abi.TokenAmount, prio
 			if err := tree.Store.Get(tree.Store.Context(), actor.Head, &st); err != nil {
 				return err
 			}
-			if summary, msgs, err := miner.CheckStateInvariants(&st, tree.Store, actor.Balance); err != nil {
-				return err
-			} else {
-				acc.WithPrefix("miner: ").AddAll(msgs)
-				minerSummaries[key] = summary
-			}
+			summary, msgs := miner.CheckStateInvariants(&st, tree.Store, actor.Balance)
+			acc.WithPrefix("miner: ").AddAll(msgs)
+			minerSummaries[key] = summary
 		case builtin.StorageMarketActorCodeID:
 			var st market.State
 			if err := tree.Store.Get(tree.Store.Context(), actor.Head, &st); err != nil {


### PR DESCRIPTION
State validation checks are typically used in tests or by manual operation on network state. If there's an error because some part of state is unreadable (e.g. corrupted bitfield or HAMT node), then we want to know this but don't want it to prevent getting any other information about unrelated state. So treating these errors in the standard Go way by propagating them immediately isn't so helpful.

This change re-arranges the miner state checks to avoid returning errors at all. Errors from low-level functions are translated into messages and, in a few cases, dependent checks are skipped. Part of #1244.

If we like it, we should propagate this pattern to all the other state checks.

While doing this, I discovered that the checks for deadline and partition expiration queue consistency were ineffective because the expiration epochs weren't propagated from partitions. This revealed that ExtendSectorExpiration has a bug, failing to update the deadline-level expiration queue (#1243). I've carved out that specific message as expected in the relevant tests.