### PR TITLE
Change miner.Sectors AMT bitwidth to 5. Move constants to state files.

### DIFF
--- a/actors/builtin/market/market_state.go
+++ b/actors/builtin/market/market_state.go
@@ -30,6 +30,10 @@ const (
 	ProviderCollateral
 )
 
+// Bitwidth of AMTs determined empirically from mutation patterns and projections of mainnet data.
+const ProposalsAmtBitwidth = 5
+const StatesAmtBitwidth = 6
+
 type State struct {
 	Proposals cid.Cid // AMT[DealID]DealProposal
 	States    cid.Cid // AMT[DealID]DealState

--- a/actors/builtin/market/policy.go
+++ b/actors/builtin/market/policy.go
@@ -26,14 +26,6 @@ var DealMaxDuration = abi.ChainEpoch(540 * builtin.EpochsInDay) // PARAM_SPEC
 // DealMaxLabelSize is the maximum size of a deal label.
 const DealMaxLabelSize = 256
 
-// Bitwidth of proposals AMT determined empirically from mutation patterns and
-// projections of mainnet data.
-const ProposalsAmtBitwidth = 5
-
-// Bitwidth of states AMT determined empirically from mutation patterns and
-// projections of mainnet data.
-const StatesAmtBitwidth = 6
-
 // Bounds (inclusive) on deal duration
 func DealDurationBounds(_ abi.PaddedPieceSize) (min abi.ChainEpoch, max abi.ChainEpoch) {
 	return DealMinDuration, DealMaxDuration

--- a/actors/builtin/miner/deadline_state.go
+++ b/actors/builtin/miner/deadline_state.go
@@ -56,7 +56,8 @@ type Deadline struct {
 	FaultyPower PowerPair
 }
 
-const DeadlinePartitionsAmtBitwidth = 3
+// Bitwidth of AMTs determined empirically from mutation patterns and projections of mainnet data.
+const DeadlinePartitionsAmtBitwidth = 3 // Usually a small array
 const DeadlineExpirationAmtBitwidth = 5
 
 //

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -77,8 +77,9 @@ type State struct {
 	EarlyTerminations bitfield.BitField
 }
 
+// Bitwidth of AMTs determined empirically from mutation patterns and projections of mainnet data.
 const PrecommitExpiryAmtBitwidth = 6
-const SectorsAmtBitwidth = 6
+const SectorsAmtBitwidth = 5
 
 type MinerInfo struct {
 	// Account that owns this miner.

--- a/actors/builtin/miner/partition_state.go
+++ b/actors/builtin/miner/partition_state.go
@@ -50,10 +50,8 @@ type Partition struct {
 	RecoveringPower PowerPair
 }
 
-// Bitwidth of partition expiration AMT determined empirically from mutation
-// patterns and projections of mainnet data.
+// Bitwidth of AMTs determined empirically from mutation patterns and projections of mainnet data.
 const PartitionExpirationAmtBitwidth = 4
-
 const PartitionEarlyTerminationArrayAmtBitwidth = 3
 
 // Value type for a pair of raw and QA power.


### PR DESCRIPTION
@ZenGround0 's benchmarks indicate that the best bitwidth for `miner.Sectors` is 5. I think they accidentally wrote 6 in #1328, which was easy to miss.

I also moved the constants consistently into the `_state.go` files, rather than `policy.go`.