### PR TITLE
Add logging and non-zero queue capacity to parallel migrations.

### DIFF
--- a/actors/migration/nv9/test/modify_pending_proposals_test.go
+++ b/actors/migration/nv9/test/modify_pending_proposals_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"context"
@@ -33,6 +33,7 @@ import (
 
 func TestUpdatePendingDealsMigration(t *testing.T) {
 	ctx := context.Background()
+	log := TestLogger{t}
 	v := vm2.NewVMWithSingletons(ctx, t)
 	addrs := vm2.CreateAccounts(ctx, t, v, 10, big.Mul(big.NewInt(100_000), vm2.FIL), 93837778)
 	worker := addrs[0]
@@ -71,7 +72,7 @@ func TestUpdatePendingDealsMigration(t *testing.T) {
 	}
 
 	// run migration
-	nextRoot, err := nv9.MigrateStateTree(ctx, v.Store(), v.StateRoot(), v.GetEpoch(), nv9.Config{MaxWorkers: 1})
+	nextRoot, err := nv9.MigrateStateTree(ctx, v.Store(), v.StateRoot(), v.GetEpoch(), nv9.Config{MaxWorkers: 1}, log)
 	require.NoError(t, err)
 
 	lookup := map[cid.Cid]rt.VMActor{}

--- a/actors/migration/nv9/test/util_test.go
+++ b/actors/migration/nv9/test/util_test.go
@@ -1,0 +1,15 @@
+package test_test
+
+import (
+	"testing"
+
+	"github.com/filecoin-project/go-state-types/rt"
+)
+
+type TestLogger struct {
+	TB testing.TB
+}
+
+func (t TestLogger) Log(_ rt.LogLevel, msg string, args ...interface{}) {
+	t.TB.Logf(msg, args...)
+}

--- a/actors/migration/nv9/top.go
+++ b/actors/migration/nv9/top.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	address "github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/rt"
 	cid "github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
 	"golang.org/x/sync/errgroup"
@@ -22,11 +25,28 @@ import (
 
 // Config parameterizes a state tree migration
 type Config struct {
-	MaxWorkers int
+	// Number of migration worker goroutines to run.
+	// More workers enables higher CPU utilization doing migration computations (including state encoding)
+	MaxWorkers uint
+	// Capacity of the queue of jobs available to workers (zero for unbuffered).
+	// A queue length of hundreds to thousands improves throughput at the cost of memory.
+	JobQueueSize uint
+	// Capacity of the queue receiving migration results from workers, for persisting (zero for unbuffered).
+	// A queue length of tens to hundreds improves throughput at the cost of memory.
+	ResultQueueSize uint
+	// Time between progress logs to emit.
+	// Zero (the default) results in no progress logs.
+	ProgressLogPeriod time.Duration
+}
+
+type Logger interface {
+	// This is the same logging interface provided by the Runtime.
+	Log(level rt.LogLevel, msg string, args ...interface{})
 }
 
 // Migrates the filecoin state tree starting from the global state tree and upgrading all actor state.
-func MigrateStateTree(ctx context.Context, store cbor.IpldStore, actorsRootIn cid.Cid, priorEpoch abi.ChainEpoch, cfg Config) (cid.Cid, error) {
+// The store must support concurrent writes (even if the configured worker count is 1).
+func MigrateStateTree(ctx context.Context, store cbor.IpldStore, actorsRootIn cid.Cid, priorEpoch abi.ChainEpoch, cfg Config, log Logger) (cid.Cid, error) {
 	if cfg.MaxWorkers <= 0 {
 		return cid.Undef, xerrors.Errorf("invalid migration config with %d workers", cfg.MaxWorkers)
 	}
@@ -52,6 +72,7 @@ func MigrateStateTree(ctx context.Context, store cbor.IpldStore, actorsRootIn ci
 	if len(migrations)+len(deferredCodeIDs) != 11 {
 		panic(fmt.Sprintf("incomplete migration specification with %d code CIDs", len(migrations)))
 	}
+	startTime := time.Now()
 
 	// Load input and output state trees
 	adtStore := adt3.WrapStore(ctx, store)
@@ -66,13 +87,18 @@ func MigrateStateTree(ctx context.Context, store cbor.IpldStore, actorsRootIn ci
 
 	// Setup synchronization
 	grp, ctx := errgroup.WithContext(ctx)
-	jobCh := make(chan *migrationJob)
-	jobResultCh := make(chan *migrationJobResult)
+	// Input and output queues for workers.
+	jobCh := make(chan *migrationJob, cfg.JobQueueSize)
+	jobResultCh := make(chan *migrationJobResult, cfg.ResultQueueSize)
+	// Atomically-modified counters for logging progress
+	var jobCount uint32
+	var doneCount uint32
 
 	// Iterate all actors in old state root to create migration jobs for each non-deferred actor.
 	grp.Go(func() error {
 		defer close(jobCh)
-		return actorsIn.ForEach(func(addr address.Address, actorIn *states2.Actor) error {
+		log.Log(rt.INFO, "Creating migration jobs for tree %s", actorsRootIn)
+		if err = actorsIn.ForEach(func(addr address.Address, actorIn *states2.Actor) error {
 			if _, ok := deferredCodeIDs[actorIn.Code]; ok {
 				return nil // Deferred for explicit migration later.
 			}
@@ -86,14 +112,20 @@ func MigrateStateTree(ctx context.Context, store cbor.IpldStore, actorsRootIn ci
 			case <-ctx.Done():
 				return ctx.Err()
 			}
+			atomic.AddUint32(&jobCount, 1)
 			return nil
-		})
+		}); err != nil {
+			return err
+		}
+		log.Log(rt.INFO, "Done creating %d migration jobs for tree %s after %v", jobCount, actorsRootIn, time.Since(startTime))
+		return nil
 	})
 
 	// Worker threads run jobs.
 	var workerWg sync.WaitGroup
-	for i := 0; i < cfg.MaxWorkers; i++ {
+	for i := uint(0); i < cfg.MaxWorkers; i++ {
 		workerWg.Add(1)
+		workerId := i
 		grp.Go(func() error {
 			defer workerWg.Done()
 			for job := range jobCh {
@@ -106,25 +138,59 @@ func MigrateStateTree(ctx context.Context, store cbor.IpldStore, actorsRootIn ci
 				case <-ctx.Done():
 					return ctx.Err()
 				}
+				atomic.AddUint32(&doneCount, 1)
 			}
+			log.Log(rt.INFO, "Worker %d done", workerId)
 			return nil
 		})
 	}
+	log.Log(rt.INFO, "Started %d workers", cfg.MaxWorkers)
 
-	// Close output channel when workers are done.
+	// Monitor the job queue. This non-critical goroutine is outside the errgroup and exits when
+	// workersFinished is closed, or the context done.
+	workersFinished := make(chan struct{}) // Closed when waitgroup is emptied.
+	if cfg.ProgressLogPeriod > 0 {
+		go func() {
+			defer log.Log(rt.DEBUG, "Job queue monitor done")
+			for {
+				select {
+				case <-time.After(cfg.ProgressLogPeriod):
+					jobsNow := jobCount // Snapshot values to avoid incorrect-looking arithmetic if they change.
+					doneNow := doneCount
+					pendingNow := jobsNow - doneNow
+					elapsed := time.Since(startTime)
+					rate := float64(doneNow) / elapsed.Seconds()
+					log.Log(rt.INFO, "%d jobs created, %d done, %d pending after %v (%.0f/s)",
+						jobsNow, doneNow, pendingNow, elapsed, rate)
+				case <-workersFinished:
+					return
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+	}
+
+	// Close result channel when workers are done sending to it.
 	grp.Go(func() error {
 		workerWg.Wait()
 		close(jobResultCh)
+		close(workersFinished)
+		log.Log(rt.INFO, "All workers done after %v", time.Since(startTime))
 		return nil
 	})
 
 	// Insert migrated records in output state tree and accumulators.
 	grp.Go(func() error {
+		log.Log(rt.INFO, "Result writer started")
+		resultCount := 0
 		for result := range jobResultCh {
 			if err := actorsOut.SetActor(result.Address, &result.Actor); err != nil {
 				return err
 			}
+			resultCount++
 		}
+		log.Log(rt.INFO, "Result writer wrote %d results to state tree after %v", resultCount, time.Since(startTime))
 		return nil
 	})
 
@@ -135,6 +201,9 @@ func MigrateStateTree(ctx context.Context, store cbor.IpldStore, actorsRootIn ci
 	// Perform any deferred migrations explicitly here.
 	// Deferred migrations might depend on values accumulated through migration of other actors.
 
+	elapsed := time.Since(startTime)
+	rate := float64(doneCount) / elapsed.Seconds()
+	log.Log(rt.INFO, "All %d done after %v (%.0f/s). Flushing state tree root.", doneCount, elapsed, rate)
 	return actorsOut.Flush()
 }
 


### PR DESCRIPTION
Adds a log callback to the migration entry point in order to log progress for the operator.

Add configuration for the internal queue sizes. These were previously zero, i.e. rendezvous points. The lack of buffering struck me as likely to be poor for throughput. From a rather unscientific test of migration 500k account actors, buffer sizes of 1000 and 10 improve throughput by ~15-20%. The impact will probably be lower with more complex actors.

This is preparation for #1285.