### PR TITLE
Feat/migrate minerinfo prooftype

### DIFF
--- a/actors/migration/nv7/miner.go
+++ b/actors/migration/nv7/miner.go
@@ -1,0 +1,42 @@
+package nv7
+
+import (
+	"context"
+
+	"github.com/filecoin-project/go-state-types/abi"
+
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/specs-actors/v2/actors/builtin/miner"
+	"github.com/filecoin-project/specs-actors/v2/actors/util/adt"
+	cid "github.com/ipfs/go-cid"
+	cbor "github.com/ipfs/go-ipld-cbor"
+)
+
+type MinerMigrator struct{}
+
+func (m MinerMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, head cid.Cid, info MigrationInfo) (*StateMigrationResult, error) {
+	var state miner.State
+	if err := store.Get(ctx, head, &state); err != nil {
+		return nil, err
+	}
+	adtStore := adt.WrapStore(ctx, store)
+
+	mInfo, err := state.GetInfo(adtStore)
+	if err != nil {
+		return nil, err
+	}
+	if mInfo.SealProofType == abi.RegisteredSealProof_StackedDrg32GiBV1 {
+		mInfo.SealProofType = abi.RegisteredSealProof_StackedDrg32GiBV1_1
+	} else if mInfo.SealProofType == abi.RegisteredSealProof_StackedDrg64GiBV1 {
+		mInfo.SealProofType = abi.RegisteredSealProof_StackedDrg64GiBV1_1
+	}
+	if err := state.SaveInfo(adtStore, mInfo); err != nil {
+		return nil, err
+	}
+
+	newHead, err := store.Put(ctx, &state)
+	return &StateMigrationResult{
+		NewHead:  newHead,
+		Transfer: big.Zero(),
+	}, err
+}

--- a/actors/migration/nv7/top.go
+++ b/actors/migration/nv7/top.go
@@ -58,8 +58,8 @@ func MigrateStateTree(ctx context.Context, store cbor.IpldStore, stateRootIn cid
 	}
 
 	err = actorsIn.ForEach(func(addr address.Address, actorIn *states.Actor) error {
-		if !actorIn.Code.Equals(builtin.StorageMinerActorCodeID) { // skip non-miners
-			return nil
+		if !actorIn.Code.Equals(builtin.StorageMinerActorCodeID) { // non miners are written with no change
+			return actorsOut.SetActor(addr, actorIn)
 		}
 		minerResult, err := MinerMigrator{}.MigrateState(ctx, store, actorIn.Head, MigrationInfo{
 			address:    addr,


### PR DESCRIPTION
Migrate minerState's Info SealProofType field from V1 to V1_1 for 32 and 64 GiB sectors.  This change was requested by lotus to ease integration.  Added in a migration of power table claim seal proof types to fix the inconsistency there too which the invariant checks caught.

We need to measure migration runtime.  If this significantly increases migration runtime we should defer this to the upcoming migration where we can do ahead-of-time migration or other strategies to reduce burden of long runtimes.