### PR TITLE
Remove vesting from PreCommitSector and ConfirmSectorProofsValid

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -547,7 +547,11 @@ func (a Actor) PreCommitSector(rt Runtime, params *PreCommitSectorParams) *abi.E
 	newlyVested := big.Zero()
 	feeToBurn := abi.NewTokenAmount(0)
 	rt.StateTransaction(&st, func() {
-		newlyVested, err = st.UnlockVestedFunds(store, rt.CurrEpoch())
+		// Stop vesting funds as of version 7. Its computationally expensive and unlikely to release any funds.
+		if rt.NetworkVersion() < network.Version7 {
+			newlyVested, err = st.UnlockVestedFunds(store, rt.CurrEpoch())
+		}
+
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to vest funds")
 		// available balance already accounts for fee debt so it is correct to call
 		// this before RepayDebts. We would have to
@@ -864,10 +868,12 @@ func (a Actor) ConfirmSectorProofsValid(rt Runtime, params *builtin.ConfirmSecto
 		newPower, err = st.AssignSectorsToDeadlines(store, rt.CurrEpoch(), newSectors, info.WindowPoStPartitionSectors, info.SectorSize)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to assign new sectors to deadlines")
 
-		// Add sector and pledge lock-up to miner state
-		newlyVested, err = st.UnlockVestedFunds(store, rt.CurrEpoch())
-		if err != nil {
-			rt.Abortf(exitcode.ErrIllegalState, "failed to vest new funds: %s", err)
+		// Stop unlocking funds as of version 7. It's computationally expensive and unlikely to actually unlock anything.
+		if rt.NetworkVersion() < network.Version7 {
+			newlyVested, err = st.UnlockVestedFunds(store, rt.CurrEpoch())
+			if err != nil {
+				rt.Abortf(exitcode.ErrIllegalState, "failed to vest new funds: %s", err)
+			}
 		}
 
 		// Unlock deposit for successful proofs, make it available for lock-up as initial pledge.

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -550,9 +550,9 @@ func (a Actor) PreCommitSector(rt Runtime, params *PreCommitSectorParams) *abi.E
 		// Stop vesting funds as of version 7. Its computationally expensive and unlikely to release any funds.
 		if rt.NetworkVersion() < network.Version7 {
 			newlyVested, err = st.UnlockVestedFunds(store, rt.CurrEpoch())
+			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to vest funds")
 		}
 
-		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to vest funds")
 		// available balance already accounts for fee debt so it is correct to call
 		// this before RepayDebts. We would have to
 		// subtract fee debt explicitly if we called this after.

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,6 @@ github.com/filecoin-project/go-hamt-ipld/v2 v2.0.0 h1:b3UDemBYN2HNfk3KOXNuxgTTxl
 github.com/filecoin-project/go-hamt-ipld/v2 v2.0.0/go.mod h1:7aWZdaQ1b16BVoQUYR+eEvrDCGJoPLxFpDynFjYfBjI=
 github.com/filecoin-project/go-state-types v0.0.0-20200928172055-2df22083d8ab h1:cEDC5Ei8UuT99hPWhCjA72SM9AuRtnpvdSTIYbnzN8I=
 github.com/filecoin-project/go-state-types v0.0.0-20200928172055-2df22083d8ab/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
-github.com/filecoin-project/go-state-types v0.0.0-20201013222834-41ea465f274f h1:TZDTu4MtBKSFLXWGKLy+cvC3nHfMFIrVgWLAz/+GgZQ=
-github.com/filecoin-project/go-state-types v0.0.0-20201013222834-41ea465f274f/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
 github.com/filecoin-project/go-state-types v0.0.0-20201021025442-0ac4de847f4f h1:aKh+3jNOemceyBOO6uOL/3Zi3yNr4r9TiWVe0tBByZE=
 github.com/filecoin-project/go-state-types v0.0.0-20201021025442-0ac4de847f4f/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
 github.com/filecoin-project/specs-actors v0.9.12 h1:iIvk58tuMtmloFNHhAOQHG+4Gci6Lui0n7DYQGi3cJk=

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/filecoin-project/go-hamt-ipld/v2 v2.0.0 h1:b3UDemBYN2HNfk3KOXNuxgTTxl
 github.com/filecoin-project/go-hamt-ipld/v2 v2.0.0/go.mod h1:7aWZdaQ1b16BVoQUYR+eEvrDCGJoPLxFpDynFjYfBjI=
 github.com/filecoin-project/go-state-types v0.0.0-20200928172055-2df22083d8ab h1:cEDC5Ei8UuT99hPWhCjA72SM9AuRtnpvdSTIYbnzN8I=
 github.com/filecoin-project/go-state-types v0.0.0-20200928172055-2df22083d8ab/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
+github.com/filecoin-project/go-state-types v0.0.0-20201013222834-41ea465f274f h1:TZDTu4MtBKSFLXWGKLy+cvC3nHfMFIrVgWLAz/+GgZQ=
+github.com/filecoin-project/go-state-types v0.0.0-20201013222834-41ea465f274f/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
 github.com/filecoin-project/go-state-types v0.0.0-20201021025442-0ac4de847f4f h1:aKh+3jNOemceyBOO6uOL/3Zi3yNr4r9TiWVe0tBByZE=
 github.com/filecoin-project/go-state-types v0.0.0-20201021025442-0ac4de847f4f/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
 github.com/filecoin-project/specs-actors v0.9.12 h1:iIvk58tuMtmloFNHhAOQHG+4Gci6Lui0n7DYQGi3cJk=


### PR DESCRIPTION
closes #1258

### Motivation

Many miner methods attempt to move funds from the vesting table to available balance. While this helps keep the available balance accurate, it can be expensive to run and means that most operations will fail to find any balance to unlock. This is particularly true for PreCommitSector and ConfirmSectorProofsValid, so this PR stops these methods from attempting to unlock funds starting network version 7.

### Proposed Changes

1. Have PreCommitSector only call `UnlockVestedFunds` if network version is less than 7.
2. Have ConfirmSectorProofsValid only call `UnlockVestedFunds` if network version is less than 7.
3. Modify miner tests and add tests to assert that the behavior is correct before and after version 7.