### PR TITLE
Remove most v2-only code paths

### DIFF
--- a/actors/builtin/miner/monies.go
+++ b/actors/builtin/miner/monies.go
@@ -4,7 +4,6 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/exitcode"
-	"github.com/filecoin-project/go-state-types/network"
 
 	"github.com/filecoin-project/specs-actors/v3/actors/builtin"
 	"github.com/filecoin-project/specs-actors/v3/actors/util/math"
@@ -57,8 +56,8 @@ const TerminationLifetimeCap = 140 // PARAM_SPEC
 const ConsensusFaultFactor = 5
 
 // Fraction of total reward (block reward + gas reward) to be locked up as of V6
-var LockedRewardFactorNumV6 = big.NewInt(75)
-var LockedRewardFactorDenomV6 = big.NewInt(100)
+var LockedRewardFactorNum = big.NewInt(75)
+var LockedRewardFactorDenom = big.NewInt(100)
 
 // The projected block reward a sector would earn over some period.
 // Also known as "BR(t)".
@@ -176,12 +175,8 @@ func ConsensusFaultPenalty(thisEpochReward abi.TokenAmount) abi.TokenAmount {
 }
 
 // Returns the amount of a reward to vest, and the vesting schedule, for a reward amount.
-func LockedRewardFromReward(reward abi.TokenAmount, nv network.Version) (abi.TokenAmount, *VestSpec) {
-	lockAmount := reward
-	spec := &RewardVestingSpec
-	if nv >= network.Version6 {
-		// Locked amount is 75% of award.
-		lockAmount = big.Div(big.Mul(reward, LockedRewardFactorNumV6), LockedRewardFactorDenomV6)
-	}
-	return lockAmount, spec
+func LockedRewardFromReward(reward abi.TokenAmount) (abi.TokenAmount, *VestSpec) {
+	// Locked amount is 75% of award.
+	lockAmount := big.Div(big.Mul(reward, LockedRewardFactorNum), LockedRewardFactorDenom)
+	return lockAmount, &RewardVestingSpec
 }

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -65,10 +65,8 @@ const (
 	MaxMultiaddrData = 1024 // PARAM_SPEC
 )
 
-// Maximum size of a single prove-commit proof, in bytes.
-// The 1024 maximum at network version 4 was an error (the expected size is 1920).
-const MaxProveCommitSizeV4 = 1024
-const MaxProveCommitSizeV5 = 10240
+// Maximum size of a single prove-commit proof, in bytes (the expected size is 1920).
+const MaxProveCommitSize = 10240
 
 // Maximum number of control addresses a miner may register.
 const MaxControlAddresses = 10
@@ -123,23 +121,15 @@ func CanPreCommitSealProof(s abi.RegisteredSealProof, nv network.Version) bool {
 }
 
 // List of proof types for which sector lifetime may be extended.
-var ExtensibleProofTypesV0 = map[abi.RegisteredSealProof]struct{}{
-	abi.RegisteredSealProof_StackedDrg32GiBV1: {},
-	abi.RegisteredSealProof_StackedDrg64GiBV1: {},
-}
-
 // From network version 7, sectors sealed with the V1 seal proof types cannot be extended.
-var ExtensibleProofTypesV7 = map[abi.RegisteredSealProof]struct{}{
+var ExtensibleProofTypes = map[abi.RegisteredSealProof]struct{}{
 	abi.RegisteredSealProof_StackedDrg32GiBV1_1: {},
 	abi.RegisteredSealProof_StackedDrg64GiBV1_1: {},
 }
 
 // Checks whether a seal proof type is supported for new miners and sectors.
-func CanExtendSealProofType(s abi.RegisteredSealProof, nv network.Version) bool {
-	_, ok := ExtensibleProofTypesV0[s]
-	if nv >= network.Version7 {
-		_, ok = ExtensibleProofTypesV7[s]
-	}
+func CanExtendSealProofType(s abi.RegisteredSealProof) bool {
+	_, ok := ExtensibleProofTypes[s]
 	return ok
 }
 

--- a/actors/builtin/multisig/multisig_test.go
+++ b/actors/builtin/multisig/multisig_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/cbor"
 	"github.com/filecoin-project/go-state-types/exitcode"
-	"github.com/filecoin-project/go-state-types/network"
 	"github.com/minio/blake2b-simd"
 	assert "github.com/stretchr/testify/assert"
 	require "github.com/stretchr/testify/require"
@@ -1916,10 +1915,6 @@ func TestLockBalance(t *testing.T) {
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			actor.lockBalance(rt, vestStart, vestDuration, abi.NewTokenAmount(-1))
 		})
-
-		// Before version 7, allow negative amount.
-		rt.SetNetworkVersion(network.Version6)
-		actor.lockBalance(rt, vestStart, vestDuration, abi.NewTokenAmount(-1))
 	})
 }
 

--- a/actors/builtin/power/power_actor.go
+++ b/actors/builtin/power/power_actor.go
@@ -8,7 +8,6 @@ import (
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/cbor"
 	"github.com/filecoin-project/go-state-types/exitcode"
-	"github.com/filecoin-project/go-state-types/network"
 	rtt "github.com/filecoin-project/go-state-types/rt"
 	power0 "github.com/filecoin-project/specs-actors/actors/builtin/power"
 	power2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/power"
@@ -137,11 +136,9 @@ func (a Actor) CreateMiner(rt Runtime, params *CreateMinerParams) *CreateMinerRe
 
 		st.MinerCount += 1
 
-		// starting version 7, call addToClaim to ensure new claim updates all power stats
-		if rt.NetworkVersion() >= network.Version7 {
-			err := st.updateStatsForNewMiner(params.SealProofType)
-			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed update power stats for new miner %v", addresses.IDAddress)
-		}
+		// Ensure new claim updates all power stats
+		err = st.updateStatsForNewMiner(params.SealProofType)
+		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed update power stats for new miner %v", addresses.IDAddress)
 
 		st.Claims, err = claims.Root()
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to flush claims")
@@ -494,10 +491,8 @@ func (a Actor) processDeferredCronEvents(rt Runtime) {
 					continue
 				}
 
-				// Starting version 7, decrement miner count to keep stats consistent.
-				if rt.NetworkVersion() >= network.Version7 {
-					st.MinerCount--
-				}
+				// Decrement miner count to keep stats consistent.
+				st.MinerCount--
 			}
 
 			st.Claims, err = claims.Root()

--- a/actors/test/multisig_delete_self_test.go
+++ b/actors/test/multisig_delete_self_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/exitcode"
-	"github.com/filecoin-project/go-state-types/network"
 
 	"github.com/filecoin-project/specs-actors/v3/actors/builtin"
 	init_ "github.com/filecoin-project/specs-actors/v3/actors/builtin/init"
@@ -19,58 +18,9 @@ import (
 	vm "github.com/filecoin-project/specs-actors/v3/support/vm"
 )
 
-func TestV5MultisigDeleteSigner1Of2(t *testing.T) {
+func TestMultisigDeleteSelf2Of3RemovedIsProposer(t *testing.T) {
 	ctx := context.Background()
 	v := vm.NewVMWithSingletons(ctx, t)
-	v, err := v.WithNetworkVersion(network.Version5)
-	require.NoError(t, err)
-	addrs := vm.CreateAccounts(ctx, t, v, 2, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
-
-	multisigParams := multisig.ConstructorParams{
-		Signers:               addrs,
-		NumApprovalsThreshold: 1,
-	}
-
-	paramBuf := new(bytes.Buffer)
-	err = multisigParams.MarshalCBOR(paramBuf)
-	require.NoError(t, err)
-
-	initParam := init_.ExecParams{
-		CodeCID:           builtin.MultisigActorCodeID,
-		ConstructorParams: paramBuf.Bytes(),
-	}
-	ret := vm.ApplyOk(t, v, addrs[0], builtin.InitActorAddr, big.Zero(), builtin.MethodsPower.CreateMiner, &initParam)
-	initRet := ret.(*init_.ExecReturn)
-	assert.NotNil(t, initRet)
-	multisigAddr := initRet.IDAddress
-
-	removeParams := multisig.RemoveSignerParams{
-		Signer:   addrs[0],
-		Decrease: false,
-	}
-
-	paramBuf = new(bytes.Buffer)
-	err = removeParams.MarshalCBOR(paramBuf)
-	require.NoError(t, err)
-
-	proposeRemoveSignerParams := multisig.ProposeParams{
-		To:     multisigAddr,
-		Value:  big.Zero(),
-		Method: builtin.MethodsMultisig.RemoveSigner,
-		Params: paramBuf.Bytes(),
-	}
-	// address 0 fails when trying to execute the transaction removing address 0
-	_, code := v.ApplyMessage(addrs[0], multisigAddr, big.Zero(), builtin.MethodsMultisig.Propose, &proposeRemoveSignerParams)
-	assert.Equal(t, exitcode.ErrIllegalState, code)
-	// address 1 succeeds when trying to execute the transaction removing address 0
-	vm.ApplyOk(t, v, addrs[1], multisigAddr, big.Zero(), builtin.MethodsMultisig.Propose, &proposeRemoveSignerParams)
-}
-
-func TestV5MultisigDeleteSelf2Of3RemovedIsProposer(t *testing.T) {
-	ctx := context.Background()
-	v := vm.NewVMWithSingletons(ctx, t)
-	v, err := v.WithNetworkVersion(network.Version5)
-	require.NoError(t, err)
 	addrs := vm.CreateAccounts(ctx, t, v, 3, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
 
 	multisigParams := multisig.ConstructorParams{
@@ -79,7 +29,7 @@ func TestV5MultisigDeleteSelf2Of3RemovedIsProposer(t *testing.T) {
 	}
 
 	paramBuf := new(bytes.Buffer)
-	err = multisigParams.MarshalCBOR(paramBuf)
+	err := multisigParams.MarshalCBOR(paramBuf)
 	require.NoError(t, err)
 
 	initParam := init_.ExecParams{
@@ -119,11 +69,9 @@ func TestV5MultisigDeleteSelf2Of3RemovedIsProposer(t *testing.T) {
 
 }
 
-func TestV5MultisigDeleteSelf2Of3RemovedIsApprover(t *testing.T) {
+func TestMultisigDeleteSelf2Of3RemovedIsApprover(t *testing.T) {
 	ctx := context.Background()
 	v := vm.NewVMWithSingletons(ctx, t)
-	v, err := v.WithNetworkVersion(network.Version5)
-	require.NoError(t, err)
 	addrs := vm.CreateAccounts(ctx, t, v, 3, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
 
 	multisigParams := multisig.ConstructorParams{
@@ -132,7 +80,7 @@ func TestV5MultisigDeleteSelf2Of3RemovedIsApprover(t *testing.T) {
 	}
 
 	paramBuf := new(bytes.Buffer)
-	err = multisigParams.MarshalCBOR(paramBuf)
+	err := multisigParams.MarshalCBOR(paramBuf)
 	require.NoError(t, err)
 
 	initParam := init_.ExecParams{
@@ -172,11 +120,9 @@ func TestV5MultisigDeleteSelf2Of3RemovedIsApprover(t *testing.T) {
 
 }
 
-func TestV5MultisigDeleteSelf2Of2(t *testing.T) {
+func TestMultisigDeleteSelf2Of2(t *testing.T) {
 	ctx := context.Background()
 	v := vm.NewVMWithSingletons(ctx, t)
-	v, err := v.WithNetworkVersion(network.Version5)
-	require.NoError(t, err)
 	addrs := vm.CreateAccounts(ctx, t, v, 2, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
 
 	multisigParams := multisig.ConstructorParams{
@@ -185,7 +131,7 @@ func TestV5MultisigDeleteSelf2Of2(t *testing.T) {
 	}
 
 	paramBuf := new(bytes.Buffer)
-	err = multisigParams.MarshalCBOR(paramBuf)
+	err := multisigParams.MarshalCBOR(paramBuf)
 	require.NoError(t, err)
 
 	initParam := init_.ExecParams{
@@ -223,63 +169,9 @@ func TestV5MultisigDeleteSelf2Of2(t *testing.T) {
 	assert.Equal(t, exitcode.ErrNotFound, code)
 }
 
-func TestV5MultisigSwapsSelf1Of2(t *testing.T) {
+func TestMultisigSwapsSelf2Of3(t *testing.T) {
 	ctx := context.Background()
 	v := vm.NewVMWithSingletons(ctx, t)
-	v, err := v.WithNetworkVersion(network.Version5)
-	require.NoError(t, err)
-	addrs := vm.CreateAccounts(ctx, t, v, 3, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
-	alice := addrs[0]
-	bob := addrs[1]
-	chuck := addrs[2]
-
-	multisigParams := multisig.ConstructorParams{
-		Signers:               []address.Address{alice, bob},
-		NumApprovalsThreshold: 1,
-	}
-
-	paramBuf := new(bytes.Buffer)
-	err = multisigParams.MarshalCBOR(paramBuf)
-	require.NoError(t, err)
-
-	initParam := init_.ExecParams{
-		CodeCID:           builtin.MultisigActorCodeID,
-		ConstructorParams: paramBuf.Bytes(),
-	}
-	ret := vm.ApplyOk(t, v, addrs[0], builtin.InitActorAddr, big.Zero(), builtin.MethodsPower.CreateMiner, &initParam)
-	initRet := ret.(*init_.ExecReturn)
-	assert.NotNil(t, initRet)
-	multisigAddr := initRet.IDAddress
-
-	swapParams := multisig.SwapSignerParams{
-		From: alice,
-		To:   chuck,
-	}
-
-	paramBuf = new(bytes.Buffer)
-	err = swapParams.MarshalCBOR(paramBuf)
-	require.NoError(t, err)
-
-	proposeSwapSignerParams := multisig.ProposeParams{
-		To:     multisigAddr,
-		Value:  big.Zero(),
-		Method: builtin.MethodsMultisig.SwapSigner,
-		Params: paramBuf.Bytes(),
-	}
-
-	// alice fails when trying to execute the transaction swapping alice for chuck
-	_, code := v.ApplyMessage(alice, multisigAddr, big.Zero(), builtin.MethodsMultisig.Propose, &proposeSwapSignerParams)
-	assert.Equal(t, exitcode.ErrIllegalState, code)
-	// bob succeeds when trying to execute the transaction swapping alice for chuck
-	vm.ApplyOk(t, v, bob, multisigAddr, big.Zero(), builtin.MethodsMultisig.Propose, &proposeSwapSignerParams)
-
-}
-
-func TestV5MultisigSwapsSelf2Of3(t *testing.T) {
-	ctx := context.Background()
-	v := vm.NewVMWithSingletons(ctx, t)
-	v, err := v.WithNetworkVersion(network.Version5)
-	require.NoError(t, err)
 	addrs := vm.CreateAccounts(ctx, t, v, 4, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
 	alice := addrs[0]
 	bob := addrs[1]
@@ -292,7 +184,7 @@ func TestV5MultisigSwapsSelf2Of3(t *testing.T) {
 	}
 
 	paramBuf := new(bytes.Buffer)
-	err = multisigParams.MarshalCBOR(paramBuf)
+	err := multisigParams.MarshalCBOR(paramBuf)
 	require.NoError(t, err)
 
 	initParam := init_.ExecParams{
@@ -440,5 +332,4 @@ func TestMultisigSwapsSelf1Of2(t *testing.T) {
 
 	// alice succeeds when trying to execute the transaction swapping alice for chuck
 	vm.ApplyOk(t, v, alice, multisigAddr, big.Zero(), builtin.MethodsMultisig.Propose, &proposeSwapSignerParams)
-
 }


### PR DESCRIPTION
This PR removes almost all handling of network versions that strictly precede actors v3. This was prompted by noise I observed in #1327.

The one path I retained is allowing the creation of new miner actors with an old seal proof type prior to v7, so that we can test how those miners are subsequently handled. This can probably go away after #1329.