### PR TITLE
avoid processing epochs multiple times in bitfield queue

### DIFF
--- a/actors/builtin/miner/bitfield_queue.go
+++ b/actors/builtin/miner/bitfield_queue.go
@@ -87,14 +87,17 @@ func (q BitfieldQueue) Cut(toCut bitfield.BitField) error {
 }
 
 func (q BitfieldQueue) AddManyToQueueValues(values map[abi.ChainEpoch][]uint64) error {
-	// Update each epoch in-order to be deterministic.
 	// Pre-quantize to reduce the number of updates.
 	quantizedValues := make(map[abi.ChainEpoch][]uint64, len(values))
-	updatedEpochs := make([]abi.ChainEpoch, 0, len(values))
 	for rawEpoch, entries := range values { // nolint:nomaprange // subsequently sorted
 		epoch := q.quant.QuantizeUp(rawEpoch)
-		updatedEpochs = append(updatedEpochs, epoch)
 		quantizedValues[epoch] = append(quantizedValues[epoch], entries...)
+	}
+
+	// Update each epoch in-order to be deterministic.
+	updatedEpochs := make([]abi.ChainEpoch, 0, len(quantizedValues))
+	for epoch := range quantizedValues { // nolint:nomaprange // subsequently sorted
+		updatedEpochs = append(updatedEpochs, epoch)
 	}
 
 	sort.Slice(updatedEpochs, func(i, j int) bool {

--- a/actors/builtin/miner/bitfield_queue_test.go
+++ b/actors/builtin/miner/bitfield_queue_test.go
@@ -223,6 +223,16 @@ func TestBitfieldQueue(t *testing.T) {
 			Equals(t, queue)
 	})
 
+	t.Run("adds empty bitfield to queue", func(t *testing.T) {
+		queue := emptyBitfieldQueue(t, testAmtBitwidth)
+
+		epoch := abi.ChainEpoch(42)
+		require.NoError(t, queue.AddToQueue(epoch, bf()))
+
+		// ensures we don't add an empty entry.
+		ExpectBQ().Equals(t, queue)
+	})
+
 }
 
 func emptyBitfieldQueueWithQuantizing(t *testing.T, quant miner.QuantSpec, bitwidth int) miner.BitfieldQueue {


### PR DESCRIPTION
Given that we're working with pre-quantized epochs, we might end up adding the same epoch to the `updatedEpochs` list multiple times. This patch fixes this by iterating twice.

Technically, we could avoid the second map iteration by adding an "is epoch in quantizedValues" check to the first loop, but doing this in two steps makes this easier to reason about.

This patch also tests an edge-case caught by mutation testing.