### PR TITLE
Simulate faults and recoveries

### DIFF
--- a/support/agent/cases_test.go
+++ b/support/agent/cases_test.go
@@ -64,7 +64,7 @@ func TestCreate20Miners(t *testing.T) {
 }
 
 func TestCommitPowerAndCheckInvariants(t *testing.T) {
-	//t.Skip("this is slow")
+	t.Skip("this is slow")
 	ctx := context.Background()
 	initialBalance := big.Mul(big.NewInt(1e9), big.NewInt(1e18))
 	minerCount := 1

--- a/support/agent/cases_test.go
+++ b/support/agent/cases_test.go
@@ -38,11 +38,12 @@ func TestCreate20Miners(t *testing.T) {
 			ProofType:       abi.RegisteredSealProof_StackedDrg32GiBV1_1,
 			StartingBalance: initialBalance,
 		},
-		1.0, // create miner probibility of 1 means a new miner is created every tick
+		1.0, // create miner probability of 1 means a new miner is created every tick
 		rnd.Int63(),
 	))
 
-	for i := 0; i < minerCount; i++ {
+	// give it twice the number of ticks to account for variation in the rate
+	for i := 0; i < 2*minerCount; i++ {
 		require.NoError(t, sim.Tick())
 	}
 

--- a/support/agent/cases_test.go
+++ b/support/agent/cases_test.go
@@ -76,6 +76,7 @@ func TestCommitPowerAndCheckInvariants(t *testing.T) {
 		accounts,
 		agent.MinerAgentConfig{
 			PrecommitRate:   2.5,
+			FaultRate:       0.01,
 			ProofType:       abi.RegisteredSealProof_StackedDrg32GiBV1_1,
 			StartingBalance: initialBalance,
 		},
@@ -100,9 +101,13 @@ func TestCommitPowerAndCheckInvariants(t *testing.T) {
 			require.True(t, acc.IsEmpty(), strings.Join(acc.Messages(), "\n"))
 
 			require.NoError(t, sim.GetVM().GetState(builtin.StoragePowerActorAddr, &pwrSt))
-			fmt.Printf("Power at %d: raw: %v  qa: %v  cmtRaw: %v  cmtQa: %v  cnsMnrs: %d avgWins: %.3f\n",
-				epoch, pwrSt.TotalRawBytePower, pwrSt.TotalQualityAdjPower, pwrSt.TotalBytesCommitted,
-				pwrSt.TotalQABytesCommitted, pwrSt.MinerAboveMinPowerCount, float64(sim.WinCount)/float64(epoch))
+
+			// assume each sector is 32Gb
+			sectorCount := big.Div(pwrSt.TotalBytesCommitted, big.NewInt(32<<30))
+
+			fmt.Printf("Power at %d: raw: %v  cmtRaw: %v  cmtSecs: %d  cnsMnrs: %d avgWins: %.3f\n",
+				epoch, pwrSt.TotalRawBytePower, pwrSt.TotalBytesCommitted, sectorCount.Uint64(),
+				pwrSt.MinerAboveMinPowerCount, float64(sim.WinCount)/float64(epoch))
 		}
 	}
 }

--- a/support/agent/cases_test.go
+++ b/support/agent/cases_test.go
@@ -3,12 +3,11 @@ package agent_test
 import (
 	"context"
 	"fmt"
-	"github.com/filecoin-project/go-state-types/abi"
-	"github.com/filecoin-project/specs-actors/v2/actors/states"
 	"math/rand"
 	"strings"
 	"testing"
 
+	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	cbor "github.com/ipfs/go-ipld-cbor"
 	"github.com/stretchr/testify/assert"
@@ -16,6 +15,7 @@ import (
 
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin/power"
+	"github.com/filecoin-project/specs-actors/v2/actors/states"
 	"github.com/filecoin-project/specs-actors/v2/actors/util/adt"
 	"github.com/filecoin-project/specs-actors/v2/support/agent"
 	"github.com/filecoin-project/specs-actors/v2/support/ipld"
@@ -64,9 +64,9 @@ func TestCreate20Miners(t *testing.T) {
 }
 
 func TestCommitPowerAndCheckInvariants(t *testing.T) {
-	t.Skip("this is slow")
+	//t.Skip("this is slow")
 	ctx := context.Background()
-	initialBalance := big.Mul(big.NewInt(1e8), big.NewInt(1e18))
+	initialBalance := big.Mul(big.NewInt(1e9), big.NewInt(1e18))
 	minerCount := 1
 
 	rnd := rand.New(rand.NewSource(42))
@@ -75,9 +75,9 @@ func TestCommitPowerAndCheckInvariants(t *testing.T) {
 	sim.AddAgent(agent.NewMinerGenerator(
 		accounts,
 		agent.MinerAgentConfig{
-			PrecommitRate:   2.0,
-			FaultRate:       0.001,
-			RecoveryRate:    0.001,
+			PrecommitRate:   0.1,
+			FaultRate:       0.0001,
+			RecoveryRate:    0.0001,
 			ProofType:       abi.RegisteredSealProof_StackedDrg32GiBV1_1,
 			StartingBalance: initialBalance,
 		},
@@ -86,7 +86,7 @@ func TestCommitPowerAndCheckInvariants(t *testing.T) {
 	))
 
 	var pwrSt power.State
-	for i := 0; i < 20_000; i++ {
+	for i := 0; i < 100_000; i++ {
 		require.NoError(t, sim.Tick())
 
 		epoch := sim.GetVM().GetEpoch()
@@ -114,7 +114,7 @@ func TestCommitPowerAndCheckInvariants(t *testing.T) {
 }
 
 func TestCommitAndCheckReadWriteStats(t *testing.T) {
-	t.Skip("this is slow")
+	//t.Skip("this is slow")
 	ctx := context.Background()
 	initialBalance := big.Mul(big.NewInt(1e8), big.NewInt(1e18))
 	minerCount := 1

--- a/support/agent/cases_test.go
+++ b/support/agent/cases_test.go
@@ -64,7 +64,7 @@ func TestCreate20Miners(t *testing.T) {
 }
 
 func TestCommitPowerAndCheckInvariants(t *testing.T) {
-	t.Skip("this is slow")
+	//t.Skip("this is slow")
 	ctx := context.Background()
 	initialBalance := big.Mul(big.NewInt(1e9), big.NewInt(1e18))
 	minerCount := 1

--- a/support/agent/cases_test.go
+++ b/support/agent/cases_test.go
@@ -64,7 +64,7 @@ func TestCreate20Miners(t *testing.T) {
 }
 
 func TestCommitPowerAndCheckInvariants(t *testing.T) {
-	t.Skip("this is slow")
+	//t.Skip("this is slow")
 	ctx := context.Background()
 	initialBalance := big.Mul(big.NewInt(1000000), big.NewInt(1e18))
 	minerCount := 10
@@ -87,7 +87,8 @@ func TestCommitPowerAndCheckInvariants(t *testing.T) {
 	for i := 0; i < 20000; i++ {
 		require.NoError(t, sim.Tick())
 
-		if sim.GetVM().GetEpoch()%100 == 0 {
+		epoch := sim.GetVM().GetEpoch()
+		if epoch%100 == 0 {
 			stateTree, err := sim.GetVM().GetStateTree()
 			require.NoError(t, err)
 
@@ -99,9 +100,9 @@ func TestCommitPowerAndCheckInvariants(t *testing.T) {
 			require.True(t, acc.IsEmpty(), strings.Join(acc.Messages(), "\n"))
 
 			require.NoError(t, sim.GetVM().GetState(builtin.StoragePowerActorAddr, &pwrSt))
-			fmt.Printf("Power at %d: raw: %v  qa: %v  cmtRaw: %v  cmtQa: %v  cnsMnrs: %d\n",
-				sim.GetVM().GetEpoch(), pwrSt.TotalRawBytePower, pwrSt.TotalQualityAdjPower, pwrSt.TotalBytesCommitted,
-				pwrSt.TotalQABytesCommitted, pwrSt.MinerAboveMinPowerCount)
+			fmt.Printf("Power at %d: raw: %v  qa: %v  cmtRaw: %v  cmtQa: %v  cnsMnrs: %d avgWins: %.3f\n",
+				epoch, pwrSt.TotalRawBytePower, pwrSt.TotalQualityAdjPower, pwrSt.TotalBytesCommitted,
+				pwrSt.TotalQABytesCommitted, pwrSt.MinerAboveMinPowerCount, float64(sim.WinCount)/float64(epoch))
 		}
 	}
 }

--- a/support/agent/cases_test.go
+++ b/support/agent/cases_test.go
@@ -64,7 +64,7 @@ func TestCreate20Miners(t *testing.T) {
 }
 
 func TestCommitPowerAndCheckInvariants(t *testing.T) {
-	//t.Skip("this is slow")
+	t.Skip("this is slow")
 	ctx := context.Background()
 	initialBalance := big.Mul(big.NewInt(1e9), big.NewInt(1e18))
 	minerCount := 1
@@ -76,8 +76,8 @@ func TestCommitPowerAndCheckInvariants(t *testing.T) {
 		accounts,
 		agent.MinerAgentConfig{
 			PrecommitRate:   0.1,
-			FaultRate:       0.0001,
-			RecoveryRate:    0.0001,
+			FaultRate:       0.001,
+			RecoveryRate:    0.00001,
 			ProofType:       abi.RegisteredSealProof_StackedDrg32GiBV1_1,
 			StartingBalance: initialBalance,
 		},
@@ -114,7 +114,7 @@ func TestCommitPowerAndCheckInvariants(t *testing.T) {
 }
 
 func TestCommitAndCheckReadWriteStats(t *testing.T) {
-	//t.Skip("this is slow")
+	t.Skip("this is slow")
 	ctx := context.Background()
 	initialBalance := big.Mul(big.NewInt(1e8), big.NewInt(1e18))
 	minerCount := 1

--- a/support/agent/math.go
+++ b/support/agent/math.go
@@ -58,9 +58,16 @@ func (ri *RateIterator) Tick(f func() error) error {
 
 // convenience method for when rate depends on changing variables
 func (ri *RateIterator) TickWithRate(rate float64, f func() error) error {
-	if rate > 0.0 && ri.rate <= 0.0 {
-		ri.nextOccurrence -= math.Log(1.0-ri.rnd.Float64()) / rate
+	if rate <= 0.0 {
+		ri.rate = rate
+		return nil
 	}
+
+	// recompute next occurrence if rate has changed
+	if ri.rate != rate {
+		ri.nextOccurrence = 1.0 - math.Log(1.0-ri.rnd.Float64())/rate
+	}
+
 	ri.rate = rate
 	return ri.Tick(f)
 }

--- a/support/agent/math.go
+++ b/support/agent/math.go
@@ -2,35 +2,46 @@ package agent
 
 import (
 	"math"
+	big2 "math/big"
 	"math/rand"
+
+	"github.com/filecoin-project/go-state-types/abi"
 )
 
 type RateIterator struct {
-	rnd           *rand.Rand
-	rate          float64
-	nextOccurence float64
+	rnd            *rand.Rand
+	rate           float64
+	nextOccurrence float64
 }
 
 func NewRateIterator(rate float64, seed int64) *RateIterator {
-	ri := &RateIterator{
-		rnd:           rand.New(rand.NewSource(seed)),
-		rate:          rate,
-		nextOccurence: 1.0, // next occurrence should happen next tick
+	rnd := rand.New(rand.NewSource(seed))
+	return &RateIterator{
+		rnd:  rnd,
+		rate: rate,
+
+		// choose first event in next tick
+		nextOccurrence: 1.0 - math.Log(1.0-rnd.Float64())/rate,
 	}
-	ri.chooseNext() // randomize first occurrence
-	return ri
 }
 
 // simulate random occurrences by calling the given function once for each event that would land in this epoch.
 // The function will be called `rate` times on average, but may be called zero or many times in any Tick.
+//
 func (ri *RateIterator) Tick(f func() error) error {
-	ri.nextOccurence -= 1.0
-	for ri.nextOccurence < 1.0 {
+	// next tick becomes this tick
+	ri.nextOccurrence -= 1.0
+
+	// choose events can call function until event occurs in next tick
+	for ri.nextOccurrence < 1.0 {
 		err := f()
 		if err != nil {
 			return err
 		}
-		ri.chooseNext()
+
+		// Choose next event
+		// Note the argument to Log is <= 1, so the right side is always negative and nextOccurrence increases
+		ri.nextOccurrence -= math.Log(1.0-ri.rnd.Float64()) / ri.rate
 	}
 	return nil
 }
@@ -41,7 +52,41 @@ func (ri *RateIterator) TickWithRate(rate float64, f func() error) error {
 	return ri.Tick(f)
 }
 
-// Choose next event according to a poisson distribution for the rate
-func (ri *RateIterator) chooseNext() {
-	ri.nextOccurence += -math.Log(1-ri.rnd.Float64()) / ri.rate
+///////////////////////////////////////
+//
+//  Win Count
+//
+///////////////////////////////////////
+
+// This is the Filecoin algorithm for winning a ticket within a block with the tickets replaced
+// with random numbers. It lets miners win according to a Poisson distribution with rate
+// proportional to the miner's fraction of network power.
+func WinCount(minerPower abi.StoragePower, totalPower abi.StoragePower, random float64) uint64 {
+	E := big2.NewRat(5, 1)
+	lambdaR := new(big2.Rat)
+	lambdaR.SetFrac(minerPower.Int, totalPower.Int)
+	lambdaR.Mul(lambdaR, E)
+	lambda, _ := lambdaR.Float64()
+
+	rhs := 1 - poissonPMF(lambda, 0)
+
+	winCount := uint64(0)
+	for rhs > random {
+		winCount++
+		rhs -= poissonPMF(lambda, winCount)
+	}
+	return winCount
+}
+
+func poissonPMF(lambda float64, k uint64) float64 {
+	fk := float64(k)
+	return (math.Exp(-lambda) * math.Pow(lambda, fk)) / fact(fk)
+}
+
+func fact(k float64) float64 {
+	fact := 1.0
+	for i := 2.0; i <= k; i += 1.0 {
+		fact *= i
+	}
+	return fact
 }

--- a/support/agent/math.go
+++ b/support/agent/math.go
@@ -1,0 +1,47 @@
+package agent
+
+import (
+	"math"
+	"math/rand"
+)
+
+type RateIterator struct {
+	rnd           *rand.Rand
+	rate          float64
+	nextOccurence float64
+}
+
+func NewRateIterator(rate float64, seed int64) *RateIterator {
+	ri := &RateIterator{
+		rnd:           rand.New(rand.NewSource(seed)),
+		rate:          rate,
+		nextOccurence: 1.0, // next occurrence should happen next tick
+	}
+	ri.chooseNext() // randomize first occurrence
+	return ri
+}
+
+// simulate random occurrences by calling the given function once for each event that would land in this epoch.
+// The function will be called `rate` times on average, but may be called zero or many times in any Tick.
+func (ri *RateIterator) Tick(f func() error) error {
+	ri.nextOccurence -= 1.0
+	for ri.nextOccurence < 1.0 {
+		err := f()
+		if err != nil {
+			return err
+		}
+		ri.chooseNext()
+	}
+	return nil
+}
+
+// convenience method for when rate depends on changing variables
+func (ri *RateIterator) TickWithRate(rate float64, f func() error) error {
+	ri.rate = rate
+	return ri.Tick(f)
+}
+
+// Choose next event according to a poisson distribution for the rate
+func (ri *RateIterator) chooseNext() {
+	ri.nextOccurence += -math.Log(1-ri.rnd.Float64()) / ri.rate
+}

--- a/support/agent/math.go
+++ b/support/agent/math.go
@@ -8,6 +8,10 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 )
 
+// RateIterator can be used to model poisson process (a process with discreet events occurring at
+// arbitrary times with a specified average rate). It's Tick function must be called at regular
+// intervals with a function that will be called zero or more times to produce the event distribution
+// at the correct rate.
 type RateIterator struct {
 	rnd            *rand.Rand
 	rate           float64
@@ -32,7 +36,6 @@ func NewRateIterator(rate float64, seed int64) *RateIterator {
 
 // simulate random occurrences by calling the given function once for each event that would land in this epoch.
 // The function will be called `rate` times on average, but may be called zero or many times in any Tick.
-//
 func (ri *RateIterator) Tick(f func() error) error {
 	// wait until we have a positive rate before doing anything
 	if ri.rate <= 0.0 {

--- a/support/agent/miner_agent.go
+++ b/support/agent/miner_agent.go
@@ -680,10 +680,6 @@ func (part *partition) expireSectors(newExpired bitfield.BitField) error {
 	if err != nil {
 		return err
 	}
-	part.faults, err = bitfield.SubtractBitField(part.faults, newExpired)
-	if err != nil {
-		return err
-	}
 	part.toBeSkipped, err = bitfield.SubtractBitField(part.toBeSkipped, newExpired)
 	if err != nil {
 		return err

--- a/support/agent/miner_agent.go
+++ b/support/agent/miner_agent.go
@@ -208,7 +208,7 @@ func (ma *MinerAgent) Tick(s SimState) ([]message, error) {
 	}
 
 	// Recover sectors.
-	// Rate must be multiplied by the number of live sectors
+	// Rate must be multiplied by the number of faulty sectors
 	recoveryRate := ma.Config.RecoveryRate * float64(len(ma.faultySectors))
 	if err := ma.recoveryEvents.TickWithRate(recoveryRate, func() error {
 		msgs, err := ma.createRecovery(s)

--- a/support/agent/miner_agent.go
+++ b/support/agent/miner_agent.go
@@ -104,8 +104,6 @@ type MinerAgent struct {
 	liveSectors []uint64
 	// total number of sectors expected to be faulty
 	faultySectors []uint64
-	// total number of sectors expected to have expired
-	expiredSectors []uint64
 
 	// priority queue used to trigger actions at future epochs
 	operationSchedule *opQueue

--- a/support/agent/sim.go
+++ b/support/agent/sim.go
@@ -2,8 +2,6 @@ package agent
 
 import (
 	"context"
-	"math"
-	big2 "math/big"
 	"math/rand"
 	"strings"
 	"testing"
@@ -32,10 +30,12 @@ import (
 // * Messages will be shuffled to simulate network entropy.
 // * Messages will be applied and an new VM will be created from the resulting state tree for the next tick.
 type Sim struct {
-	Config        SimConfig
-	Agents        []Agent
+	Config SimConfig
+	Agents []Agent
+
 	v             *vm.VM
 	rnd           *rand.Rand
+	WinCount      uint64
 	statsByMethod map[vm.MethodKey]*vm.CallStats
 }
 
@@ -115,7 +115,8 @@ func (s *Sim) Tick() error {
 	// interleaving them with the rest of the messages).
 	for _, miner := range powerTable.minerPower {
 		if powerTable.totalQAPower.GreaterThan(big.Zero()) {
-			wins := s.winCount(miner.qaPower, powerTable.totalQAPower)
+			wins := WinCount(miner.qaPower, powerTable.totalQAPower, s.rnd.Float64())
+			s.WinCount += wins
 			err := s.rewardMiner(miner.addr, wins)
 			if err != nil {
 				return err
@@ -223,40 +224,6 @@ func computePowerTable(v *vm.VM, agents []Agent) (powerTable, error) {
 		}
 	}
 	return pt, nil
-}
-
-// This is the Filecoin algorithm for winning a ticket within a block with the tickets replaced
-// with random numbers. It lets miners win according to a Poisson distribution with rate
-// proportional to the miner's fraction of network power.
-func (s *Sim) winCount(minerPower abi.StoragePower, totalPower abi.StoragePower) uint64 {
-	E := big2.NewRat(5, 1)
-	lambdaR := new(big2.Rat)
-	lambdaR.SetFrac(minerPower.Int, totalPower.Int)
-	lambdaR.Mul(lambdaR, E)
-	lambda, _ := lambdaR.Float64()
-
-	h := s.rnd.Float64()
-	rhs := 1 - poissonPMF(lambda, 0)
-
-	winCount := uint64(0)
-	for rhs > h {
-		winCount++
-		rhs -= poissonPMF(lambda, winCount)
-	}
-	return winCount
-}
-
-func poissonPMF(lambda float64, k uint64) float64 {
-	fk := float64(k)
-	return (math.Exp(-lambda) * math.Pow(lambda, fk)) / fact(fk)
-}
-
-func fact(k float64) float64 {
-	fact := 1.0
-	for i := 2.0; i <= k; i += 1.0 {
-		fact *= i
-	}
-	return fact
 }
 
 //////////////////////////////////////////////

--- a/support/agent/sim.go
+++ b/support/agent/sim.go
@@ -36,6 +36,7 @@ type Sim struct {
 	v             *vm.VM
 	rnd           *rand.Rand
 	WinCount      uint64
+	MessageCount  uint64
 	statsByMethod map[vm.MethodKey]*vm.CallStats
 }
 
@@ -108,6 +109,7 @@ func (s *Sim) Tick() error {
 			}
 		}
 	}
+	s.MessageCount += uint64(len(blockMessages))
 
 	// Apply block rewards
 	// Note that this differs from the specification in that it applies all reward messages at the end, whereas


### PR DESCRIPTION
### Motivation

To better simulate all actor processes we need to simulate miner behavior when storage faults. This PR adds a mechanism to simulate and track faults which either result in declared fault messages or sectors being skipped when PoSts are submitted. Similarly, miners can recover their faults, so the simulation can now add a probability that a fault will be recovered resulting in a declare fault recovered message.

This PR also:

1. Introduces a `math.go` file with a new `RateIterator` to contain some of the stochastic machinery used by the simulation.
2. Introduces the `RateIterator` struct that will call a function some number of times each tick based on a rate and the Poisson distribution.