### PR TITLE
various agent testing bug fixes and improvements

### DIFF
--- a/actors/builtin/market/testing.go
+++ b/actors/builtin/market/testing.go
@@ -227,7 +227,7 @@ func CheckStateInvariants(st *State, store adt.Store, balance abi.TokenAmount, c
 
 	dealOpEpochCount := uint64(0)
 	dealOpCount := uint64(0)
-	if dealOps, err := AsSetMultimap(store, st.DealOpsByEpoch);  err != nil {
+	if dealOps, err := AsSetMultimap(store, st.DealOpsByEpoch); err != nil {
 		acc.Addf("error loading deal ops: %v", err)
 	} else {
 		// get into internals just to iterate through full data structure

--- a/support/agent/cases_test.go
+++ b/support/agent/cases_test.go
@@ -62,6 +62,86 @@ func TestCreate20Miners(t *testing.T) {
 	}
 }
 
+func Test500Epochs(t *testing.T) {
+	ctx := context.Background()
+	initialBalance := big.Mul(big.NewInt(1e8), big.NewInt(1e18))
+	cumulativeStats := make(vm_test.StatsByCall)
+	minerCount := 10
+	clientCount := 9
+
+	// set up sim
+	rnd := rand.New(rand.NewSource(42))
+	sim := agent.NewSim(ctx, t, agent.SimConfig{
+		Seed:             rnd.Int63(),
+		CheckpointEpochs: 1000,
+	})
+
+	// create miners
+	workerAccounts := vm_test.CreateAccounts(ctx, t, sim.GetVM(), minerCount, initialBalance, rnd.Int63())
+	sim.AddAgent(agent.NewMinerGenerator(
+		workerAccounts,
+		agent.MinerAgentConfig{
+			PrecommitRate:    2.0,
+			FaultRate:        0.0001,
+			RecoveryRate:     0.0001,
+			UpgradeSectors:   true,
+			ProofType:        abi.RegisteredSealProof_StackedDrg32GiBV1_1,
+			StartingBalance:  big.Div(initialBalance, big.NewInt(2)),
+			MinMarketBalance: big.NewInt(1e18),
+			MaxMarketBalance: big.NewInt(2e18),
+		},
+		1.0, // create miner probability of 1 means a new miner is created every tick
+		rnd.Int63(),
+	))
+
+	clientAccounts := vm_test.CreateAccounts(ctx, t, sim.GetVM(), clientCount, initialBalance, rnd.Int63())
+	dealAgents := agent.AddDealClientsForAccounts(sim, clientAccounts, rnd.Int63(), agent.DealClientConfig{
+		DealRate:         .05,
+		MinPieceSize:     1 << 29,
+		MaxPieceSize:     32 << 30,
+		MinStoragePrice:  big.Zero(),
+		MaxStoragePrice:  abi.NewTokenAmount(200_000_000),
+		MinMarketBalance: big.NewInt(1e18),
+		MaxMarketBalance: big.NewInt(2e18),
+	})
+
+	var pwrSt power.State
+	for i := 0; i < 500; i++ {
+		require.NoError(t, sim.Tick())
+
+		epoch := sim.GetVM().GetEpoch()
+		if epoch%100 == 0 {
+			// compute number of deals
+			deals := 0
+			for _, da := range dealAgents {
+				deals += da.DealCount
+			}
+
+			stateTree, err := sim.GetVM().GetStateTree()
+			require.NoError(t, err)
+
+			totalBalance, err := sim.GetVM().GetTotalActorBalance()
+			require.NoError(t, err)
+
+			acc, err := states.CheckStateInvariants(stateTree, totalBalance, sim.GetVM().GetEpoch()-1)
+			require.NoError(t, err)
+			require.True(t, acc.IsEmpty(), strings.Join(acc.Messages(), "\n"))
+
+			require.NoError(t, sim.GetVM().GetState(builtin.StoragePowerActorAddr, &pwrSt))
+
+			// assume each sector is 32Gb
+			sectorCount := big.Div(pwrSt.TotalBytesCommitted, big.NewInt(32<<30))
+
+			fmt.Printf("Power at %d: raw: %v  cmtRaw: %v  cmtSecs: %d  msgs: %d  deals: %d  gets: %d  puts: %d  write bytes: %d  read bytes: %d\n",
+				epoch, pwrSt.TotalRawBytePower, pwrSt.TotalBytesCommitted, sectorCount.Uint64(),
+				sim.MessageCount, deals, sim.GetVM().StoreReads(), sim.GetVM().StoreWrites(),
+				sim.GetVM().StoreReadBytes(), sim.GetVM().StoreWriteBytes())
+		}
+
+		cumulativeStats.MergeAllStats(sim.GetCallStats())
+	}
+}
+
 func TestCommitPowerAndCheckInvariants(t *testing.T) {
 	t.Skip("this is slow")
 	ctx := context.Background()
@@ -149,7 +229,7 @@ func TestCommitAndCheckReadWriteStats(t *testing.T) {
 
 	clientAccounts := vm_test.CreateAccounts(ctx, t, sim.GetVM(), clientCount, initialBalance, rnd.Int63())
 	dealAgents := agent.AddDealClientsForAccounts(sim, clientAccounts, rnd.Int63(), agent.DealClientConfig{
-		DealRate:         .01,
+		DealRate:         .05,
 		MinPieceSize:     1 << 29,
 		MaxPieceSize:     32 << 30,
 		MinStoragePrice:  big.Zero(),
@@ -159,7 +239,7 @@ func TestCommitAndCheckReadWriteStats(t *testing.T) {
 	})
 
 	var pwrSt power.State
-	for i := 0; i < 50_000; i++ {
+	for i := 0; i < 20_000; i++ {
 		require.NoError(t, sim.Tick())
 
 		epoch := sim.GetVM().GetEpoch()
@@ -348,9 +428,10 @@ func TestCCUpgrades(t *testing.T) {
 }
 
 func printCallStats(method vm_test.MethodKey, stats *vm_test.CallStats, indent string) { // nolint:unused
-	fmt.Printf("%s%v:%d: calls: %d  gets: %d  puts: %d  avg gets: %.2f, avg puts: %.2f\n",
+	fmt.Printf("%s%v:%d: calls: %d  gets: %d  puts: %d  read: %d  written: %d  avg gets: %.2f, avg puts: %.2f\n",
 		indent, builtin.ActorNameByCode(method.Code), method.Method, stats.Calls, stats.Reads, stats.Writes,
-		float32(stats.Reads)/float32(stats.Calls), float32(stats.Writes)/float32(stats.Calls))
+		stats.ReadBytes, stats.WriteBytes, float32(stats.Reads)/float32(stats.Calls),
+		float32(stats.Writes)/float32(stats.Calls))
 
 	if stats.SubStats == nil {
 		return

--- a/support/agent/cases_test.go
+++ b/support/agent/cases_test.go
@@ -62,6 +62,9 @@ func TestCreate20Miners(t *testing.T) {
 	}
 }
 
+// This test covers all the simulation functionality.
+// 500 epochs is long enough for most, not all, important processes to take place, but runs fast enough
+// to keep in CI.
 func Test500Epochs(t *testing.T) {
 	ctx := context.Background()
 	initialBalance := big.Mul(big.NewInt(1e8), big.NewInt(1e18))

--- a/support/agent/deal_client_agent.go
+++ b/support/agent/deal_client_agent.go
@@ -64,12 +64,15 @@ func NewDealClientAgent(account address.Address, seed int64, config DealClientCo
 }
 
 func (dca *DealClientAgent) Tick(s SimState) ([]message, error) {
-	var providers []DealProvider
-
 	// aggregate all deals into one message
 	if err := dca.dealEvents.Tick(func() error {
 		provider := s.ChooseDealProvider()
-		providers = append(providers, provider)
+
+		// provider will be nil if called before any miners are added to system
+		if provider == nil {
+			return nil
+		}
+
 		if err := dca.createDeal(s, provider); err != nil {
 			return err
 		}

--- a/support/agent/math.go
+++ b/support/agent/math.go
@@ -66,12 +66,11 @@ func (ri *RateIterator) Tick(f func() error) error {
 // If the rate has changed, it will compute a new next occurrence before running tick.
 // This prevents having to wait a long time to recognize a change from a very slow rate to a higher one.
 func (ri *RateIterator) TickWithRate(rate float64, f func() error) error {
-	ri.rate = rate
-
 	// recompute next occurrence if rate has changed
 	if ri.rate != rate && rate > 0.0 {
 		ri.nextOccurrence = 1.0 + poissonDelay(ri.rnd.Float64(), rate)
 	}
+	ri.rate = rate
 
 	return ri.Tick(f)
 }

--- a/support/vm/stats.go
+++ b/support/vm/stats.go
@@ -38,28 +38,38 @@ func (sbc StatsByCall) MergeAllStats(other StatsByCall) {
 type CallStats struct {
 	Reads       uint64
 	Writes      uint64
+	ReadBytes   uint64
+	WriteBytes  uint64
 	Calls       uint64
 	statsSource StatsSource
 	SubStats    StatsByCall
 
-	startReads  uint64
-	startWrites uint64
+	startReads      uint64
+	startWrites     uint64
+	startReadBytes  uint64
+	startWriteBytes uint64
 }
 
 func NewCallStats(statsSource StatsSource) *CallStats {
-	var startReads, startWrites uint64
+	var startReads, startWrites, startReadBytes, startWriteBytes uint64
 	if statsSource != nil {
 		startReads = statsSource.ReadCount()
 		startWrites = statsSource.WriteCount()
+		startReadBytes = statsSource.ReadSize()
+		startWriteBytes = statsSource.WriteSize()
 	}
 	return &CallStats{
-		Reads:       0,
-		Writes:      0,
-		Calls:       0,
-		statsSource: statsSource,
-		SubStats:    nil,
-		startReads:  startReads,
-		startWrites: startWrites,
+		Reads:           0,
+		Writes:          0,
+		ReadBytes:       0,
+		WriteBytes:      0,
+		Calls:           0,
+		statsSource:     statsSource,
+		SubStats:        nil,
+		startReads:      startReads,
+		startWrites:     startWrites,
+		startReadBytes:  startReadBytes,
+		startWriteBytes: startWriteBytes,
 	}
 }
 
@@ -71,6 +81,8 @@ func (s *CallStats) Capture() {
 	s.Calls++
 	s.Writes = s.statsSource.WriteCount() - s.startWrites
 	s.Reads = s.statsSource.ReadCount() - s.startReads
+	s.WriteBytes = s.statsSource.WriteSize() - s.startWriteBytes
+	s.ReadBytes = s.statsSource.ReadSize() - s.startReadBytes
 }
 
 // assume stats have same method type and that other will be discarded after this call
@@ -78,6 +90,8 @@ func (s *CallStats) MergeStats(other *CallStats) {
 	s.Calls += other.Calls
 	s.Reads += other.Reads
 	s.Writes += other.Writes
+	s.WriteBytes += other.WriteBytes
+	s.ReadBytes += other.WriteBytes
 
 	if other.SubStats == nil {
 		return


### PR DESCRIPTION
### Motivation

In the process of using the agent testing framework to predict the benefits of market actor performance enhancements, I discovered some of its issues and limitations. This PR Addresses those

### Proposed Changes

1. Added a 500 epoch sanity check simulation. The agent testing framework was broken in master. Because the simulations are too slow to run in CI, actor changes are likely to break the simulation without anyone knowing. This ensures anything that obviously breaks the simulation will draw attention.
2. Fixed an issue with the rate iterator that caused it to fire too often (this fixed the issue mentioned above).
3. Fixed an issue where the simulation would fail if a client attempted to make a deal before any miners had been constructed.
4. Add ReadBytes and WriteBytes to per-call stats. This data was made available in the store in a previous update, so this just wires it to the call stats.