### PR TITLE
Simulate deals in actor code

### DIFF
--- a/support/agent/cases_test.go
+++ b/support/agent/cases_test.go
@@ -34,9 +34,11 @@ func TestCreate20Miners(t *testing.T) {
 	sim.AddAgent(agent.NewMinerGenerator(
 		accounts,
 		agent.MinerAgentConfig{
-			PrecommitRate:   2.5,
-			ProofType:       abi.RegisteredSealProof_StackedDrg32GiBV1_1,
-			StartingBalance: initialBalance,
+			PrecommitRate:    2.5,
+			ProofType:        abi.RegisteredSealProof_StackedDrg32GiBV1_1,
+			StartingBalance:  initialBalance,
+			MinMarketBalance: big.Zero(),
+			MaxMarketBalance: big.Zero(),
 		},
 		1.0, // create miner probability of 1 means a new miner is created every tick
 		rnd.Int63(),
@@ -75,11 +77,13 @@ func TestCommitPowerAndCheckInvariants(t *testing.T) {
 	sim.AddAgent(agent.NewMinerGenerator(
 		accounts,
 		agent.MinerAgentConfig{
-			PrecommitRate:   0.1,
-			FaultRate:       0.00001,
-			RecoveryRate:    0.0001,
-			ProofType:       abi.RegisteredSealProof_StackedDrg32GiBV1_1,
-			StartingBalance: initialBalance,
+			PrecommitRate:    0.1,
+			FaultRate:        0.00001,
+			RecoveryRate:     0.0001,
+			ProofType:        abi.RegisteredSealProof_StackedDrg32GiBV1_1,
+			StartingBalance:  initialBalance,
+			MinMarketBalance: big.Zero(),
+			MaxMarketBalance: big.Zero(),
 		},
 		1.0, // create miner probability of 1 means a new miner is created every tick
 		rnd.Int63(),
@@ -128,11 +132,13 @@ func TestCommitAndCheckReadWriteStats(t *testing.T) {
 	sim.AddAgent(agent.NewMinerGenerator(
 		accounts,
 		agent.MinerAgentConfig{
-			PrecommitRate:   2.0,
-			FaultRate:       0.001,
-			RecoveryRate:    0.001,
-			ProofType:       abi.RegisteredSealProof_StackedDrg32GiBV1_1,
-			StartingBalance: initialBalance,
+			PrecommitRate:    2.0,
+			FaultRate:        0.001,
+			RecoveryRate:     0.001,
+			ProofType:        abi.RegisteredSealProof_StackedDrg32GiBV1_1,
+			StartingBalance:  initialBalance,
+			MinMarketBalance: big.Zero(),
+			MaxMarketBalance: big.Zero(),
 		},
 		1.0, // create miner probibility of 1 means a new miner is created every tick
 		rnd.Int63(),
@@ -162,7 +168,7 @@ func TestCommitAndCheckReadWriteStats(t *testing.T) {
 }
 
 func TestCreateDeals(t *testing.T) {
-	//t.Skip("this is slow")
+	t.Skip("this is slow")
 	ctx := context.Background()
 	initialBalance := big.Mul(big.NewInt(1e9), big.NewInt(1e18))
 	minerCount := 3

--- a/support/agent/deal_client_agent.go
+++ b/support/agent/deal_client_agent.go
@@ -1,0 +1,206 @@
+package agent
+
+import (
+	"crypto/sha256"
+	mh "github.com/multiformats/go-multihash"
+	"math/bits"
+	"math/rand"
+	"strconv"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/cbor"
+	"github.com/filecoin-project/go-state-types/crypto"
+	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
+	"github.com/filecoin-project/specs-actors/v2/actors/builtin/market"
+	"github.com/filecoin-project/specs-actors/v2/actors/builtin/power"
+	"github.com/filecoin-project/specs-actors/v2/actors/builtin/reward"
+	"github.com/ipfs/go-cid"
+)
+
+type DealClientConfig struct {
+	DealRate         float64         // deals made per epoch
+	MinPieceSize     uint64          // minimum piece size (actual piece size be rounded up to power of 2)
+	MaxPieceSize     uint64          // maximum piece size
+	MinStoragePrice  abi.TokenAmount // minimum price per epoch a client will pay for storage (may be zero)
+	MaxStoragePrice  abi.TokenAmount // maximum price per epoch a client will pay for storage
+	MinMarketBalance abi.TokenAmount // balance below which client will top up funds in market actor
+	MaxMarketBalance abi.TokenAmount // balance to which client will top up funds in market actor
+}
+
+type DealClientAgent struct {
+	DealCount int
+
+	account    address.Address
+	config     DealClientConfig
+	dealEvents *RateIterator
+	rnd        *rand.Rand
+
+	// tracks funds expected to be locked for client deal payment
+	expectedMarketBalance abi.TokenAmount
+}
+
+func AddDealClientsForAccounts(s SimState, accounts []address.Address, seed int64, config DealClientConfig) []*DealClientAgent {
+	rnd := rand.New(rand.NewSource(seed))
+	var agents []*DealClientAgent
+	for _, account := range accounts {
+		agent := NewDealClientAgent(account, rnd.Int63(), config)
+		agents = append(agents, agent)
+		s.AddAgent(agent)
+	}
+	return agents
+}
+
+func NewDealClientAgent(account address.Address, seed int64, config DealClientConfig) *DealClientAgent {
+	rnd := rand.New(rand.NewSource(seed))
+	return &DealClientAgent{
+		account:               account,
+		config:                config,
+		rnd:                   rnd,
+		expectedMarketBalance: big.Zero(),
+		dealEvents:            NewRateIterator(config.DealRate, rnd.Int63()),
+	}
+}
+
+func (dca *DealClientAgent) Tick(s SimState) ([]message, error) {
+	var providers []DealProvider
+
+	// aggregate all deals into one message
+	if err := dca.dealEvents.Tick(func() error {
+		provider := s.ChooseDealProvider()
+		providers = append(providers, provider)
+		if err := dca.createDeal(s, provider); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	// add message to update market balance if necessary
+	messages := dca.updateMarketBalance()
+
+	return messages, nil
+}
+
+func (dca *DealClientAgent) updateMarketBalance() []message {
+	if dca.expectedMarketBalance.GreaterThanEqual(dca.config.MinMarketBalance) {
+		return []message{}
+	}
+
+	balanceToAdd := big.Sub(dca.config.MaxMarketBalance, dca.expectedMarketBalance)
+
+	return []message{{
+		From:   dca.account,
+		To:     builtin.StorageMarketActorAddr,
+		Value:  balanceToAdd,
+		Method: builtin.MethodsMarket.AddBalance,
+		Params: &dca.account,
+		ReturnHandler: func(v SimState, msg message, ret cbor.Marshaler) error {
+			dca.expectedMarketBalance = dca.config.MaxMarketBalance
+			return nil
+		},
+	}}
+}
+
+// Create a proposal
+// Return false if provider if deal can't be performed because client or provider lacks funds
+func (dca *DealClientAgent) createDeal(s SimState, provider DealProvider) error {
+	pieceCid, err := dca.generatePieceCID()
+	if err != nil {
+		return err
+	}
+
+	pieceSize := dca.config.MinPieceSize +
+		uint64(dca.rnd.Int63n(int64(dca.config.MaxPieceSize-dca.config.MinPieceSize)))
+
+	// round to next power of two
+	if bits.OnesCount64(pieceSize) > 1 {
+		pieceSize = 1 << bits.Len64(pieceSize)
+	}
+
+	providerCollateral, err := calculateProviderCollateral(s, abi.PaddedPieceSize(pieceSize))
+	if err != nil {
+		return err
+	}
+
+	// if provider does not have enough collateral, just skip this deal
+	if provider.AvailableCollateral().LessThan(providerCollateral) {
+		return nil
+	}
+
+	// storage price is uniformly distributed between min an max
+	price := big.Add(dca.config.MinStoragePrice,
+		big.NewInt(dca.rnd.Int63n(int64(big.Sub(dca.config.MaxStoragePrice, dca.config.MinStoragePrice).Uint64()))))
+
+	// deal start is earliest possible epoch, deal end is uniformly distributed between start and max.
+	dealStart, maxDealEnd := provider.DealRange(s.GetEpoch())
+	dealEnd := dealStart + abi.ChainEpoch(dca.rnd.Int63n(int64(maxDealEnd-dealStart)))
+	if dealEnd-dealStart < market.DealMinDuration {
+		dealEnd = dealStart + market.DealMinDuration
+	}
+
+	// lower expected balance in anticipation of market actor locking storage fee
+	storageFee := big.Mul(big.NewInt(int64(dealEnd-dealStart)), price)
+
+	// if this client does not have enough balance for storage fee, just skip this deal
+	if dca.expectedMarketBalance.LessThan(storageFee) {
+		return nil
+	}
+
+	dca.expectedMarketBalance = big.Sub(dca.expectedMarketBalance, storageFee)
+
+	proposal := market.DealProposal{
+		PieceCID:             pieceCid,
+		PieceSize:            abi.PaddedPieceSize(pieceSize),
+		VerifiedDeal:         false,
+		Client:               dca.account,
+		Provider:             provider.Address(),
+		Label:                dca.account.String() + ":" + strconv.Itoa(dca.DealCount),
+		StartEpoch:           dealStart,
+		EndEpoch:             dealEnd,
+		StoragePricePerEpoch: price,
+		ProviderCollateral:   providerCollateral,
+		ClientCollateral:     big.Zero(),
+	}
+
+	provider.CreateDeal(market.ClientDealProposal{
+		Proposal:        proposal,
+		ClientSignature: crypto.Signature{},
+	})
+	dca.DealCount++
+	return nil
+}
+
+func (dca *DealClientAgent) generatePieceCID() (cid.Cid, error) {
+	data := make([]byte, 10)
+	if _, err := dca.rnd.Read(data); err != nil {
+		return cid.Cid{}, err
+	}
+
+	sum := sha256.Sum256(data)
+	hash, err := mh.Encode(sum[:], market.PieceCIDPrefix.MhType)
+	if err != nil {
+		panic(err)
+	}
+	return cid.NewCidV1(market.PieceCIDPrefix.Codec, hash), nil
+}
+
+// Always choose the minimum collateral. This appears to be realistic, and there's is not an obvious way to model a
+// more complex distribution.
+func calculateProviderCollateral(s SimState, pieceSize abi.PaddedPieceSize) (abi.TokenAmount, error) {
+	var powerSt power.State
+	if err := s.GetState(builtin.StoragePowerActorAddr, &powerSt); err != nil {
+		return big.Zero(), err
+	}
+
+	var rewardSt reward.State
+	if err := s.GetState(builtin.RewardActorAddr, &rewardSt); err != nil {
+		return big.Zero(), err
+	}
+
+	min, _ := market.DealProviderCollateralBounds(pieceSize, false, powerSt.TotalRawBytePower,
+		powerSt.TotalQualityAdjPower, rewardSt.ThisEpochBaselinePower, s.NetworkCirculatingSupply())
+	return min, nil
+}

--- a/support/agent/math.go
+++ b/support/agent/math.go
@@ -6,7 +6,10 @@ import (
 	"math/rand"
 
 	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
 )
+
+var DisbursedAmount = big.Mul(big.NewInt(41e6), big.NewInt(1e18))
 
 // RateIterator can be used to model poisson process (a process with discreet events occurring at
 // arbitrary times with a specified average rate). It's Tick function must be called at regular

--- a/support/agent/miner_agent.go
+++ b/support/agent/miner_agent.go
@@ -551,7 +551,7 @@ func (ma *MinerAgent) fillSectorWithPendingDeals(expiration abi.ChainEpoch) ([]a
 	loc := uint64(0)
 	for _, piece := range ma.dealsPendingInclusion {
 		size := uint64(piece.size)
-		loc = (loc + size - 1) / size * size
+		loc = ((loc + size - 1) / size) * size // round loc up to the next multiple of size
 		if loc+size > uint64(sectorSize) {
 			break
 		}

--- a/support/agent/miner_generator.go
+++ b/support/agent/miner_generator.go
@@ -1,0 +1,83 @@
+package agent
+
+import (
+	"github.com/pkg/errors"
+	"math/rand"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/cbor"
+
+	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
+	"github.com/filecoin-project/specs-actors/v2/actors/builtin/power"
+)
+
+// MinerGenerator adds miner agents to the simulation at a configured rate.
+// When triggered to add a new miner, it:
+// * Selects the next owner address from the accounts it has been given.
+// * Sends a createMiner message from that account
+// * Handles the response by creating a MinerAgent with MinerAgentConfig and registering it in the sim.
+type MinerGenerator struct {
+	config            MinerAgentConfig // eventually this should become a set of probabilities to support miner differentiation
+	createMinerEvents *RateIterator
+	minersCreated     int
+	accounts          []address.Address
+	rnd               *rand.Rand
+}
+
+func NewMinerGenerator(accounts []address.Address, config MinerAgentConfig, createMinerRate float64, rndSeed int64) *MinerGenerator {
+	rnd := rand.New(rand.NewSource(rndSeed))
+	return &MinerGenerator{
+		config:            config,
+		createMinerEvents: NewRateIterator(createMinerRate, rnd.Int63()),
+		accounts:          accounts,
+		rnd:               rnd,
+	}
+}
+
+func (mg *MinerGenerator) Tick(_ SimState) ([]message, error) {
+	var msgs []message
+	if mg.minersCreated >= len(mg.accounts) {
+		return msgs, nil
+	}
+
+	err := mg.createMinerEvents.Tick(func() error {
+		if mg.minersCreated < len(mg.accounts) {
+			addr := mg.accounts[mg.minersCreated]
+			mg.minersCreated++
+			msgs = append(msgs, mg.createMiner(addr, mg.config))
+		}
+		return nil
+	})
+	return msgs, err
+}
+
+func (mg *MinerGenerator) createMiner(owner address.Address, cfg MinerAgentConfig) message {
+	return message{
+		From:   owner,
+		To:     builtin.StoragePowerActorAddr,
+		Value:  mg.config.StartingBalance, // miner gets all account funds
+		Method: builtin.MethodsPower.CreateMiner,
+		Params: &power.CreateMinerParams{
+			Owner:         owner,
+			Worker:        owner,
+			SealProofType: cfg.ProofType,
+		},
+		ReturnHandler: func(s SimState, msg message, ret cbor.Marshaler) error {
+			createMinerRet, ok := ret.(*power.CreateMinerReturn)
+			if !ok {
+				return errors.Errorf("create miner return has wrong type: %v", ret)
+			}
+
+			params := msg.Params.(*power.CreateMinerParams)
+			if !ok {
+				return errors.Errorf("create miner params has wrong type: %v", msg.Params)
+			}
+
+			// register agent as both a miner and deal provider
+			minerAgent := NewMinerAgent(params.Owner, params.Worker, createMinerRet.IDAddress, createMinerRet.RobustAddress, mg.rnd.Int63(), cfg)
+			s.AddAgent(minerAgent)
+			s.AddDealProvider(minerAgent)
+			return nil
+		},
+	}
+}

--- a/support/agent/sim.go
+++ b/support/agent/sim.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
+	"github.com/filecoin-project/specs-actors/v2/actors/builtin/market"
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin/power"
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin/reward"
 	"github.com/filecoin-project/specs-actors/v2/actors/util/adt"
@@ -30,44 +31,33 @@ import (
 // * Messages will be shuffled to simulate network entropy.
 // * Messages will be applied and an new VM will be created from the resulting state tree for the next tick.
 type Sim struct {
-	Config SimConfig
-	Agents []Agent
+	Config        SimConfig
+	Agents        []Agent
+	DealProviders []DealProvider
+	WinCount      uint64
+	MessageCount  uint64
 
 	v             *vm.VM
 	rnd           *rand.Rand
-	WinCount      uint64
-	MessageCount  uint64
 	statsByMethod map[vm.MethodKey]*vm.CallStats
-}
-
-type SimState interface {
-	GetEpoch() abi.ChainEpoch
-	GetState(addr address.Address, out cbor.Unmarshaler) error
-	Store() adt.Store
-	AddAgent(a Agent)
-	Rnd() int64
-}
-
-type Agent interface {
-	Tick(v SimState) ([]message, error)
-}
-
-type SimConfig struct {
-	AccountCount           int
-	AccountInitialBalance  abi.TokenAmount
-	Seed                   int64
-	CreateMinerProbability float32
 }
 
 func NewSim(ctx context.Context, t testing.TB, store adt.Store, config SimConfig) *Sim {
 	v := vm.NewCustomStoreVMWithSingletons(ctx, store, t)
 	return &Sim{
-		Config: config,
-		Agents: []Agent{},
-		v:      v,
-		rnd:    rand.New(rand.NewSource(config.Seed)),
+		Config:        config,
+		Agents:        []Agent{},
+		DealProviders: []DealProvider{},
+		v:             v,
+		rnd:           rand.New(rand.NewSource(config.Seed)),
 	}
 }
+
+//////////////////////////////////////////
+//
+//  Sim execution
+//
+//////////////////////////////////////////
 
 func (s *Sim) Tick() error {
 	var err error
@@ -76,6 +66,10 @@ func (s *Sim) Tick() error {
 	// compute power table before state transition to create block rewards at the end
 	powerTable, err := computePowerTable(s.v, s.Agents)
 	if err != nil {
+		return err
+	}
+
+	if err := computeCircSupply(s.v); err != nil {
 		return err
 	}
 
@@ -161,6 +155,10 @@ func (s *Sim) AddAgent(a Agent) {
 	s.Agents = append(s.Agents, a)
 }
 
+func (s *Sim) AddDealProvider(d DealProvider) {
+	s.DealProviders = append(s.DealProviders, d)
+}
+
 func (s *Sim) Rnd() int64 {
 	return s.rnd.Int63()
 }
@@ -171,6 +169,17 @@ func (s *Sim) GetVM() *vm.VM {
 
 func (s *Sim) GetCallStats() map[vm.MethodKey]*vm.CallStats {
 	return s.statsByMethod
+}
+
+func (s *Sim) ChooseDealProvider() DealProvider {
+	if len(s.DealProviders) == 0 {
+		return nil
+	}
+	return s.DealProviders[s.rnd.Int63n(int64(len(s.DealProviders)))]
+}
+
+func (s *Sim) NetworkCirculatingSupply() abi.TokenAmount {
+	return s.v.GetCirculatingSupply()
 }
 
 //////////////////////////////////////////////////
@@ -228,11 +237,66 @@ func computePowerTable(v *vm.VM, agents []Agent) (powerTable, error) {
 	return pt, nil
 }
 
+func computeCircSupply(v *vm.VM) error {
+	// disbursed + reward.State.TotalStoragePowerReward - burnt.Balance - power.State.TotalPledgeCollateral
+	var rewardSt reward.State
+	if err := v.GetState(builtin.RewardActorAddr, &rewardSt); err != nil {
+		return err
+	}
+
+	var powerSt power.State
+	if err := v.GetState(builtin.StoragePowerActorAddr, &powerSt); err != nil {
+		return err
+	}
+
+	burnt, found, err := v.GetActor(builtin.BurntFundsActorAddr)
+	if err != nil {
+		return err
+	} else if !found {
+		return errors.Errorf("burnt actor not found at %v", builtin.BurntFundsActorAddr)
+	}
+
+	v.SetCirculatingSupply(big.Sum(DisbursedAmount, rewardSt.TotalStoragePowerReward,
+		powerSt.TotalPledgeCollateral.Neg(), burnt.Balance.Neg()))
+	return nil
+}
+
 //////////////////////////////////////////////
 //
 //  Internal Types
 //
 //////////////////////////////////////////////
+
+type SimState interface {
+	GetEpoch() abi.ChainEpoch
+	GetState(addr address.Address, out cbor.Unmarshaler) error
+	Store() adt.Store
+	AddAgent(a Agent)
+	AddDealProvider(d DealProvider)
+	NetworkCirculatingSupply() abi.TokenAmount
+
+	// randomly select an agent capable of making deals.
+	// Returns nil if no providers exist.
+	ChooseDealProvider() DealProvider
+}
+
+type Agent interface {
+	Tick(v SimState) ([]message, error)
+}
+
+type DealProvider interface {
+	Address() address.Address
+	DealRange(currentEpoch abi.ChainEpoch) (start abi.ChainEpoch, end abi.ChainEpoch)
+	CreateDeal(proposal market.ClientDealProposal)
+	AvailableCollateral() abi.TokenAmount
+}
+
+type SimConfig struct {
+	AccountCount           int
+	AccountInitialBalance  abi.TokenAmount
+	Seed                   int64
+	CreateMinerProbability float32
+}
 
 type returnHandler func(v SimState, msg message, ret cbor.Marshaler) error
 

--- a/support/vm/invocation_context.go
+++ b/support/vm/invocation_context.go
@@ -54,6 +54,7 @@ type topLevelContext struct {
 	originatorCallSeq       uint64          // Call sequence number of the top-level message.
 	newActorAddressCount    uint64          // Count of calls to NewActorAddress (mutable).
 	statsSource             StatsSource     // optional source of external statistics that can be used to profile calls
+	circSupply              abi.TokenAmount // default or externally specified circulating FIL supply
 }
 
 func newInvocationContext(rt *VM, topLevel *topLevelContext, msg InternalMessage, fromActor *states.Actor, emptyObject cid.Cid) invocationContext {
@@ -408,7 +409,7 @@ func (ic *invocationContext) DeleteActor(beneficiary address.Address) {
 }
 
 func (ic *invocationContext) TotalFilCircSupply() abi.TokenAmount {
-	return big.Mul(big.NewInt(1e9), big.NewInt(1e18))
+	return ic.topLevel.circSupply
 }
 
 func (ic *invocationContext) Context() context.Context {

--- a/support/vm/vm.go
+++ b/support/vm/vm.go
@@ -47,6 +47,8 @@ type VM struct {
 
 	statsSource   StatsSource
 	statsByMethod StatsByCall
+
+	circSupply abi.TokenAmount
 }
 
 // VM types
@@ -91,6 +93,7 @@ func NewVM(ctx context.Context, actorImpls ActorImplLookup, store adt.Store) *VM
 		emptyObject:    emptyObject,
 		networkVersion: network.VersionMax,
 		statsByMethod:  make(StatsByCall),
+		circSupply:     big.Mul(big.NewInt(1e9), big.NewInt(1e18)),
 	}
 }
 
@@ -117,6 +120,7 @@ func NewVMAtEpoch(ctx context.Context, actorImpls ActorImplLookup, store adt.Sto
 		emptyObject:    emptyObject,
 		networkVersion: network.VersionMax,
 		statsByMethod:  make(StatsByCall),
+		circSupply:     big.Mul(big.NewInt(1e9), big.NewInt(1e18)),
 	}, nil
 }
 
@@ -143,6 +147,7 @@ func (vm *VM) WithEpoch(epoch abi.ChainEpoch) (*VM, error) {
 		networkVersion: vm.networkVersion,
 		statsSource:    vm.statsSource,
 		statsByMethod:  make(StatsByCall),
+		circSupply:     vm.circSupply,
 	}, nil
 }
 
@@ -169,6 +174,7 @@ func (vm *VM) WithNetworkVersion(nv network.Version) (*VM, error) {
 		networkVersion: nv,
 		statsSource:    vm.statsSource,
 		statsByMethod:  make(StatsByCall),
+		circSupply:     vm.circSupply,
 	}, nil
 }
 
@@ -322,6 +328,7 @@ func (vm *VM) ApplyMessage(from, to address.Address, value abi.TokenAmount, meth
 		originatorCallSeq:    vm.callSequence,
 		newActorAddressCount: 0,
 		statsSource:          vm.statsSource,
+		circSupply:           vm.circSupply,
 	}
 	vm.callSequence++
 
@@ -408,6 +415,16 @@ func (vm *VM) GetEpoch() abi.ChainEpoch {
 // Get call stats
 func (vm *VM) GetCallStats() map[MethodKey]*CallStats {
 	return vm.statsByMethod
+}
+
+// Set the FIL circulating supply passed to actors through runtime
+func (vm *VM) SetCirculatingSupply(supply abi.TokenAmount) {
+	vm.circSupply = supply
+}
+
+// Set the FIL circulating supply passed to actors through runtime
+func (vm *VM) GetCirculatingSupply() abi.TokenAmount {
+	return vm.circSupply
 }
 
 // transfer debits money from one account and credits it to another.


### PR DESCRIPTION
### Motivation

In order to create a more accurate and complete simulation, this PR adds `DealClientAgent`s that interact with `MinerAgent`s to create and publish deals. This PR does a few other things along the way:

1. It moves `MinerGenerator` into its own file.
2. It modifies the sim to allow agents to chose a `DealProvider` allowing clients to communicate to miners to make deals.
3. It better simulates the circulating supply function in the VM runtime. since this is now used when calculating deal collateral.