### PR TITLE
Market actor accepts deals published from miner control addresses

### DIFF
--- a/actors/builtin/market/market_actor.go
+++ b/actors/builtin/market/market_actor.go
@@ -181,9 +181,17 @@ func (a Actor) PublishStorageDeals(rt Runtime, params *PublishStorageDealsParams
 		rt.Abortf(exitcode.ErrIllegalArgument, "deal provider is not a StorageMinerActor")
 	}
 
-	_, worker, _ := builtin.RequestMinerControlAddrs(rt, provider)
-	if worker != rt.Caller() {
-		rt.Abortf(exitcode.ErrForbidden, "caller is not provider %v", provider)
+	caller := rt.Caller()
+	_, worker, controllers := builtin.RequestMinerControlAddrs(rt, provider)
+	callerOk := caller == worker
+	for _, controller := range controllers {
+		if callerOk {
+			break
+		}
+		callerOk = caller == controller
+	}
+	if !callerOk {
+		rt.Abortf(exitcode.ErrForbidden, "caller %v is not worker or control address of provider %v", caller, provider)
 	}
 
 	resolvedAddrs := make(map[addr.Address]addr.Address, len(params.Deals))


### PR DESCRIPTION
The market actor currently requires a deal to be published by the worker address of the deal provider (miner). This change also allows the miner's control addresses, which gives more flexibility to miners. The change is straightforward, and I refactored tests a little to support exercising it.

Closes #1317