### PR TITLE
Make Map bitwidth configurable for each instance

### DIFF
--- a/actors/builtin/init/init_actor.go
+++ b/actors/builtin/init/init_actor.go
@@ -43,10 +43,8 @@ type ConstructorParams = init0.ConstructorParams
 
 func (a Actor) Constructor(rt runtime.Runtime, params *ConstructorParams) *abi.EmptyValue {
 	rt.ValidateImmediateCallerIs(builtin.SystemActorAddr)
-	emptyMap, err := adt.MakeEmptyMap(adt.AsStore(rt)).Root()
+	st, err := ConstructState(adt.AsStore(rt), params.NetworkName)
 	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to construct state")
-
-	st := ConstructState(emptyMap, params.NetworkName)
 	rt.StateCreate(st)
 	return nil
 }

--- a/actors/builtin/init/init_test.go
+++ b/actors/builtin/init/init_test.go
@@ -238,7 +238,7 @@ func (h *initHarness) constructAndVerify(rt *mock.Runtime) {
 
 	var st init_.State
 	rt.GetState(&st)
-	emptyMap, err := adt.AsMap(adt.AsStore(rt), st.AddressMap)
+	emptyMap, err := adt.AsMap(adt.AsStore(rt), st.AddressMap, builtin.DefaultHamtBitwidth)
 	assert.NoError(h.t, err)
 	assert.Equal(h.t, tutil.MustRoot(h.t, emptyMap), st.AddressMap)
 	assert.Equal(h.t, abi.ActorID(builtin.FirstNonSingletonActorId), st.NextID)

--- a/actors/builtin/init/testing.go
+++ b/actors/builtin/init/testing.go
@@ -26,7 +26,7 @@ func CheckStateInvariants(st *State, store adt.Store) (*StateSummary, *builtin.M
 		NextID:  st.NextID,
 	}
 
-	lut, err := adt.AsMap(store, st.AddressMap)
+	lut, err := adt.AsMap(store, st.AddressMap, builtin.DefaultHamtBitwidth)
 	if err != nil {
 		acc.Addf("error loading address map: %v", err)
 		// Stop here, it's hard to make other useful checks.

--- a/actors/builtin/market/market_actor.go
+++ b/actors/builtin/market/market_actor.go
@@ -64,16 +64,8 @@ var _ runtime.VMActor = Actor{}
 func (a Actor) Constructor(rt Runtime, _ *abi.EmptyValue) *abi.EmptyValue {
 	rt.ValidateImmediateCallerIs(builtin.SystemActorAddr)
 
-	emptyArray, err := adt.MakeEmptyArray(adt.AsStore(rt)).Root()
+	st, err := ConstructState(adt.AsStore(rt))
 	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to create state")
-
-	emptyMap, err := adt.MakeEmptyMap(adt.AsStore(rt)).Root()
-	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to create state")
-
-	emptyMSet, err := MakeEmptySetMultimap(adt.AsStore(rt)).Root()
-	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to create state")
-
-	st := ConstructState(emptyArray, emptyMap, emptyMSet)
 	rt.StateCreate(st)
 	return nil
 }

--- a/actors/builtin/market/market_state.go
+++ b/actors/builtin/market/market_state.go
@@ -337,7 +337,7 @@ func (m *marketStateMutation) build() (*marketStateMutation, error) {
 	}
 
 	if m.dpePermit != Invalid {
-		dbe, err := AsSetMultimap(m.store, m.st.DealOpsByEpoch, builtin.DefaultHamtBitwidth)
+		dbe, err := AsSetMultimap(m.store, m.st.DealOpsByEpoch, builtin.DefaultHamtBitwidth, builtin.DefaultHamtBitwidth)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to load deals by epoch: %w", err)
 		}

--- a/actors/builtin/market/market_state.go
+++ b/actors/builtin/market/market_state.go
@@ -60,7 +60,20 @@ type State struct {
 	TotalClientStorageFee abi.TokenAmount
 }
 
-func ConstructState(emptyArrayCid, emptyMapCid, emptyMSetCid cid.Cid) *State {
+func ConstructState(store adt.Store) (*State, error) {
+	emptyArrayCid, err := adt.MakeEmptyArray(store).Root()
+	if err != nil {
+		return nil, xerrors.Errorf("failed to create empty array: %w", err)
+	}
+	emptyMapCid, err := adt.MakeEmptyMap(store, builtin.DefaultHamtBitwidth).Root()
+	if err != nil {
+		return nil, xerrors.Errorf("failed to create empty map: %w", err)
+	}
+	emptyMSetCid, err := MakeEmptySetMultimap(store, builtin.DefaultHamtBitwidth).Root()
+	if err != nil {
+		return nil, xerrors.Errorf("failed to create empty multiset: %w", err)
+	}
+
 	return &State{
 		Proposals:        emptyArrayCid,
 		States:           emptyArrayCid,
@@ -74,7 +87,7 @@ func ConstructState(emptyArrayCid, emptyMapCid, emptyMSetCid cid.Cid) *State {
 		TotalClientLockedCollateral:   abi.NewTokenAmount(0),
 		TotalProviderLockedCollateral: abi.NewTokenAmount(0),
 		TotalClientStorageFee:         abi.NewTokenAmount(0),
-	}
+	}, nil
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -316,7 +329,7 @@ func (m *marketStateMutation) build() (*marketStateMutation, error) {
 	}
 
 	if m.pendingPermit != Invalid {
-		pending, err := adt.AsSet(m.store, m.st.PendingProposals)
+		pending, err := adt.AsSet(m.store, m.st.PendingProposals, builtin.DefaultHamtBitwidth)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to load pending proposals: %w", err)
 		}
@@ -324,7 +337,7 @@ func (m *marketStateMutation) build() (*marketStateMutation, error) {
 	}
 
 	if m.dpePermit != Invalid {
-		dbe, err := AsSetMultimap(m.store, m.st.DealOpsByEpoch)
+		dbe, err := AsSetMultimap(m.store, m.st.DealOpsByEpoch, builtin.DefaultHamtBitwidth)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to load deals by epoch: %w", err)
 		}

--- a/actors/builtin/market/market_test.go
+++ b/actors/builtin/market/market_test.go
@@ -50,7 +50,7 @@ func TestRemoveAllError(t *testing.T) {
 	rt := builder.Build(t)
 	store := adt.AsStore(rt)
 
-	smm := market.MakeEmptySetMultimap(store)
+	smm := market.MakeEmptySetMultimap(store, builtin.DefaultHamtBitwidth)
 
 	if err := smm.RemoveAll(42); err != nil {
 		t.Fatalf("expected no error, got: %s", err)
@@ -82,13 +82,13 @@ func TestMarketActor(t *testing.T) {
 
 		store := adt.AsStore(rt)
 
-		emptyMap, err := adt.MakeEmptyMap(store).Root()
+		emptyMap, err := adt.MakeEmptyMap(store, builtin.DefaultHamtBitwidth).Root()
 		assert.NoError(t, err)
 
 		emptyArray, err := adt.MakeEmptyArray(store).Root()
 		assert.NoError(t, err)
 
-		emptyMultiMap, err := market.MakeEmptySetMultimap(store).Root()
+		emptyMultiMap, err := market.MakeEmptySetMultimap(store, builtin.DefaultHamtBitwidth).Root()
 		assert.NoError(t, err)
 
 		var state market.State
@@ -3058,7 +3058,7 @@ func (h *marketActorTestHarness) assertDealDeleted(rt *mock.Runtime, dealId abi.
 
 	pcid, err := p.Cid()
 	require.NoError(h.t, err)
-	pending, err := adt.AsMap(adt.AsStore(rt), st.PendingProposals)
+	pending, err := adt.AsMap(adt.AsStore(rt), st.PendingProposals, builtin.DefaultHamtBitwidth)
 	require.NoError(h.t, err)
 	found, err = pending.Get(abi.CidKey(pcid), nil)
 	require.NoError(h.t, err)

--- a/actors/builtin/market/set_multimap.go
+++ b/actors/builtin/market/set_multimap.go
@@ -14,23 +14,26 @@ import (
 )
 
 type SetMultimap struct {
-	mp    *adt.Map
-	store adt.Store
+	mp            *adt.Map
+	store         adt.Store
+	innerBitwidth int
 }
 
 // Interprets a store as a HAMT-based map of HAMT-based sets with root `r`.
-func AsSetMultimap(s adt.Store, r cid.Cid) (*SetMultimap, error) {
-	m, err := adt.AsMap(s, r)
+// Both inner and outer HAMTs are interpreted with branching factor 2^bitwidth.
+func AsSetMultimap(s adt.Store, r cid.Cid, bitwidth int) (*SetMultimap, error) {
+	m, err := adt.AsMap(s, r, bitwidth)
 	if err != nil {
 		return nil, err
 	}
-	return &SetMultimap{mp: m, store: s}, nil
+	return &SetMultimap{mp: m, store: s, innerBitwidth: bitwidth}, nil
 }
 
 // Creates a new map backed by an empty HAMT and flushes it to the store.
-func MakeEmptySetMultimap(s adt.Store) *SetMultimap {
-	m := adt.MakeEmptyMap(s)
-	return &SetMultimap{m, s}
+// Both inner and outer HAMTs have branching factor 2^bitwidth.
+func MakeEmptySetMultimap(s adt.Store, bitwidth int) *SetMultimap {
+	m := adt.MakeEmptyMap(s, bitwidth)
+	return &SetMultimap{mp: m, store: s, innerBitwidth: bitwidth}
 }
 
 // Returns the root cid of the underlying HAMT.
@@ -46,7 +49,7 @@ func (mm *SetMultimap) Put(epoch abi.ChainEpoch, v abi.DealID) error {
 		return err
 	}
 	if !found {
-		set = adt.MakeEmptySet(mm.store)
+		set = adt.MakeEmptySet(mm.store, mm.innerBitwidth)
 	}
 
 	// Add to the set.
@@ -75,7 +78,7 @@ func (mm *SetMultimap) PutMany(epoch abi.ChainEpoch, vs []abi.DealID) error {
 		return err
 	}
 	if !found {
-		set = adt.MakeEmptySet(mm.store)
+		set = adt.MakeEmptySet(mm.store, mm.innerBitwidth)
 	}
 
 	// Add to the set.
@@ -133,7 +136,7 @@ func (mm *SetMultimap) get(key abi.Keyer) (*adt.Set, bool, error) {
 	}
 	var set *adt.Set
 	if found {
-		set, err = adt.AsSet(mm.store, cid.Cid(setRoot))
+		set, err = adt.AsSet(mm.store, cid.Cid(setRoot), mm.innerBitwidth)
 		if err != nil {
 			return nil, false, err
 		}

--- a/actors/builtin/market/set_multimap.go
+++ b/actors/builtin/market/set_multimap.go
@@ -21,12 +21,12 @@ type SetMultimap struct {
 
 // Interprets a store as a HAMT-based map of HAMT-based sets with root `r`.
 // Both inner and outer HAMTs are interpreted with branching factor 2^bitwidth.
-func AsSetMultimap(s adt.Store, r cid.Cid, bitwidth int) (*SetMultimap, error) {
-	m, err := adt.AsMap(s, r, bitwidth)
+func AsSetMultimap(s adt.Store, r cid.Cid, outerBitwidth, innerBitwidth int) (*SetMultimap, error) {
+	m, err := adt.AsMap(s, r, outerBitwidth)
 	if err != nil {
 		return nil, err
 	}
-	return &SetMultimap{mp: m, store: s, innerBitwidth: bitwidth}, nil
+	return &SetMultimap{mp: m, store: s, innerBitwidth: innerBitwidth}, nil
 }
 
 // Creates a new map backed by an empty HAMT and flushes it to the store.

--- a/actors/builtin/market/testing.go
+++ b/actors/builtin/market/testing.go
@@ -150,7 +150,7 @@ func CheckStateInvariants(st *State, store adt.Store, balance abi.TokenAmount, c
 	//
 
 	pendingProposalCount := uint64(0)
-	if pendingProposals, err := adt.AsMap(store, st.PendingProposals); err != nil {
+	if pendingProposals, err := adt.AsMap(store, st.PendingProposals, builtin.DefaultHamtBitwidth); err != nil {
 		acc.Addf("error loading pending proposals: %v", err)
 	} else {
 		err = pendingProposals.ForEach(nil, func(key string) error {
@@ -220,7 +220,7 @@ func CheckStateInvariants(st *State, store adt.Store, balance abi.TokenAmount, c
 
 	dealOpEpochCount := uint64(0)
 	dealOpCount := uint64(0)
-	if dealOps, err := AsSetMultimap(store, st.DealOpsByEpoch); err != nil {
+	if dealOps, err := AsSetMultimap(store, st.DealOpsByEpoch, builtin.DefaultHamtBitwidth); err != nil {
 		acc.Addf("error loading deal ops: %v", err)
 	} else {
 		// get into internals just to iterate through full data structure

--- a/actors/builtin/market/testing.go
+++ b/actors/builtin/market/testing.go
@@ -220,7 +220,7 @@ func CheckStateInvariants(st *State, store adt.Store, balance abi.TokenAmount, c
 
 	dealOpEpochCount := uint64(0)
 	dealOpCount := uint64(0)
-	if dealOps, err := AsSetMultimap(store, st.DealOpsByEpoch, builtin.DefaultHamtBitwidth); err != nil {
+	if dealOps, err := AsSetMultimap(store, st.DealOpsByEpoch, builtin.DefaultHamtBitwidth, builtin.DefaultHamtBitwidth); err != nil {
 		acc.Addf("error loading deal ops: %v", err)
 	} else {
 		// get into internals just to iterate through full data structure

--- a/actors/builtin/miner/miner_state_test.go
+++ b/actors/builtin/miner/miner_state_test.go
@@ -888,23 +888,6 @@ func (h *stateHarness) deletePreCommit(sectorNo abi.SectorNumber) {
 func constructStateHarness(t *testing.T, periodBoundary abi.ChainEpoch) *stateHarness {
 	// store init
 	store := ipld.NewADTStore(context.Background())
-	emptyMap, err := adt.MakeEmptyMap(store).Root()
-	require.NoError(t, err)
-
-	emptyBitfield := bitfield.NewFromSet(nil)
-	emptyBitfieldCid, err := store.Put(store.Context(), emptyBitfield)
-	require.NoError(t, err)
-
-	emptyArray, err := adt.MakeEmptyArray(store).Root()
-	require.NoError(t, err)
-	emptyDeadline := miner.ConstructDeadline(emptyArray)
-	emptyDeadlineCid, err := store.Put(store.Context(), emptyDeadline)
-	require.NoError(t, err)
-
-	emptyDeadlines := miner.ConstructDeadlines(emptyDeadlineCid)
-	emptyDeadlinesCid, err := store.Put(context.Background(), emptyDeadlines)
-	require.NoError(t, err)
-
 	// state field init
 	owner := tutils.NewBLSAddr(t, 1)
 	worker := tutils.NewBLSAddr(t, 2)
@@ -930,12 +913,7 @@ func constructStateHarness(t *testing.T, periodBoundary abi.ChainEpoch) *stateHa
 	infoCid, err := store.Put(context.Background(), &info)
 	require.NoError(t, err)
 
-	emptyVestingFunds := miner.ConstructVestingFunds()
-	emptyVestingFundsCid, err := store.Put(context.Background(), emptyVestingFunds)
-	require.NoError(t, err)
-
-	state, err := miner.ConstructState(infoCid, periodBoundary, 0, emptyBitfieldCid, emptyArray, emptyMap, emptyDeadlinesCid,
-		emptyVestingFundsCid)
+	state, err := miner.ConstructState(store, infoCid, periodBoundary, 0)
 	require.NoError(t, err)
 
 	return &stateHarness{

--- a/actors/builtin/miner/testing.go
+++ b/actors/builtin/miner/testing.go
@@ -726,7 +726,7 @@ func CheckPreCommits(st *State, store adt.Store, allocatedSectors map[uint64]boo
 	}
 
 	precommitTotal := big.Zero()
-	if precommitted, err := adt.AsMap(store, st.PreCommittedSectors); err != nil {
+	if precommitted, err := adt.AsMap(store, st.PreCommittedSectors, builtin.DefaultHamtBitwidth); err != nil {
 		acc.Addf("error loading precommitted sectors: %v", err)
 	} else {
 		var precommit SectorPreCommitOnChainInfo

--- a/actors/builtin/multisig/multisig_actor.go
+++ b/actors/builtin/multisig/multisig_actor.go
@@ -120,7 +120,7 @@ func (a Actor) Constructor(rt runtime.Runtime, params *ConstructorParams) *abi.E
 		rt.Abortf(exitcode.ErrIllegalArgument, "negative unlock duration disallowed")
 	}
 
-	pending, err := adt.MakeEmptyMap(adt.AsStore(rt)).Root()
+	pending, err := adt.MakeEmptyMap(adt.AsStore(rt), builtin.DefaultHamtBitwidth).Root()
 	if err != nil {
 		rt.Abortf(exitcode.ErrIllegalState, "failed to create empty map: %v", err)
 	}
@@ -174,7 +174,7 @@ func (a Actor) Propose(rt runtime.Runtime, params *ProposeParams) *ProposeReturn
 			rt.Abortf(exitcode.ErrForbidden, "%s is not a signer", proposer)
 		}
 
-		ptx, err := adt.AsMap(adt.AsStore(rt), st.PendingTxns)
+		ptx, err := adt.AsMap(adt.AsStore(rt), st.PendingTxns, builtin.DefaultHamtBitwidth)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load pending transactions")
 
 		txnID = st.NextTxnID
@@ -236,7 +236,7 @@ func (a Actor) Approve(rt runtime.Runtime, params *TxnIDParams) *ApproveReturn {
 			rt.Abortf(exitcode.ErrForbidden, "%s is not a signer", approver)
 		}
 
-		ptx, err := adt.AsMap(adt.AsStore(rt), st.PendingTxns)
+		ptx, err := adt.AsMap(adt.AsStore(rt), st.PendingTxns, builtin.DefaultHamtBitwidth)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load pending transactions")
 
 		txn = getTransaction(rt, ptx, params.ID, params.ProposalHash, true)
@@ -268,7 +268,7 @@ func (a Actor) Cancel(rt runtime.Runtime, params *TxnIDParams) *abi.EmptyValue {
 			rt.Abortf(exitcode.ErrForbidden, "%s is not a signer", callerAddr)
 		}
 
-		ptx, err := adt.AsMap(adt.AsStore(rt), st.PendingTxns)
+		ptx, err := adt.AsMap(adt.AsStore(rt), st.PendingTxns, builtin.DefaultHamtBitwidth)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load pending txns")
 
 		txn, err := getPendingTransaction(ptx, params.ID)
@@ -487,7 +487,7 @@ func (a Actor) approveTransaction(rt runtime.Runtime, txnID TxnID, txn *Transact
 
 	// add the caller to the list of approvers
 	rt.StateTransaction(&st, func() {
-		ptx, err := adt.AsMap(adt.AsStore(rt), st.PendingTxns)
+		ptx, err := adt.AsMap(adt.AsStore(rt), st.PendingTxns, builtin.DefaultHamtBitwidth)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load pending transactions")
 
 		// update approved on the transaction
@@ -548,7 +548,7 @@ func executeTransactionIfApproved(rt runtime.Runtime, st State, txnID TxnID, txn
 
 		// This could be rearranged to happen inside the first state transaction, before the send().
 		rt.StateTransaction(&st, func() {
-			ptx, err := adt.AsMap(adt.AsStore(rt), st.PendingTxns)
+			ptx, err := adt.AsMap(adt.AsStore(rt), st.PendingTxns, builtin.DefaultHamtBitwidth)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load pending transactions")
 
 			// Prior to version 6 we attempt to delete all transactions, even those

--- a/actors/builtin/multisig/multisig_state.go
+++ b/actors/builtin/multisig/multisig_state.go
@@ -8,6 +8,7 @@ import (
 	cid "github.com/ipfs/go-cid"
 	"golang.org/x/xerrors"
 
+	"github.com/filecoin-project/specs-actors/v3/actors/builtin"
 	"github.com/filecoin-project/specs-actors/v3/actors/util/adt"
 )
 
@@ -67,7 +68,7 @@ func (st *State) AmountLocked(elapsedEpoch abi.ChainEpoch) abi.TokenAmount {
 // Iterates all pending transactions and removes an address from each list of approvals, if present.
 // If an approval list becomes empty, the pending transaction is deleted.
 func (st *State) PurgeApprovals(store adt.Store, addr address.Address) error {
-	txns, err := adt.AsMap(store, st.PendingTxns)
+	txns, err := adt.AsMap(store, st.PendingTxns, builtin.DefaultHamtBitwidth)
 	if err != nil {
 		return xerrors.Errorf("failed to load transactions: %w", err)
 	}

--- a/actors/builtin/multisig/multisig_test.go
+++ b/actors/builtin/multisig/multisig_test.go
@@ -67,7 +67,7 @@ func TestConstruction(t *testing.T) {
 		assert.Equal(t, abi.NewTokenAmount(100), st.InitialBalance)
 		assert.Equal(t, unlockDuration, st.UnlockDuration)
 		assert.Equal(t, startEpoch, st.StartEpoch)
-		txns, err := adt.AsMap(adt.AsStore(rt), st.PendingTxns)
+		txns, err := adt.AsMap(adt.AsStore(rt), st.PendingTxns, builtin.DefaultHamtBitwidth)
 		assert.NoError(t, err)
 		keys, err := txns.CollectKeys()
 		require.NoError(t, err)
@@ -120,7 +120,7 @@ func TestConstruction(t *testing.T) {
 		assert.Equal(t, abi.ChainEpoch(1234), st.StartEpoch)
 
 		// assert no transactions
-		empty, err := adt.MakeEmptyMap(rt.AdtStore()).Root()
+		empty, err := adt.MakeEmptyMap(rt.AdtStore(), builtin.DefaultHamtBitwidth).Root()
 		require.NoError(t, err)
 		assert.Equal(t, empty, st.PendingTxns)
 
@@ -2074,7 +2074,7 @@ func (h *msActorHarness) assertTransactions(rt *mock.Runtime, expected ...multis
 	var st multisig.State
 	rt.GetState(&st)
 
-	txns, err := adt.AsMap(adt.AsStore(rt), st.PendingTxns)
+	txns, err := adt.AsMap(adt.AsStore(rt), st.PendingTxns, builtin.DefaultHamtBitwidth)
 	assert.NoError(h.t, err)
 	keys, err := txns.CollectKeys()
 	assert.NoError(h.t, err)

--- a/actors/builtin/multisig/testing.go
+++ b/actors/builtin/multisig/testing.go
@@ -37,7 +37,7 @@ func CheckStateInvariants(st *State, store adt.Store) (*StateSummary, *builtin.M
 	// test pending transactions
 	maxTxnID := TxnID(-1)
 	numPending := uint64(0)
-	if transactions, err := adt.AsMap(store, st.PendingTxns); err != nil {
+	if transactions, err := adt.AsMap(store, st.PendingTxns, builtin.DefaultHamtBitwidth); err != nil {
 		acc.Addf("error loading transactions: %v", err)
 	} else {
 		var txn Transaction

--- a/actors/builtin/power/power_actor.go
+++ b/actors/builtin/power/power_actor.go
@@ -79,12 +79,8 @@ type MinerConstructorParams = power2.MinerConstructorParams
 func (a Actor) Constructor(rt Runtime, _ *abi.EmptyValue) *abi.EmptyValue {
 	rt.ValidateImmediateCallerIs(builtin.SystemActorAddr)
 
-	emptyMap, err := adt.MakeEmptyMap(adt.AsStore(rt)).Root()
+	st, err := ConstructState(adt.AsStore(rt))
 	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to construct state")
-	emptyMMapCid, err := adt.MakeEmptyMultimap(adt.AsStore(rt)).Root()
-	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to construct state")
-
-	st := ConstructState(emptyMap, emptyMMapCid)
 	rt.StateCreate(st)
 	return nil
 }
@@ -133,7 +129,7 @@ func (a Actor) CreateMiner(rt Runtime, params *CreateMinerParams) *CreateMinerRe
 
 	var st State
 	rt.StateTransaction(&st, func() {
-		claims, err := adt.AsMap(adt.AsStore(rt), st.Claims)
+		claims, err := adt.AsMap(adt.AsStore(rt), st.Claims, builtin.DefaultHamtBitwidth)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load claims")
 
 		err = setClaim(claims, addresses.IDAddress, &Claim{params.SealProofType, abi.NewStoragePower(0), abi.NewStoragePower(0)})
@@ -169,7 +165,7 @@ func (a Actor) UpdateClaimedPower(rt Runtime, params *UpdateClaimedPowerParams) 
 	minerAddr := rt.Caller()
 	var st State
 	rt.StateTransaction(&st, func() {
-		claims, err := adt.AsMap(adt.AsStore(rt), st.Claims)
+		claims, err := adt.AsMap(adt.AsStore(rt), st.Claims, builtin.DefaultHamtBitwidth)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load claims")
 
 		err = st.addToClaim(claims, minerAddr, params.RawByteDelta, params.QualityAdjustedDelta)
@@ -202,7 +198,7 @@ func (a Actor) EnrollCronEvent(rt Runtime, params *EnrollCronEventParams) *abi.E
 
 	var st State
 	rt.StateTransaction(&st, func() {
-		events, err := adt.AsMultimap(adt.AsStore(rt), st.CronEventQueue)
+		events, err := adt.AsMultimap(adt.AsStore(rt), st.CronEventQueue, builtin.DefaultHamtBitwidth)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load cron events")
 
 		err = st.appendCronEvent(events, params.EventEpoch, &minerEvent)
@@ -274,10 +270,10 @@ func (a Actor) SubmitPoRepForBulkVerify(rt Runtime, sealInfo *proof.SealVerifyIn
 		store := adt.AsStore(rt)
 		var mmap *adt.Multimap
 		if st.ProofValidationBatch == nil {
-			mmap = adt.MakeEmptyMultimap(store)
+			mmap = adt.MakeEmptyMultimap(store, builtin.DefaultHamtBitwidth)
 		} else {
 			var err error
-			mmap, err = adt.AsMultimap(adt.AsStore(rt), *st.ProofValidationBatch)
+			mmap, err = adt.AsMultimap(adt.AsStore(rt), *st.ProofValidationBatch, builtin.DefaultHamtBitwidth)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load proof batch set")
 		}
 
@@ -331,7 +327,7 @@ func (a Actor) CurrentTotalPower(rt Runtime, _ *abi.EmptyValue) *CurrentTotalPow
 ////////////////////////////////////////////////////////////////////////////////
 
 func validateMinerHasClaim(rt Runtime, st State, minerAddr addr.Address) {
-	claims, err := adt.AsMap(adt.AsStore(rt), st.Claims)
+	claims, err := adt.AsMap(adt.AsStore(rt), st.Claims, builtin.DefaultHamtBitwidth)
 	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load claims")
 
 	found, err := claims.Has(abi.AddrKey(minerAddr))
@@ -352,10 +348,10 @@ func (a Actor) processBatchProofVerifies(rt Runtime) {
 		if st.ProofValidationBatch == nil {
 			return
 		}
-		mmap, err := adt.AsMultimap(store, *st.ProofValidationBatch)
+		mmap, err := adt.AsMultimap(store, *st.ProofValidationBatch, builtin.DefaultHamtBitwidth)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load proofs validation batch")
 
-		claims, err := adt.AsMap(adt.AsStore(rt), st.Claims)
+		claims, err := adt.AsMap(adt.AsStore(rt), st.Claims, builtin.DefaultHamtBitwidth)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load claims")
 
 		err = mmap.ForAll(func(k string, arr *adt.Array) error {
@@ -434,10 +430,10 @@ func (a Actor) processDeferredCronEvents(rt Runtime) {
 	var cronEvents []CronEvent
 	var st State
 	rt.StateTransaction(&st, func() {
-		events, err := adt.AsMultimap(adt.AsStore(rt), st.CronEventQueue)
+		events, err := adt.AsMultimap(adt.AsStore(rt), st.CronEventQueue, builtin.DefaultHamtBitwidth)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load cron events")
 
-		claims, err := adt.AsMap(adt.AsStore(rt), st.Claims)
+		claims, err := adt.AsMap(adt.AsStore(rt), st.Claims, builtin.DefaultHamtBitwidth)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load claims")
 
 		for epoch := st.FirstCronEpoch; epoch <= rtEpoch; epoch++ {
@@ -487,7 +483,7 @@ func (a Actor) processDeferredCronEvents(rt Runtime) {
 
 	if len(failedMinerCrons) > 0 {
 		rt.StateTransaction(&st, func() {
-			claims, err := adt.AsMap(adt.AsStore(rt), st.Claims)
+			claims, err := adt.AsMap(adt.AsStore(rt), st.Claims, builtin.DefaultHamtBitwidth)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load claims")
 
 			// Remove miner claim and leave miner frozen

--- a/actors/builtin/power/power_test.go
+++ b/actors/builtin/power/power_test.go
@@ -60,7 +60,7 @@ func TestConstruction(t *testing.T) {
 		assert.Equal(t, abi.NewStoragePower(0), st.TotalRawBytePower)
 		assert.Equal(t, int64(0), st.MinerAboveMinPowerCount)
 
-		claim, err := adt.AsMap(adt.AsStore(rt), st.Claims)
+		claim, err := adt.AsMap(adt.AsStore(rt), st.Claims, builtin.DefaultHamtBitwidth)
 		assert.NoError(t, err)
 		keys, err := claim.CollectKeys()
 		require.NoError(t, err)
@@ -673,7 +673,7 @@ func TestCron(t *testing.T) {
 		// assert used cron events are cleaned up
 		st := getState(rt)
 
-		mmap, err := adt.AsMultimap(rt.AdtStore(), st.CronEventQueue)
+		mmap, err := adt.AsMultimap(rt.AdtStore(), st.CronEventQueue, builtin.DefaultHamtBitwidth)
 		require.NoError(t, err)
 
 		var ev power.CronEvent
@@ -867,7 +867,7 @@ func TestSubmitPoRepForBulkVerify(t *testing.T) {
 		st := getState(rt)
 		store := rt.AdtStore()
 		require.NotNil(t, st.ProofValidationBatch)
-		mmap, err := adt.AsMultimap(store, *st.ProofValidationBatch)
+		mmap, err := adt.AsMultimap(store, *st.ProofValidationBatch, builtin.DefaultHamtBitwidth)
 		require.NoError(t, err)
 		arr, found, err := mmap.Get(abi.AddrKey(miner))
 		require.NoError(t, err)
@@ -1131,7 +1131,7 @@ func asKey(in string) abi.Keyer {
 }
 
 func verifyEmptyMap(t testing.TB, rt *mock.Runtime, cid cid.Cid) {
-	mapChecked, err := adt.AsMap(adt.AsStore(rt), cid)
+	mapChecked, err := adt.AsMap(adt.AsStore(rt), cid, builtin.DefaultHamtBitwidth)
 	assert.NoError(t, err)
 	keys, err := mapChecked.CollectKeys()
 	require.NoError(t, err)
@@ -1251,7 +1251,7 @@ func (h *spActorHarness) getClaim(rt *mock.Runtime, a addr.Address) *power.Claim
 	var st power.State
 	rt.GetState(&st)
 
-	claims, err := adt.AsMap(adt.AsStore(rt), st.Claims)
+	claims, err := adt.AsMap(adt.AsStore(rt), st.Claims, builtin.DefaultHamtBitwidth)
 	require.NoError(h.t, err)
 
 	var out power.Claim
@@ -1264,7 +1264,7 @@ func (h *spActorHarness) getClaim(rt *mock.Runtime, a addr.Address) *power.Claim
 
 func (h *spActorHarness) deleteClaim(rt *mock.Runtime, a addr.Address) {
 	st := getState(rt)
-	claims, err := adt.AsMap(adt.AsStore(rt), st.Claims)
+	claims, err := adt.AsMap(adt.AsStore(rt), st.Claims, builtin.DefaultHamtBitwidth)
 	require.NoError(h.t, err)
 	err = claims.Delete(abi.AddrKey(a))
 	require.NoError(h.t, err)
@@ -1277,7 +1277,7 @@ func (h *spActorHarness) getEnrolledCronTicks(rt *mock.Runtime, epoch abi.ChainE
 	var st power.State
 	rt.GetState(&st)
 
-	events, err := adt.AsMultimap(adt.AsStore(rt), st.CronEventQueue)
+	events, err := adt.AsMultimap(adt.AsStore(rt), st.CronEventQueue, builtin.DefaultHamtBitwidth)
 	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load cron events")
 
 	evts, found, err := events.Get(abi.IntKey(int64(epoch)))

--- a/actors/builtin/power/testing.go
+++ b/actors/builtin/power/testing.go
@@ -57,7 +57,7 @@ func CheckStateInvariants(st *State, store adt.Store) (*StateSummary, *builtin.M
 
 func CheckCronInvariants(st *State, store adt.Store, acc *builtin.MessageAccumulator) CronEventsByAddress {
 	byAddress := make(CronEventsByAddress)
-	queue, err := adt.AsMultimap(store, st.CronEventQueue)
+	queue, err := adt.AsMultimap(store, st.CronEventQueue, builtin.DefaultHamtBitwidth)
 	if err != nil {
 		acc.Addf("error loading cron event queue: %v", err)
 		// Bail here.
@@ -90,7 +90,7 @@ func CheckCronInvariants(st *State, store adt.Store, acc *builtin.MessageAccumul
 
 func CheckClaimInvariants(st *State, store adt.Store, acc *builtin.MessageAccumulator) ClaimsByAddress {
 	byAddress := make(ClaimsByAddress)
-	claims, err := adt.AsMap(store, st.Claims)
+	claims, err := adt.AsMap(store, st.Claims, builtin.DefaultHamtBitwidth)
 	if err != nil {
 		acc.Addf("error loading power claims: %v", err)
 		// Bail here
@@ -152,7 +152,7 @@ func CheckProofValidationInvariants(st *State, store adt.Store, claims ClaimsByA
 	}
 
 	proofs := make(ProofsByAddress)
-	if queue, err := adt.AsMultimap(store, *st.ProofValidationBatch); err != nil {
+	if queue, err := adt.AsMultimap(store, *st.ProofValidationBatch, builtin.DefaultHamtBitwidth); err != nil {
 		acc.Addf("error loading proof validation queue: %v", err)
 	} else {
 		err = queue.ForAll(func(key string, arr *adt.Array) error {

--- a/actors/builtin/shared.go
+++ b/actors/builtin/shared.go
@@ -17,6 +17,10 @@ import (
 
 ///// Code shared by multiple built-in actors. /////
 
+// Default log2 of branching factor for HAMTs.
+// This value has been empirically chosen, but the optimal value for maps with different mutation profiles may differ.
+const DefaultHamtBitwidth = 5
+
 type BigFrac struct {
 	Numerator   big.Int
 	Denominator big.Int

--- a/actors/builtin/verifreg/testing.go
+++ b/actors/builtin/verifreg/testing.go
@@ -21,7 +21,7 @@ func CheckStateInvariants(st *State, store adt.Store) (*StateSummary, *builtin.M
 
 	// Check verifiers
 	allVerifiers := map[addr.Address]DataCap{}
-	if verifiers, err := adt.AsMap(store, st.Verifiers); err != nil {
+	if verifiers, err := adt.AsMap(store, st.Verifiers, builtin.DefaultHamtBitwidth); err != nil {
 		acc.Addf("error loading verifiers: %v", err)
 	} else {
 		var vcap abi.StoragePower
@@ -41,7 +41,7 @@ func CheckStateInvariants(st *State, store adt.Store) (*StateSummary, *builtin.M
 
 	// Check clients
 	allClients := map[addr.Address]DataCap{}
-	if clients, err := adt.AsMap(store, st.VerifiedClients); err != nil {
+	if clients, err := adt.AsMap(store, st.VerifiedClients, builtin.DefaultHamtBitwidth); err != nil {
 		acc.Addf("error loading clients: %v", err)
 	} else {
 		var ccap abi.StoragePower

--- a/actors/builtin/verifreg/verified_registry_actor.go
+++ b/actors/builtin/verifreg/verified_registry_actor.go
@@ -53,10 +53,8 @@ func (a Actor) Constructor(rt runtime.Runtime, rootKey *addr.Address) *abi.Empty
 	idAddr, ok := rt.ResolveAddress(*rootKey)
 	builtin.RequireParam(rt, ok, "root should be an ID address")
 
-	emptyMap, err := adt.MakeEmptyMap(adt.AsStore(rt)).Root()
-	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to create state")
-
-	st := ConstructState(emptyMap, idAddr)
+	st, err := ConstructState(adt.AsStore(rt), idAddr)
+	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to construct state")
 	rt.StateCreate(st)
 	return nil
 }
@@ -83,10 +81,10 @@ func (a Actor) AddVerifier(rt runtime.Runtime, params *AddVerifierParams) *abi.E
 		rt.Abortf(exitcode.ErrIllegalArgument, "Rootkey cannot be added as verifier")
 	}
 	rt.StateTransaction(&st, func() {
-		verifiers, err := adt.AsMap(adt.AsStore(rt), st.Verifiers)
+		verifiers, err := adt.AsMap(adt.AsStore(rt), st.Verifiers, builtin.DefaultHamtBitwidth)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load verifiers")
 
-		verifiedClients, err := adt.AsMap(adt.AsStore(rt), st.VerifiedClients)
+		verifiedClients, err := adt.AsMap(adt.AsStore(rt), st.VerifiedClients, builtin.DefaultHamtBitwidth)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load verified clients")
 
 		// A verified client cannot become a verifier
@@ -115,7 +113,7 @@ func (a Actor) RemoveVerifier(rt runtime.Runtime, verifierAddr *addr.Address) *a
 	rt.ValidateImmediateCallerIs(st.RootKey)
 
 	rt.StateTransaction(&st, func() {
-		verifiers, err := adt.AsMap(adt.AsStore(rt), st.Verifiers)
+		verifiers, err := adt.AsMap(adt.AsStore(rt), st.Verifiers, builtin.DefaultHamtBitwidth)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load verifiers")
 
 		err = verifiers.Delete(abi.AddrKey(verifier))
@@ -152,10 +150,10 @@ func (a Actor) AddVerifiedClient(rt runtime.Runtime, params *AddVerifiedClientPa
 	}
 
 	rt.StateTransaction(&st, func() {
-		verifiers, err := adt.AsMap(adt.AsStore(rt), st.Verifiers)
+		verifiers, err := adt.AsMap(adt.AsStore(rt), st.Verifiers, builtin.DefaultHamtBitwidth)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load verifiers")
 
-		verifiedClients, err := adt.AsMap(adt.AsStore(rt), st.VerifiedClients)
+		verifiedClients, err := adt.AsMap(adt.AsStore(rt), st.VerifiedClients, builtin.DefaultHamtBitwidth)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load verified clients")
 
 		// Validate caller is one of the verifiers.
@@ -227,7 +225,7 @@ func (a Actor) UseBytes(rt runtime.Runtime, params *UseBytesParams) *abi.EmptyVa
 
 	var st State
 	rt.StateTransaction(&st, func() {
-		verifiedClients, err := adt.AsMap(adt.AsStore(rt), st.VerifiedClients)
+		verifiedClients, err := adt.AsMap(adt.AsStore(rt), st.VerifiedClients, builtin.DefaultHamtBitwidth)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load verified clients")
 
 		var vcCap DataCap
@@ -288,10 +286,10 @@ func (a Actor) RestoreBytes(rt runtime.Runtime, params *RestoreBytesParams) *abi
 	}
 
 	rt.StateTransaction(&st, func() {
-		verifiedClients, err := adt.AsMap(adt.AsStore(rt), st.VerifiedClients)
+		verifiedClients, err := adt.AsMap(adt.AsStore(rt), st.VerifiedClients, builtin.DefaultHamtBitwidth)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load verified clients")
 
-		verifiers, err := adt.AsMap(adt.AsStore(rt), st.Verifiers)
+		verifiers, err := adt.AsMap(adt.AsStore(rt), st.Verifiers, builtin.DefaultHamtBitwidth)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load verifiers")
 
 		// validate we are NOT attempting to do this for a verifier

--- a/actors/builtin/verifreg/verified_registry_state.go
+++ b/actors/builtin/verifreg/verified_registry_state.go
@@ -4,6 +4,10 @@ import (
 	addr "github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	cid "github.com/ipfs/go-cid"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/specs-actors/v3/actors/builtin"
+	"github.com/filecoin-project/specs-actors/v3/actors/util/adt"
 )
 
 // DataCap is an integer number of bytes.
@@ -26,10 +30,15 @@ type State struct {
 var MinVerifiedDealSize = abi.NewStoragePower(1 << 20)
 
 // rootKeyAddress comes from genesis.
-func ConstructState(emptyMapCid cid.Cid, rootKeyAddress addr.Address) *State {
+func ConstructState(store adt.Store, rootKeyAddress addr.Address) (*State, error) {
+	emptyMapCid, err := adt.MakeEmptyMap(store, builtin.DefaultHamtBitwidth).Root()
+	if err != nil {
+		return nil, xerrors.Errorf("failed to create empty map: %w", err)
+	}
+
 	return &State{
 		RootKey:         rootKeyAddress,
 		Verifiers:       emptyMapCid,
 		VerifiedClients: emptyMapCid,
-	}
+	}, nil
 }

--- a/actors/builtin/verifreg/verified_registry_test.go
+++ b/actors/builtin/verifreg/verified_registry_test.go
@@ -40,7 +40,7 @@ func TestConstruction(t *testing.T) {
 		actor := verifRegActorTestHarness{t: t, rootkey: raddr}
 		actor.constructAndVerify(rt)
 
-		emptyMap, err := adt.MakeEmptyMap(rt.AdtStore()).Root()
+		emptyMap, err := adt.MakeEmptyMap(rt.AdtStore(), builtin.DefaultHamtBitwidth).Root()
 		require.NoError(t, err)
 
 		state := actor.state(rt)
@@ -60,7 +60,7 @@ func TestConstruction(t *testing.T) {
 		actor := verifRegActorTestHarness{t: t, rootkey: raddr}
 		actor.constructAndVerify(rt)
 
-		emptyMap, err := adt.MakeEmptyMap(rt.AdtStore()).Root()
+		emptyMap, err := adt.MakeEmptyMap(rt.AdtStore(), builtin.DefaultHamtBitwidth).Root()
 		require.NoError(t, err)
 
 		var state verifreg.State
@@ -916,7 +916,7 @@ func (h *verifRegActorTestHarness) getVerifierCap(rt *mock.Runtime, a address.Ad
 	var st verifreg.State
 	rt.GetState(&st)
 
-	v, err := adt.AsMap(adt.AsStore(rt), st.Verifiers)
+	v, err := adt.AsMap(adt.AsStore(rt), st.Verifiers, builtin.DefaultHamtBitwidth)
 	require.NoError(h.t, err)
 
 	var dc verifreg.DataCap
@@ -930,7 +930,7 @@ func (h *verifRegActorTestHarness) getClientCap(rt *mock.Runtime, a address.Addr
 	var st verifreg.State
 	rt.GetState(&st)
 
-	v, err := adt.AsMap(adt.AsStore(rt), st.VerifiedClients)
+	v, err := adt.AsMap(adt.AsStore(rt), st.VerifiedClients, builtin.DefaultHamtBitwidth)
 	require.NoError(h.t, err)
 
 	var dc verifreg.DataCap
@@ -944,7 +944,7 @@ func (h *verifRegActorTestHarness) assertVerifierRemoved(rt *mock.Runtime, a add
 	var st verifreg.State
 	rt.GetState(&st)
 
-	v, err := adt.AsMap(adt.AsStore(rt), st.Verifiers)
+	v, err := adt.AsMap(adt.AsStore(rt), st.Verifiers, builtin.DefaultHamtBitwidth)
 	require.NoError(h.t, err)
 
 	var dc verifreg.DataCap
@@ -957,7 +957,7 @@ func (h *verifRegActorTestHarness) assertClientRemoved(rt *mock.Runtime, a addre
 	var st verifreg.State
 	rt.GetState(&st)
 
-	v, err := adt.AsMap(adt.AsStore(rt), st.VerifiedClients)
+	v, err := adt.AsMap(adt.AsStore(rt), st.VerifiedClients, builtin.DefaultHamtBitwidth)
 	require.NoError(h.t, err)
 
 	var dc verifreg.DataCap

--- a/actors/migration/nv4/miner.go
+++ b/actors/migration/nv4/miner.go
@@ -11,6 +11,7 @@ import (
 	cbor "github.com/ipfs/go-ipld-cbor"
 	"golang.org/x/xerrors"
 
+	builtin2 "github.com/filecoin-project/specs-actors/v3/actors/builtin"
 	miner2 "github.com/filecoin-project/specs-actors/v3/actors/builtin/miner"
 	adt2 "github.com/filecoin-project/specs-actors/v3/actors/util/adt"
 )
@@ -139,7 +140,7 @@ func (m *minerMigrator) migratePreCommittedSectors(ctx context.Context, store cb
 	if err != nil {
 		return cid.Undef, err
 	}
-	outMap := adt2.MakeEmptyMap(adt2.WrapStore(ctx, store))
+	outMap := adt2.MakeEmptyMap(adt2.WrapStore(ctx, store), builtin2.DefaultHamtBitwidth)
 
 	var inSPCOCI miner0.SectorPreCommitOnChainInfo
 	if err = inMap.ForEach(&inSPCOCI, func(key string) error {

--- a/actors/migration/nv4/power.go
+++ b/actors/migration/nv4/power.go
@@ -14,6 +14,7 @@ import (
 	cbor "github.com/ipfs/go-ipld-cbor"
 	"golang.org/x/xerrors"
 
+	builtin2 "github.com/filecoin-project/specs-actors/v3/actors/builtin"
 	power2 "github.com/filecoin-project/specs-actors/v3/actors/builtin/power"
 	adt2 "github.com/filecoin-project/specs-actors/v3/actors/util/adt"
 	smoothing2 "github.com/filecoin-project/specs-actors/v3/actors/util/smoothing"
@@ -121,7 +122,7 @@ func (m *powerMigrator) migrateClaims(ctx context.Context, store cbor.IpldStore,
 	if err != nil {
 		return cid.Undef, err
 	}
-	outMap := adt2.MakeEmptyMap(adt2.WrapStore(ctx, store))
+	outMap := adt2.MakeEmptyMap(adt2.WrapStore(ctx, store), builtin2.DefaultHamtBitwidth)
 
 	var inClaim power0.Claim
 	if err = inMap.ForEach(&inClaim, func(key string) error {

--- a/actors/migration/nv4/verifreg.go
+++ b/actors/migration/nv4/verifreg.go
@@ -63,7 +63,7 @@ func (m *verifregMigrator) migrateCapTable(ctx context.Context, store cbor.IpldS
 	if err != nil {
 		return cid.Undef, err
 	}
-	outMap := adt2.MakeEmptyMap(adt2.WrapStore(ctx, store))
+	outMap := adt2.MakeEmptyMap(adt2.WrapStore(ctx, store), builtin2.DefaultHamtBitwidth)
 
 	outInit, found, err := m.actorsOut.GetActor(builtin2.InitActorAddr)
 	if err != nil {

--- a/actors/migration/nv7/power.go
+++ b/actors/migration/nv7/power.go
@@ -9,7 +9,7 @@ import (
 	cbor "github.com/ipfs/go-ipld-cbor"
 
 	"github.com/filecoin-project/specs-actors/v3/actors/builtin"
-	power "github.com/filecoin-project/specs-actors/v3/actors/builtin/power"
+	"github.com/filecoin-project/specs-actors/v3/actors/builtin/power"
 	"github.com/filecoin-project/specs-actors/v3/actors/util/adt"
 )
 
@@ -60,7 +60,7 @@ func (m PowerMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, h
 }
 
 func (a PowerMigrator) ComputeClaimsStats(ctx context.Context, store cbor.IpldStore, claimsRoot cid.Cid) (*claimsSummary, error) {
-	claims, err := adt.AsMap(adt.WrapStore(ctx, store), claimsRoot)
+	claims, err := adt.AsMap(adt.WrapStore(ctx, store), claimsRoot, builtin.DefaultHamtBitwidth)
 	if err != nil {
 		return nil, err
 	}

--- a/actors/migration/nv9/market.go
+++ b/actors/migration/nv9/market.go
@@ -9,6 +9,7 @@ import (
 	market2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/market"
 	adt2 "github.com/filecoin-project/specs-actors/v2/actors/util/adt"
 
+	builtin3 "github.com/filecoin-project/specs-actors/v3/actors/builtin"
 	market3 "github.com/filecoin-project/specs-actors/v3/actors/builtin/market"
 	adt3 "github.com/filecoin-project/specs-actors/v3/actors/util/adt"
 )
@@ -52,7 +53,7 @@ func (a MarketMigrator) MapPendingProposals(ctx context.Context, store cbor.Ipld
 		return cid.Undef, err
 	}
 
-	newPendingProposals := adt3.MakeEmptySet(adt3.WrapStore(ctx, store))
+	newPendingProposals := adt3.MakeEmptySet(adt3.WrapStore(ctx, store), builtin3.DefaultHamtBitwidth)
 
 	err = oldPendingProposals.ForEach(nil, func(key string) error {
 		return newPendingProposals.Put(StringKey(key))

--- a/actors/states/election_test.go
+++ b/actors/states/election_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/go-bitfield"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/stretchr/testify/assert"
@@ -164,42 +163,17 @@ func constructMinerState(ctx context.Context, t *testing.T, store adt.Store, own
 
 	periodStart := abi.ChainEpoch(0)
 
-	emptyMap, err := adt.MakeEmptyMap(store).Root()
-	require.NoError(t, err)
-
-	emptyArray, err := adt.MakeEmptyArray(store).Root()
-	require.NoError(t, err)
-
-	emptyBitfield := bitfield.NewFromSet(nil)
-	emptyBitfieldCid, err := store.Put(ctx, emptyBitfield)
-	require.NoError(t, err)
-
-	emptyDeadline := miner.ConstructDeadline(emptyArray)
-	emptyDeadlineCid, err := store.Put(ctx, emptyDeadline)
-	require.NoError(t, err)
-
-	emptyDeadlines := miner.ConstructDeadlines(emptyDeadlineCid)
-	emptyVestingFunds := miner.ConstructVestingFunds()
-	emptyDeadlinesCid, err := store.Put(ctx, emptyDeadlines)
-	require.NoError(t, err)
-
-	emptyVestingFundsCid, err := store.Put(ctx, emptyVestingFunds)
-	require.NoError(t, err)
-
-	st, err := miner.ConstructState(infoCid, periodStart, 0, emptyBitfieldCid, emptyArray, emptyMap, emptyDeadlinesCid, emptyVestingFundsCid)
+	st, err := miner.ConstructState(store, infoCid, periodStart, 0)
 	require.NoError(t, err)
 
 	return st
 }
 
 func constructPowerStateWithMiner(t *testing.T, store adt.Store, maddr address.Address, pwr abi.StoragePower, proof abi.RegisteredSealProof) *power.State {
-	emptyMap, err := adt.MakeEmptyMap(store).Root()
+	pSt, err := power.ConstructState(store)
 	require.NoError(t, err)
-	emptyMMap, err := adt.MakeEmptyMultimap(store).Root()
-	require.NoError(t, err)
-	pSt := power.ConstructState(emptyMap, emptyMMap)
 
-	claims, err := adt.AsMap(store, pSt.Claims)
+	claims, err := adt.AsMap(store, pSt.Claims, builtin.DefaultHamtBitwidth)
 	require.NoError(t, err)
 
 	claim := &power.Claim{SealProofType: proof, RawBytePower: pwr, QualityAdjPower: pwr}

--- a/actors/states/tree.go
+++ b/actors/states/tree.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ipfs/go-cid"
 	"golang.org/x/xerrors"
 
+	"github.com/filecoin-project/specs-actors/v3/actors/builtin"
 	"github.com/filecoin-project/specs-actors/v3/actors/util/adt"
 )
 
@@ -28,7 +29,7 @@ type Tree struct {
 
 // Initializes a new, empty state tree backed by a store.
 func NewTree(store adt.Store) (*Tree, error) {
-	emptyMap := adt.MakeEmptyMap(store)
+	emptyMap := adt.MakeEmptyMap(store, builtin.DefaultHamtBitwidth)
 	return &Tree{
 		Map:   emptyMap,
 		Store: store,
@@ -37,7 +38,7 @@ func NewTree(store adt.Store) (*Tree, error) {
 
 // Loads a tree from a root CID and store.
 func LoadTree(s adt.Store, r cid.Cid) (*Tree, error) {
-	m, err := adt.AsMap(s, r)
+	m, err := adt.AsMap(s, r, builtin.DefaultHamtBitwidth)
 	if err != nil {
 		return nil, err
 	}

--- a/actors/util/adt/balancetable.go
+++ b/actors/util/adt/balancetable.go
@@ -6,6 +6,8 @@ import (
 	"github.com/filecoin-project/go-state-types/big"
 	cid "github.com/ipfs/go-cid"
 	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/specs-actors/v3/actors/builtin"
 )
 
 // A specialization of a map of addresses to (positive) token amounts.
@@ -14,7 +16,7 @@ type BalanceTable Map
 
 // Interprets a store as balance table with root `r`.
 func AsBalanceTable(s Store, r cid.Cid) (*BalanceTable, error) {
-	m, err := AsMap(s, r)
+	m, err := AsMap(s, r, builtin.DefaultHamtBitwidth)
 	if err != nil {
 		return nil, err
 	}

--- a/actors/util/adt/balancetable_test.go
+++ b/actors/util/adt/balancetable_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/filecoin-project/specs-actors/v3/actors/builtin"
 	"github.com/filecoin-project/specs-actors/v3/actors/util/adt"
 	"github.com/filecoin-project/specs-actors/v3/support/mock"
 	tutil "github.com/filecoin-project/specs-actors/v3/support/testing"
@@ -19,7 +20,7 @@ func TestBalanceTable(t *testing.T) {
 	buildBalanceTable := func() *adt.BalanceTable {
 		rt := mock.NewBuilder(context.Background(), address.Undef).Build(t)
 		store := adt.AsStore(rt)
-		emptyMap := adt.MakeEmptyMap(store)
+		emptyMap := adt.MakeEmptyMap(store, builtin.DefaultHamtBitwidth)
 
 		bt, err := adt.AsBalanceTable(store, tutil.MustRoot(t, emptyMap))
 		require.NoError(t, err)
@@ -128,7 +129,7 @@ func TestSubtractWithMinimum(t *testing.T) {
 	buildBalanceTable := func() *adt.BalanceTable {
 		rt := mock.NewBuilder(context.Background(), address.Undef).Build(t)
 		store := adt.AsStore(rt)
-		emptyMap := adt.MakeEmptyMap(store)
+		emptyMap := adt.MakeEmptyMap(store, builtin.DefaultHamtBitwidth)
 
 		bt, err := adt.AsBalanceTable(store, tutil.MustRoot(t, emptyMap))
 		require.NoError(t, err)

--- a/actors/util/adt/multimap.go
+++ b/actors/util/adt/multimap.go
@@ -16,8 +16,9 @@ type Multimap struct {
 }
 
 // Interprets a store as a HAMT-based map of AMTs with root `r`.
-func AsMultimap(s Store, r cid.Cid) (*Multimap, error) {
-	m, err := AsMap(s, r)
+// The outer map is interpreted with a branching factor of 2^bitwidth.
+func AsMultimap(s Store, r cid.Cid, outerBitwidth int) (*Multimap, error) {
+	m, err := AsMap(s, r, outerBitwidth)
 	if err != nil {
 		return nil, err
 	}
@@ -26,8 +27,9 @@ func AsMultimap(s Store, r cid.Cid) (*Multimap, error) {
 }
 
 // Creates a new map backed by an empty HAMT and flushes it to the store.
-func MakeEmptyMultimap(s Store) *Multimap {
-	m := MakeEmptyMap(s)
+// The outer map has a branching factor of 2^bitwidth.
+func MakeEmptyMultimap(s Store, outerBitwidth int) *Multimap {
+	m := MakeEmptyMap(s, outerBitwidth)
 	return &Multimap{m}
 }
 

--- a/actors/util/adt/set.go
+++ b/actors/util/adt/set.go
@@ -11,8 +11,9 @@ type Set struct {
 }
 
 // AsSet interprets a store as a HAMT-based set with root `r`.
-func AsSet(s Store, r cid.Cid) (*Set, error) {
-	m, err := AsMap(s, r)
+// The HAMT is interpreted with branching factor 2^bitwidth.
+func AsSet(s Store, r cid.Cid, bitwidth int) (*Set, error) {
+	m, err := AsMap(s, r, bitwidth)
 	if err != nil {
 		return nil, err
 	}
@@ -23,8 +24,9 @@ func AsSet(s Store, r cid.Cid) (*Set, error) {
 }
 
 // NewSet creates a new HAMT with root `r` and store `s`.
-func MakeEmptySet(s Store) *Set {
-	m := MakeEmptyMap(s)
+// The HAMT has branching factor 2^bitwidth.
+func MakeEmptySet(s Store, bitwidth int) *Set {
+	m := MakeEmptyMap(s, bitwidth)
 	return &Set{m}
 }
 

--- a/support/vm/testing.go
+++ b/support/vm/testing.go
@@ -65,16 +65,10 @@ func NewCustomStoreVMWithSingletons(ctx context.Context, store adt.Store, t test
 
 	vm := NewVM(ctx, lookup, store)
 
-	emptyMapCID, err := adt.MakeEmptyMap(vm.store).Root()
-	require.NoError(t, err)
-	emptyArrayCID, err := adt.MakeEmptyArray(vm.store).Root()
-	require.NoError(t, err)
-	emptyMultimapCID, err := adt.MakeEmptyMultimap(vm.store).Root()
-	require.NoError(t, err)
-
 	initializeActor(ctx, t, vm, &system.State{}, builtin.SystemActorCodeID, builtin.SystemActorAddr, big.Zero())
 
-	initState := initactor.ConstructState(emptyMapCID, "scenarios")
+	initState, err := initactor.ConstructState(store, "scenarios")
+	require.NoError(t, err)
 	initializeActor(ctx, t, vm, initState, builtin.InitActorCodeID, builtin.InitActorAddr, big.Zero())
 
 	rewardState := reward.ConstructState(abi.NewStoragePower(0))
@@ -83,15 +77,18 @@ func NewCustomStoreVMWithSingletons(ctx context.Context, store adt.Store, t test
 	cronState := cron.ConstructState(cron.BuiltInEntries())
 	initializeActor(ctx, t, vm, cronState, builtin.CronActorCodeID, builtin.CronActorAddr, big.Zero())
 
-	powerState := power.ConstructState(emptyMapCID, emptyMultimapCID)
+	powerState, err := power.ConstructState(store)
+	require.NoError(t, err)
 	initializeActor(ctx, t, vm, powerState, builtin.StoragePowerActorCodeID, builtin.StoragePowerActorAddr, big.Zero())
 
-	marketState := market.ConstructState(emptyArrayCID, emptyMapCID, emptyMultimapCID)
+	marketState, err := market.ConstructState(store)
+	require.NoError(t, err)
 	initializeActor(ctx, t, vm, marketState, builtin.StorageMarketActorCodeID, builtin.StorageMarketActorAddr, big.Zero())
 
 	// this will need to be replaced with the address of a multisig actor for the verified registry to be tested accurately
 	initializeActor(ctx, t, vm, &account.State{Address: VerifregRoot}, builtin.AccountActorCodeID, VerifregRoot, big.Zero())
-	vrState := verifreg.ConstructState(emptyMapCID, VerifregRoot)
+	vrState, err := verifreg.ConstructState(store, VerifregRoot)
+	require.NoError(t, err)
 	initializeActor(ctx, t, vm, vrState, builtin.VerifiedRegistryActorCodeID, builtin.VerifiedRegistryActorAddr, big.Zero())
 
 	// burnt funds

--- a/support/vm/vm.go
+++ b/support/vm/vm.go
@@ -72,7 +72,7 @@ type Invocation struct {
 
 // NewVM creates a new runtime for executing messages.
 func NewVM(ctx context.Context, actorImpls ActorImplLookup, store adt.Store) *VM {
-	actors := adt.MakeEmptyMap(store)
+	actors := adt.MakeEmptyMap(store, builtin.DefaultHamtBitwidth)
 	actorRoot, err := actors.Root()
 	if err != nil {
 		panic(err)
@@ -99,7 +99,7 @@ func NewVM(ctx context.Context, actorImpls ActorImplLookup, store adt.Store) *VM
 
 // NewVM creates a new runtime for executing messages.
 func NewVMAtEpoch(ctx context.Context, actorImpls ActorImplLookup, store adt.Store, stateRoot cid.Cid, epoch abi.ChainEpoch) (*VM, error) {
-	actors, err := adt.AsMap(store, stateRoot)
+	actors, err := adt.AsMap(store, stateRoot, builtin.DefaultHamtBitwidth)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +130,7 @@ func (vm *VM) WithEpoch(epoch abi.ChainEpoch) (*VM, error) {
 		return nil, err
 	}
 
-	actors, err := adt.AsMap(vm.store, vm.stateRoot)
+	actors, err := adt.AsMap(vm.store, vm.stateRoot, builtin.DefaultHamtBitwidth)
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +157,7 @@ func (vm *VM) WithNetworkVersion(nv network.Version) (*VM, error) {
 		return nil, err
 	}
 
-	actors, err := adt.AsMap(vm.store, vm.stateRoot)
+	actors, err := adt.AsMap(vm.store, vm.stateRoot, builtin.DefaultHamtBitwidth)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +180,7 @@ func (vm *VM) WithNetworkVersion(nv network.Version) (*VM, error) {
 
 func (vm *VM) rollback(root cid.Cid) error {
 	var err error
-	vm.actors, err = adt.AsMap(vm.store, root)
+	vm.actors, err = adt.AsMap(vm.store, root, builtin.DefaultHamtBitwidth)
 	if err != nil {
 		return errors.Wrapf(err, "failed to load node for %s", root)
 	}


### PR DESCRIPTION
We're likely to tune some HAMT bitwidths to values other than `5`. This is a fairly mechanical refactor to make that possible. It's a little noisy, some of the noise pointing to poor encapsualtion.

Partial satisfaction of #1313.