### PR TITLE
Vest a portion of block reward immediately (FIP-0004)

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -1507,7 +1507,7 @@ func (a Actor) ApplyRewards(rt Runtime, params *builtin.ApplyRewardParams) *abi.
 		unlockedBalance, err := st.GetUnlockedBalance(rt.CurrentBalance())
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to calculate unlocked balance")
 		if unlockedBalance.LessThan(rewardToLock) {
-			rt.Abortf(exitcode.ErrInsufficientFunds, "insufficient funds to lock, available: %v, requested: %v", unlockedBalance, params.Reward)
+			rt.Abortf(exitcode.ErrInsufficientFunds, "insufficient funds to lock, available: %v, requested: %v", unlockedBalance, rewardToLock)
 		}
 
 		newlyVested, err := st.AddLockedFunds(store, rt.CurrEpoch(), rewardToLock, lockedRewardVestingSpec)

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -1492,12 +1492,7 @@ func (a Actor) ApplyRewards(rt Runtime, params *builtin.ApplyRewardParams) *abi.
 		store := adt.AsStore(rt)
 		rt.ValidateImmediateCallerIs(builtin.RewardActorAddr)
 
-		rewardToLock := params.Reward
-		lockedRewardVestingSpec := &RewardVestingSpec
-		if nv >= network.Version6 {
-			// rewardToLock is 75% of params.Reward
-			rewardToLock = LockedRewardFromRewardV6(params.Reward)
-		}
+		rewardToLock, lockedRewardVestingSpec := LockedRewardFromReward(params.Reward, nv)
 
 		// This ensures the miner has sufficient funds to lock up amountToLock.
 		// This should always be true if reward actor sends reward funds with the message.

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -1493,13 +1493,10 @@ func (a Actor) ApplyRewards(rt Runtime, params *builtin.ApplyRewardParams) *abi.
 		rt.ValidateImmediateCallerIs(builtin.RewardActorAddr)
 
 		rewardToLock := params.Reward
-		lockedRewardVestingSpec := &RewardVestingSpecV5
+		lockedRewardVestingSpec := &RewardVestingSpec
 		if nv >= network.Version6 {
 			// rewardToLock is 75% of params.Reward
 			rewardToLock = LockedRewardFromRewardV6(params.Reward)
-
-			// vesting spec adds back in delay
-			lockedRewardVestingSpec = &RewardVestingSpecV6
 		}
 
 		// This ensures the miner has sufficient funds to lock up amountToLock.

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -3072,11 +3072,12 @@ func TestRepayDebts(t *testing.T) {
 		rt := builder.Build(t)
 		actor.constructAndVerify(rt)
 
-		amountToLock := big.Mul(big.NewInt(3), big.NewInt(1e18))
-		rt.SetBalance(amountToLock)
-		rt.SetNetworkVersion(network.Version5)
-		actor.applyRewards(rt, amountToLock, big.Zero())
-		rt.SetNetworkVersion(network.VersionMax)
+		rewardAmount := big.Mul(big.NewInt(4), big.NewInt(1e18))
+		amountLocked := miner.LockedRewardFromRewardV6(rewardAmount)
+		rt.SetBalance(amountLocked)
+		actor.applyRewards(rt, rewardAmount, big.Zero())
+		require.Equal(t, amountLocked, actor.getLockedFunds(rt))
+
 		// introduce fee debt
 		st := getState(rt)
 		feeDebt := big.Mul(big.NewInt(4), big.NewInt(1e18))
@@ -3086,7 +3087,7 @@ func TestRepayDebts(t *testing.T) {
 		// send 1 FIL and repay all debt from vesting funds and balance
 		actor.repayDebt(rt,
 			big.NewInt(1e18), // send 1 FIL
-			amountToLock,     // 3 FIL comes from vesting funds
+			amountLocked,     // 3 FIL comes from vesting funds
 			big.NewInt(1e18)) // 1 FIL sent from balance
 
 		st = getState(rt)

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -3923,20 +3923,20 @@ func TestApplyRewards(t *testing.T) {
 		require.Len(t, vestingFunds.Funds, 180)
 
 		// Vested FIL pays out on epochs with expected offset
-		quantSpecV6 := miner.NewQuantSpec(miner.RewardVestingSpecV6.Quantization, periodOffset)
+		quantSpecV6 := miner.NewQuantSpec(miner.RewardVestingSpec.Quantization, periodOffset)
 
 		currEpoch := rt.Epoch()
 		for i := range vestingFunds.Funds {
-			step := miner.RewardVestingSpecV6.InitialDelay + abi.ChainEpoch(i+1)*miner.RewardVestingSpecV6.StepDuration
+			step := miner.RewardVestingSpec.InitialDelay + abi.ChainEpoch(i+1)*miner.RewardVestingSpec.StepDuration
 			expectedEpoch := quantSpecV6.QuantizeUp(currEpoch + step)
 			vf := vestingFunds.Funds[i]
 			assert.Equal(t, expectedEpoch, vf.Epoch)
 		}
 
-		expectedOffset := periodOffset % miner.RewardVestingSpecV6.Quantization
+		expectedOffset := periodOffset % miner.RewardVestingSpec.Quantization
 		for i := range vestingFunds.Funds {
 			vf := vestingFunds.Funds[i]
-			require.EqualValues(t, expectedOffset, int64(vf.Epoch)%int64(miner.RewardVestingSpecV6.Quantization))
+			require.EqualValues(t, expectedOffset, int64(vf.Epoch)%int64(miner.RewardVestingSpec.Quantization))
 		}
 
 		lockedAmt := miner.LockedRewardFromRewardV6(amt)

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -3074,8 +3074,9 @@ func TestRepayDebts(t *testing.T) {
 
 		amountToLock := big.Mul(big.NewInt(3), big.NewInt(1e18))
 		rt.SetBalance(amountToLock)
+		rt.SetNetworkVersion(network.Version5)
 		actor.applyRewards(rt, amountToLock, big.Zero())
-
+		rt.SetNetworkVersion(network.VersionMax)
 		// introduce fee debt
 		st := getState(rt)
 		feeDebt := big.Mul(big.NewInt(4), big.NewInt(1e18))
@@ -3921,11 +3922,11 @@ func TestApplyRewards(t *testing.T) {
 		require.Len(t, vestingFunds.Funds, 180)
 
 		// Vested FIL pays out on epochs with expected offset
-		expectedOffset := periodOffset % miner.RewardVestingSpec.Quantization
+		expectedOffset := periodOffset % miner.RewardVestingSpecV5.Quantization
 
 		for i := range vestingFunds.Funds {
 			vf := vestingFunds.Funds[i]
-			require.EqualValues(t, expectedOffset, int64(vf.Epoch)%int64(miner.RewardVestingSpec.Quantization))
+			require.EqualValues(t, expectedOffset, int64(vf.Epoch)%int64(miner.RewardVestingSpecV5.Quantization))
 		}
 
 		assert.Equal(t, amt, st.LockedFunds)

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -3922,8 +3922,17 @@ func TestApplyRewards(t *testing.T) {
 		require.Len(t, vestingFunds.Funds, 180)
 
 		// Vested FIL pays out on epochs with expected offset
-		expectedOffset := periodOffset % miner.RewardVestingSpecV6.Quantization
+		quantSpecV6 := miner.NewQuantSpec(miner.RewardVestingSpecV6.Quantization, periodOffset)
 
+		currEpoch := rt.Epoch()
+		for i := range vestingFunds.Funds {
+			step := miner.RewardVestingSpecV6.InitialDelay + abi.ChainEpoch(i+1)*miner.RewardVestingSpecV6.StepDuration
+			expectedEpoch := quantSpecV6.QuantizeUp(currEpoch + step)
+			vf := vestingFunds.Funds[i]
+			assert.Equal(t, expectedEpoch, vf.Epoch)
+		}
+
+		expectedOffset := periodOffset % miner.RewardVestingSpecV6.Quantization
 		for i := range vestingFunds.Funds {
 			vf := vestingFunds.Funds[i]
 			require.EqualValues(t, expectedOffset, int64(vf.Epoch)%int64(miner.RewardVestingSpecV6.Quantization))

--- a/actors/builtin/miner/monies.go
+++ b/actors/builtin/miner/monies.go
@@ -55,6 +55,10 @@ const TerminationLifetimeCap = 140 // PARAM_SPEC
 // Multiplier of whole per-winner rewards for a consensus fault penalty.
 const ConsensusFaultFactor = 5
 
+// Fraction of total reward (block reward + gas reward) to be locked up as of V6
+var LockedRewardFactorNumV6 = big.NewInt(75)
+var LockedRewardFactorDenomV6 = big.NewInt(100)
+
 // The projected block reward a sector would earn over some period.
 // Also known as "BR(t)".
 // BR(t) = ProjectedRewardFraction(t) * SectorQualityAdjustedPower
@@ -168,4 +172,8 @@ func ConsensusFaultPenalty(thisEpochReward abi.TokenAmount) abi.TokenAmount {
 		big.Mul(thisEpochReward, big.NewInt(ConsensusFaultFactor)),
 		big.NewInt(builtin.ExpectedLeadersPerEpoch),
 	)
+}
+
+func LockedRewardFromRewardV6(reward abi.TokenAmount) abi.TokenAmount {
+	return big.Div(big.Mul(reward, LockedRewardFactorNumV6), LockedRewardFactorDenomV6)
 }

--- a/actors/builtin/miner/monies.go
+++ b/actors/builtin/miner/monies.go
@@ -4,6 +4,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/exitcode"
+	"github.com/filecoin-project/go-state-types/network"
 
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
 	"github.com/filecoin-project/specs-actors/v2/actors/util/math"
@@ -174,6 +175,13 @@ func ConsensusFaultPenalty(thisEpochReward abi.TokenAmount) abi.TokenAmount {
 	)
 }
 
-func LockedRewardFromRewardV6(reward abi.TokenAmount) abi.TokenAmount {
-	return big.Div(big.Mul(reward, LockedRewardFactorNumV6), LockedRewardFactorDenomV6)
+// Returns the amount of a reward to vest, and the vesting schedule, for a reward amount.
+func LockedRewardFromReward(reward abi.TokenAmount, nv network.Version) (abi.TokenAmount, *VestSpec) {
+	lockAmount := reward
+	spec := &RewardVestingSpec
+	if nv >= network.Version6 {
+		// Locked amount is 75% of award.
+		lockAmount = big.Div(big.Mul(reward, LockedRewardFactorNumV6), LockedRewardFactorDenomV6)
+	}
+	return lockAmount, spec
 }

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -230,9 +230,19 @@ type VestSpec struct {
 	Quantization abi.ChainEpoch // Maximum precision of vesting table (limits cardinality of table).
 }
 
-// The vesting schedule for block rewards earned by a block producer.
-var RewardVestingSpec = VestSpec{ // PARAM_SPEC
+// The vesting schedule for total rewards (block reward + gas reward) earned
+//  by a block producer up to and including network version 5
+var RewardVestingSpecV5 = VestSpec{ // PARAM_SPEC
 	InitialDelay: abi.ChainEpoch(0),
+	VestPeriod:   abi.ChainEpoch(180 * builtin.EpochsInDay),
+	StepDuration: abi.ChainEpoch(1 * builtin.EpochsInDay),
+	Quantization: 12 * builtin.EpochsInHour,
+}
+
+// The vesting schedule for locked total rewards earned by a block producer
+// as of network version 6
+var RewardVestingSpecV6 = VestSpec{ // PARAM_SPEC
+	InitialDelay: ChainFinality,
 	VestPeriod:   abi.ChainEpoch(180 * builtin.EpochsInDay),
 	StepDuration: abi.ChainEpoch(1 * builtin.EpochsInDay),
 	Quantization: 12 * builtin.EpochsInHour,

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -230,19 +230,9 @@ type VestSpec struct {
 	Quantization abi.ChainEpoch // Maximum precision of vesting table (limits cardinality of table).
 }
 
-// The vesting schedule for total rewards (block reward + gas reward) earned
-//  by a block producer up to and including network version 5
-var RewardVestingSpecV5 = VestSpec{ // PARAM_SPEC
+// The vesting schedule for total rewards (block reward + gas reward) earned by a block producer.
+var RewardVestingSpec = VestSpec{ // PARAM_SPEC
 	InitialDelay: abi.ChainEpoch(0),
-	VestPeriod:   abi.ChainEpoch(180 * builtin.EpochsInDay),
-	StepDuration: abi.ChainEpoch(1 * builtin.EpochsInDay),
-	Quantization: 12 * builtin.EpochsInHour,
-}
-
-// The vesting schedule for locked total rewards earned by a block producer
-// as of network version 6
-var RewardVestingSpecV6 = VestSpec{ // PARAM_SPEC
-	InitialDelay: ChainFinality,
 	VestPeriod:   abi.ChainEpoch(180 * builtin.EpochsInDay),
 	StepDuration: abi.ChainEpoch(1 * builtin.EpochsInDay),
 	Quantization: 12 * builtin.EpochsInHour,

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/filecoin-project/go-bitfield v0.2.0
 	github.com/filecoin-project/go-hamt-ipld v0.1.5
 	github.com/filecoin-project/go-hamt-ipld/v2 v2.0.0
-	github.com/filecoin-project/go-state-types v0.0.0-20201003010437-c33112184a2b
+	github.com/filecoin-project/go-state-types v0.0.0-20201013222834-41ea465f274f
 	github.com/filecoin-project/specs-actors v0.9.12
 	github.com/ipfs/go-block-format v0.0.2
 	github.com/ipfs/go-cid v0.0.7

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/filecoin-project/go-hamt-ipld/v2 v2.0.0 h1:b3UDemBYN2HNfk3KOXNuxgTTxl
 github.com/filecoin-project/go-hamt-ipld/v2 v2.0.0/go.mod h1:7aWZdaQ1b16BVoQUYR+eEvrDCGJoPLxFpDynFjYfBjI=
 github.com/filecoin-project/go-state-types v0.0.0-20200928172055-2df22083d8ab h1:cEDC5Ei8UuT99hPWhCjA72SM9AuRtnpvdSTIYbnzN8I=
 github.com/filecoin-project/go-state-types v0.0.0-20200928172055-2df22083d8ab/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
-github.com/filecoin-project/go-state-types v0.0.0-20201003010437-c33112184a2b h1:bMUfG6Sy6YSMbsjQAO1Q2vEZldbSdsbRy/FX3OlTck0=
-github.com/filecoin-project/go-state-types v0.0.0-20201003010437-c33112184a2b/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
+github.com/filecoin-project/go-state-types v0.0.0-20201013222834-41ea465f274f h1:TZDTu4MtBKSFLXWGKLy+cvC3nHfMFIrVgWLAz/+GgZQ=
+github.com/filecoin-project/go-state-types v0.0.0-20201013222834-41ea465f274f/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
 github.com/filecoin-project/specs-actors v0.9.12 h1:iIvk58tuMtmloFNHhAOQHG+4Gci6Lui0n7DYQGi3cJk=
 github.com/filecoin-project/specs-actors v0.9.12/go.mod h1:TS1AW/7LbG+615j4NsjMK1qlpAwaFsG9w0V2tg2gSao=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=


### PR DESCRIPTION
- [x] Code should be correct
- [x] Unrelated test failures caused by those tests using applyRewards as a test state setup helper are now fixed.
- [x] Reward tests updated to test new behavior
- [x] Reward test exercising rewards in both versions to catch any unexpected balance table assumptions about not having consistent vesting specs applied.
- [x] Land #1251 and rebase on master
- [ ] Update PR title when FIP is published if the number changes