### PR TITLE
Repackage the migration to network version 4 as migration/nv4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,11 @@ build:
 
 test:
 	$(GO_BIN) test ./...
-	$(GO_BIN) test -race ./actors/migration/test
+	$(GO_BIN) test -race ./actors/migration/nv4/test
 .PHONY: test
 
 test-migration:
-	$(GO_BIN) test -race ./actors/migration/test
+	$(GO_BIN) test -race ./actors/migration/nv4/test
 .PHONY: test-migration
 
 test-coverage:

--- a/actors/migration/nv4/account.go
+++ b/actors/migration/nv4/account.go
@@ -1,4 +1,4 @@
-package migration
+package nv4
 
 import (
 	"context"

--- a/actors/migration/nv4/cron.go
+++ b/actors/migration/nv4/cron.go
@@ -1,4 +1,4 @@
-package migration
+package nv4
 
 import (
 	"context"

--- a/actors/migration/nv4/init.go
+++ b/actors/migration/nv4/init.go
@@ -1,4 +1,4 @@
-package migration
+package nv4
 
 import (
 	"context"

--- a/actors/migration/nv4/market.go
+++ b/actors/migration/nv4/market.go
@@ -1,4 +1,4 @@
-package migration
+package nv4
 
 import (
 	"context"

--- a/actors/migration/nv4/miner.go
+++ b/actors/migration/nv4/miner.go
@@ -1,4 +1,4 @@
-package migration
+package nv4
 
 import (
 	"context"

--- a/actors/migration/nv4/miner_corrections.go
+++ b/actors/migration/nv4/miner_corrections.go
@@ -1,4 +1,4 @@
-package migration
+package nv4
 
 import (
 	"bytes"

--- a/actors/migration/nv4/multisig.go
+++ b/actors/migration/nv4/multisig.go
@@ -1,4 +1,4 @@
-package migration
+package nv4
 
 import (
 	"context"

--- a/actors/migration/nv4/paych.go
+++ b/actors/migration/nv4/paych.go
@@ -1,4 +1,4 @@
-package migration
+package nv4
 
 import (
 	"context"

--- a/actors/migration/nv4/power.go
+++ b/actors/migration/nv4/power.go
@@ -1,4 +1,4 @@
-package migration
+package nv4
 
 import (
 	"context"

--- a/actors/migration/nv4/reward.go
+++ b/actors/migration/nv4/reward.go
@@ -1,4 +1,4 @@
-package migration
+package nv4
 
 import (
 	"context"

--- a/actors/migration/nv4/system.go
+++ b/actors/migration/nv4/system.go
@@ -1,4 +1,4 @@
-package migration
+package nv4
 
 import (
 	"context"

--- a/actors/migration/nv4/test/correct_cc_upgrade_then_fault_scenario_test.go
+++ b/actors/migration/nv4/test/correct_cc_upgrade_then_fault_scenario_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/ipfs/go-cid"
 
-	"github.com/filecoin-project/specs-actors/v2/actors/migration"
+	"github.com/filecoin-project/specs-actors/v2/actors/migration/nv4"
 	"github.com/filecoin-project/specs-actors/v2/actors/runtime"
 	"github.com/filecoin-project/specs-actors/v2/actors/states"
 
@@ -309,7 +309,7 @@ func TestMigrationCorrectsCCThenFaultIssue(t *testing.T) {
 	// migrate miner
 	//
 
-	nextRoot, err := migration.MigrateStateTree(ctx, v.Store(), v.StateRoot(), v.GetEpoch(), migration.Config{MaxWorkers: 1}) // v.Store() is not threadsafe
+	nextRoot, err := nv4.MigrateStateTree(ctx, v.Store(), v.StateRoot(), v.GetEpoch(), nv4.Config{MaxWorkers: 1}) // v.Store() is not threadsafe
 	require.NoError(t, err)
 
 	lookup := map[cid.Cid]runtime.VMActor{}

--- a/actors/migration/nv4/test/parallel_migration_test.go
+++ b/actors/migration/nv4/test/parallel_migration_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/builtin/verifreg"
 	"github.com/filecoin-project/specs-actors/actors/states"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
-	"github.com/filecoin-project/specs-actors/v2/actors/migration"
+	"github.com/filecoin-project/specs-actors/v2/actors/migration/nv4"
 	ipld2 "github.com/filecoin-project/specs-actors/v2/support/ipld"
 	cid "github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/assert"
@@ -84,7 +84,7 @@ func TestParallelMigrationCalls(t *testing.T) {
 
 	// Migrate to v2
 
-	endRootSerial, err := migration.MigrateStateTree(ctx, syncStore, startRoot, abi.ChainEpoch(0), migration.Config{MaxWorkers: 1})
+	endRootSerial, err := nv4.MigrateStateTree(ctx, syncStore, startRoot, abi.ChainEpoch(0), nv4.Config{MaxWorkers: 1})
 	require.NoError(t, err)
 
 	// Migrate in parallel
@@ -92,12 +92,12 @@ func TestParallelMigrationCalls(t *testing.T) {
 	grp, ctx := errgroup.WithContext(ctx)
 	grp.Go(func() error {
 		var err1 error
-		endRootParallel1, err1 = migration.MigrateStateTree(ctx, syncStore, startRoot, abi.ChainEpoch(0), migration.Config{MaxWorkers: 2})
+		endRootParallel1, err1 = nv4.MigrateStateTree(ctx, syncStore, startRoot, abi.ChainEpoch(0), nv4.Config{MaxWorkers: 2})
 		return err1
 	})
 	grp.Go(func() error {
 		var err2 error
-		endRootParallel2, err2 = migration.MigrateStateTree(ctx, syncStore, startRoot, abi.ChainEpoch(0), migration.Config{MaxWorkers: 2})
+		endRootParallel2, err2 = nv4.MigrateStateTree(ctx, syncStore, startRoot, abi.ChainEpoch(0), nv4.Config{MaxWorkers: 2})
 		return err2
 	})
 	require.NoError(t, grp.Wait())

--- a/actors/migration/nv4/top.go
+++ b/actors/migration/nv4/top.go
@@ -1,4 +1,4 @@
-package migration
+package nv4
 
 import (
 	"context"

--- a/actors/migration/nv4/util.go
+++ b/actors/migration/nv4/util.go
@@ -1,4 +1,4 @@
-package migration
+package nv4
 
 import (
 	"bytes"

--- a/actors/migration/nv4/verifreg.go
+++ b/actors/migration/nv4/verifreg.go
@@ -1,4 +1,4 @@
-package migration
+package nv4
 
 import (
 	"context"


### PR DESCRIPTION
This makes room for another migration for network version 7 without a new major version.