### PR TITLE
add minor version 7 fixes to keep power stats edge cases from breaking invariants

### DIFF
--- a/actors/builtin/power/power_state.go
+++ b/actors/builtin/power/power_state.go
@@ -206,6 +206,18 @@ func (st *State) addToClaim(claims *adt.Map, miner addr.Address, power abi.Stora
 	return setClaim(claims, miner, &newClaim)
 }
 
+func (st *State) updateStatsForNewMiner(sealProof abi.RegisteredSealProof) error {
+	minPower, err := builtin.ConsensusMinerMinPower(sealProof)
+	if err != nil {
+		return fmt.Errorf("could not get consensus miner min power: %w", err)
+	}
+
+	if minPower.LessThanEqual(big.Zero()) {
+		st.MinerAboveMinPowerCount++
+	}
+	return nil
+}
+
 func (st *State) deleteClaim(claims *adt.Map, miner addr.Address) error {
 	oldClaim, ok, err := getClaim(claims, miner)
 	if err != nil {

--- a/actors/builtin/power/power_test.go
+++ b/actors/builtin/power/power_test.go
@@ -838,7 +838,7 @@ func TestCron(t *testing.T) {
 			// expect cron failure was logged
 			rt.ExpectLogsContain("OnDeferredCronEvent failed for miner")
 
-			// miner count is still one
+			// miner count has been changed or not depending on version
 			st = getState(rt)
 			assert.Equal(t, test.expectedMinerCount, st.MinerCount)
 		}

--- a/actors/builtin/power/power_test.go
+++ b/actors/builtin/power/power_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/filecoin-project/go-state-types/network"
 	"strconv"
 	"strings"
 	"testing"
@@ -323,6 +324,38 @@ func TestPowerAndPledgeAccounting(t *testing.T) {
 		require.Equal(t, big.Zero(), claim2.RawBytePower)
 		require.Equal(t, big.Zero(), claim2.QualityAdjPower)
 		actor.checkState(rt)
+	})
+
+	t.Run("after version 7, new miner updates MinerAboveMinPowerCount", func(t *testing.T) {
+		for _, test := range []struct {
+			version        network.Version
+			proof          abi.RegisteredSealProof
+			expectedMiners int64
+		}{{
+			version:        network.Version6,
+			proof:          abi.RegisteredSealProof_StackedDrg2KiBV1, // 2K sectors have zero consensus minimum
+			expectedMiners: 0,
+		}, {
+			version:        network.Version6,
+			proof:          abi.RegisteredSealProof_StackedDrg32GiBV1,
+			expectedMiners: 0,
+		}, {
+			version:        network.Version7,
+			proof:          abi.RegisteredSealProof_StackedDrg2KiBV1, // 2K sectors have zero consensus minimum
+			expectedMiners: 1,
+		}, {
+			version:        network.Version7,
+			proof:          abi.RegisteredSealProof_StackedDrg32GiBV1,
+			expectedMiners: 0,
+		}} {
+			rt := builder.WithNetworkVersion(test.version).Build(t)
+			actor.constructAndVerify(rt)
+			actor.sealProof = test.proof
+			actor.createMinerBasic(rt, owner, owner, miner1)
+
+			st := getState(rt)
+			assert.Equal(t, test.expectedMiners, st.MinerAboveMinPowerCount)
+		}
 	})
 
 	t.Run("power accounting crossing threshold", func(t *testing.T) {
@@ -757,6 +790,58 @@ func TestCron(t *testing.T) {
 		rt.Call(actor.Actor.OnEpochTickEnd, nil)
 		rt.Verify()
 		actor.checkState(rt)
+	})
+
+	t.Run("failed call decrements miner count at network version 7", func(t *testing.T) {
+		for _, test := range []struct {
+			version            network.Version
+			versionLabel       string
+			expectedMinerCount int64
+		}{{
+			version:            network.Version6,
+			versionLabel:       "Version6",
+			expectedMinerCount: 1,
+		}, {
+			version:            network.Version7,
+			versionLabel:       "Version7",
+			expectedMinerCount: 0,
+		}} {
+			rt := builder.WithNetworkVersion(test.version).Build(t)
+			rt.NetworkVersion()
+			actor.constructAndVerify(rt)
+
+			rt.SetEpoch(1)
+			actor.createMinerBasic(rt, owner, owner, miner1)
+
+			// expect one miner
+			st := getState(rt)
+			assert.Equal(t, int64(1), st.MinerCount)
+
+			actor.enrollCronEvent(rt, miner1, 1, []byte{})
+
+			rt.SetEpoch(2)
+			rt.ExpectValidateCallerAddr(builtin.CronActorAddr)
+
+			// process batch verifies first
+			rt.ExpectBatchVerifySeals(nil, nil, nil)
+
+			// send fails
+			rt.ExpectSend(miner1, builtin.MethodsMiner.OnDeferredCronEvent, builtin.CBORBytes(nil), big.Zero(), nil, exitcode.ErrIllegalState)
+
+			// Reward actor still invoked
+			power := abi.NewStoragePower(0)
+			rt.ExpectSend(builtin.RewardActorAddr, builtin.MethodsReward.UpdateNetworkKPI, &power, big.Zero(), nil, exitcode.Ok)
+			rt.SetCaller(builtin.CronActorAddr, builtin.CronActorCodeID)
+			rt.Call(actor.Actor.OnEpochTickEnd, nil)
+			rt.Verify()
+
+			// expect cron failure was logged
+			rt.ExpectLogsContain("OnDeferredCronEvent failed for miner")
+
+			// miner count is still one
+			st = getState(rt)
+			assert.Equal(t, test.expectedMinerCount, st.MinerCount)
+		}
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/filecoin-project/go-bitfield v0.2.0
 	github.com/filecoin-project/go-hamt-ipld v0.1.5
 	github.com/filecoin-project/go-hamt-ipld/v2 v2.0.0
-	github.com/filecoin-project/go-state-types v0.0.0-20201013222834-41ea465f274f
+	github.com/filecoin-project/go-state-types v0.0.0-20201021025442-0ac4de847f4f
 	github.com/filecoin-project/specs-actors v0.9.12
 	github.com/ipfs/go-block-format v0.0.2
 	github.com/ipfs/go-cid v0.0.7

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/filecoin-project/go-hamt-ipld/v2 v2.0.0 h1:b3UDemBYN2HNfk3KOXNuxgTTxl
 github.com/filecoin-project/go-hamt-ipld/v2 v2.0.0/go.mod h1:7aWZdaQ1b16BVoQUYR+eEvrDCGJoPLxFpDynFjYfBjI=
 github.com/filecoin-project/go-state-types v0.0.0-20200928172055-2df22083d8ab h1:cEDC5Ei8UuT99hPWhCjA72SM9AuRtnpvdSTIYbnzN8I=
 github.com/filecoin-project/go-state-types v0.0.0-20200928172055-2df22083d8ab/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
-github.com/filecoin-project/go-state-types v0.0.0-20201013222834-41ea465f274f h1:TZDTu4MtBKSFLXWGKLy+cvC3nHfMFIrVgWLAz/+GgZQ=
-github.com/filecoin-project/go-state-types v0.0.0-20201013222834-41ea465f274f/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
+github.com/filecoin-project/go-state-types v0.0.0-20201021025442-0ac4de847f4f h1:aKh+3jNOemceyBOO6uOL/3Zi3yNr4r9TiWVe0tBByZE=
+github.com/filecoin-project/go-state-types v0.0.0-20201021025442-0ac4de847f4f/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
 github.com/filecoin-project/specs-actors v0.9.12 h1:iIvk58tuMtmloFNHhAOQHG+4Gci6Lui0n7DYQGi3cJk=
 github.com/filecoin-project/specs-actors v0.9.12/go.mod h1:TS1AW/7LbG+615j4NsjMK1qlpAwaFsG9w0V2tg2gSao=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=

--- a/support/mock/builder.go
+++ b/support/mock/builder.go
@@ -87,6 +87,11 @@ func (b *RuntimeBuilder) WithBalance(balance, received abi.TokenAmount) *Runtime
 	return b
 }
 
+func (b *RuntimeBuilder) WithNetworkVersion(version network.Version) *RuntimeBuilder {
+	b.rt.networkVersion = version
+	return b
+}
+
 func (b *RuntimeBuilder) WithActorType(addr addr.Address, code cid.Cid) *RuntimeBuilder {
 	b.rt.actorCodeCIDs[addr] = code
 	return b


### PR DESCRIPTION
closes #1228 and #1232

### Motivation

We now have invariant tests for the power actor and these have exposed some edge cases that can break invariants:

1. Adding a miner whose zero power claim exceeds the `ConsensusMinerMinPower` does not update `MinerAboveMinPowerCount`, so the count of claims above the threshold does not match the count.
2. Deleting a miner's claim (currently only done when a miner cron fails) updates most power stats, but does not decrement `MinerCount` so the claims table size no longer matches `MinerCount`.

This PR addresses both issues

### Proposed Changes

1. Update `go-state-types` to get some new network versions.
2. Call `updateStatsForNewMiner` in `power.CreateMiner`. This is a new method on state that currently only deals with incrementing `MinerAboveMinPowerCount`.
3. Decrement `MinerCount` when we delete a miner.
4. Test both behaviors do nothing prior to network version 7, and operate as expected afterwards.