### PR TITLE
Rename and re-arrange private migration inputs

### DIFF
--- a/actors/migration/nv9/init.go
+++ b/actors/migration/nv9/init.go
@@ -12,7 +12,7 @@ import (
 
 type initMigrator struct{}
 
-func (m initMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, in StateMigrationInput) (*StateMigrationResult, error) {
+func (m initMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, in actorMigrationInput) (*actorMigrationResult, error) {
 	var inState init2.State
 	if err := store.Get(ctx, in.head, &inState); err != nil {
 		return nil, err
@@ -29,7 +29,7 @@ func (m initMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, in
 		NetworkName: inState.NetworkName,
 	}
 	newHead, err := store.Put(ctx, &outState)
-	return &StateMigrationResult{
+	return &actorMigrationResult{
 		NewCodeCID: builtin3.InitActorCodeID,
 		NewHead:    newHead,
 	}, err

--- a/actors/migration/nv9/init.go
+++ b/actors/migration/nv9/init.go
@@ -12,7 +12,7 @@ import (
 
 type initMigrator struct{}
 
-func (m initMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, in actorMigrationInput) (*actorMigrationResult, error) {
+func (m initMigrator) migrateState(ctx context.Context, store cbor.IpldStore, in actorMigrationInput) (*actorMigrationResult, error) {
 	var inState init2.State
 	if err := store.Get(ctx, in.head, &inState); err != nil {
 		return nil, err
@@ -30,7 +30,7 @@ func (m initMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, in
 	}
 	newHead, err := store.Put(ctx, &outState)
 	return &actorMigrationResult{
-		NewCodeCID: builtin3.InitActorCodeID,
-		NewHead:    newHead,
+		newCodeCID: builtin3.InitActorCodeID,
+		newHead:    newHead,
 	}, err
 }

--- a/actors/migration/nv9/market.go
+++ b/actors/migration/nv9/market.go
@@ -16,7 +16,7 @@ import (
 
 type marketMigrator struct{}
 
-func (m marketMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, in StateMigrationInput) (*StateMigrationResult, error) {
+func (m marketMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, in actorMigrationInput) (*actorMigrationResult, error) {
 	var inState market2.State
 	if err := store.Get(ctx, in.head, &inState); err != nil {
 		return nil, err
@@ -62,7 +62,7 @@ func (m marketMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, 
 	}
 
 	newHead, err := store.Put(ctx, &outState)
-	return &StateMigrationResult{
+	return &actorMigrationResult{
 		NewCodeCID: builtin3.StorageMarketActorCodeID,
 		NewHead:    newHead,
 	}, err

--- a/actors/migration/nv9/market.go
+++ b/actors/migration/nv9/market.go
@@ -16,7 +16,7 @@ import (
 
 type marketMigrator struct{}
 
-func (m marketMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, in actorMigrationInput) (*actorMigrationResult, error) {
+func (m marketMigrator) migrateState(ctx context.Context, store cbor.IpldStore, in actorMigrationInput) (*actorMigrationResult, error) {
 	var inState market2.State
 	if err := store.Get(ctx, in.head, &inState); err != nil {
 		return nil, err
@@ -63,8 +63,8 @@ func (m marketMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, 
 
 	newHead, err := store.Put(ctx, &outState)
 	return &actorMigrationResult{
-		NewCodeCID: builtin3.StorageMarketActorCodeID,
-		NewHead:    newHead,
+		newCodeCID: builtin3.StorageMarketActorCodeID,
+		newHead:    newHead,
 	}, err
 }
 

--- a/actors/migration/nv9/miner.go
+++ b/actors/migration/nv9/miner.go
@@ -16,7 +16,7 @@ import (
 
 type minerMigrator struct{}
 
-func (m minerMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, in actorMigrationInput) (*actorMigrationResult, error) {
+func (m minerMigrator) migrateState(ctx context.Context, store cbor.IpldStore, in actorMigrationInput) (*actorMigrationResult, error) {
 	var inState miner2.State
 	if err := store.Get(ctx, in.head, &inState); err != nil {
 		return nil, err
@@ -58,8 +58,8 @@ func (m minerMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, i
 	}
 	newHead, err := store.Put(ctx, &outState)
 	return &actorMigrationResult{
-		NewCodeCID: builtin3.StorageMinerActorCodeID,
-		NewHead:    newHead,
+		newCodeCID: builtin3.StorageMinerActorCodeID,
+		newHead:    newHead,
 	}, err
 }
 

--- a/actors/migration/nv9/miner.go
+++ b/actors/migration/nv9/miner.go
@@ -16,7 +16,7 @@ import (
 
 type minerMigrator struct{}
 
-func (m minerMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, in StateMigrationInput) (*StateMigrationResult, error) {
+func (m minerMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, in actorMigrationInput) (*actorMigrationResult, error) {
 	var inState miner2.State
 	if err := store.Get(ctx, in.head, &inState); err != nil {
 		return nil, err
@@ -57,7 +57,7 @@ func (m minerMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, i
 		EarlyTerminations:         inState.EarlyTerminations,
 	}
 	newHead, err := store.Put(ctx, &outState)
-	return &StateMigrationResult{
+	return &actorMigrationResult{
 		NewCodeCID: builtin3.StorageMinerActorCodeID,
 		NewHead:    newHead,
 	}, err

--- a/actors/migration/nv9/multisig.go
+++ b/actors/migration/nv9/multisig.go
@@ -12,7 +12,7 @@ import (
 
 type multisigMigrator struct{}
 
-func (m multisigMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, in actorMigrationInput) (*actorMigrationResult, error) {
+func (m multisigMigrator) migrateState(ctx context.Context, store cbor.IpldStore, in actorMigrationInput) (*actorMigrationResult, error) {
 	var inState multisig2.State
 	if err := store.Get(ctx, in.head, &inState); err != nil {
 		return nil, err
@@ -34,7 +34,7 @@ func (m multisigMigrator) MigrateState(ctx context.Context, store cbor.IpldStore
 	}
 	newHead, err := store.Put(ctx, &outState)
 	return &actorMigrationResult{
-		NewCodeCID: builtin3.MultisigActorCodeID,
-		NewHead:    newHead,
+		newCodeCID: builtin3.MultisigActorCodeID,
+		newHead:    newHead,
 	}, err
 }

--- a/actors/migration/nv9/multisig.go
+++ b/actors/migration/nv9/multisig.go
@@ -12,7 +12,7 @@ import (
 
 type multisigMigrator struct{}
 
-func (m multisigMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, in StateMigrationInput) (*StateMigrationResult, error) {
+func (m multisigMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, in actorMigrationInput) (*actorMigrationResult, error) {
 	var inState multisig2.State
 	if err := store.Get(ctx, in.head, &inState); err != nil {
 		return nil, err
@@ -33,7 +33,7 @@ func (m multisigMigrator) MigrateState(ctx context.Context, store cbor.IpldStore
 		PendingTxns:           pendingTxnsOut,
 	}
 	newHead, err := store.Put(ctx, &outState)
-	return &StateMigrationResult{
+	return &actorMigrationResult{
 		NewCodeCID: builtin3.MultisigActorCodeID,
 		NewHead:    newHead,
 	}, err

--- a/actors/migration/nv9/paych.go
+++ b/actors/migration/nv9/paych.go
@@ -12,7 +12,7 @@ import (
 
 type paychMigrator struct{}
 
-func (m paychMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, in StateMigrationInput) (*StateMigrationResult, error) {
+func (m paychMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, in actorMigrationInput) (*actorMigrationResult, error) {
 	var inState paych2.State
 	if err := store.Get(ctx, in.head, &inState); err != nil {
 		return nil, err
@@ -32,7 +32,7 @@ func (m paychMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, i
 		LaneStates:      laneStatesOut,
 	}
 	newHead, err := store.Put(ctx, &outState)
-	return &StateMigrationResult{
+	return &actorMigrationResult{
 		NewCodeCID: builtin3.PaymentChannelActorCodeID,
 		NewHead:    newHead,
 	}, err

--- a/actors/migration/nv9/paych.go
+++ b/actors/migration/nv9/paych.go
@@ -12,7 +12,7 @@ import (
 
 type paychMigrator struct{}
 
-func (m paychMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, in actorMigrationInput) (*actorMigrationResult, error) {
+func (m paychMigrator) migrateState(ctx context.Context, store cbor.IpldStore, in actorMigrationInput) (*actorMigrationResult, error) {
 	var inState paych2.State
 	if err := store.Get(ctx, in.head, &inState); err != nil {
 		return nil, err
@@ -33,7 +33,7 @@ func (m paychMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, i
 	}
 	newHead, err := store.Put(ctx, &outState)
 	return &actorMigrationResult{
-		NewCodeCID: builtin3.PaymentChannelActorCodeID,
-		NewHead:    newHead,
+		newCodeCID: builtin3.PaymentChannelActorCodeID,
+		newHead:    newHead,
 	}, err
 }

--- a/actors/migration/nv9/power.go
+++ b/actors/migration/nv9/power.go
@@ -14,7 +14,7 @@ import (
 
 type powerMigrator struct{}
 
-func (m powerMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, in actorMigrationInput) (*actorMigrationResult, error) {
+func (m powerMigrator) migrateState(ctx context.Context, store cbor.IpldStore, in actorMigrationInput) (*actorMigrationResult, error) {
 	var inState power2.State
 	if err := store.Get(ctx, in.head, &inState); err != nil {
 		return nil, err
@@ -58,7 +58,7 @@ func (m powerMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, i
 	}
 	newHead, err := store.Put(ctx, &outState)
 	return &actorMigrationResult{
-		NewCodeCID: builtin3.StoragePowerActorCodeID,
-		NewHead:    newHead,
+		newCodeCID: builtin3.StoragePowerActorCodeID,
+		newHead:    newHead,
 	}, err
 }

--- a/actors/migration/nv9/power.go
+++ b/actors/migration/nv9/power.go
@@ -14,7 +14,7 @@ import (
 
 type powerMigrator struct{}
 
-func (m powerMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, in StateMigrationInput) (*StateMigrationResult, error) {
+func (m powerMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, in actorMigrationInput) (*actorMigrationResult, error) {
 	var inState power2.State
 	if err := store.Get(ctx, in.head, &inState); err != nil {
 		return nil, err
@@ -57,7 +57,7 @@ func (m powerMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, i
 		ProofValidationBatch:      proofValidationBatchOut,
 	}
 	newHead, err := store.Put(ctx, &outState)
-	return &StateMigrationResult{
+	return &actorMigrationResult{
 		NewCodeCID: builtin3.StoragePowerActorCodeID,
 		NewHead:    newHead,
 	}, err

--- a/actors/migration/nv9/top.go
+++ b/actors/migration/nv9/top.go
@@ -66,23 +66,23 @@ func MigrateStateTree(ctx context.Context, store cbor.IpldStore, actorsRootIn ci
 
 	// Setup synchronization
 	grp, ctx := errgroup.WithContext(ctx)
-	inputCh := make(chan *migrationInput)
-	resultCh := make(chan *migrationResult)
+	jobCh := make(chan *migrationJob)
+	jobResultCh := make(chan *migrationJobResult)
 
-	// Iterate all actors in old state root to generate migration inputs for each non-deferred actor.
+	// Iterate all actors in old state root to create migration jobs for each non-deferred actor.
 	grp.Go(func() error {
-		defer close(inputCh)
+		defer close(jobCh)
 		return actorsIn.ForEach(func(addr address.Address, actorIn *states2.Actor) error {
 			if _, ok := deferredCodeIDs[actorIn.Code]; ok {
 				return nil // Deferred for explicit migration later.
 			}
-			nextInput := &migrationInput{
+			nextInput := &migrationJob{
 				Address:        addr,
 				Actor:          *actorIn, // Must take a copy, the pointer is not stable.
 				actorMigration: migrations[actorIn.Code],
 			}
 			select {
-			case inputCh <- nextInput:
+			case jobCh <- nextInput:
 			case <-ctx.Done():
 				return ctx.Err()
 			}
@@ -90,19 +90,19 @@ func MigrateStateTree(ctx context.Context, store cbor.IpldStore, actorsRootIn ci
 		})
 	})
 
-	// Worker threads run migrations on inputs.
+	// Worker threads run jobs.
 	var workerWg sync.WaitGroup
 	for i := 0; i < cfg.MaxWorkers; i++ {
 		workerWg.Add(1)
 		grp.Go(func() error {
 			defer workerWg.Done()
-			for input := range inputCh {
-				result, err := migrateOneActor(ctx, store, input, priorEpoch)
+			for job := range jobCh {
+				result, err := job.run(ctx, store, priorEpoch)
 				if err != nil {
 					return err
 				}
 				select {
-				case resultCh <- result:
+				case jobResultCh <- result:
 				case <-ctx.Done():
 					return ctx.Err()
 				}
@@ -114,13 +114,13 @@ func MigrateStateTree(ctx context.Context, store cbor.IpldStore, actorsRootIn ci
 	// Close output channel when workers are done.
 	grp.Go(func() error {
 		workerWg.Wait()
-		close(resultCh)
+		close(jobResultCh)
 		return nil
 	})
 
 	// Insert migrated records in output state tree and accumulators.
 	grp.Go(func() error {
-		for result := range resultCh {
+		for result := range jobResultCh {
 			if err := actorsOut.SetActor(result.Address, &result.Actor); err != nil {
 				return err
 			}
@@ -156,36 +156,36 @@ type actorMigration interface {
 	MigrateState(ctx context.Context, store cbor.IpldStore, input actorMigrationInput) (result *actorMigrationResult, err error)
 }
 
-type migrationInput struct {
+type migrationJob struct {
 	address.Address
 	states2.Actor
 	actorMigration
 }
-type migrationResult struct {
+type migrationJobResult struct {
 	address.Address
 	states3.Actor
 }
 
-func migrateOneActor(ctx context.Context, store cbor.IpldStore, input *migrationInput, priorEpoch abi.ChainEpoch) (*migrationResult, error) {
-	result, err := input.MigrateState(ctx, store, actorMigrationInput{
-		address:    input.Address,
-		balance:    input.Actor.Balance,
-		head:       input.Actor.Head,
+func (job *migrationJob) run(ctx context.Context, store cbor.IpldStore, priorEpoch abi.ChainEpoch) (*migrationJobResult, error) {
+	result, err := job.MigrateState(ctx, store, actorMigrationInput{
+		address:    job.Address,
+		balance:    job.Actor.Balance,
+		head:       job.Actor.Head,
 		priorEpoch: priorEpoch,
 	})
 	if err != nil {
 		return nil, xerrors.Errorf("state migration failed for %s actor, addr %s: %w",
-			builtin2.ActorNameByCode(input.Actor.Code), input.Address, err)
+			builtin2.ActorNameByCode(job.Actor.Code), job.Address, err)
 	}
 
 	// Set up new actor record with the migrated state.
-	return &migrationResult{
-		input.Address, // Unchanged
+	return &migrationJobResult{
+		job.Address, // Unchanged
 		states3.Actor{
 			Code:       result.NewCodeCID,
 			Head:       result.NewHead,
-			CallSeqNum: input.Actor.CallSeqNum, // Unchanged
-			Balance:    input.Actor.Balance,    // Unchanged
+			CallSeqNum: job.Actor.CallSeqNum, // Unchanged
+			Balance:    job.Actor.Balance,    // Unchanged
 		},
 	}, nil
 }
@@ -201,4 +201,3 @@ func (n nilMigrator) MigrateState(_ context.Context, _ cbor.IpldStore, in actorM
 		NewHead:    in.head,
 	}, nil
 }
-

--- a/actors/migration/nv9/top.go
+++ b/actors/migration/nv9/top.go
@@ -146,14 +146,14 @@ type actorMigrationInput struct {
 }
 
 type actorMigrationResult struct {
-	NewCodeCID cid.Cid
-	NewHead    cid.Cid
+	newCodeCID cid.Cid
+	newHead    cid.Cid
 }
 
 type actorMigration interface {
 	// Loads an actor's state from an input store and writes new state to an output store.
 	// Returns the new state head CID.
-	MigrateState(ctx context.Context, store cbor.IpldStore, input actorMigrationInput) (result *actorMigrationResult, err error)
+	migrateState(ctx context.Context, store cbor.IpldStore, input actorMigrationInput) (result *actorMigrationResult, err error)
 }
 
 type migrationJob struct {
@@ -167,7 +167,7 @@ type migrationJobResult struct {
 }
 
 func (job *migrationJob) run(ctx context.Context, store cbor.IpldStore, priorEpoch abi.ChainEpoch) (*migrationJobResult, error) {
-	result, err := job.MigrateState(ctx, store, actorMigrationInput{
+	result, err := job.migrateState(ctx, store, actorMigrationInput{
 		address:    job.Address,
 		balance:    job.Actor.Balance,
 		head:       job.Actor.Head,
@@ -182,8 +182,8 @@ func (job *migrationJob) run(ctx context.Context, store cbor.IpldStore, priorEpo
 	return &migrationJobResult{
 		job.Address, // Unchanged
 		states3.Actor{
-			Code:       result.NewCodeCID,
-			Head:       result.NewHead,
+			Code:       result.newCodeCID,
+			Head:       result.newHead,
 			CallSeqNum: job.Actor.CallSeqNum, // Unchanged
 			Balance:    job.Actor.Balance,    // Unchanged
 		},
@@ -195,9 +195,9 @@ type nilMigrator struct {
 	OutCodeCID cid.Cid
 }
 
-func (n nilMigrator) MigrateState(_ context.Context, _ cbor.IpldStore, in actorMigrationInput) (*actorMigrationResult, error) {
+func (n nilMigrator) migrateState(_ context.Context, _ cbor.IpldStore, in actorMigrationInput) (*actorMigrationResult, error) {
 	return &actorMigrationResult{
-		NewCodeCID: n.OutCodeCID,
-		NewHead:    in.head,
+		newCodeCID: n.OutCodeCID,
+		newHead:    in.head,
 	}, nil
 }

--- a/actors/migration/nv9/verifreg.go
+++ b/actors/migration/nv9/verifreg.go
@@ -12,7 +12,7 @@ import (
 
 type verifregMigrator struct{}
 
-func (m verifregMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, in StateMigrationInput) (*StateMigrationResult, error) {
+func (m verifregMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, in actorMigrationInput) (*actorMigrationResult, error) {
 	var inState verifreg2.State
 	if err := store.Get(ctx, in.head, &inState); err != nil {
 		return nil, err
@@ -34,7 +34,7 @@ func (m verifregMigrator) MigrateState(ctx context.Context, store cbor.IpldStore
 	}
 
 	newHead, err := store.Put(ctx, &outState)
-	return &StateMigrationResult{
+	return &actorMigrationResult{
 		NewCodeCID: builtin3.VerifiedRegistryActorCodeID,
 		NewHead:    newHead,
 	}, err

--- a/actors/migration/nv9/verifreg.go
+++ b/actors/migration/nv9/verifreg.go
@@ -12,7 +12,7 @@ import (
 
 type verifregMigrator struct{}
 
-func (m verifregMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, in actorMigrationInput) (*actorMigrationResult, error) {
+func (m verifregMigrator) migrateState(ctx context.Context, store cbor.IpldStore, in actorMigrationInput) (*actorMigrationResult, error) {
 	var inState verifreg2.State
 	if err := store.Get(ctx, in.head, &inState); err != nil {
 		return nil, err
@@ -35,7 +35,7 @@ func (m verifregMigrator) MigrateState(ctx context.Context, store cbor.IpldStore
 
 	newHead, err := store.Put(ctx, &outState)
 	return &actorMigrationResult{
-		NewCodeCID: builtin3.VerifiedRegistryActorCodeID,
-		NewHead:    newHead,
+		newCodeCID: builtin3.VerifiedRegistryActorCodeID,
+		newHead:    newHead,
 	}, err
 }


### PR DESCRIPTION
This is a cosmetic PR, no functional change required.

- Changed naming so that migration of a single actor is "actor migration" rather than "state migration" (which is the top-level thing)
- Distinguished between the migration job (incl the function to be called) from the functional input/result. The job only exists to support parallelism.
- Un-exported and moved the internal things to the bottom of `top.go`.