### PR TITLE
Replace V1 seal proof types with V1_1 in a two-stage upgrade.

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -99,8 +99,7 @@ func (a Actor) Constructor(rt Runtime, params *ConstructorParams) *abi.EmptyValu
 	checkControlAddresses(rt, params.ControlAddrs)
 	checkPeerInfo(rt, params.PeerId, params.Multiaddrs)
 
-	_, ok := SupportedProofTypes[params.SealProofType]
-	if !ok {
+	if !CanPreCommitSealProof(params.SealProofType, rt.NetworkVersion()) {
 		rt.Abortf(exitcode.ErrIllegalArgument, "proof type %d not allowed for new miner actors", params.SealProofType)
 	}
 
@@ -511,13 +510,27 @@ func (a Actor) SubmitWindowedPoSt(rt Runtime, params *SubmitWindowedPoStParams) 
 // Sector Commitment //
 ///////////////////////
 
+//type SectorPreCommitInfo struct {
+//	SealProof       abi.RegisteredSealProof
+//	SectorNumber    abi.SectorNumber
+//	SealedCID       cid.Cid `checked:"true"` // CommR
+//	SealRandEpoch   abi.ChainEpoch
+//	DealIDs         []abi.DealID
+//	Expiration      abi.ChainEpoch
+//	ReplaceCapacity bool // Whether to replace a "committed capacity" no-deal sector (requires non-empty DealIDs)
+//	// The committed capacity sector to replace, and it's deadline/partition location
+//	ReplaceSectorDeadline  uint64
+//	ReplaceSectorPartition uint64
+//	ReplaceSectorNumber    abi.SectorNumber
+//}
 type PreCommitSectorParams = miner0.SectorPreCommitInfo
 
 // Proposals must be posted on chain via sma.PublishStorageDeals before PreCommitSector.
 // Optimization: PreCommitSector could contain a list of deals that are not published yet.
 func (a Actor) PreCommitSector(rt Runtime, params *PreCommitSectorParams) *abi.EmptyValue {
-	if _, ok := SupportedProofTypes[params.SealProof]; !ok {
-		rt.Abortf(exitcode.ErrIllegalArgument, "unsupported seal proof type: %s", params.SealProof)
+	nv := rt.NetworkVersion()
+	if !CanPreCommitSealProof(params.SealProof, nv) {
+		rt.Abortf(exitcode.ErrIllegalArgument, "unsupported seal proof type %v at network version %v", params.SealProof, nv)
 	}
 	if params.SectorNumber > abi.MaxSectorNumber {
 		rt.Abortf(exitcode.ErrIllegalArgument, "sector number %d out of range 0..(2^63-1)", params.SectorNumber)
@@ -584,8 +597,22 @@ func (a Actor) PreCommitSector(rt Runtime, params *PreCommitSectorParams) *abi.E
 			rt.Abortf(exitcode.ErrForbidden, "precommit not allowed during active consensus fault")
 		}
 
-		if params.SealProof != info.SealProofType {
-			rt.Abortf(exitcode.ErrIllegalArgument, "sector seal proof %v must match miner seal proof type %d", params.SealProof, info.SealProofType)
+		if nv < network.Version7 {
+			if params.SealProof != info.SealProofType {
+				rt.Abortf(exitcode.ErrIllegalArgument, "sector seal proof %v must match miner seal proof type %d", params.SealProof, info.SealProofType)
+			}
+		} else {
+			// From network version 7, the pre-commit seal type must have the same Window PoSt proof type as the miner's
+			// recorded seal type has, rather than be exactly the same seal type.
+			// This permits a transition window from V1 to V1_1 seal types (which share Window PoSt proof type).
+			minerWPoStProof, err := info.SealProofType.RegisteredWindowPoStProof()
+			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to lookup Window PoSt proof type for miner seal proof %d", info.SealProofType)
+			sectorWPoStProof, err := params.SealProof.RegisteredWindowPoStProof()
+			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalArgument, "failed to lookup Window PoSt proof type for sector seal proof %d", params.SealProof)
+			if sectorWPoStProof != minerWPoStProof {
+				rt.Abortf(exitcode.ErrIllegalArgument, "sector Window PoSt proof type %d must match miner Window PoSt proof type %d (seal proof type %d)",
+					sectorWPoStProof, minerWPoStProof, params.SealProof)
+			}
 		}
 
 		dealCountMax := SectorDealsMax(info.SectorSize)
@@ -960,6 +987,7 @@ type ExpirationExtension = miner0.ExpirationExtension
 // The sector must not be terminated or faulty.
 // The sector's power is recomputed for the new expiration.
 func (a Actor) ExtendSectorExpiration(rt Runtime, params *ExtendSectorExpirationParams) *abi.EmptyValue {
+	nv := rt.NetworkVersion()
 	if uint64(len(params.Extensions)) > DeclarationsMax {
 		rt.Abortf(exitcode.ErrIllegalArgument, "too many declarations %d, max %d", len(params.Extensions), DeclarationsMax)
 	}
@@ -989,7 +1017,6 @@ func (a Actor) ExtendSectorExpiration(rt Runtime, params *ExtendSectorExpiration
 	}
 
 	currEpoch := rt.CurrEpoch()
-	nv := rt.NetworkVersion()
 
 	powerDelta := NewPowerPairZero()
 	pledgeDelta := big.Zero()
@@ -1047,6 +1074,10 @@ func (a Actor) ExtendSectorExpiration(rt Runtime, params *ExtendSectorExpiration
 				builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load sectors in deadline %v partition %v", dlIdx, decl.Partition)
 				newSectors := make([]*SectorOnChainInfo, len(oldSectors))
 				for i, sector := range oldSectors {
+					if !CanExtendSealProofType(sector.SealProof, nv) {
+						rt.Abortf(exitcode.ErrForbidden, "cannot extend expiration for sector %v with unsupported seal type %v",
+							sector.SectorNumber, sector.SealProof)
+					}
 					// This can happen if the sector should have already expired, but hasn't
 					// because the end of its deadline hasn't passed yet.
 					if sector.Expiration < currEpoch {
@@ -1989,6 +2020,7 @@ func validateExpiration(rt Runtime, activation, expiration abi.ChainEpoch, sealP
 }
 
 func validateReplaceSector(rt Runtime, st *State, store adt.Store, params *PreCommitSectorParams) {
+	nv := rt.NetworkVersion()
 	replaceSector, found, err := st.GetSector(store, params.ReplaceSectorNumber)
 	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load sector %v", params.SectorNumber)
 	if !found {
@@ -1998,9 +2030,23 @@ func validateReplaceSector(rt Runtime, st *State, store adt.Store, params *PreCo
 	if len(replaceSector.DealIDs) > 0 {
 		rt.Abortf(exitcode.ErrIllegalArgument, "cannot replace sector %v which has deals", params.ReplaceSectorNumber)
 	}
-	if params.SealProof != replaceSector.SealProof {
-		rt.Abortf(exitcode.ErrIllegalArgument, "cannot replace sector %v seal proof %v with seal proof %v",
-			params.ReplaceSectorNumber, replaceSector.SealProof, params.SealProof)
+	if nv < network.Version7 {
+		if params.SealProof != replaceSector.SealProof {
+			rt.Abortf(exitcode.ErrIllegalArgument, "cannot replace sector %v seal proof %v with seal proof %v",
+				params.ReplaceSectorNumber, replaceSector.SealProof, params.SealProof)
+		}
+	} else {
+		// From network version 7, the new sector's seal type must have the same Window PoSt proof type as the one
+		// being replaced, rather than be exactly the same seal type.
+		// This permits replacing sectors with V1 seal types with V1_1 seal types.
+		replaceWPoStProof, err := replaceSector.SealProof.RegisteredWindowPoStProof()
+		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to lookup Window PoSt proof type for sector seal proof %d", replaceSector.SealProof)
+		newWPoStProof, err := params.SealProof.RegisteredWindowPoStProof()
+		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalArgument, "failed to lookup Window PoSt proof type for new seal proof %d", params.SealProof)
+		if newWPoStProof != replaceWPoStProof {
+			rt.Abortf(exitcode.ErrIllegalArgument, "new sector window PoSt proof type %d must match replaced proof type %d (seal proof type %d)",
+				newWPoStProof, replaceWPoStProof, params.SealProof)
+		}
 	}
 	if params.Expiration < replaceSector.Expiration {
 		rt.Abortf(exitcode.ErrIllegalArgument, "cannot replace sector %v expiration %v with sooner expiration %v",

--- a/actors/builtin/miner/miner_state_test.go
+++ b/actors/builtin/miner/miner_state_test.go
@@ -622,9 +622,9 @@ func TestAddPreCommitExpiry(t *testing.T) {
 }
 
 func TestSectorAssignment(t *testing.T) {
-	partitionSectors, err := builtin.SealProofWindowPoStPartitionSectors(abi.RegisteredSealProof_StackedDrg32GiBV1)
+	partitionSectors, err := builtin.SealProofWindowPoStPartitionSectors(abi.RegisteredSealProof_StackedDrg32GiBV1_1)
 	require.NoError(t, err)
-	sectorSize, err := abi.RegisteredSealProof_StackedDrg32GiBV1.SectorSize()
+	sectorSize, err := abi.RegisteredSealProof_StackedDrg32GiBV1_1.SectorSize()
 	require.NoError(t, err)
 
 	openDeadlines := miner.WPoStPeriodDeadlines - 2
@@ -910,7 +910,7 @@ func constructStateHarness(t *testing.T, periodBoundary abi.ChainEpoch) *stateHa
 	owner := tutils.NewBLSAddr(t, 1)
 	worker := tutils.NewBLSAddr(t, 2)
 
-	testSealProofType := abi.RegisteredSealProof_StackedDrg2KiBV1
+	testSealProofType := abi.RegisteredSealProof_StackedDrg2KiBV1_1
 
 	sectorSize, err := testSealProofType.SectorSize()
 	require.NoError(t, err)
@@ -972,7 +972,7 @@ const (
 func newSectorOnChainInfo(sectorNo abi.SectorNumber, sealed cid.Cid, weight big.Int, activation abi.ChainEpoch) *miner.SectorOnChainInfo {
 	return &miner.SectorOnChainInfo{
 		SectorNumber:          sectorNo,
-		SealProof:             abi.RegisteredSealProof_StackedDrg32GiBV1,
+		SealProof:             abi.RegisteredSealProof_StackedDrg32GiBV1_1,
 		SealedCID:             sealed,
 		DealIDs:               nil,
 		Activation:            activation,
@@ -990,7 +990,7 @@ func newSectorOnChainInfo(sectorNo abi.SectorNumber, sealed cid.Cid, weight big.
 // returns a unique SectorPreCommitInfo with each invocation with SectorNumber set to `sectorNo`.
 func newSectorPreCommitInfo(sectorNo abi.SectorNumber, sealed cid.Cid) *miner.SectorPreCommitInfo {
 	return &miner.SectorPreCommitInfo{
-		SealProof:     abi.RegisteredSealProof_StackedDrg32GiBV1,
+		SealProof:     abi.RegisteredSealProof_StackedDrg32GiBV1_1,
 		SectorNumber:  sectorNo,
 		SealedCID:     sealed,
 		SealRandEpoch: sectorSealRandEpochValue,

--- a/actors/builtin/miner/partition_state_test.go
+++ b/actors/builtin/miner/partition_state_test.go
@@ -687,7 +687,7 @@ func TestPartitions(t *testing.T) {
 		store := ipld.NewADTStore(context.Background())
 		partition := emptyPartition(t, store)
 
-		proofType := abi.RegisteredSealProof_StackedDrg32GiBV1
+		proofType := abi.RegisteredSealProof_StackedDrg32GiBV1_1
 		sectorSize, err := proofType.SectorSize()
 		require.NoError(t, err)
 		partitionSectors, err := builtin.SealProofWindowPoStPartitionSectors(proofType)

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/network"
 	"github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
 
@@ -90,11 +91,56 @@ var SealedCIDPrefix = cid.Prefix{
 	MhLength: 32,
 }
 
-// List of proof types which may be used when creating a new miner actor.
+// List of proof types which may be used when creating a new miner actor or pre-committing a new sector.
 // This is mutable to allow configuration of testing and development networks.
-var SupportedProofTypes = map[abi.RegisteredSealProof]struct{}{
+var PreCommitSealProofTypesV0 = map[abi.RegisteredSealProof]struct{}{
 	abi.RegisteredSealProof_StackedDrg32GiBV1: {},
 	abi.RegisteredSealProof_StackedDrg64GiBV1: {},
+}
+var PreCommitSealProofTypesV7 = map[abi.RegisteredSealProof]struct{}{
+	abi.RegisteredSealProof_StackedDrg32GiBV1:   {},
+	abi.RegisteredSealProof_StackedDrg64GiBV1:   {},
+	abi.RegisteredSealProof_StackedDrg32GiBV1_1: {},
+	abi.RegisteredSealProof_StackedDrg64GiBV1_1: {},
+}
+
+// From network version 8, sectors sealed with the V1 seal proof types cannot be committed.
+var PreCommitSealProofTypesV8 = map[abi.RegisteredSealProof]struct{}{
+	abi.RegisteredSealProof_StackedDrg32GiBV1_1: {},
+	abi.RegisteredSealProof_StackedDrg64GiBV1_1: {},
+}
+
+// Checks whether a seal proof type is supported for new miners and sectors.
+func CanPreCommitSealProof(s abi.RegisteredSealProof, nv network.Version) bool {
+	_, ok := PreCommitSealProofTypesV0[s]
+	if nv >= network.Version7 {
+		_, ok = PreCommitSealProofTypesV7[s]
+	}
+	if nv >= network.Version8 {
+		_, ok = PreCommitSealProofTypesV8[s]
+	}
+	return ok
+}
+
+// List of proof types for which sector lifetime may be extended.
+var ExtensibleProofTypesV0 = map[abi.RegisteredSealProof]struct{}{
+	abi.RegisteredSealProof_StackedDrg32GiBV1: {},
+	abi.RegisteredSealProof_StackedDrg64GiBV1: {},
+}
+
+// From network version 7, sectors sealed with the V1 seal proof types cannot be extended.
+var ExtensibleProofTypesV7 = map[abi.RegisteredSealProof]struct{}{
+	abi.RegisteredSealProof_StackedDrg32GiBV1_1: {},
+	abi.RegisteredSealProof_StackedDrg64GiBV1_1: {},
+}
+
+// Checks whether a seal proof type is supported for new miners and sectors.
+func CanExtendSealProofType(s abi.RegisteredSealProof, nv network.Version) bool {
+	_, ok := ExtensibleProofTypesV0[s]
+	if nv >= network.Version7 {
+		_, ok = ExtensibleProofTypesV7[s]
+	}
+	return ok
 }
 
 // Maximum delay to allow between sector pre-commit and subsequent proof.
@@ -105,6 +151,12 @@ var MaxProveCommitDuration = map[abi.RegisteredSealProof]abi.ChainEpoch{
 	abi.RegisteredSealProof_StackedDrg8MiBV1:   builtin.EpochsInDay + PreCommitChallengeDelay,
 	abi.RegisteredSealProof_StackedDrg512MiBV1: builtin.EpochsInDay + PreCommitChallengeDelay,
 	abi.RegisteredSealProof_StackedDrg64GiBV1:  builtin.EpochsInDay + PreCommitChallengeDelay,
+
+	abi.RegisteredSealProof_StackedDrg32GiBV1_1:  builtin.EpochsInDay + PreCommitChallengeDelay, // PARAM_SPEC
+	abi.RegisteredSealProof_StackedDrg2KiBV1_1:   builtin.EpochsInDay + PreCommitChallengeDelay,
+	abi.RegisteredSealProof_StackedDrg8MiBV1_1:   builtin.EpochsInDay + PreCommitChallengeDelay,
+	abi.RegisteredSealProof_StackedDrg512MiBV1_1: builtin.EpochsInDay + PreCommitChallengeDelay,
+	abi.RegisteredSealProof_StackedDrg64GiBV1_1:  builtin.EpochsInDay + PreCommitChallengeDelay,
 }
 
 // Maximum delay between challenge and pre-commitment.

--- a/actors/builtin/miner/sectors_test.go
+++ b/actors/builtin/miner/sectors_test.go
@@ -25,7 +25,7 @@ func TestSectors(t *testing.T) {
 	makeSector := func(t *testing.T, i uint64) *miner.SectorOnChainInfo {
 		return &miner.SectorOnChainInfo{
 			SectorNumber:          abi.SectorNumber(i),
-			SealProof:             abi.RegisteredSealProof_StackedDrg32GiBV1,
+			SealProof:             abi.RegisteredSealProof_StackedDrg32GiBV1_1,
 			SealedCID:             tutil.MakeCID(fmt.Sprintf("commR-%d", i), &miner.SealedCIDPrefix),
 			DealWeight:            big.Zero(),
 			VerifiedDealWeight:    big.Zero(),

--- a/actors/builtin/power/power_test.go
+++ b/actors/builtin/power/power_test.go
@@ -51,7 +51,7 @@ func TestConstruction(t *testing.T) {
 		rt := builder.Build(t)
 		actor.constructAndVerify(rt)
 
-		actor.createMiner(rt, owner, owner, miner, actr, abi.PeerID("miner"), []abi.Multiaddrs{{1}}, abi.RegisteredSealProof_StackedDrg32GiBV1, abi.NewTokenAmount(10))
+		actor.createMiner(rt, owner, owner, miner, actr, abi.PeerID("miner"), []abi.Multiaddrs{{1}}, abi.RegisteredSealProof_StackedDrg32GiBV1_1, abi.NewTokenAmount(10))
 
 		var st power.State
 		rt.GetState(&st)
@@ -69,7 +69,7 @@ func TestConstruction(t *testing.T) {
 		found, err_ := claim.Get(asKey(keys[0]), &actualClaim)
 		require.NoError(t, err_)
 		assert.True(t, found)
-		assert.Equal(t, power.Claim{abi.RegisteredSealProof_StackedDrg32GiBV1, big.Zero(), big.Zero()}, actualClaim) // miner has not proven anything
+		assert.Equal(t, power.Claim{abi.RegisteredSealProof_StackedDrg32GiBV1_1, big.Zero(), big.Zero()}, actualClaim) // miner has not proven anything
 
 		verifyEmptyMap(t, rt, st.CronEventQueue)
 		actor.checkState(rt)
@@ -80,7 +80,7 @@ func TestCreateMinerFailures(t *testing.T) {
 	owner := tutil.NewIDAddr(t, 101)
 	peer := abi.PeerID("miner")
 	mAddr := []abi.Multiaddrs{{1}}
-	sealProofType := abi.RegisteredSealProof_StackedDrg2KiBV1
+	sealProofType := abi.RegisteredSealProof_StackedDrg2KiBV1_1
 
 	t.Run("fails when caller is not of signable type", func(t *testing.T) {
 		rt, ac := basicPowerSetup(t)
@@ -259,7 +259,7 @@ func TestPowerAndPledgeAccounting(t *testing.T) {
 	miner5 := tutil.NewIDAddr(t, 115)
 
 	// These tests use the min power for consensus to check the accounting above and below that value.
-	powerUnit, err := builtin.ConsensusMinerMinPower(abi.RegisteredSealProof_StackedDrg32GiBV1)
+	powerUnit, err := builtin.ConsensusMinerMinPower(abi.RegisteredSealProof_StackedDrg32GiBV1_1)
 	require.NoError(t, err)
 
 	mul := func(a big.Int, b int64) big.Int {
@@ -445,9 +445,9 @@ func TestPowerAndPledgeAccounting(t *testing.T) {
 
 		// miner 5 uses 64GiB sectors and has a higher minimum
 		actor.createMiner(rt, owner, owner, miner5, tutil.NewActorAddr(t, "m5"), abi.PeerID("m5"),
-			nil, abi.RegisteredSealProof_StackedDrg64GiBV1, big.Zero())
+			nil, abi.RegisteredSealProof_StackedDrg64GiBV1_1, big.Zero())
 
-		power64Unit, err := builtin.ConsensusMinerMinPower(abi.RegisteredSealProof_StackedDrg64GiBV1)
+		power64Unit, err := builtin.ConsensusMinerMinPower(abi.RegisteredSealProof_StackedDrg64GiBV1_1)
 		require.NoError(t, err)
 		assert.True(t, power64Unit.GreaterThan(powerUnit))
 
@@ -578,7 +578,7 @@ func TestCron(t *testing.T) {
 	})
 
 	t.Run("test amount sent to reward actor and state change", func(t *testing.T) {
-		powerUnit, err := builtin.ConsensusMinerMinPower(abi.RegisteredSealProof_StackedDrg2KiBV1)
+		powerUnit, err := builtin.ConsensusMinerMinPower(abi.RegisteredSealProof_StackedDrg2KiBV1_1)
 		require.NoError(t, err)
 
 		miner3 := tutil.NewIDAddr(t, 103)
@@ -741,7 +741,7 @@ func TestCron(t *testing.T) {
 		actor.enrollCronEvent(rt, miner1, 2, []byte{})
 		actor.enrollCronEvent(rt, miner2, 2, []byte{})
 
-		rawPow, err := builtin.ConsensusMinerMinPower(abi.RegisteredSealProof_StackedDrg32GiBV1)
+		rawPow, err := builtin.ConsensusMinerMinPower(abi.RegisteredSealProof_StackedDrg32GiBV1_1)
 		require.NoError(t, err)
 
 		qaPow := rawPow
@@ -1149,7 +1149,7 @@ func newHarness(t *testing.T) *spActorHarness {
 	return &spActorHarness{
 		Actor:     power.Actor{},
 		t:         t,
-		sealProof: abi.RegisteredSealProof_StackedDrg32GiBV1,
+		sealProof: abi.RegisteredSealProof_StackedDrg32GiBV1_1,
 	}
 }
 

--- a/actors/builtin/sector.go
+++ b/actors/builtin/sector.go
@@ -36,6 +36,27 @@ var SealProofPolicies = map[stabi.RegisteredSealProof]*SealProofPolicy{
 		SectorMaxLifetime:          fiveYears,
 		ConsensusMinerMinPower:     stabi.NewStoragePower(20 << 40),
 	},
+
+	stabi.RegisteredSealProof_StackedDrg2KiBV1_1: {
+		SectorMaxLifetime:          fiveYears,
+		ConsensusMinerMinPower:     stabi.NewStoragePower(0),
+	},
+	stabi.RegisteredSealProof_StackedDrg8MiBV1_1: {
+		SectorMaxLifetime:          fiveYears,
+		ConsensusMinerMinPower:     stabi.NewStoragePower(16 << 20),
+	},
+	stabi.RegisteredSealProof_StackedDrg512MiBV1_1: {
+		SectorMaxLifetime:          fiveYears,
+		ConsensusMinerMinPower:     stabi.NewStoragePower(1 << 30),
+	},
+	stabi.RegisteredSealProof_StackedDrg32GiBV1_1: {
+		SectorMaxLifetime:          fiveYears,
+		ConsensusMinerMinPower:     stabi.NewStoragePower(10 << 40),
+	},
+	stabi.RegisteredSealProof_StackedDrg64GiBV1_1: {
+		SectorMaxLifetime:          fiveYears,
+		ConsensusMinerMinPower:     stabi.NewStoragePower(20 << 40),
+	},
 }
 
 // Returns the partition size, in sectors, associated with a seal proof type.

--- a/actors/migration/nv4/test/correct_cc_upgrade_then_fault_scenario_test.go
+++ b/actors/migration/nv4/test/correct_cc_upgrade_then_fault_scenario_test.go
@@ -48,7 +48,7 @@ func TestMigrationCorrectsCCThenFaultIssue(t *testing.T) {
 	minerBalance := big.Mul(big.NewInt(10_000), vm0.FIL)
 	sectorNumber := abi.SectorNumber(100)
 	sealedCid := tutil.MakeCID("100", &miner0.SealedCIDPrefix)
-	sealProof := abi.RegisteredSealProof_StackedDrg32GiBV1
+	sealProof := abi.RegisteredSealProof_StackedDrg32GiBV1 // Old seal proof type to match v0 expectations.
 
 	// create miner
 	params := power.CreateMinerParams{

--- a/actors/runtime/runtime.go
+++ b/actors/runtime/runtime.go
@@ -178,6 +178,7 @@ type Syscalls interface {
 	// Computes an unsealed sector CID (CommD) from its constituent piece CIDs (CommPs) and sizes.
 	ComputeUnsealedSectorCID(reg abi.RegisteredSealProof, pieces []abi.PieceInfo) (cid.Cid, error)
 	// Verifies a sector seal proof.
+	// Deprecated and un-used.
 	VerifySeal(vi proof.SealVerifyInfo) error
 
 	BatchVerifySeals(vis map[addr.Address][]proof.SealVerifyInfo) (map[addr.Address][]bool, error)

--- a/actors/states/election_test.go
+++ b/actors/states/election_test.go
@@ -23,7 +23,7 @@ import (
 func TestMinerEligibleForElection(t *testing.T) {
 	ctx := context.Background()
 	store := ipld.NewADTStore(ctx)
-	proofType := abi.RegisteredSealProof_StackedDrg32GiBV1
+	proofType := abi.RegisteredSealProof_StackedDrg32GiBV1_1
 	pwr := abi.NewStoragePower(1)
 
 	owner := tutil.NewIDAddr(t, 100)
@@ -81,14 +81,14 @@ func TestMinerEligibleForElection(t *testing.T) {
 func TestMinerEligibleAtLookback(t *testing.T) {
 	ctx := context.Background()
 	store := ipld.NewADTStore(ctx)
-	proofType := abi.RegisteredSealProof_StackedDrg32GiBV1
+	proofType := abi.RegisteredSealProof_StackedDrg32GiBV1_1
 	maddr := tutil.NewIDAddr(t, 101)
 
 	t.Run("power does not meet minimum", func(t *testing.T) {
 		// get minimums
 		pow32GiBMin, err := builtin.ConsensusMinerMinPower(proofType)
 		require.NoError(t, err)
-		pow64GiBMin, err := builtin.ConsensusMinerMinPower(abi.RegisteredSealProof_StackedDrg64GiBV1)
+		pow64GiBMin, err := builtin.ConsensusMinerMinPower(abi.RegisteredSealProof_StackedDrg64GiBV1_1)
 		require.NoError(t, err)
 
 		for _, tc := range []struct {
@@ -121,13 +121,13 @@ func TestMinerEligibleAtLookback(t *testing.T) {
 		}, {
 			// bigger sector size requires higher minimum
 			consensusMiners: power.ConsensusMinerMinMiners,
-			minerProof:      abi.RegisteredSealProof_StackedDrg64GiBV1,
+			minerProof:      abi.RegisteredSealProof_StackedDrg64GiBV1_1,
 			power:           pow32GiBMin,
 			eligible:        false,
 		}, {
 			// bigger sector size requires higher minimum
 			consensusMiners: power.ConsensusMinerMinMiners,
-			minerProof:      abi.RegisteredSealProof_StackedDrg64GiBV1,
+			minerProof:      abi.RegisteredSealProof_StackedDrg64GiBV1_1,
 			power:           pow64GiBMin,
 			eligible:        true,
 		}} {
@@ -141,7 +141,7 @@ func TestMinerEligibleAtLookback(t *testing.T) {
 }
 
 func constructMinerState(ctx context.Context, t *testing.T, store adt.Store, owner address.Address) *miner.State {
-	proofType := abi.RegisteredSealProof_StackedDrg32GiBV1
+	proofType := abi.RegisteredSealProof_StackedDrg32GiBV1_1
 	ssize, err := proofType.SectorSize()
 	require.NoError(t, err)
 	psize, err := builtin.SealProofWindowPoStPartitionSectors(proofType)

--- a/actors/test/commit_post_test.go
+++ b/actors/test/commit_post_test.go
@@ -28,7 +28,7 @@ func TestCommitPoStFlow(t *testing.T) {
 	addrs := vm.CreateAccounts(ctx, t, v, 1, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
 
 	minerBalance := big.Mul(big.NewInt(10_000), vm.FIL)
-	sealProof := abi.RegisteredSealProof_StackedDrg32GiBV1
+	sealProof := abi.RegisteredSealProof_StackedDrg32GiBV1_1
 
 	// create miner
 	params := power.CreateMinerParams{

--- a/actors/test/committed_capacity_scenario_test.go
+++ b/actors/test/committed_capacity_scenario_test.go
@@ -29,7 +29,7 @@ func TestReplaceCommittedCapacitySectorWithDealLadenSector(t *testing.T) {
 	minerBalance := big.Mul(big.NewInt(1_000), vm.FIL)
 	sectorNumber := abi.SectorNumber(100)
 	sealedCid := tutil.MakeCID("100", &miner.SealedCIDPrefix)
-	sealProof := abi.RegisteredSealProof_StackedDrg32GiBV1
+	sealProof := abi.RegisteredSealProof_StackedDrg32GiBV1_1
 
 	// create miner
 	params := power.CreateMinerParams{

--- a/actors/test/cron_catches_expiries_scenario_test.go
+++ b/actors/test/cron_catches_expiries_scenario_test.go
@@ -29,7 +29,7 @@ func TestCronCatchedCCExpirationsAtDeadlineBoundary(t *testing.T) {
 	minerBalance := big.Mul(big.NewInt(1_000), vm.FIL)
 	sectorNumber := abi.SectorNumber(100)
 	sealedCid := tutil.MakeCID("100", &miner.SealedCIDPrefix)
-	sealProof := abi.RegisteredSealProof_StackedDrg32GiBV1
+	sealProof := abi.RegisteredSealProof_StackedDrg32GiBV1_1
 
 	// create miner
 	params := power.CreateMinerParams{

--- a/actors/test/power_scenario_test.go
+++ b/actors/test/power_scenario_test.go
@@ -22,7 +22,7 @@ func TestCreateMiner(t *testing.T) {
 	params := power.CreateMinerParams{
 		Owner:         addrs[0],
 		Worker:        addrs[0],
-		SealProofType: abi.RegisteredSealProof_StackedDrg32GiBV1,
+		SealProofType: abi.RegisteredSealProof_StackedDrg32GiBV1_1,
 		Peer:          abi.PeerID("not really a peer id"),
 	}
 	ret := vm.ApplyOk(t, v, addrs[0], builtin.StoragePowerActorAddr, big.NewInt(1e10), builtin.MethodsPower.CreateMiner, &params)
@@ -71,7 +71,7 @@ func TestOnEpochTickEnd(t *testing.T) {
 	addrs := vm.CreateAccounts(ctx, t, v, 1, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
 
 	// create a miner
-	params := power.CreateMinerParams{Owner: addrs[0], Worker: addrs[0], SealProofType: abi.RegisteredSealProof_StackedDrg32GiBV1, Peer: abi.PeerID("pid")}
+	params := power.CreateMinerParams{Owner: addrs[0], Worker: addrs[0], SealProofType: abi.RegisteredSealProof_StackedDrg32GiBV1_1, Peer: abi.PeerID("pid")}
 	ret := vm.ApplyOk(t, v, addrs[0], builtin.StoragePowerActorAddr, big.NewInt(1e10), builtin.MethodsPower.CreateMiner, &params)
 
 	ret, ok := ret.(*power.CreateMinerReturn)

--- a/actors/test/terminate_sectors_scenario_test.go
+++ b/actors/test/terminate_sectors_scenario_test.go
@@ -31,7 +31,7 @@ func TestTerminateSectors(t *testing.T) {
 	minerBalance := big.Mul(big.NewInt(1_000), vm.FIL)
 	sectorNumber := abi.SectorNumber(100)
 	sealedCid := tutil.MakeCID("100", &miner.SealedCIDPrefix)
-	sealProof := abi.RegisteredSealProof_StackedDrg32GiBV1
+	sealProof := abi.RegisteredSealProof_StackedDrg32GiBV1_1
 
 	// create miner
 	ret := vm.ApplyOk(t, v, addrs[0], builtin.StoragePowerActorAddr, minerBalance, builtin.MethodsPower.CreateMiner, &power.CreateMinerParams{

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/filecoin-project/go-bitfield v0.2.0
 	github.com/filecoin-project/go-hamt-ipld v0.1.5
 	github.com/filecoin-project/go-hamt-ipld/v2 v2.0.0
-	github.com/filecoin-project/go-state-types v0.0.0-20201021025442-0ac4de847f4f
-	github.com/filecoin-project/specs-actors v0.9.12
+	github.com/filecoin-project/go-state-types v0.0.0-20201013222834-41ea465f274f
+	github.com/filecoin-project/specs-actors v0.9.13
 	github.com/ipfs/go-block-format v0.0.2
 	github.com/ipfs/go-cid v0.0.7
 	github.com/ipfs/go-ipld-cbor v0.0.4

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/filecoin-project/go-bitfield v0.2.0
 	github.com/filecoin-project/go-hamt-ipld v0.1.5
 	github.com/filecoin-project/go-hamt-ipld/v2 v2.0.0
-	github.com/filecoin-project/go-state-types v0.0.0-20201013222834-41ea465f274f
+	github.com/filecoin-project/go-state-types v0.0.0-20201102161440-c8033295a1fc
 	github.com/filecoin-project/specs-actors v0.9.13
 	github.com/ipfs/go-block-format v0.0.2
 	github.com/ipfs/go-cid v0.0.7

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/filecoin-project/go-hamt-ipld v0.1.5/go.mod h1:6Is+ONR5Cd5R6XZoCse1CW
 github.com/filecoin-project/go-hamt-ipld/v2 v2.0.0 h1:b3UDemBYN2HNfk3KOXNuxgTTxlWi3xVvbQP0IT38fvM=
 github.com/filecoin-project/go-hamt-ipld/v2 v2.0.0/go.mod h1:7aWZdaQ1b16BVoQUYR+eEvrDCGJoPLxFpDynFjYfBjI=
 github.com/filecoin-project/go-state-types v0.0.0-20200928172055-2df22083d8ab/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
-github.com/filecoin-project/go-state-types v0.0.0-20201013222834-41ea465f274f h1:TZDTu4MtBKSFLXWGKLy+cvC3nHfMFIrVgWLAz/+GgZQ=
-github.com/filecoin-project/go-state-types v0.0.0-20201013222834-41ea465f274f/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
+github.com/filecoin-project/go-state-types v0.0.0-20201102161440-c8033295a1fc h1:+hbMY4Pcx2oizrfH08VWXwrj5mU8aJT6g0UNxGHFCGU=
+github.com/filecoin-project/go-state-types v0.0.0-20201102161440-c8033295a1fc/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
 github.com/filecoin-project/specs-actors v0.9.13 h1:rUEOQouefi9fuVY/2HOroROJlZbOzWYXXeIh41KF2M4=
 github.com/filecoin-project/specs-actors v0.9.13/go.mod h1:TS1AW/7LbG+615j4NsjMK1qlpAwaFsG9w0V2tg2gSao=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=

--- a/go.sum
+++ b/go.sum
@@ -17,12 +17,11 @@ github.com/filecoin-project/go-hamt-ipld v0.1.5/go.mod h1:6Is+ONR5Cd5R6XZoCse1CW
 github.com/filecoin-project/go-hamt-ipld v0.1.5/go.mod h1:6Is+ONR5Cd5R6XZoCse1CWaXZc0Hdb/JeX+EQCQzX24=
 github.com/filecoin-project/go-hamt-ipld/v2 v2.0.0 h1:b3UDemBYN2HNfk3KOXNuxgTTxlWi3xVvbQP0IT38fvM=
 github.com/filecoin-project/go-hamt-ipld/v2 v2.0.0/go.mod h1:7aWZdaQ1b16BVoQUYR+eEvrDCGJoPLxFpDynFjYfBjI=
-github.com/filecoin-project/go-state-types v0.0.0-20200928172055-2df22083d8ab h1:cEDC5Ei8UuT99hPWhCjA72SM9AuRtnpvdSTIYbnzN8I=
 github.com/filecoin-project/go-state-types v0.0.0-20200928172055-2df22083d8ab/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
-github.com/filecoin-project/go-state-types v0.0.0-20201021025442-0ac4de847f4f h1:aKh+3jNOemceyBOO6uOL/3Zi3yNr4r9TiWVe0tBByZE=
-github.com/filecoin-project/go-state-types v0.0.0-20201021025442-0ac4de847f4f/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
-github.com/filecoin-project/specs-actors v0.9.12 h1:iIvk58tuMtmloFNHhAOQHG+4Gci6Lui0n7DYQGi3cJk=
-github.com/filecoin-project/specs-actors v0.9.12/go.mod h1:TS1AW/7LbG+615j4NsjMK1qlpAwaFsG9w0V2tg2gSao=
+github.com/filecoin-project/go-state-types v0.0.0-20201013222834-41ea465f274f h1:TZDTu4MtBKSFLXWGKLy+cvC3nHfMFIrVgWLAz/+GgZQ=
+github.com/filecoin-project/go-state-types v0.0.0-20201013222834-41ea465f274f/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
+github.com/filecoin-project/specs-actors v0.9.13 h1:rUEOQouefi9fuVY/2HOroROJlZbOzWYXXeIh41KF2M4=
+github.com/filecoin-project/specs-actors v0.9.13/go.mod h1:TS1AW/7LbG+615j4NsjMK1qlpAwaFsG9w0V2tg2gSao=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=


### PR DESCRIPTION
TODO
- [x] merge https://github.com/filecoin-project/go-state-types/pull/19 and update go-state-types dep