### PR TITLE
Multisig Signer cannot remove self

### DIFF
--- a/actors/builtin/multisig/multisig_actor.go
+++ b/actors/builtin/multisig/multisig_actor.go
@@ -548,17 +548,8 @@ func executeTransactionIfApproved(rt runtime.Runtime, st State, txnID TxnID, txn
 			ptx, err := adt.AsMap(adt.AsStore(rt), st.PendingTxns)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load pending transactions")
 
-			// It is possible for the send to result in deleting the transaction (e.g. if a signer removes themself)
-			// which would cause Delete to fail. Check first to prevent that.
-			txnExists, err := ptx.Has(txnID)
-			if err != nil {
-				rt.Abortf(exitcode.ErrIllegalState, "failed to find transaction for cleanup: %v", err)
-			}
-
-			if txnExists {
-				if err := ptx.Delete(txnID); err != nil {
-					rt.Abortf(exitcode.ErrIllegalState, "failed to delete transaction for cleanup: %v", err)
-				}
+			if err := ptx.Delete(txnID); err != nil {
+				rt.Abortf(exitcode.ErrIllegalState, "failed to delete transaction for cleanup: %v", err)
 			}
 
 			st.PendingTxns, err = ptx.Root()

--- a/actors/builtin/multisig/multisig_actor.go
+++ b/actors/builtin/multisig/multisig_actor.go
@@ -558,9 +558,7 @@ func executeTransactionIfApproved(rt runtime.Runtime, st State, txnID TxnID, txn
 			// by the swapped/removed signer to go through without an illegal state error
 			if nv >= network.Version6 {
 				txnExists, err := ptx.Has(txnID)
-				if err != nil {
-					rt.Abortf(exitcode.ErrIllegalState, "failed to check existance of transaction for cleanup: %v", err)
-				}
+				builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to check existance of transaction %v for cleanup", txnID)
 				shouldDelete = txnExists
 			}
 

--- a/actors/builtin/multisig/multisig_actor.go
+++ b/actors/builtin/multisig/multisig_actor.go
@@ -548,8 +548,17 @@ func executeTransactionIfApproved(rt runtime.Runtime, st State, txnID TxnID, txn
 			ptx, err := adt.AsMap(adt.AsStore(rt), st.PendingTxns)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load pending transactions")
 
-			if err := ptx.Delete(txnID); err != nil {
-				rt.Abortf(exitcode.ErrIllegalState, "failed to delete transaction for cleanup: %v", err)
+			// It is possible for the send to result in deleting the transaction (e.g. if a signer removes themself)
+			// which would cause Delete to fail. Check first to prevent that.
+			txnExists, err := ptx.Has(txnID)
+			if err != nil {
+				rt.Abortf(exitcode.ErrIllegalState, "failed to find transaction for cleanup: %v", err)
+			}
+
+			if txnExists {
+				if err := ptx.Delete(txnID); err != nil {
+					rt.Abortf(exitcode.ErrIllegalState, "failed to delete transaction for cleanup: %v", err)
+				}
 			}
 
 			st.PendingTxns, err = ptx.Root()

--- a/actors/test/multisig_delete_self_test.go
+++ b/actors/test/multisig_delete_self_test.go
@@ -1,0 +1,57 @@
+package test
+
+import (
+	"bytes"
+	"context"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+
+	"github.com/filecoin-project/go-state-types/big"
+
+	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
+	init_ "github.com/filecoin-project/specs-actors/v2/actors/builtin/init"
+	"github.com/filecoin-project/specs-actors/v2/actors/builtin/multisig"
+	vm "github.com/filecoin-project/specs-actors/v2/support/vm"
+)
+
+func TestMultisigDeleteSelf(t *testing.T) {
+	ctx := context.Background()
+	v := vm.NewVMWithSingletons(ctx, t)
+	addrs := vm.CreateAccounts(ctx, t, v, 2, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
+
+	multisigParams := multisig.ConstructorParams{
+		Signers:               addrs,
+		NumApprovalsThreshold: 1,
+	}
+
+	paramBuf := new(bytes.Buffer)
+	err := multisigParams.MarshalCBOR(paramBuf)
+	require.NoError(t, err)
+
+	initParam := init_.ExecParams{
+		CodeCID:           builtin.MultisigActorCodeID,
+		ConstructorParams: paramBuf.Bytes(),
+	}
+	ret := vm.ApplyOk(t, v, addrs[0], builtin.InitActorAddr, big.Zero(), builtin.MethodsPower.CreateMiner, &initParam)
+	initRet := ret.(*init_.ExecReturn)
+	assert.NotNil(t, initRet)
+	multisigAddr := initRet.IDAddress
+
+	removeParams := multisig.RemoveSignerParams{
+		Signer:   addrs[0],
+		Decrease: false,
+	}
+
+	paramBuf = new(bytes.Buffer)
+	err = removeParams.MarshalCBOR(paramBuf)
+	require.NoError(t, err)
+
+	proposeRemoveSignerParams := multisig.ProposeParams{
+		To:     multisigAddr,
+		Value:  big.Zero(),
+		Method: builtin.MethodsMultisig.RemoveSigner,
+		Params: paramBuf.Bytes(),
+	}
+	vm.ApplyOk(t, v, addrs[0], multisigAddr, big.Zero(), builtin.MethodsMultisig.Propose, &proposeRemoveSignerParams)
+}

--- a/actors/test/multisig_delete_self_test.go
+++ b/actors/test/multisig_delete_self_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/exitcode"
+	"github.com/filecoin-project/go-state-types/network"
 
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
 	init_ "github.com/filecoin-project/specs-actors/v2/actors/builtin/init"
@@ -21,6 +22,8 @@ import (
 func TestV5MultisigDeleteSigner1Of2(t *testing.T) {
 	ctx := context.Background()
 	v := vm.NewVMWithSingletons(ctx, t)
+	v, err := v.WithNetworkVersion(network.Version5)
+	require.NoError(t, err)
 	addrs := vm.CreateAccounts(ctx, t, v, 2, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
 
 	multisigParams := multisig.ConstructorParams{
@@ -29,7 +32,7 @@ func TestV5MultisigDeleteSigner1Of2(t *testing.T) {
 	}
 
 	paramBuf := new(bytes.Buffer)
-	err := multisigParams.MarshalCBOR(paramBuf)
+	err = multisigParams.MarshalCBOR(paramBuf)
 	require.NoError(t, err)
 
 	initParam := init_.ExecParams{
@@ -66,6 +69,8 @@ func TestV5MultisigDeleteSigner1Of2(t *testing.T) {
 func TestV5MultisigDeleteSelf2Of3RemovedIsProposer(t *testing.T) {
 	ctx := context.Background()
 	v := vm.NewVMWithSingletons(ctx, t)
+	v, err := v.WithNetworkVersion(network.Version5)
+	require.NoError(t, err)
 	addrs := vm.CreateAccounts(ctx, t, v, 3, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
 
 	multisigParams := multisig.ConstructorParams{
@@ -74,7 +79,7 @@ func TestV5MultisigDeleteSelf2Of3RemovedIsProposer(t *testing.T) {
 	}
 
 	paramBuf := new(bytes.Buffer)
-	err := multisigParams.MarshalCBOR(paramBuf)
+	err = multisigParams.MarshalCBOR(paramBuf)
 	require.NoError(t, err)
 
 	initParam := init_.ExecParams{
@@ -117,6 +122,8 @@ func TestV5MultisigDeleteSelf2Of3RemovedIsProposer(t *testing.T) {
 func TestV5MultisigDeleteSelf2Of3RemovedIsApprover(t *testing.T) {
 	ctx := context.Background()
 	v := vm.NewVMWithSingletons(ctx, t)
+	v, err := v.WithNetworkVersion(network.Version5)
+	require.NoError(t, err)
 	addrs := vm.CreateAccounts(ctx, t, v, 3, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
 
 	multisigParams := multisig.ConstructorParams{
@@ -125,7 +132,7 @@ func TestV5MultisigDeleteSelf2Of3RemovedIsApprover(t *testing.T) {
 	}
 
 	paramBuf := new(bytes.Buffer)
-	err := multisigParams.MarshalCBOR(paramBuf)
+	err = multisigParams.MarshalCBOR(paramBuf)
 	require.NoError(t, err)
 
 	initParam := init_.ExecParams{
@@ -168,6 +175,8 @@ func TestV5MultisigDeleteSelf2Of3RemovedIsApprover(t *testing.T) {
 func TestV5MultisigDeleteSelf2Of2(t *testing.T) {
 	ctx := context.Background()
 	v := vm.NewVMWithSingletons(ctx, t)
+	v, err := v.WithNetworkVersion(network.Version5)
+	require.NoError(t, err)
 	addrs := vm.CreateAccounts(ctx, t, v, 2, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
 
 	multisigParams := multisig.ConstructorParams{
@@ -176,7 +185,7 @@ func TestV5MultisigDeleteSelf2Of2(t *testing.T) {
 	}
 
 	paramBuf := new(bytes.Buffer)
-	err := multisigParams.MarshalCBOR(paramBuf)
+	err = multisigParams.MarshalCBOR(paramBuf)
 	require.NoError(t, err)
 
 	initParam := init_.ExecParams{
@@ -217,6 +226,8 @@ func TestV5MultisigDeleteSelf2Of2(t *testing.T) {
 func TestV5MultisigSwapsSelf1Of2(t *testing.T) {
 	ctx := context.Background()
 	v := vm.NewVMWithSingletons(ctx, t)
+	v, err := v.WithNetworkVersion(network.Version5)
+	require.NoError(t, err)
 	addrs := vm.CreateAccounts(ctx, t, v, 3, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
 	alice := addrs[0]
 	bob := addrs[1]
@@ -228,7 +239,7 @@ func TestV5MultisigSwapsSelf1Of2(t *testing.T) {
 	}
 
 	paramBuf := new(bytes.Buffer)
-	err := multisigParams.MarshalCBOR(paramBuf)
+	err = multisigParams.MarshalCBOR(paramBuf)
 	require.NoError(t, err)
 
 	initParam := init_.ExecParams{
@@ -267,6 +278,8 @@ func TestV5MultisigSwapsSelf1Of2(t *testing.T) {
 func TestV5MultisigSwapsSelf2Of3(t *testing.T) {
 	ctx := context.Background()
 	v := vm.NewVMWithSingletons(ctx, t)
+	v, err := v.WithNetworkVersion(network.Version5)
+	require.NoError(t, err)
 	addrs := vm.CreateAccounts(ctx, t, v, 4, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
 	alice := addrs[0]
 	bob := addrs[1]
@@ -279,7 +292,7 @@ func TestV5MultisigSwapsSelf2Of3(t *testing.T) {
 	}
 
 	paramBuf := new(bytes.Buffer)
-	err := multisigParams.MarshalCBOR(paramBuf)
+	err = multisigParams.MarshalCBOR(paramBuf)
 	require.NoError(t, err)
 
 	initParam := init_.ExecParams{
@@ -338,5 +351,94 @@ func TestV5MultisigSwapsSelf2Of3(t *testing.T) {
 	// approve from swapped address goes ok
 	approveSwapSignerParams2 := multisig.TxnIDParams{ID: multisig.TxnID(1)}
 	vm.ApplyOk(t, v, dinesh, multisigAddr, big.Zero(), builtin.MethodsMultisig.Approve, &approveSwapSignerParams2)
+
+}
+
+func TestMultisigDeleteSigner1Of2(t *testing.T) {
+	ctx := context.Background()
+	v := vm.NewVMWithSingletons(ctx, t)
+	addrs := vm.CreateAccounts(ctx, t, v, 2, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
+
+	multisigParams := multisig.ConstructorParams{
+		Signers:               addrs,
+		NumApprovalsThreshold: 1,
+	}
+
+	paramBuf := new(bytes.Buffer)
+	err := multisigParams.MarshalCBOR(paramBuf)
+	require.NoError(t, err)
+
+	initParam := init_.ExecParams{
+		CodeCID:           builtin.MultisigActorCodeID,
+		ConstructorParams: paramBuf.Bytes(),
+	}
+	ret := vm.ApplyOk(t, v, addrs[0], builtin.InitActorAddr, big.Zero(), builtin.MethodsPower.CreateMiner, &initParam)
+	initRet := ret.(*init_.ExecReturn)
+	assert.NotNil(t, initRet)
+	multisigAddr := initRet.IDAddress
+
+	removeParams := multisig.RemoveSignerParams{
+		Signer:   addrs[0],
+		Decrease: false,
+	}
+
+	paramBuf = new(bytes.Buffer)
+	err = removeParams.MarshalCBOR(paramBuf)
+	require.NoError(t, err)
+
+	proposeRemoveSignerParams := multisig.ProposeParams{
+		To:     multisigAddr,
+		Value:  big.Zero(),
+		Method: builtin.MethodsMultisig.RemoveSigner,
+		Params: paramBuf.Bytes(),
+	}
+	// address 0 succeeds when trying to execute the transaction removing address 0
+	vm.ApplyOk(t, v, addrs[0], multisigAddr, big.Zero(), builtin.MethodsMultisig.Propose, &proposeRemoveSignerParams)
+}
+
+func TestMultisigSwapsSelf1Of2(t *testing.T) {
+	ctx := context.Background()
+	v := vm.NewVMWithSingletons(ctx, t)
+	addrs := vm.CreateAccounts(ctx, t, v, 3, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
+	alice := addrs[0]
+	bob := addrs[1]
+	chuck := addrs[2]
+
+	multisigParams := multisig.ConstructorParams{
+		Signers:               []address.Address{alice, bob},
+		NumApprovalsThreshold: 1,
+	}
+
+	paramBuf := new(bytes.Buffer)
+	err := multisigParams.MarshalCBOR(paramBuf)
+	require.NoError(t, err)
+
+	initParam := init_.ExecParams{
+		CodeCID:           builtin.MultisigActorCodeID,
+		ConstructorParams: paramBuf.Bytes(),
+	}
+	ret := vm.ApplyOk(t, v, addrs[0], builtin.InitActorAddr, big.Zero(), builtin.MethodsPower.CreateMiner, &initParam)
+	initRet := ret.(*init_.ExecReturn)
+	assert.NotNil(t, initRet)
+	multisigAddr := initRet.IDAddress
+
+	swapParams := multisig.SwapSignerParams{
+		From: alice,
+		To:   chuck,
+	}
+
+	paramBuf = new(bytes.Buffer)
+	err = swapParams.MarshalCBOR(paramBuf)
+	require.NoError(t, err)
+
+	proposeSwapSignerParams := multisig.ProposeParams{
+		To:     multisigAddr,
+		Value:  big.Zero(),
+		Method: builtin.MethodsMultisig.SwapSigner,
+		Params: paramBuf.Bytes(),
+	}
+
+	// alice succeeds when trying to execute the transaction swapping alice for chuck
+	vm.ApplyOk(t, v, alice, multisigAddr, big.Zero(), builtin.MethodsMultisig.Propose, &proposeSwapSignerParams)
 
 }

--- a/actors/test/multisig_delete_self_test.go
+++ b/actors/test/multisig_delete_self_test.go
@@ -3,11 +3,14 @@ package test
 import (
 	"bytes"
 	"context"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/exitcode"
 
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
 	init_ "github.com/filecoin-project/specs-actors/v2/actors/builtin/init"
@@ -15,7 +18,7 @@ import (
 	vm "github.com/filecoin-project/specs-actors/v2/support/vm"
 )
 
-func TestMultisigDeleteSelf(t *testing.T) {
+func TestV5MultisigDeleteSigner1Of2(t *testing.T) {
 	ctx := context.Background()
 	v := vm.NewVMWithSingletons(ctx, t)
 	addrs := vm.CreateAccounts(ctx, t, v, 2, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
@@ -53,5 +56,287 @@ func TestMultisigDeleteSelf(t *testing.T) {
 		Method: builtin.MethodsMultisig.RemoveSigner,
 		Params: paramBuf.Bytes(),
 	}
+	// address 0 fails when trying to execute the transaction removing address 0
+	_, code := v.ApplyMessage(addrs[0], multisigAddr, big.Zero(), builtin.MethodsMultisig.Propose, &proposeRemoveSignerParams)
+	assert.Equal(t, exitcode.ErrIllegalState, code)
+	// address 1 succeeds when trying to execute the transaction removing address 0
+	vm.ApplyOk(t, v, addrs[1], multisigAddr, big.Zero(), builtin.MethodsMultisig.Propose, &proposeRemoveSignerParams)
+}
+
+func TestV5MultisigDeleteSelf2Of3RemovedIsProposer(t *testing.T) {
+	ctx := context.Background()
+	v := vm.NewVMWithSingletons(ctx, t)
+	addrs := vm.CreateAccounts(ctx, t, v, 3, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
+
+	multisigParams := multisig.ConstructorParams{
+		Signers:               addrs,
+		NumApprovalsThreshold: 2,
+	}
+
+	paramBuf := new(bytes.Buffer)
+	err := multisigParams.MarshalCBOR(paramBuf)
+	require.NoError(t, err)
+
+	initParam := init_.ExecParams{
+		CodeCID:           builtin.MultisigActorCodeID,
+		ConstructorParams: paramBuf.Bytes(),
+	}
+	ret := vm.ApplyOk(t, v, addrs[0], builtin.InitActorAddr, big.Zero(), builtin.MethodsPower.CreateMiner, &initParam)
+	initRet := ret.(*init_.ExecReturn)
+	assert.NotNil(t, initRet)
+	multisigAddr := initRet.IDAddress
+
+	removeParams := multisig.RemoveSignerParams{
+		Signer:   addrs[0],
+		Decrease: false,
+	}
+
+	paramBuf = new(bytes.Buffer)
+	err = removeParams.MarshalCBOR(paramBuf)
+	require.NoError(t, err)
+
+	proposeRemoveSignerParams := multisig.ProposeParams{
+		To:     multisigAddr,
+		Value:  big.Zero(),
+		Method: builtin.MethodsMultisig.RemoveSigner,
+		Params: paramBuf.Bytes(),
+	}
+
+	// first proposal goes ok and should have txnid = 0
 	vm.ApplyOk(t, v, addrs[0], multisigAddr, big.Zero(), builtin.MethodsMultisig.Propose, &proposeRemoveSignerParams)
+	// approval goes through
+	approveRemoveSignerParams := multisig.TxnIDParams{ID: multisig.TxnID(0)}
+	vm.ApplyOk(t, v, addrs[1], multisigAddr, big.Zero(), builtin.MethodsMultisig.Approve, &approveRemoveSignerParams)
+
+	// txnid not found when third approval gets processed indicating that the transaction has gone through successfully
+	_, code := v.ApplyMessage(addrs[2], multisigAddr, big.Zero(), builtin.MethodsMultisig.Approve, &approveRemoveSignerParams)
+	assert.Equal(t, exitcode.ErrNotFound, code)
+
+}
+
+func TestV5MultisigDeleteSelf2Of3RemovedIsApprover(t *testing.T) {
+	ctx := context.Background()
+	v := vm.NewVMWithSingletons(ctx, t)
+	addrs := vm.CreateAccounts(ctx, t, v, 3, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
+
+	multisigParams := multisig.ConstructorParams{
+		Signers:               addrs,
+		NumApprovalsThreshold: 2,
+	}
+
+	paramBuf := new(bytes.Buffer)
+	err := multisigParams.MarshalCBOR(paramBuf)
+	require.NoError(t, err)
+
+	initParam := init_.ExecParams{
+		CodeCID:           builtin.MultisigActorCodeID,
+		ConstructorParams: paramBuf.Bytes(),
+	}
+	ret := vm.ApplyOk(t, v, addrs[0], builtin.InitActorAddr, big.Zero(), builtin.MethodsPower.CreateMiner, &initParam)
+	initRet := ret.(*init_.ExecReturn)
+	assert.NotNil(t, initRet)
+	multisigAddr := initRet.IDAddress
+
+	removeParams := multisig.RemoveSignerParams{
+		Signer:   addrs[0],
+		Decrease: false,
+	}
+
+	paramBuf = new(bytes.Buffer)
+	err = removeParams.MarshalCBOR(paramBuf)
+	require.NoError(t, err)
+
+	proposeRemoveSignerParams := multisig.ProposeParams{
+		To:     multisigAddr,
+		Value:  big.Zero(),
+		Method: builtin.MethodsMultisig.RemoveSigner,
+		Params: paramBuf.Bytes(),
+	}
+
+	// first proposal goes ok and should have txnid = 0
+	vm.ApplyOk(t, v, addrs[1], multisigAddr, big.Zero(), builtin.MethodsMultisig.Propose, &proposeRemoveSignerParams)
+	// approval goes through
+	approveRemoveSignerParams := multisig.TxnIDParams{ID: multisig.TxnID(0)}
+	vm.ApplyOk(t, v, addrs[0], multisigAddr, big.Zero(), builtin.MethodsMultisig.Approve, &approveRemoveSignerParams)
+
+	// txnid not found when third approval gets processed indicating that the transaction has gone through successfully
+	_, code := v.ApplyMessage(addrs[2], multisigAddr, big.Zero(), builtin.MethodsMultisig.Approve, &approveRemoveSignerParams)
+	assert.Equal(t, exitcode.ErrNotFound, code)
+
+}
+
+func TestV5MultisigDeleteSelf2Of2(t *testing.T) {
+	ctx := context.Background()
+	v := vm.NewVMWithSingletons(ctx, t)
+	addrs := vm.CreateAccounts(ctx, t, v, 2, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
+
+	multisigParams := multisig.ConstructorParams{
+		Signers:               addrs,
+		NumApprovalsThreshold: 2,
+	}
+
+	paramBuf := new(bytes.Buffer)
+	err := multisigParams.MarshalCBOR(paramBuf)
+	require.NoError(t, err)
+
+	initParam := init_.ExecParams{
+		CodeCID:           builtin.MultisigActorCodeID,
+		ConstructorParams: paramBuf.Bytes(),
+	}
+	ret := vm.ApplyOk(t, v, addrs[0], builtin.InitActorAddr, big.Zero(), builtin.MethodsPower.CreateMiner, &initParam)
+	initRet := ret.(*init_.ExecReturn)
+	assert.NotNil(t, initRet)
+	multisigAddr := initRet.IDAddress
+
+	removeParams := multisig.RemoveSignerParams{
+		Signer:   addrs[0],
+		Decrease: true,
+	}
+
+	paramBuf = new(bytes.Buffer)
+	err = removeParams.MarshalCBOR(paramBuf)
+	require.NoError(t, err)
+
+	// first proposal goes ok and should have txnid = 0
+	proposeRemoveSignerParams := multisig.ProposeParams{
+		To:     multisigAddr,
+		Value:  big.Zero(),
+		Method: builtin.MethodsMultisig.RemoveSigner,
+		Params: paramBuf.Bytes(),
+	}
+	vm.ApplyOk(t, v, addrs[0], multisigAddr, big.Zero(), builtin.MethodsMultisig.Propose, &proposeRemoveSignerParams)
+	// approval goes through
+	approveRemoveSignerParams := multisig.TxnIDParams{ID: multisig.TxnID(0)}
+	vm.ApplyOk(t, v, addrs[1], multisigAddr, big.Zero(), builtin.MethodsMultisig.Approve, &approveRemoveSignerParams)
+
+	// txnid not found when another approval gets processed indicating that the transaction has gone through successfully
+	_, code := v.ApplyMessage(addrs[1], multisigAddr, big.Zero(), builtin.MethodsMultisig.Approve, &approveRemoveSignerParams)
+	assert.Equal(t, exitcode.ErrNotFound, code)
+}
+
+func TestV5MultisigSwapsSelf1Of2(t *testing.T) {
+	ctx := context.Background()
+	v := vm.NewVMWithSingletons(ctx, t)
+	addrs := vm.CreateAccounts(ctx, t, v, 3, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
+	alice := addrs[0]
+	bob := addrs[1]
+	chuck := addrs[2]
+
+	multisigParams := multisig.ConstructorParams{
+		Signers:               []address.Address{alice, bob},
+		NumApprovalsThreshold: 1,
+	}
+
+	paramBuf := new(bytes.Buffer)
+	err := multisigParams.MarshalCBOR(paramBuf)
+	require.NoError(t, err)
+
+	initParam := init_.ExecParams{
+		CodeCID:           builtin.MultisigActorCodeID,
+		ConstructorParams: paramBuf.Bytes(),
+	}
+	ret := vm.ApplyOk(t, v, addrs[0], builtin.InitActorAddr, big.Zero(), builtin.MethodsPower.CreateMiner, &initParam)
+	initRet := ret.(*init_.ExecReturn)
+	assert.NotNil(t, initRet)
+	multisigAddr := initRet.IDAddress
+
+	swapParams := multisig.SwapSignerParams{
+		From: alice,
+		To:   chuck,
+	}
+
+	paramBuf = new(bytes.Buffer)
+	err = swapParams.MarshalCBOR(paramBuf)
+	require.NoError(t, err)
+
+	proposeSwapSignerParams := multisig.ProposeParams{
+		To:     multisigAddr,
+		Value:  big.Zero(),
+		Method: builtin.MethodsMultisig.SwapSigner,
+		Params: paramBuf.Bytes(),
+	}
+
+	// alice fails when trying to execute the transaction swapping alice for chuck
+	_, code := v.ApplyMessage(alice, multisigAddr, big.Zero(), builtin.MethodsMultisig.Propose, &proposeSwapSignerParams)
+	assert.Equal(t, exitcode.ErrIllegalState, code)
+	// bob succeeds when trying to execute the transaction swapping alice for chuck
+	vm.ApplyOk(t, v, bob, multisigAddr, big.Zero(), builtin.MethodsMultisig.Propose, &proposeSwapSignerParams)
+
+}
+
+func TestV5MultisigSwapsSelf2Of3(t *testing.T) {
+	ctx := context.Background()
+	v := vm.NewVMWithSingletons(ctx, t)
+	addrs := vm.CreateAccounts(ctx, t, v, 4, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
+	alice := addrs[0]
+	bob := addrs[1]
+	chuck := addrs[2]
+	dinesh := addrs[3]
+
+	multisigParams := multisig.ConstructorParams{
+		Signers:               []address.Address{alice, bob, chuck},
+		NumApprovalsThreshold: 2,
+	}
+
+	paramBuf := new(bytes.Buffer)
+	err := multisigParams.MarshalCBOR(paramBuf)
+	require.NoError(t, err)
+
+	initParam := init_.ExecParams{
+		CodeCID:           builtin.MultisigActorCodeID,
+		ConstructorParams: paramBuf.Bytes(),
+	}
+	ret := vm.ApplyOk(t, v, addrs[0], builtin.InitActorAddr, big.Zero(), builtin.MethodsPower.CreateMiner, &initParam)
+	initRet := ret.(*init_.ExecReturn)
+	assert.NotNil(t, initRet)
+	multisigAddr := initRet.IDAddress
+
+	// Case 1 swapped out is proposer (swap alice for dinesh, alice is removed)
+	swapParams := multisig.SwapSignerParams{
+		From: alice,
+		To:   dinesh,
+	}
+
+	paramBuf = new(bytes.Buffer)
+	err = swapParams.MarshalCBOR(paramBuf)
+	require.NoError(t, err)
+
+	proposeSwapSignerParams := multisig.ProposeParams{
+		To:     multisigAddr,
+		Value:  big.Zero(),
+		Method: builtin.MethodsMultisig.SwapSigner,
+		Params: paramBuf.Bytes(),
+	}
+
+	// proposal from swapped address goes ok and should have txnid = 0
+	vm.ApplyOk(t, v, alice, multisigAddr, big.Zero(), builtin.MethodsMultisig.Propose, &proposeSwapSignerParams)
+
+	// approval goes through
+	approveSwapSignerParams := multisig.TxnIDParams{ID: multisig.TxnID(0)}
+	vm.ApplyOk(t, v, bob, multisigAddr, big.Zero(), builtin.MethodsMultisig.Approve, &approveSwapSignerParams)
+
+	// Case 2 swapped out is approver (swap dinesh for alice, dinesh is removed)
+	swapParams2 := multisig.SwapSignerParams{
+		From: dinesh,
+		To:   alice,
+	}
+
+	paramBuf2 := new(bytes.Buffer)
+	err = swapParams2.MarshalCBOR(paramBuf2)
+	require.NoError(t, err)
+
+	proposeSwapSignerParams2 := multisig.ProposeParams{
+		To:     multisigAddr,
+		Value:  big.Zero(),
+		Method: builtin.MethodsMultisig.SwapSigner,
+		Params: paramBuf2.Bytes(),
+	}
+
+	// proposal from regular address goes ok txnid = 1
+	vm.ApplyOk(t, v, bob, multisigAddr, big.Zero(), builtin.MethodsMultisig.Propose, &proposeSwapSignerParams2)
+
+	// approve from swapped address goes ok
+	approveSwapSignerParams2 := multisig.TxnIDParams{ID: multisig.TxnID(1)}
+	vm.ApplyOk(t, v, dinesh, multisigAddr, big.Zero(), builtin.MethodsMultisig.Approve, &approveSwapSignerParams2)
+
 }

--- a/support/vm/vm.go
+++ b/support/vm/vm.go
@@ -137,6 +137,30 @@ func (vm *VM) WithEpoch(epoch abi.ChainEpoch) (*VM, error) {
 	}, nil
 }
 
+func (vm *VM) WithNetworkVersion(nv network.Version) (*VM, error) {
+	_, err := vm.checkpoint()
+	if err != nil {
+		return nil, err
+	}
+
+	actors, err := adt.AsMap(vm.store, vm.stateRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	return &VM{
+		ctx:            vm.ctx,
+		actorImpls:     vm.actorImpls,
+		store:          vm.store,
+		actors:         actors,
+		stateRoot:      vm.stateRoot,
+		actorsDirty:    false,
+		emptyObject:    vm.emptyObject,
+		currentEpoch:   vm.currentEpoch,
+		networkVersion: nv,
+	}, nil
+}
+
 func (vm *VM) rollback(root cid.Cid) error {
 	var err error
 	vm.actors, err = adt.AsMap(vm.store, root)


### PR DESCRIPTION
@whyrusleeping reported a multisig error when removing a signer earlier today.  @acruikshank and I have traced this down to a classic blockchain re-entrancy bug related to the recent purge-removed-signers change.

This PR is WIP
- [x] scenario test reproducing problem (unit tests won't catch)
- [x] prototype fix
- [x] proper protocol versioning of fix
- [x] scenario testing more possibilities to confirm expectations of behavior
  * in v5 y > 1 out of x approval does NOT fail on removeSigner
  * in v5 1 out of x approval does fail on removeSigner
  * in v5 1 out x does fail on swapSigner
- [x] scenario testing of fix
  * in v6 1 out x approval does NOT fail on removeSigner
  * in v6 1 out of x approval does NOT fail on swapSigner
