### PR TITLE
Actor tree traversal for migration nv9

### DIFF
--- a/actors/migration/nv9/market.go
+++ b/actors/migration/nv9/market.go
@@ -14,11 +14,11 @@ import (
 	adt3 "github.com/filecoin-project/specs-actors/v3/actors/util/adt"
 )
 
-type MarketMigrator struct{}
+type marketMigrator struct{}
 
-func (m MarketMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, head cid.Cid, info MigrationInfo) (*StateMigrationResult, error) {
+func (m marketMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, in StateMigrationInput) (*StateMigrationResult, error) {
 	var inState market2.State
-	if err := store.Get(ctx, head, &inState); err != nil {
+	if err := store.Get(ctx, in.head, &inState); err != nil {
 		return nil, err
 	}
 
@@ -43,11 +43,12 @@ func (m MarketMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, 
 
 	newHead, err := store.Put(ctx, &outState)
 	return &StateMigrationResult{
-		NewHead: newHead,
+		NewCodeCID: builtin3.StorageMarketActorCodeID,
+		NewHead:    newHead,
 	}, err
 }
 
-func (a MarketMigrator) MapPendingProposals(ctx context.Context, store cbor.IpldStore, pendingProposalsRoot cid.Cid) (cid.Cid, error) {
+func (a marketMigrator) MapPendingProposals(ctx context.Context, store cbor.IpldStore, pendingProposalsRoot cid.Cid) (cid.Cid, error) {
 	oldPendingProposals, err := adt2.AsMap(adt2.WrapStore(ctx, store), pendingProposalsRoot)
 	if err != nil {
 		return cid.Undef, err

--- a/actors/migration/nv9/test/parallel_migration_test.go
+++ b/actors/migration/nv9/test/parallel_migration_test.go
@@ -1,0 +1,107 @@
+package test_test
+
+import (
+	"context"
+	"testing"
+
+	addr "github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/cbor"
+	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
+	account2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/account"
+	cron2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/cron"
+	init2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/init"
+	market2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/market"
+	power2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/power"
+	reward2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/reward"
+	system2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/system"
+	verifreg2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/verifreg"
+	states2 "github.com/filecoin-project/specs-actors/v2/actors/states"
+	adt2 "github.com/filecoin-project/specs-actors/v2/actors/util/adt"
+	ipld2 "github.com/filecoin-project/specs-actors/v2/support/ipld"
+	cid "github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/filecoin-project/specs-actors/v3/actors/migration/nv9"
+)
+
+func TestParallelMigrationCalls(t *testing.T) {
+	// Construct simple prior state tree over a locking store
+	ctx := context.Background()
+	syncStore := ipld2.NewSyncADTStore(ctx)
+	initializeActor := func(ctx context.Context, t *testing.T, actors *states2.Tree, state cbor.Marshaler, code cid.Cid, a addr.Address, balance abi.TokenAmount) {
+		stateCID, err := actors.Store.Put(ctx, state)
+		require.NoError(t, err)
+		actor := &states2.Actor{
+			Head:    stateCID,
+			Code:    code,
+			Balance: balance,
+		}
+		err = actors.SetActor(a, actor)
+		require.NoError(t, err)
+	}
+	actorsIn, err := states2.NewTree(syncStore)
+	require.NoError(t, err)
+
+	emptyMapCID, err := adt2.MakeEmptyMap(syncStore).Root()
+	require.NoError(t, err)
+	emptyArrayCID, err := adt2.MakeEmptyArray(syncStore).Root()
+	require.NoError(t, err)
+	emptyMultimapCID, err := adt2.MakeEmptyMultimap(syncStore).Root()
+	require.NoError(t, err)
+
+	initializeActor(ctx, t, actorsIn, &system2.State{}, builtin2.SystemActorCodeID, builtin2.SystemActorAddr, big.Zero())
+
+	initState := init2.ConstructState(emptyMapCID, "scenarios")
+	initializeActor(ctx, t, actorsIn, initState, builtin2.InitActorCodeID, builtin2.InitActorAddr, big.Zero())
+
+	rewardState := reward2.ConstructState(abi.NewStoragePower(0))
+	initializeActor(ctx, t, actorsIn, rewardState, builtin2.RewardActorCodeID, builtin2.RewardActorAddr, builtin2.TotalFilecoin)
+
+	cronState := cron2.ConstructState(cron2.BuiltInEntries())
+	initializeActor(ctx, t, actorsIn, cronState, builtin2.CronActorCodeID, builtin2.CronActorAddr, big.Zero())
+
+	powerState := power2.ConstructState(emptyMapCID, emptyMultimapCID)
+	initializeActor(ctx, t, actorsIn, powerState, builtin2.StoragePowerActorCodeID, builtin2.StoragePowerActorAddr, big.Zero())
+
+	marketState := market2.ConstructState(emptyArrayCID, emptyMapCID, emptyMultimapCID)
+	initializeActor(ctx, t, actorsIn, marketState, builtin2.StorageMarketActorCodeID, builtin2.StorageMarketActorAddr, big.Zero())
+
+	// this will need to be replaced with the address of a multisig actor for the verified registry to be tested accurately
+	verifregRoot, err := addr.NewIDAddress(80)
+	require.NoError(t, err)
+	initializeActor(ctx, t, actorsIn, &account2.State{Address: verifregRoot}, builtin2.AccountActorCodeID, verifregRoot, big.Zero())
+	vrState := verifreg2.ConstructState(emptyMapCID, verifregRoot)
+	initializeActor(ctx, t, actorsIn, vrState, builtin2.VerifiedRegistryActorCodeID, builtin2.VerifiedRegistryActorAddr, big.Zero())
+
+	// burnt funds
+	initializeActor(ctx, t, actorsIn, &account2.State{Address: builtin2.BurntFundsActorAddr}, builtin2.AccountActorCodeID, builtin2.BurntFundsActorAddr, big.Zero())
+
+	startRoot, err := actorsIn.Flush()
+	require.NoError(t, err)
+
+	// Run migration
+
+	endRootSerial, err := nv9.MigrateStateTree(ctx, syncStore, startRoot, abi.ChainEpoch(0), nv9.Config{MaxWorkers: 1})
+	require.NoError(t, err)
+
+	// Migrate in parallel
+	var endRootParallel1, endRootParallel2 cid.Cid
+	grp, ctx := errgroup.WithContext(ctx)
+	grp.Go(func() error {
+		var err1 error
+		endRootParallel1, err1 = nv9.MigrateStateTree(ctx, syncStore, startRoot, abi.ChainEpoch(0), nv9.Config{MaxWorkers: 2})
+		return err1
+	})
+	grp.Go(func() error {
+		var err2 error
+		endRootParallel2, err2 = nv9.MigrateStateTree(ctx, syncStore, startRoot, abi.ChainEpoch(0), nv9.Config{MaxWorkers: 2})
+		return err2
+	})
+	require.NoError(t, grp.Wait())
+	assert.Equal(t, endRootSerial, endRootParallel1)
+	assert.Equal(t, endRootParallel1, endRootParallel2)
+}

--- a/actors/migration/nv9/top.go
+++ b/actors/migration/nv9/top.go
@@ -2,77 +2,206 @@ package nv9
 
 import (
 	"context"
+	"fmt"
+	"sync"
 
 	address "github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
-	"github.com/ipfs/go-cid"
+	cid "github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
+	"golang.org/x/sync/errgroup"
 	"golang.org/x/xerrors"
 
-	"github.com/filecoin-project/specs-actors/v3/actors/builtin"
-	"github.com/filecoin-project/specs-actors/v3/actors/states"
-	"github.com/filecoin-project/specs-actors/v3/actors/util/adt"
+	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
+	states2 "github.com/filecoin-project/specs-actors/v2/actors/states"
+
+	builtin3 "github.com/filecoin-project/specs-actors/v3/actors/builtin"
+	states3 "github.com/filecoin-project/specs-actors/v3/actors/states"
+	adt3 "github.com/filecoin-project/specs-actors/v3/actors/util/adt"
 )
 
 // Config parameterizes a state tree migration
-type Config struct{}
-
-func DefaultConfig() Config {
-	return Config{}
+type Config struct {
+	MaxWorkers int
 }
 
-type MigrationInfo struct {
+type StateMigrationInput struct {
 	address    address.Address // actor's address
 	balance    abi.TokenAmount // actor's balance
+	head       cid.Cid         // actor's state head CID
 	priorEpoch abi.ChainEpoch  // epoch of last state transition prior to migration
 }
 
 type StateMigrationResult struct {
-	NewHead cid.Cid
+	NewCodeCID cid.Cid
+	NewHead    cid.Cid
 }
 
 type StateMigration interface {
 	// Loads an actor's state from an input store and writes new state to an output store.
 	// Returns the new state head CID.
-	MigrateState(ctx context.Context, store cbor.IpldStore, head cid.Cid, info MigrationInfo) (result *StateMigrationResult, err error)
+	MigrateState(ctx context.Context, store cbor.IpldStore, input StateMigrationInput) (result *StateMigrationResult, err error)
+}
+
+// Migrator which preserves the head CID and provides a fixed result code CID.
+type nilMigrator struct {
+	OutCodeCID cid.Cid
+}
+
+func (n nilMigrator) MigrateState(_ context.Context, _ cbor.IpldStore, in StateMigrationInput) (*StateMigrationResult, error) {
+	return &StateMigrationResult{
+		NewCodeCID: n.OutCodeCID,
+		NewHead:    in.head,
+	}, nil
 }
 
 // Migrates the filecoin state tree starting from the global state tree and upgrading all actor state.
-func MigrateStateTree(ctx context.Context, store cbor.IpldStore, stateRootIn cid.Cid, priorEpoch abi.ChainEpoch, _ Config) (cid.Cid, error) {
+func MigrateStateTree(ctx context.Context, store cbor.IpldStore, stateRootIn cid.Cid, priorEpoch abi.ChainEpoch, cfg Config) (cid.Cid, error) {
+	if cfg.MaxWorkers <= 0 {
+		return cid.Undef, xerrors.Errorf("invalid migration config with %d workers", cfg.MaxWorkers)
+	}
 
-	// Setup input and output state tree helpers
-	adtStore := adt.WrapStore(ctx, store)
-	actorsIn, err := states.LoadTree(adtStore, stateRootIn)
+	// Maps prior version code CIDs to migration functions.
+	var migrations = map[cid.Cid]StateMigration{
+		builtin2.AccountActorCodeID:          nilMigrator{builtin3.AccountActorCodeID},
+		builtin2.CronActorCodeID:             nilMigrator{builtin3.CronActorCodeID},
+		builtin2.InitActorCodeID:             nilMigrator{builtin3.InitActorCodeID},
+		builtin2.MultisigActorCodeID:         nilMigrator{builtin3.MultisigActorCodeID},
+		builtin2.PaymentChannelActorCodeID:   nilMigrator{builtin3.PaymentChannelActorCodeID},
+		builtin2.RewardActorCodeID:           nilMigrator{builtin3.RewardActorCodeID},
+		builtin2.StorageMarketActorCodeID:    marketMigrator{},
+		builtin2.StorageMinerActorCodeID:     nilMigrator{builtin3.StorageMinerActorCodeID},
+		builtin2.StoragePowerActorCodeID:     nilMigrator{builtin3.StoragePowerActorCodeID},
+		builtin2.SystemActorCodeID:           nilMigrator{builtin3.SystemActorCodeID},
+		builtin2.VerifiedRegistryActorCodeID: nilMigrator{builtin3.VerifiedRegistryActorCodeID},
+	}
+	// Set of prior vresion code CIDs for actors to defer during iteration, for explicit migration afterwards.
+	var deferredCodeIDs = map[cid.Cid]struct{}{
+		// None
+	}
+	if len(migrations)+len(deferredCodeIDs) != 11 {
+		panic(fmt.Sprintf("incomplete migration specification with %d code CIDs", len(migrations)))
+	}
+
+	// Load input and output state trees
+	adtStore := adt3.WrapStore(ctx, store)
+	actorsIn, err := states2.LoadTree(adtStore, stateRootIn) // FIXME actorsRootIn?
+	if err != nil {
+		return cid.Undef, err
+	}
+	actorsOut, err := states3.NewTree(adtStore)
 	if err != nil {
 		return cid.Undef, err
 	}
 
-	// Migrate Market actor
-	marketActorIn, found, err := actorsIn.GetActor(builtin.StorageMarketActorAddr)
-	if err != nil {
+	// Setup synchronization
+	grp, ctx := errgroup.WithContext(ctx)
+	inputCh := make(chan *migrationInput)
+	resultCh := make(chan *migrationResult)
+
+	// Iterate all actors in old state root to generate migration inputs for each non-deferred actor.
+	grp.Go(func() error {
+		defer close(inputCh)
+		return actorsIn.ForEach(func(addr address.Address, actorIn *states2.Actor) error {
+			if _, ok := deferredCodeIDs[actorIn.Code]; ok {
+				return nil // Deferred for explicit migration later.
+			}
+			nextInput := &migrationInput{
+				Address:        addr,
+				Actor:          *actorIn, // Must take a copy, the pointer is not stable.
+				StateMigration: migrations[actorIn.Code],
+			}
+			select {
+			case inputCh <- nextInput:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+			return nil
+		})
+	})
+
+	// Worker threads run migrations on inputs.
+	var workerWg sync.WaitGroup
+	for i := 0; i < cfg.MaxWorkers; i++ {
+		workerWg.Add(1)
+		grp.Go(func() error {
+			defer workerWg.Done()
+			for input := range inputCh {
+				result, err := migrateOneActor(ctx, store, input, priorEpoch)
+				if err != nil {
+					return err
+				}
+				if result == nil { // Actor is deferred
+					continue
+				}
+				select {
+				case resultCh <- result:
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			}
+			return nil
+		})
+	}
+
+	// Close output channel when workers are done.
+	grp.Go(func() error {
+		workerWg.Wait()
+		close(resultCh)
+		return nil
+	})
+
+	// Insert migrated records in output state tree and accumulators.
+	grp.Go(func() error {
+		for result := range resultCh {
+			if err := actorsOut.SetActor(result.Address, &result.Actor); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+
+	if err := grp.Wait(); err != nil {
 		return cid.Undef, err
 	}
-	if !found {
-		return cid.Undef, xerrors.Errorf("could not find market actor in state")
-	}
-	marketResult, err := MarketMigrator{}.MigrateState(ctx, store, marketActorIn.Head, MigrationInfo{
-		address:    builtin.StorageMarketActorAddr,
-		balance:    marketActorIn.Balance,
+
+	// Perform any deferred migrations explicitly here.
+	// Deferred migrations might depend on values accumulated through migration of other actors.
+
+	return actorsOut.Flush()
+}
+
+type migrationInput struct {
+	address.Address
+	states2.Actor
+	StateMigration
+}
+type migrationResult struct {
+	address.Address
+	states3.Actor
+}
+
+func migrateOneActor(ctx context.Context, store cbor.IpldStore, input *migrationInput, priorEpoch abi.ChainEpoch) (*migrationResult, error) {
+	actorIn := input.Actor
+	addr := input.Address
+	result, err := input.MigrateState(ctx, store, StateMigrationInput{
+		address:    addr,
+		balance:    actorIn.Balance,
+		head:       actorIn.Head,
 		priorEpoch: priorEpoch,
 	})
 	if err != nil {
-		return cid.Undef, err
-	}
-	marketActorOut := states.Actor{
-		Code:       builtin.StorageMarketActorCodeID,
-		Head:       marketResult.NewHead,
-		CallSeqNum: marketActorIn.CallSeqNum,
-		Balance:    marketActorIn.Balance,
-	}
-	err = actorsIn.SetActor(builtin.StorageMarketActorAddr, &marketActorOut)
-	if err != nil {
-		return cid.Undef, err
+		return nil, xerrors.Errorf("state migration failed for %s actor, addr %s: %w", builtin2.ActorNameByCode(actorIn.Code), addr, err)
 	}
 
-	return actorsIn.Flush()
+	// Set up new actor record with the migrated state.
+	return &migrationResult{
+		addr,
+		states3.Actor{
+			Code:       result.NewCodeCID,
+			Head:       result.NewHead,
+			CallSeqNum: actorIn.CallSeqNum, // Unchanged
+			Balance:    actorIn.Balance,    // Unchanged
+		},
+	}, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -21,5 +21,6 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/whyrusleeping/cbor-gen v0.0.0-20200812213548-958ddffe352c
 	github.com/xorcare/golden v0.6.0
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 )


### PR DESCRIPTION
For the upgrade to actors v3 (network version 9) we expect to migrate most actors in order to upgrade H/AMT data structures. This PR copies the full state migration setup from the nv4 migration, but then simplifies it a fair bit.

- Removed handling of balance transfers and power claim recalculations
- Removed some layers of wrapping for migration objects, inputs, and outputs.