### PR TITLE
[v2] Attach PoSt proof policy to the PoSt proof type instead of seal proof type.

### DIFF
--- a/actors/builtin/miner/testing.go
+++ b/actors/builtin/miner/testing.go
@@ -663,12 +663,13 @@ func CheckMinerInfo(info *MinerInfo, acc *builtin.MessageAccumulator) {
 		acc.Require(sealProofInfo.SectorSize == info.SectorSize,
 			"sector size %d is wrong for seal proof type %d: %d", info.SectorSize, info.SealProofType, sealProofInfo.SectorSize)
 	}
-	sealProofPolicy, found := builtin.SealProofPolicies[info.SealProofType]
+	windowPoStProof := sealProofInfo.WindowPoStProof
+	poStProofPolicy, found := builtin.PoStProofPolicies[windowPoStProof]
 	acc.Require(found, "no seal proof policy exists for proof type %d", info.SealProofType)
 	if found {
-		acc.Require(sealProofPolicy.WindowPoStPartitionSectors == info.WindowPoStPartitionSectors,
+		acc.Require(poStProofPolicy.WindowPoStPartitionSectors == info.WindowPoStPartitionSectors,
 			"miner partition sectors %d does not match partition sectors %d for seal proof type %d",
-			info.WindowPoStPartitionSectors, sealProofPolicy.WindowPoStPartitionSectors, info.SealProofType)
+			info.WindowPoStPartitionSectors, poStProofPolicy.WindowPoStPartitionSectors, info.SealProofType)
 	}
 }
 

--- a/actors/builtin/sector.go
+++ b/actors/builtin/sector.go
@@ -5,9 +5,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Metadata about a seal proof type.
+// Policy values associated with a seal proof type.
 type SealProofPolicy struct {
-	WindowPoStPartitionSectors uint64
 	SectorMaxLifetime          stabi.ChainEpoch
 	ConsensusMinerMinPower     stabi.StoragePower
 }
@@ -16,45 +15,37 @@ type SealProofPolicy struct {
 const epochsPerYear = 1_051_200
 const fiveYears = stabi.ChainEpoch(5 * epochsPerYear)
 
-// Partition sizes must match those used by the proofs library.
-// See https://github.com/filecoin-project/rust-fil-proofs/blob/master/filecoin-proofs/src/constants.rs#L85
 var SealProofPolicies = map[stabi.RegisteredSealProof]*SealProofPolicy{
 	stabi.RegisteredSealProof_StackedDrg2KiBV1: {
-		WindowPoStPartitionSectors: 2,
 		SectorMaxLifetime:          fiveYears,
 		ConsensusMinerMinPower:     stabi.NewStoragePower(0),
 	},
 	stabi.RegisteredSealProof_StackedDrg8MiBV1: {
-		WindowPoStPartitionSectors: 2,
 		SectorMaxLifetime:          fiveYears,
 		ConsensusMinerMinPower:     stabi.NewStoragePower(16 << 20),
 	},
 	stabi.RegisteredSealProof_StackedDrg512MiBV1: {
-		WindowPoStPartitionSectors: 2,
 		SectorMaxLifetime:          fiveYears,
 		ConsensusMinerMinPower:     stabi.NewStoragePower(1 << 30),
 	},
 	stabi.RegisteredSealProof_StackedDrg32GiBV1: {
-
-		WindowPoStPartitionSectors: 2349,
 		SectorMaxLifetime:          fiveYears,
 		ConsensusMinerMinPower:     stabi.NewStoragePower(10 << 40),
 	},
 	stabi.RegisteredSealProof_StackedDrg64GiBV1: {
-		WindowPoStPartitionSectors: 2300,
 		SectorMaxLifetime:          fiveYears,
 		ConsensusMinerMinPower:     stabi.NewStoragePower(20 << 40),
 	},
 }
 
-// Returns the partition size, in sectors, associated with a proof type.
+// Returns the partition size, in sectors, associated with a seal proof type.
 // The partition size is the number of sectors proved in a single PoSt proof.
 func SealProofWindowPoStPartitionSectors(p stabi.RegisteredSealProof) (uint64, error) {
-	info, ok := SealProofPolicies[p]
-	if !ok {
-		return 0, errors.Errorf("unsupported proof type: %v", p)
+	wPoStProofType, err := p.RegisteredWindowPoStProof()
+	if err != nil {
+		return 0, err
 	}
-	return info.WindowPoStPartitionSectors, nil
+	return PoStProofWindowPoStPartitionSectors(wPoStProofType)
 }
 
 // SectorMaximumLifetime is the maximum duration a sector sealed with this proof may exist between activation and expiration
@@ -82,12 +73,39 @@ func ConsensusMinerMinPower(p stabi.RegisteredSealProof) (stabi.StoragePower, er
 	return info.ConsensusMinerMinPower, nil
 }
 
-// Returns the partition size, in sectors, associated with a proof type.
+// Policy values associated with a PoSt proof type.
+type PoStProofPolicy struct {
+	WindowPoStPartitionSectors uint64
+}
+
+// Partition sizes must match those used by the proofs library.
+// See https://github.com/filecoin-project/rust-fil-proofs/blob/master/filecoin-proofs/src/constants.rs#L85
+var PoStProofPolicies = map[stabi.RegisteredPoStProof]*PoStProofPolicy{
+	stabi.RegisteredPoStProof_StackedDrgWindow2KiBV1: {
+		WindowPoStPartitionSectors: 2,
+	},
+	stabi.RegisteredPoStProof_StackedDrgWindow8MiBV1: {
+		WindowPoStPartitionSectors: 2,
+	},
+	stabi.RegisteredPoStProof_StackedDrgWindow512MiBV1: {
+		WindowPoStPartitionSectors: 2,
+	},
+	stabi.RegisteredPoStProof_StackedDrgWindow32GiBV1: {
+		WindowPoStPartitionSectors: 2349,
+	},
+	stabi.RegisteredPoStProof_StackedDrgWindow64GiBV1: {
+		WindowPoStPartitionSectors: 2300,
+	},
+	// Winning PoSt proof types omitted.
+}
+
+
+// Returns the partition size, in sectors, associated with a Window PoSt proof type.
 // The partition size is the number of sectors proved in a single PoSt proof.
 func PoStProofWindowPoStPartitionSectors(p stabi.RegisteredPoStProof) (uint64, error) {
-	sp, err := p.RegisteredSealProof()
-	if err != nil {
-		return 0, err
+	info, ok := PoStProofPolicies[p]
+	if !ok {
+		return 0, errors.Errorf("unsupported proof type: %v", p)
 	}
-	return SealProofWindowPoStPartitionSectors(sp)
+	return info.WindowPoStPartitionSectors, nil
 }


### PR DESCRIPTION
This removes use of the RegisteredPoStProof.RegisteredSealProof() method, which we can then remove because that bijection shouldn't really exist.

See also #1268