### PR TITLE
Revert "Porep Gas charge reduced 4x past v7 (#1301)"

### DIFF
--- a/actors/builtin/power/power_actor.go
+++ b/actors/builtin/power/power_actor.go
@@ -2,7 +2,6 @@ package power
 
 import (
 	"bytes"
-
 	addr "github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/cbor"
@@ -258,17 +257,12 @@ func (a Actor) UpdatePledgeTotal(rt Runtime, pledgeDelta *abi.TokenAmount) *abi.
 
 // GasOnSubmitVerifySeal is amount of gas charged for SubmitPoRepForBulkVerify
 // This number is empirically determined
-const GasOnSubmitVerifySeal = power0.GasOnSubmitVerifySeal
-
-// GasOnSubmitVerifySealV7 is the amount of gas charged for SubmitPoRepForBulkVerify
-// after v7 corresponding to 4x speedup in porep.
-const GasOnSubmitVerifySealV7 = 8509249
+const GasOnSubmitVerifySeal = 34721049
 
 func (a Actor) SubmitPoRepForBulkVerify(rt Runtime, sealInfo *proof.SealVerifyInfo) *abi.EmptyValue {
 	rt.ValidateImmediateCallerType(builtin.StorageMinerActorCodeID)
 
 	minerAddr := rt.Caller()
-	nv := rt.NetworkVersion()
 
 	var st State
 	rt.StateTransaction(&st, func() {
@@ -296,11 +290,7 @@ func (a Actor) SubmitPoRepForBulkVerify(rt Runtime, sealInfo *proof.SealVerifyIn
 		mmrc, err := mmap.Root()
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to flush proof batch")
 
-		if nv < network.Version7 {
-			rt.ChargeGas("OnSubmitVerifySeal", GasOnSubmitVerifySeal, 0)
-		} else {
-			rt.ChargeGas("OnSubmitVerifySeal", GasOnSubmitVerifySealV7, 0)
-		}
+		rt.ChargeGas("OnSubmitVerifySeal", GasOnSubmitVerifySeal, 0)
 		st.ProofValidationBatch = &mmrc
 	})
 


### PR DESCRIPTION
This reverts commit d84628a278c877bd7ff3a0eadca42fc06105b899.

Due to cryptoeconomic requirements we will not be able to ship this adjustment
in next network version.

@ZenGround0 sorry for making you write this on short time and now reverting it,
and also causing another release having to be pushed.