### PR TITLE
add miner/market cross check

### DIFF
--- a/actors/builtin/market/testing.go
+++ b/actors/builtin/market/testing.go
@@ -15,7 +15,7 @@ import (
 	"github.com/filecoin-project/specs-actors/v2/actors/util/adt"
 )
 
-type DealStats struct {
+type DealSummary struct {
 	Provider         address.Address
 	StartEpoch       abi.ChainEpoch
 	EndEpoch         abi.ChainEpoch
@@ -25,7 +25,7 @@ type DealStats struct {
 }
 
 type StateSummary struct {
-	Deals                map[abi.DealID]*DealStats
+	Deals                map[abi.DealID]*DealSummary
 	PendingProposalCount uint64
 	DealStateCount       uint64
 	LockTableCount       uint64
@@ -55,7 +55,7 @@ func CheckStateInvariants(st *State, store adt.Store, balance abi.TokenAmount, c
 
 	proposalCids := make(map[cid.Cid]struct{})
 	maxDealID := int64(-1)
-	proposalStats := make(map[abi.DealID]*DealStats)
+	proposalStats := make(map[abi.DealID]*DealSummary)
 	expectedDealOps := make(map[abi.DealID]struct{})
 
 	proposals, err := adt.AsArray(store, st.Proposals)
@@ -79,7 +79,7 @@ func CheckStateInvariants(st *State, store adt.Store, balance abi.TokenAmount, c
 		if dealID > maxDealID {
 			maxDealID = dealID
 		}
-		proposalStats[abi.DealID(dealID)] = &DealStats{
+		proposalStats[abi.DealID(dealID)] = &DealSummary{
 			Provider:         proposal.Provider,
 			StartEpoch:       proposal.StartEpoch,
 			EndEpoch:         proposal.EndEpoch,
@@ -232,7 +232,7 @@ func CheckStateInvariants(st *State, store adt.Store, balance abi.TokenAmount, c
 		return nil, acc, err
 	}
 	acc.Require(escrowTotal.LessThanEqual(balance), "escrow total, %v, greater than actor balance, %v", escrowTotal, balance)
-	acc.Require(escrowTotal.GreaterThanEqual(totalProposalCollateral), "escrow total, %v, lset than sum of proposal collateral, %v", escrowTotal, totalProposalCollateral)
+	acc.Require(escrowTotal.GreaterThanEqual(totalProposalCollateral), "escrow total, %v, less than sum of proposal collateral, %v", escrowTotal, totalProposalCollateral)
 
 	//
 	// Deal Ops by Epoch

--- a/actors/states/check.go
+++ b/actors/states/check.go
@@ -233,9 +233,7 @@ func CheckDealStatesAgainstSectors(acc *builtin.MessageAccumulator, minerSummari
 
 		sectorDeal, found := minerSummary.Deals[dealID]
 		if !found {
-			if deal.SlashEpoch < 0 {
-				acc.Addf("un-slashed deal %d not referenced in active sectors of miner %v", dealID, deal.Provider)
-			}
+			acc.Require(deal.SlashEpoch >= 0, "un-slashed deal %d not referenced in active sectors of miner %v", dealID, deal.Provider)
 			continue
 		}
 

--- a/actors/states/check.go
+++ b/actors/states/check.go
@@ -232,8 +232,10 @@ func CheckDealStatesAgainstSectors(acc *builtin.MessageAccumulator, minerSummari
 		}
 
 		sectorDeal, found := minerSummary.Deals[dealID]
-		if deal.SlashEpoch < 0 && !found {
-			acc.Addf("un-slashed deal %d not referenced in active sectors of miner %v", dealID, deal.Provider)
+		if !found {
+			if deal.SlashEpoch < 0 {
+				acc.Addf("un-slashed deal %d not referenced in active sectors of miner %v", dealID, deal.Provider)
+			}
 			continue
 		}
 


### PR DESCRIPTION
work towards #1166

**This PR only affects tests.**

### Motivation

We have many consistency checks for miner state and many checks for market state. We would like to add checks that miner and market state are consistent between each other. This PR adds checks that activated deals are referenced within a sector being proving by the deal provider, and that the deal state times line up with those of the sector.

### Proposed Changes

1. Add summary info for deal states in `MarketSummary`
2. Add deal info for sectors in `MinerSummary`
3. Implement `CheckDealStatesAgainstSectors` to check consistency between the above.