### PR TITLE
Convert market actor VerifyDealsForActivation to batch

### DIFF
--- a/actors/builtin/market/cbor_gen.go
+++ b/actors/builtin/market/cbor_gen.go
@@ -255,6 +255,367 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
+var lengthBufVerifyDealsForActivationParams = []byte{129}
+
+func (t *VerifyDealsForActivationParams) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write(lengthBufVerifyDealsForActivationParams); err != nil {
+		return err
+	}
+
+	scratch := make([]byte, 9)
+
+	// t.Sectors ([]market.SectorDeals) (slice)
+	if len(t.Sectors) > cbg.MaxLength {
+		return xerrors.Errorf("Slice value in field t.Sectors was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.Sectors))); err != nil {
+		return err
+	}
+	for _, v := range t.Sectors {
+		if err := v.MarshalCBOR(w); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *VerifyDealsForActivationParams) UnmarshalCBOR(r io.Reader) error {
+	*t = VerifyDealsForActivationParams{}
+
+	br := cbg.GetPeeker(r)
+	scratch := make([]byte, 8)
+
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 1 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.Sectors ([]market.SectorDeals) (slice)
+
+	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("t.Sectors: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.Sectors = make([]SectorDeals, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+
+		var v SectorDeals
+		if err := v.UnmarshalCBOR(br); err != nil {
+			return err
+		}
+
+		t.Sectors[i] = v
+	}
+
+	return nil
+}
+
+var lengthBufVerifyDealsForActivationReturn = []byte{129}
+
+func (t *VerifyDealsForActivationReturn) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write(lengthBufVerifyDealsForActivationReturn); err != nil {
+		return err
+	}
+
+	scratch := make([]byte, 9)
+
+	// t.Sectors ([]market.SectorWeights) (slice)
+	if len(t.Sectors) > cbg.MaxLength {
+		return xerrors.Errorf("Slice value in field t.Sectors was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.Sectors))); err != nil {
+		return err
+	}
+	for _, v := range t.Sectors {
+		if err := v.MarshalCBOR(w); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *VerifyDealsForActivationReturn) UnmarshalCBOR(r io.Reader) error {
+	*t = VerifyDealsForActivationReturn{}
+
+	br := cbg.GetPeeker(r)
+	scratch := make([]byte, 8)
+
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 1 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.Sectors ([]market.SectorWeights) (slice)
+
+	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("t.Sectors: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.Sectors = make([]SectorWeights, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+
+		var v SectorWeights
+		if err := v.UnmarshalCBOR(br); err != nil {
+			return err
+		}
+
+		t.Sectors[i] = v
+	}
+
+	return nil
+}
+
+var lengthBufSectorDeals = []byte{130}
+
+func (t *SectorDeals) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write(lengthBufSectorDeals); err != nil {
+		return err
+	}
+
+	scratch := make([]byte, 9)
+
+	// t.SectorExpiry (abi.ChainEpoch) (int64)
+	if t.SectorExpiry >= 0 {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.SectorExpiry)); err != nil {
+			return err
+		}
+	} else {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.SectorExpiry-1)); err != nil {
+			return err
+		}
+	}
+
+	// t.DealIDs ([]abi.DealID) (slice)
+	if len(t.DealIDs) > cbg.MaxLength {
+		return xerrors.Errorf("Slice value in field t.DealIDs was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.DealIDs))); err != nil {
+		return err
+	}
+	for _, v := range t.DealIDs {
+		if err := cbg.CborWriteHeader(w, cbg.MajUnsignedInt, uint64(v)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *SectorDeals) UnmarshalCBOR(r io.Reader) error {
+	*t = SectorDeals{}
+
+	br := cbg.GetPeeker(r)
+	scratch := make([]byte, 8)
+
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 2 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.SectorExpiry (abi.ChainEpoch) (int64)
+	{
+		maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+		var extraI int64
+		if err != nil {
+			return err
+		}
+		switch maj {
+		case cbg.MajUnsignedInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 positive overflow")
+			}
+		case cbg.MajNegativeInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 negative oveflow")
+			}
+			extraI = -1 - extraI
+		default:
+			return fmt.Errorf("wrong type for int64 field: %d", maj)
+		}
+
+		t.SectorExpiry = abi.ChainEpoch(extraI)
+	}
+	// t.DealIDs ([]abi.DealID) (slice)
+
+	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("t.DealIDs: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.DealIDs = make([]abi.DealID, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+
+		maj, val, err := cbg.CborReadHeaderBuf(br, scratch)
+		if err != nil {
+			return xerrors.Errorf("failed to read uint64 for t.DealIDs slice: %w", err)
+		}
+
+		if maj != cbg.MajUnsignedInt {
+			return xerrors.Errorf("value read for array t.DealIDs was not a uint, instead got %d", maj)
+		}
+
+		t.DealIDs[i] = abi.DealID(val)
+	}
+
+	return nil
+}
+
+var lengthBufSectorWeights = []byte{131}
+
+func (t *SectorWeights) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write(lengthBufSectorWeights); err != nil {
+		return err
+	}
+
+	scratch := make([]byte, 9)
+
+	// t.DealSpace (uint64) (uint64)
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.DealSpace)); err != nil {
+		return err
+	}
+
+	// t.DealWeight (big.Int) (struct)
+	if err := t.DealWeight.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.VerifiedDealWeight (big.Int) (struct)
+	if err := t.VerifiedDealWeight.MarshalCBOR(w); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *SectorWeights) UnmarshalCBOR(r io.Reader) error {
+	*t = SectorWeights{}
+
+	br := cbg.GetPeeker(r)
+	scratch := make([]byte, 8)
+
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 3 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.DealSpace (uint64) (uint64)
+
+	{
+
+		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.DealSpace = uint64(extra)
+
+	}
+	// t.DealWeight (big.Int) (struct)
+
+	{
+
+		if err := t.DealWeight.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.DealWeight: %w", err)
+		}
+
+	}
+	// t.VerifiedDealWeight (big.Int) (struct)
+
+	{
+
+		if err := t.VerifiedDealWeight.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.VerifiedDealWeight: %w", err)
+		}
+
+	}
+	return nil
+}
+
 var lengthBufDealState = []byte{131}
 
 func (t *DealState) MarshalCBOR(w io.Writer) error {

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -4954,21 +4954,24 @@ func (h *actorHarness) preCommitSector(rt *mock.Runtime, params *miner.PreCommit
 	if len(params.DealIDs) > 0 {
 		// If there are any deal IDs, allocate half the weight to non-verified and half to verified.
 		vdParams := market.VerifyDealsForActivationParams{
-			DealIDs:      params.DealIDs,
-			SectorStart:  rt.Epoch(),
-			SectorExpiry: params.Expiration,
+			Sectors: []market.SectorDeals{{
+				SectorExpiry: params.Expiration,
+				DealIDs:      params.DealIDs,
+			}},
 		}
 
+		if conf.dealWeight.Nil() {
+			conf.dealWeight = big.Zero()
+		}
+		if conf.verifiedDealWeight.Nil() {
+			conf.verifiedDealWeight = big.Zero()
+		}
 		vdReturn := market.VerifyDealsForActivationReturn{
-			DealWeight:         conf.dealWeight,
-			VerifiedDealWeight: conf.verifiedDealWeight,
-			DealSpace:          uint64(conf.dealSpace),
-		}
-		if vdReturn.DealWeight.Nil() {
-			vdReturn.DealWeight = big.Zero()
-		}
-		if vdReturn.VerifiedDealWeight.Nil() {
-			vdReturn.VerifiedDealWeight = big.Zero()
+			Sectors: []market.SectorWeights{{
+				DealSpace:          uint64(conf.dealSpace),
+				DealWeight:         conf.dealWeight,
+				VerifiedDealWeight: conf.verifiedDealWeight,
+			}},
 		}
 		rt.ExpectSend(builtin.StorageMarketActorAddr, builtin.MethodsMarket.VerifyDealsForActivation, &vdParams, big.Zero(), &vdReturn, exitcode.Ok)
 	}

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -150,13 +150,15 @@ func main() {
 		//market.PublishStorageDealsParams{}, // Aliased from v0
 		//market.PublishStorageDealsReturn{}, // Aliased from v0
 		//market.ActivateDealsParams{}, // Aliased from v0
-		//market.VerifyDealsForActivationParams{}, // Aliased from v0
-		// market.VerifyDealsForActivationReturn{}, // Aliased from v2
+		market.VerifyDealsForActivationParams{},
+		market.VerifyDealsForActivationReturn{},
 		//market.ComputeDataCommitmentParams{}, // Aliased from v0
 		//market.OnMinerSectorsTerminateParams{}, // Aliased from v0
 		// other types
 		//market.DealProposal{}, // Aliased from v0
 		//market.ClientDealProposal{}, // Aliased from v0
+		market.SectorDeals{},
+		market.SectorWeights{},
 		market.DealState{},
 	); err != nil {
 		panic(err)


### PR DESCRIPTION
As pre-work to batching sector pre-commits (#1241), this PR changes the market actor's `VerifyDealsForActivation` to accept deal information for multiple sectors in a single call.

Along the way, I looked to solve #981. I removed the fake sector start epoch from the method parameters, but left the check in place (using the current epoch as determined by the market actor). I think it is more helpful to check this here than not to, since this could prevent a miner losing a pre-commit deposit. It can't prevent all cases, but it can stop some.

`VerifyDealsForActivation` is only invoked internally, by the miner actor, so the changed API is expected to have little external impact.

- [x] Wait for #1299 to land first

FYI @Stebalien. Closes #981