### PR TITLE
Porep Gas charge reduced 4x past v7

### DIFF
--- a/actors/builtin/power/power_actor.go
+++ b/actors/builtin/power/power_actor.go
@@ -2,6 +2,7 @@ package power
 
 import (
 	"bytes"
+
 	addr "github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/cbor"
@@ -259,10 +260,15 @@ func (a Actor) UpdatePledgeTotal(rt Runtime, pledgeDelta *abi.TokenAmount) *abi.
 // This number is empirically determined
 const GasOnSubmitVerifySeal = 34721049
 
+// GasOnSubmitVerifySealV7 is the amount of gas charged for SubmitPoRepForBulkVerify
+// after v7 corresponding to 4x speedup in porep.
+const GasOnSubmitVerifySealV7 = 8509249
+
 func (a Actor) SubmitPoRepForBulkVerify(rt Runtime, sealInfo *proof.SealVerifyInfo) *abi.EmptyValue {
 	rt.ValidateImmediateCallerType(builtin.StorageMinerActorCodeID)
 
 	minerAddr := rt.Caller()
+	nv := rt.NetworkVersion()
 
 	var st State
 	rt.StateTransaction(&st, func() {
@@ -290,7 +296,11 @@ func (a Actor) SubmitPoRepForBulkVerify(rt Runtime, sealInfo *proof.SealVerifyIn
 		mmrc, err := mmap.Root()
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to flush proof batch")
 
-		rt.ChargeGas("OnSubmitVerifySeal", GasOnSubmitVerifySeal, 0)
+		if nv < network.Version7 {
+			rt.ChargeGas("OnSubmitVerifySeal", GasOnSubmitVerifySeal, 0)
+		} else {
+			rt.ChargeGas("OnSubmitVerifySeal", GasOnSubmitVerifySealV7, 0)
+		}
 		st.ProofValidationBatch = &mmrc
 	})
 

--- a/actors/builtin/power/power_actor.go
+++ b/actors/builtin/power/power_actor.go
@@ -258,7 +258,7 @@ func (a Actor) UpdatePledgeTotal(rt Runtime, pledgeDelta *abi.TokenAmount) *abi.
 
 // GasOnSubmitVerifySeal is amount of gas charged for SubmitPoRepForBulkVerify
 // This number is empirically determined
-const GasOnSubmitVerifySeal = 34721049
+const GasOnSubmitVerifySeal = power0.GasOnSubmitVerifySeal
 
 // GasOnSubmitVerifySealV7 is the amount of gas charged for SubmitPoRepForBulkVerify
 // after v7 corresponding to 4x speedup in porep.

--- a/actors/builtin/power/power_test.go
+++ b/actors/builtin/power/power_test.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/filecoin-project/go-state-types/network"
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/filecoin-project/go-state-types/network"
 
 	addr "github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
@@ -863,6 +864,37 @@ func TestSubmitPoRepForBulkVerify(t *testing.T) {
 			UnsealedCID: commD,
 		}
 		actor.submitPoRepForBulkVerify(rt, miner, sealInfo)
+		rt.ExpectGasCharged(power.GasOnSubmitVerifySealV7)
+		st := getState(rt)
+		store := rt.AdtStore()
+		require.NotNil(t, st.ProofValidationBatch)
+		mmap, err := adt.AsMultimap(store, *st.ProofValidationBatch)
+		require.NoError(t, err)
+		arr, found, err := mmap.Get(abi.AddrKey(miner))
+		require.NoError(t, err)
+		require.True(t, found)
+		assert.Equal(t, uint64(1), arr.Length())
+		var storedSealInfo proof.SealVerifyInfo
+		found, err = arr.Get(0, &storedSealInfo)
+		require.NoError(t, err)
+		require.True(t, found)
+		assert.Equal(t, commR, storedSealInfo.SealedCID)
+		actor.checkState(rt)
+	})
+
+	t.Run("charges 4x for gas before network version 7", func(t *testing.T) {
+		rt := builder.Build(t)
+		rt.SetNetworkVersion(network.Version6)
+		actor.constructAndVerify(rt)
+		actor.createMinerBasic(rt, owner, owner, miner)
+		commR := tutil.MakeCID("commR", &mineract.SealedCIDPrefix)
+		commD := tutil.MakeCID("commD", &market.PieceCIDPrefix)
+		sealInfo := &proof.SealVerifyInfo{
+			SealProof:   actor.sealProof,
+			SealedCID:   commR,
+			UnsealedCID: commD,
+		}
+		actor.submitPoRepForBulkVerify(rt, miner, sealInfo)
 		rt.ExpectGasCharged(power.GasOnSubmitVerifySeal)
 		st := getState(rt)
 		store := rt.AdtStore()
@@ -903,7 +935,7 @@ func TestSubmitPoRepForBulkVerify(t *testing.T) {
 		})
 
 		// Gas only charged for successful submissions
-		rt.ExpectGasCharged(power.GasOnSubmitVerifySeal * power.MaxMinerProveCommitsPerEpoch)
+		rt.ExpectGasCharged(power.GasOnSubmitVerifySealV7 * power.MaxMinerProveCommitsPerEpoch)
 	})
 
 	t.Run("aborts when miner has no claim", func(t *testing.T) {


### PR DESCRIPTION
Gas rebalancing [here](https://github.com/filecoin-project/FIPs/issues/31) puts PoRep gas charges 4x lower to account for speedup in default proofs implementation.  @Kubuxu has requested we include this in actors v2.3.x.  Iit is high impact and a simple change hence this PR.