### PR TITLE
Remove error returns from state validation functions

### DIFF
--- a/actors/builtin/account/account_test.go
+++ b/actors/builtin/account/account_test.go
@@ -2,6 +2,7 @@ package account_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/filecoin-project/go-address"
@@ -85,7 +86,6 @@ func checkState(t *testing.T, rt *mock.Runtime) {
 	require.NoError(t, err)
 	var st account.State
 	rt.GetState(&st)
-	_, msgs, err := account.CheckStateInvariants(&st, testAddress)
-	assert.NoError(t, err)
-	assert.True(t, msgs.IsEmpty())
+	_, msgs := account.CheckStateInvariants(&st, testAddress)
+	assert.True(t, msgs.IsEmpty(), strings.Join(msgs.Messages(), "\n"))
 }

--- a/actors/builtin/account/testing.go
+++ b/actors/builtin/account/testing.go
@@ -2,6 +2,7 @@ package account
 
 import (
 	"github.com/filecoin-project/go-address"
+
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
 )
 
@@ -10,20 +11,18 @@ type StateSummary struct {
 }
 
 // Checks internal invariants of account state.
-func CheckStateInvariants(st *State, idAddr address.Address) (*StateSummary, *builtin.MessageAccumulator, error) {
+func CheckStateInvariants(st *State, idAddr address.Address) (*StateSummary, *builtin.MessageAccumulator) {
 	acc := &builtin.MessageAccumulator{}
-
-	id, err := address.IDFromAddress(idAddr)
-	if err != nil {
-		return nil, acc, err
+	accountSummary := &StateSummary{
+		PubKeyAddr: st.Address,
 	}
-	if id >= builtin.FirstNonSingletonActorId {
-		acc.Require(
-			st.Address.Protocol() == address.BLS || st.Address.Protocol() == address.SECP256K1,
+
+	if id, err := address.IDFromAddress(idAddr); err != nil {
+		acc.Addf("error extracting actor ID from address: %v", err)
+	} else if id >= builtin.FirstNonSingletonActorId {
+		acc.Require(st.Address.Protocol() == address.BLS || st.Address.Protocol() == address.SECP256K1,
 			"actor address %v must be BLS or SECP256K1 protocol", st.Address)
 	}
 
-	return &StateSummary{
-		PubKeyAddr: st.Address,
-	}, acc, nil
+	return accountSummary, acc
 }

--- a/actors/builtin/cron/cron_test.go
+++ b/actors/builtin/cron/cron_test.go
@@ -124,7 +124,6 @@ func (h *cronHarness) epochTickAndVerify(rt *mock.Runtime) {
 func (h *cronHarness) checkState(rt *mock.Runtime) {
 	var st cron.State
 	rt.GetState(&st)
-	_, msgs, err := cron.CheckStateInvariants(&st, rt.AdtStore())
-	assert.NoError(h.t, err)
+	_, msgs := cron.CheckStateInvariants(&st, rt.AdtStore())
 	assert.True(h.t, msgs.IsEmpty())
 }

--- a/actors/builtin/cron/testing.go
+++ b/actors/builtin/cron/testing.go
@@ -11,14 +11,14 @@ type StateSummary struct {
 }
 
 // Checks internal invariants of cron state.
-func CheckStateInvariants(st *State, store adt.Store) (*StateSummary, *builtin.MessageAccumulator, error) {
+func CheckStateInvariants(st *State, store adt.Store) (*StateSummary, *builtin.MessageAccumulator) {
 	acc := &builtin.MessageAccumulator{}
+	cronSummary := &StateSummary{
+		EntryCount: len(st.Entries),
+	}
 	for i, e := range st.Entries {
 		acc.Require(e.Receiver.Protocol() == address.ID, "entry %d receiver address %v must be ID protocol", i, e.Receiver)
 		acc.Require(e.MethodNum > 0, "entry %d has invalid method number %d", i, e.MethodNum)
 	}
-
-	return &StateSummary{
-		EntryCount: len(st.Entries),
-	}, acc, nil
+	return cronSummary, acc
 }

--- a/actors/builtin/init/init_test.go
+++ b/actors/builtin/init/init_test.go
@@ -226,8 +226,7 @@ func (h *initHarness) state(rt *mock.Runtime) *init_.State {
 
 func (h *initHarness) checkState(rt *mock.Runtime) {
 	st := h.state(rt)
-	_, msgs, err := init_.CheckStateInvariants(st, rt.AdtStore())
-	assert.NoError(h.t, err)
+	_, msgs := init_.CheckStateInvariants(st, rt.AdtStore())
 	assert.True(h.t, msgs.IsEmpty(), strings.Join(msgs.Messages(), "\n"))
 }
 

--- a/actors/builtin/market/market_test.go
+++ b/actors/builtin/market/market_test.go
@@ -3130,8 +3130,7 @@ func (h *marketActorTestHarness) generateDealWithCollateralAndAddFunds(rt *mock.
 func (h *marketActorTestHarness) checkState(rt *mock.Runtime) {
 	var st market.State
 	rt.GetState(&st)
-	_, msgs, err := market.CheckStateInvariants(&st, rt.AdtStore(), rt.Balance(), rt.Epoch())
-	assert.NoError(h.t, err)
+	_, msgs := market.CheckStateInvariants(&st, rt.AdtStore(), rt.Balance(), rt.Epoch())
 	assert.True(h.t, msgs.IsEmpty(), strings.Join(msgs.Messages(), "\n"))
 }
 

--- a/actors/builtin/multisig/multisig_test.go
+++ b/actors/builtin/multisig/multisig_test.go
@@ -2096,8 +2096,7 @@ func (h *msActorHarness) checkState(rt *mock.Runtime) {
 }
 
 func assertStateInvariants(t testing.TB, rt *mock.Runtime, st *multisig.State) {
-	_, msgs, err := multisig.CheckStateInvariants(st, rt.AdtStore())
-	assert.NoError(t, err)
+	_, msgs := multisig.CheckStateInvariants(st, rt.AdtStore())
 	assert.True(t, msgs.IsEmpty(), strings.Join(msgs.Messages(), "\n"))
 }
 

--- a/actors/builtin/paych/paych_test.go
+++ b/actors/builtin/paych/paych_test.go
@@ -957,8 +957,7 @@ func (h *pcActorHarness) constructAndVerify(t *testing.T, rt *mock.Runtime, send
 func (h *pcActorHarness) checkState(rt *mock.Runtime) {
 	var st State
 	rt.GetState(&st)
-	_, msgs, err := CheckStateInvariants(&st, rt.AdtStore(), rt.Balance())
-	require.NoError(h.t, err)
+	_, msgs := CheckStateInvariants(&st, rt.AdtStore(), rt.Balance())
 	assert.True(h.t, msgs.IsEmpty(), strings.Join(msgs.Messages(), "\n"))
 }
 

--- a/actors/builtin/paych/testing.go
+++ b/actors/builtin/paych/testing.go
@@ -13,34 +13,31 @@ type StateSummary struct {
 }
 
 // Checks internal invariants of paych state.
-func CheckStateInvariants(st *State, store adt.Store, balance abi.TokenAmount) (*StateSummary, *builtin.MessageAccumulator, error) {
+func CheckStateInvariants(st *State, store adt.Store, balance abi.TokenAmount) (*StateSummary, *builtin.MessageAccumulator) {
 	acc := &builtin.MessageAccumulator{}
+	paychSummary := &StateSummary{
+		Redeemed: big.Zero(),
+	}
 
 	acc.Require(st.From.Protocol() == address.ID, "from address is not ID address %v", st.From)
 	acc.Require(st.To.Protocol() == address.ID, "to address is not ID address %v", st.To)
 	acc.Require(st.SettlingAt >= st.MinSettleHeight,
 		"channel is setting at epoch %d before min settle height %d", st.SettlingAt, st.MinSettleHeight)
 
-	lanes, err := adt.AsArray(store, st.LaneStates)
-	if err != nil {
-		return nil, acc, err
-	}
-
-	redeemed := big.Zero()
-	var lane LaneState
-	err = lanes.ForEach(&lane, func(i int64) error {
-		acc.Require(lane.Redeemed.GreaterThan(big.Zero()), "land %d redeemed is not greater than zero %v", i, lane.Redeemed)
-		redeemed = big.Add(redeemed, lane.Redeemed)
-		return nil
-	})
-	if err != nil {
-		return nil, acc, err
+	if lanes, err := adt.AsArray(store, st.LaneStates); err != nil {
+		acc.Addf("error loading lanes: %v", err)
+	} else {
+		var lane LaneState
+		err = lanes.ForEach(&lane, func(i int64) error {
+			acc.Require(lane.Redeemed.GreaterThan(big.Zero()), "land %d redeemed is not greater than zero %v", i, lane.Redeemed)
+			paychSummary.Redeemed = big.Add(paychSummary.Redeemed, lane.Redeemed)
+			return nil
+		})
+		acc.RequireNoError(err, "error iterating lanes")
 	}
 
 	acc.Require(balance.GreaterThanEqual(st.ToSend),
 		"channel has insufficient funds to send (%v < %v)", balance, st.ToSend)
 
-	return &StateSummary{
-		Redeemed: redeemed,
-	}, acc, nil
+	return paychSummary, acc
 }

--- a/actors/builtin/power/power_test.go
+++ b/actors/builtin/power/power_test.go
@@ -1398,8 +1398,7 @@ func (h *spActorHarness) expectTotalPledgeEager(rt *mock.Runtime, expectedPledge
 
 func (h *spActorHarness) checkState(rt *mock.Runtime) {
 	st := getState(rt)
-	_, msgs, err := power.CheckStateInvariants(st, rt.AdtStore())
-	require.NoError(h.t, err)
+	_, msgs := power.CheckStateInvariants(st, rt.AdtStore())
 	assert.True(h.t, msgs.IsEmpty(), strings.Join(msgs.Messages(), "\n"))
 }
 

--- a/actors/builtin/power/testing.go
+++ b/actors/builtin/power/testing.go
@@ -4,6 +4,7 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
+
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
 	"github.com/filecoin-project/specs-actors/v2/actors/runtime/proof"
 	"github.com/filecoin-project/specs-actors/v2/actors/util/adt"
@@ -25,7 +26,7 @@ type StateSummary struct {
 }
 
 // Checks internal invariants of power state.
-func CheckStateInvariants(st *State, store adt.Store) (*StateSummary, *builtin.MessageAccumulator, error) {
+func CheckStateInvariants(st *State, store adt.Store) (*StateSummary, *builtin.MessageAccumulator) {
 	acc := &builtin.MessageAccumulator{}
 
 	// basic invariants around recorded power
@@ -43,35 +44,26 @@ func CheckStateInvariants(st *State, store adt.Store) (*StateSummary, *builtin.M
 	acc.Require(st.TotalQualityAdjPower.LessThanEqual(st.TotalQABytesCommitted),
 		"total qua power %v is greater than qa power committed %v", st.TotalQualityAdjPower, st.TotalQABytesCommitted)
 
-	crons, err := CheckCronInvariants(st, store, acc)
-	if err != nil {
-		return nil, acc, err
-	}
-
-	claims, err := CheckClaimInvariants(st, store, acc)
-	if err != nil {
-		return nil, acc, err
-	}
-
-	proofs, err := CheckProofValidationInvariants(st, store, claims, acc)
-	if err != nil {
-		return nil, acc, err
-	}
+	crons := CheckCronInvariants(st, store, acc)
+	claims := CheckClaimInvariants(st, store, acc)
+	proofs := CheckProofValidationInvariants(st, store, claims, acc)
 
 	return &StateSummary{
 		Crons:  crons,
 		Claims: claims,
 		Proofs: proofs,
-	}, acc, nil
+	}, acc
 }
 
-func CheckCronInvariants(st *State, store adt.Store, acc *builtin.MessageAccumulator) (CronEventsByAddress, error) {
+func CheckCronInvariants(st *State, store adt.Store, acc *builtin.MessageAccumulator) CronEventsByAddress {
+	byAddress := make(CronEventsByAddress)
 	queue, err := adt.AsMultimap(store, st.CronEventQueue)
 	if err != nil {
-		return nil, err
+		acc.Addf("error loading cron event queue: %v", err)
+		// Bail here.
+		return byAddress
 	}
 
-	byAddress := make(CronEventsByAddress)
 	err = queue.ForAll(func(ekey string, arr *adt.Array) error {
 		epoch, err := abi.ParseIntKey(ekey)
 		acc.Require(err == nil, "non-int key in cron array")
@@ -92,15 +84,17 @@ func CheckCronInvariants(st *State, store adt.Store, acc *builtin.MessageAccumul
 			return nil
 		})
 	})
-	acc.Require(err == nil, "error attempting to read through power actor cron tasks: %v", err)
-
-	return byAddress, nil
+	acc.RequireNoError(err, "error iterating cron tasks")
+	return byAddress
 }
 
-func CheckClaimInvariants(st *State, store adt.Store, acc *builtin.MessageAccumulator) (ClaimsByAddress, error) {
+func CheckClaimInvariants(st *State, store adt.Store, acc *builtin.MessageAccumulator) ClaimsByAddress {
+	byAddress := make(ClaimsByAddress)
 	claims, err := adt.AsMap(store, st.Claims)
 	if err != nil {
-		return nil, err
+		acc.Addf("error loading power claims: %v", err)
+		// Bail here
+		return byAddress
 	}
 
 	committedRawPower := abi.NewStoragePower(0)
@@ -108,7 +102,6 @@ func CheckClaimInvariants(st *State, store adt.Store, acc *builtin.MessageAccumu
 	rawPower := abi.NewStoragePower(0)
 	qaPower := abi.NewStoragePower(0)
 	claimsWithSufficientPowerCount := int64(0)
-	byAddress := make(ClaimsByAddress)
 	var claim Claim
 	err = claims.ForEach(&claim, func(key string) error {
 		addr, err := address.NewFromBytes([]byte(key))
@@ -132,9 +125,7 @@ func CheckClaimInvariants(st *State, store adt.Store, acc *builtin.MessageAccumu
 		}
 		return nil
 	})
-	if err != nil {
-		return nil, err
-	}
+	acc.RequireNoError(err, "error iterating power claims")
 
 	acc.Require(committedRawPower.Equals(st.TotalBytesCommitted),
 		"sum of raw power in claims %v does not match recorded bytes committed %v",
@@ -152,48 +143,45 @@ func CheckClaimInvariants(st *State, store adt.Store, acc *builtin.MessageAccumu
 	acc.Require(st.TotalQualityAdjPower.Equals(qaPower),
 		"recorded qa power %v does not match qa power in claims %v", st.TotalQualityAdjPower, qaPower)
 
-	return byAddress, nil
+	return byAddress
 }
 
-func CheckProofValidationInvariants(st *State, store adt.Store, claims ClaimsByAddress, acc *builtin.MessageAccumulator) (ProofsByAddress, error) {
+func CheckProofValidationInvariants(st *State, store adt.Store, claims ClaimsByAddress, acc *builtin.MessageAccumulator) ProofsByAddress {
 	if st.ProofValidationBatch == nil {
-		return nil, nil
-	}
-
-	queue, err := adt.AsMultimap(store, *st.ProofValidationBatch)
-	if err != nil {
-		return nil, err
+		return nil
 	}
 
 	proofs := make(ProofsByAddress)
-	err = queue.ForAll(func(key string, arr *adt.Array) error {
-		addr, err := address.NewFromBytes([]byte(key))
-		if err != nil {
-			return err
-		}
+	if queue, err := adt.AsMultimap(store, *st.ProofValidationBatch); err != nil {
+		acc.Addf("error loading proof validation queue: %v", err)
+	} else {
+		err = queue.ForAll(func(key string, arr *adt.Array) error {
+			addr, err := address.NewFromBytes([]byte(key))
+			if err != nil {
+				return err
+			}
 
-		claim, found := claims[addr]
-		acc.Require(found, "miner %v has proofs awaiting validation but no claim", addr)
-		if !found {
-			return nil
-		}
+			claim, found := claims[addr]
+			acc.Require(found, "miner %v has proofs awaiting validation but no claim", addr)
+			if !found {
+				return nil
+			}
 
-		var info proof.SealVerifyInfo
-		err = arr.ForEach(&info, func(i int64) error {
-			acc.Require(claim.SealProofType == info.SealProof, "miner submitted proof with proof type %d different from claim %d",
-				info.SealProof, claim.SealProofType)
-			proofs[addr] = append(proofs[addr], info)
+			var info proof.SealVerifyInfo
+			err = arr.ForEach(&info, func(i int64) error {
+				acc.Require(claim.SealProofType == info.SealProof, "miner submitted proof with proof type %d different from claim %d",
+					info.SealProof, claim.SealProofType)
+				proofs[addr] = append(proofs[addr], info)
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+			acc.Require(len(proofs[addr]) <= MaxMinerProveCommitsPerEpoch,
+				"miner %v has submitted too many proofs (%d) for batch verification", addr, len(proofs[addr]))
 			return nil
 		})
-		if err != nil {
-			return err
-		}
-		acc.Require(len(proofs[addr]) <= MaxMinerProveCommitsPerEpoch,
-			"miner %v has submitted too many proofs (%d) for batch verification", addr, len(proofs[addr]))
-		return nil
-	})
-	if err != nil {
-		return nil, err
+		acc.RequireNoError(err, "error iterating proof validation queue")
 	}
-	return proofs, nil
+	return proofs
 }

--- a/actors/builtin/reward/testing.go
+++ b/actors/builtin/reward/testing.go
@@ -12,7 +12,7 @@ type StateSummary struct{}
 var FIL = big.NewInt(1e18)
 var StorageMiningAllocationCheck = big.Mul(big.NewInt(1_100_000_000), FIL)
 
-func CheckStateInvariants(st *State, store adt.Store, priorEpoch abi.ChainEpoch, balance abi.TokenAmount) (*StateSummary, *builtin.MessageAccumulator, error) {
+func CheckStateInvariants(st *State, store adt.Store, priorEpoch abi.ChainEpoch, balance abi.TokenAmount) (*StateSummary, *builtin.MessageAccumulator) {
 	acc := &builtin.MessageAccumulator{}
 
 	// Can't assert equality because anyone can send funds to reward actor (and already have on mainnet)
@@ -25,5 +25,5 @@ func CheckStateInvariants(st *State, store adt.Store, priorEpoch abi.ChainEpoch,
 	acc.Require(st.CumsumRealized.GreaterThanEqual(big.Zero()), "cumsum realized < 0")
 	acc.Require(st.EffectiveBaselinePower.LessThanEqual(st.ThisEpochBaselinePower), "effective baseline power > baseline power")
 
-	return &StateSummary{}, acc, nil
+	return &StateSummary{}, acc
 }

--- a/actors/builtin/verifreg/testing.go
+++ b/actors/builtin/verifreg/testing.go
@@ -15,49 +15,47 @@ type StateSummary struct {
 }
 
 // Checks internal invariants of verified registry state.
-func CheckStateInvariants(st *State, store adt.Store) (*StateSummary, *builtin.MessageAccumulator, error) {
+func CheckStateInvariants(st *State, store adt.Store) (*StateSummary, *builtin.MessageAccumulator) {
 	acc := &builtin.MessageAccumulator{}
 	acc.Require(st.RootKey.Protocol() == addr.ID, "root key %v should have ID protocol", st.RootKey)
 
 	// Check verifiers
-	verifiers, err := adt.AsMap(store, st.Verifiers)
-	if err != nil {
-		return nil, nil, err
+	allVerifiers := map[addr.Address]DataCap{}
+	if verifiers, err := adt.AsMap(store, st.Verifiers); err != nil {
+		acc.Addf("error loading verifiers: %v", err)
+	} else {
+		var vcap abi.StoragePower
+		err = verifiers.ForEach(&vcap, func(key string) error {
+			verifier, err := addr.NewFromBytes([]byte(key))
+			if err != nil {
+				return err
+			}
+			acc.Require(verifier.Protocol() == addr.ID, "verifier %v should have ID protocol", verifier)
+			acc.Require(vcap.GreaterThanEqual(big.Zero()), "verifier %v cap %v is negative", verifier, vcap)
+			allVerifiers[verifier] = vcap.Copy()
+			return nil
+		})
+		acc.RequireNoError(err, "error iterating verifiers")
 	}
 
-	allVerifiers := map[addr.Address]DataCap{}
-	var vcap abi.StoragePower
-	if err = verifiers.ForEach(&vcap, func(key string) error {
-		verifier, err := addr.NewFromBytes([]byte(key))
-		if err != nil {
-			return err
-		}
-		acc.Require(verifier.Protocol() == addr.ID, "verifier %v should have ID protocol", verifier)
-		acc.Require(vcap.GreaterThanEqual(big.Zero()), "verifier %v cap %v is negative", verifier, vcap)
-		allVerifiers[verifier] = vcap.Copy()
-		return nil
-	}); err != nil {
-		return nil, nil, err
-	}
 
 	// Check clients
-	clients, err := adt.AsMap(store, st.VerifiedClients)
-	if err != nil {
-		return nil, nil, err
-	}
-
 	allClients := map[addr.Address]DataCap{}
-	if err = clients.ForEach(&vcap, func(key string) error {
-		client, err := addr.NewFromBytes([]byte(key))
-		if err != nil {
-			return err
-		}
-		acc.Require(client.Protocol() == addr.ID, "client %v should have ID protocol", client)
-		acc.Require(vcap.GreaterThanEqual(big.Zero()), "client %v cap %v is negative", client, vcap)
-		allClients[client] = vcap.Copy()
-		return nil
-	}); err != nil {
-		return nil, nil, err
+	if clients, err := adt.AsMap(store, st.VerifiedClients); err != nil {
+		acc.Addf("error loading clients: %v", err)
+	} else {
+		var ccap abi.StoragePower
+		err = clients.ForEach(&ccap, func(key string) error {
+			client, err := addr.NewFromBytes([]byte(key))
+			if err != nil {
+				return err
+			}
+			acc.Require(client.Protocol() == addr.ID, "client %v should have ID protocol", client)
+			acc.Require(ccap.GreaterThanEqual(big.Zero()), "client %v cap %v is negative", client, ccap)
+			allClients[client] = ccap.Copy()
+			return nil
+		})
+		acc.RequireNoError(err, "error iterating clients")
 	}
 
 	// Check verifiers and clients are disjoint.
@@ -70,5 +68,5 @@ func CheckStateInvariants(st *State, store adt.Store) (*StateSummary, *builtin.M
 	return &StateSummary{
 		Verifiers: allVerifiers,
 		Clients:   allClients,
-	}, acc, nil
+	}, acc
 }

--- a/actors/builtin/verifreg/verified_registry_test.go
+++ b/actors/builtin/verifreg/verified_registry_test.go
@@ -806,8 +806,7 @@ func (h *verifRegActorTestHarness) state(rt *mock.Runtime) *verifreg.State {
 
 func (h *verifRegActorTestHarness) checkState(rt *mock.Runtime) {
 	st := h.state(rt)
-	_, msgs, err := verifreg.CheckStateInvariants(st, rt.AdtStore())
-	assert.NoError(h.t, err)
+	_, msgs := verifreg.CheckStateInvariants(st, rt.AdtStore())
 	assert.True(h.t, msgs.IsEmpty(), strings.Join(msgs.Messages(), "\n"))
 }
 

--- a/actors/states/check.go
+++ b/actors/states/check.go
@@ -2,11 +2,13 @@ package states
 
 import (
 	"bytes"
+
 	addr "github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
-	"github.com/filecoin-project/specs-actors/v2/actors/builtin/power"
 	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/specs-actors/v2/actors/builtin/power"
 
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin/account"
@@ -52,46 +54,33 @@ func CheckStateInvariants(tree *Tree, expectedBalanceTotal abi.TokenAmount, prio
 			if err := tree.Store.Get(tree.Store.Context(), actor.Head, &st); err != nil {
 				return err
 			}
-			if summary, msgs, err := init_.CheckStateInvariants(&st, tree.Store); err != nil {
-				return err
-			} else {
-				acc.WithPrefix("init: ").AddAll(msgs)
-				initSummary = summary
-			}
+			summary, msgs := init_.CheckStateInvariants(&st, tree.Store)
+			acc.WithPrefix("init: ").AddAll(msgs)
+			initSummary = summary
 		case builtin.CronActorCodeID:
 			var st cron.State
 			if err := tree.Store.Get(tree.Store.Context(), actor.Head, &st); err != nil {
 				return err
 			}
-			if summary, msgs, err := cron.CheckStateInvariants(&st, tree.Store); err != nil {
-				return err
-			} else {
-				acc.WithPrefix("cron: ").AddAll(msgs)
-				cronSummary = summary
-			}
-
+			summary, msgs := cron.CheckStateInvariants(&st, tree.Store)
+			acc.WithPrefix("cron: ").AddAll(msgs)
+			cronSummary = summary
 		case builtin.AccountActorCodeID:
 			var st account.State
 			if err := tree.Store.Get(tree.Store.Context(), actor.Head, &st); err != nil {
 				return err
 			}
-			if summary, msgs, err := account.CheckStateInvariants(&st, key); err != nil {
-				return err
-			} else {
-				acc.WithPrefix("account: ").AddAll(msgs)
-				accountSummaries = append(accountSummaries, summary)
-			}
+			summary, msgs := account.CheckStateInvariants(&st, key)
+			acc.WithPrefix("account: ").AddAll(msgs)
+			accountSummaries = append(accountSummaries, summary)
 		case builtin.StoragePowerActorCodeID:
 			var st power.State
 			if err := tree.Store.Get(tree.Store.Context(), actor.Head, &st); err != nil {
 				return err
 			}
-			if summary, msgs, err := power.CheckStateInvariants(&st, tree.Store); err != nil {
-				return err
-			} else {
-				acc.WithPrefix("power: ").AddAll(msgs)
-				powerSummary = summary
-			}
+			summary, msgs := power.CheckStateInvariants(&st, tree.Store)
+			acc.WithPrefix("power: ").AddAll(msgs)
+			powerSummary = summary
 		case builtin.StorageMinerActorCodeID:
 			var st miner.State
 			if err := tree.Store.Get(tree.Store.Context(), actor.Head, &st); err != nil {
@@ -105,60 +94,41 @@ func CheckStateInvariants(tree *Tree, expectedBalanceTotal abi.TokenAmount, prio
 			if err := tree.Store.Get(tree.Store.Context(), actor.Head, &st); err != nil {
 				return err
 			}
-			if summary, msgs, err := market.CheckStateInvariants(&st, tree.Store, actor.Balance, priorEpoch); err != nil {
-				return err
-			} else {
-				acc.WithPrefix("market: ").AddAll(msgs)
-				marketSummary = summary
-			}
-
+			summary, msgs := market.CheckStateInvariants(&st, tree.Store, actor.Balance, priorEpoch)
+			acc.WithPrefix("market: ").AddAll(msgs)
+			marketSummary = summary
 		case builtin.PaymentChannelActorCodeID:
 			var st paych.State
 			if err := tree.Store.Get(tree.Store.Context(), actor.Head, &st); err != nil {
 				return err
 			}
-			if summary, msgs, err := paych.CheckStateInvariants(&st, tree.Store, actor.Balance); err != nil {
-				return err
-			} else {
-				acc.WithPrefix("paych: ").AddAll(msgs)
-				paychSummaries = append(paychSummaries, summary)
-			}
-
+			summary, msgs := paych.CheckStateInvariants(&st, tree.Store, actor.Balance)
+			acc.WithPrefix("paych: ").AddAll(msgs)
+			paychSummaries = append(paychSummaries, summary)
 		case builtin.MultisigActorCodeID:
 			var st multisig.State
 			if err := tree.Store.Get(tree.Store.Context(), actor.Head, &st); err != nil {
 				return err
 			}
-			if summary, msgs, err := multisig.CheckStateInvariants(&st, tree.Store); err != nil {
-				return err
-			} else {
-				acc.WithPrefix("multisig: ").AddAll(msgs)
-				multisigSummaries = append(multisigSummaries, summary)
-			}
-
+			summary, msgs := multisig.CheckStateInvariants(&st, tree.Store)
+			acc.WithPrefix("multisig: ").AddAll(msgs)
+			multisigSummaries = append(multisigSummaries, summary)
 		case builtin.RewardActorCodeID:
 			var st reward.State
 			if err := tree.Store.Get(tree.Store.Context(), actor.Head, &st); err != nil {
 				return err
 			}
-			if summary, msgs, err := reward.CheckStateInvariants(&st, tree.Store, priorEpoch, actor.Balance); err != nil {
-				return err
-			} else {
-				acc.WithPrefix("reward: ").AddAll(msgs)
-				rewardSummary = summary
-			}
-
+			summary, msgs := reward.CheckStateInvariants(&st, tree.Store, priorEpoch, actor.Balance)
+			acc.WithPrefix("reward: ").AddAll(msgs)
+			rewardSummary = summary
 		case builtin.VerifiedRegistryActorCodeID:
 			var st verifreg.State
 			if err := tree.Store.Get(tree.Store.Context(), actor.Head, &st); err != nil {
 				return err
 			}
-			if summary, msgs, err := verifreg.CheckStateInvariants(&st, tree.Store); err != nil {
-				return err
-			} else {
-				acc.WithPrefix("verifreg: ").AddAll(msgs)
-				verifregSummary = summary
-			}
+			summary, msgs := verifreg.CheckStateInvariants(&st, tree.Store)
+			acc.WithPrefix("verifreg: ").AddAll(msgs)
+			verifregSummary = summary
 		default:
 			return xerrors.Errorf("unexpected actor code CID %v for address %v", actor.Code, key)
 		}


### PR DESCRIPTION
Instead of returning an error that prevents the validation completing at all, all errors are now accumulated as messages. In some cases this might lead to a bit of an overload, but I think that's better than getting nothing.

I was unable to run a full mainnet state validation with `ent` because Lotus has not yet upgraded to consume the changes that preceded this. It could be worth trying to break the ent->Lotus dependency some day.

Closes #1244.