### PR TITLE
Inject block store into VM and sim

### DIFF
--- a/actors/test/commit_post_test.go
+++ b/actors/test/commit_post_test.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/filecoin-project/specs-actors/v3/actors/states"
-
 	"github.com/filecoin-project/go-bitfield"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
@@ -18,13 +16,15 @@ import (
 	"github.com/filecoin-project/specs-actors/v3/actors/builtin/miner"
 	"github.com/filecoin-project/specs-actors/v3/actors/builtin/power"
 	"github.com/filecoin-project/specs-actors/v3/actors/runtime/proof"
+	"github.com/filecoin-project/specs-actors/v3/actors/states"
+	"github.com/filecoin-project/specs-actors/v3/support/ipld"
 	tutil "github.com/filecoin-project/specs-actors/v3/support/testing"
 	vm "github.com/filecoin-project/specs-actors/v3/support/vm"
 )
 
 func TestCommitPoStFlow(t *testing.T) {
 	ctx := context.Background()
-	v := vm.NewVMWithSingletons(ctx, t)
+	v := vm.NewVMWithSingletons(ctx, t, ipld.NewBlockStoreInMemory())
 	addrs := vm.CreateAccounts(ctx, t, v, 1, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
 
 	minerBalance := big.Mul(big.NewInt(10_000), vm.FIL)

--- a/actors/test/committed_capacity_scenario_test.go
+++ b/actors/test/committed_capacity_scenario_test.go
@@ -16,13 +16,14 @@ import (
 	"github.com/filecoin-project/specs-actors/v3/actors/builtin/power"
 	"github.com/filecoin-project/specs-actors/v3/actors/builtin/verifreg"
 	"github.com/filecoin-project/specs-actors/v3/actors/runtime/proof"
+	"github.com/filecoin-project/specs-actors/v3/support/ipld"
 	tutil "github.com/filecoin-project/specs-actors/v3/support/testing"
 	vm "github.com/filecoin-project/specs-actors/v3/support/vm"
 )
 
 func TestReplaceCommittedCapacitySectorWithDealLadenSector(t *testing.T) {
 	ctx := context.Background()
-	v := vm.NewVMWithSingletons(ctx, t)
+	v := vm.NewVMWithSingletons(ctx, t, ipld.NewBlockStoreInMemory())
 	addrs := vm.CreateAccounts(ctx, t, v, 4, big.Mul(big.NewInt(10_000), vm.FIL), 93837778)
 	worker, verifier, unverifiedClient, verifiedClient := addrs[0], addrs[1], addrs[2], addrs[3]
 

--- a/actors/test/cron_catches_expiries_scenario_test.go
+++ b/actors/test/cron_catches_expiries_scenario_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/filecoin-project/specs-actors/v3/actors/builtin/miner"
 	"github.com/filecoin-project/specs-actors/v3/actors/builtin/power"
 	"github.com/filecoin-project/specs-actors/v3/actors/runtime/proof"
+	"github.com/filecoin-project/specs-actors/v3/support/ipld"
 	tutil "github.com/filecoin-project/specs-actors/v3/support/testing"
 	vm "github.com/filecoin-project/specs-actors/v3/support/vm"
 )
@@ -22,7 +23,7 @@ var fakeChainRandomness = []byte("not really random")
 
 func TestCronCatchedCCExpirationsAtDeadlineBoundary(t *testing.T) {
 	ctx := context.Background()
-	v := vm.NewVMWithSingletons(ctx, t)
+	v := vm.NewVMWithSingletons(ctx, t, ipld.NewBlockStoreInMemory())
 	addrs := vm.CreateAccounts(ctx, t, v, 2, big.Mul(big.NewInt(10_000), vm.FIL), 93837778)
 	worker, unverifiedClient := addrs[0], addrs[1]
 

--- a/actors/test/market_withdrawal_test.go
+++ b/actors/test/market_withdrawal_test.go
@@ -10,12 +10,13 @@ import (
 
 	"github.com/filecoin-project/specs-actors/v3/actors/builtin"
 	"github.com/filecoin-project/specs-actors/v3/actors/builtin/market"
+	"github.com/filecoin-project/specs-actors/v3/support/ipld"
 	vm "github.com/filecoin-project/specs-actors/v3/support/vm"
 )
 
 func TestMarketWithdraw(t *testing.T) {
 	ctx := context.Background()
-	v := vm.NewVMWithSingletons(ctx, t)
+	v := vm.NewVMWithSingletons(ctx, t, ipld.NewBlockStoreInMemory())
 	initialBalance := big.Mul(big.NewInt(6), big.NewInt(1e18))
 	addrs := vm.CreateAccounts(ctx, t, v, 1, initialBalance, 93837778)
 	caller := addrs[0]

--- a/actors/test/multisig_delete_self_test.go
+++ b/actors/test/multisig_delete_self_test.go
@@ -5,22 +5,22 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/exitcode"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/specs-actors/v3/actors/builtin"
 	init_ "github.com/filecoin-project/specs-actors/v3/actors/builtin/init"
 	"github.com/filecoin-project/specs-actors/v3/actors/builtin/multisig"
+	"github.com/filecoin-project/specs-actors/v3/support/ipld"
 	vm "github.com/filecoin-project/specs-actors/v3/support/vm"
 )
 
 func TestMultisigDeleteSelf2Of3RemovedIsProposer(t *testing.T) {
 	ctx := context.Background()
-	v := vm.NewVMWithSingletons(ctx, t)
+	v := vm.NewVMWithSingletons(ctx, t, ipld.NewBlockStoreInMemory())
 	addrs := vm.CreateAccounts(ctx, t, v, 3, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
 
 	multisigParams := multisig.ConstructorParams{
@@ -71,7 +71,7 @@ func TestMultisigDeleteSelf2Of3RemovedIsProposer(t *testing.T) {
 
 func TestMultisigDeleteSelf2Of3RemovedIsApprover(t *testing.T) {
 	ctx := context.Background()
-	v := vm.NewVMWithSingletons(ctx, t)
+	v := vm.NewVMWithSingletons(ctx, t, ipld.NewBlockStoreInMemory())
 	addrs := vm.CreateAccounts(ctx, t, v, 3, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
 
 	multisigParams := multisig.ConstructorParams{
@@ -122,7 +122,7 @@ func TestMultisigDeleteSelf2Of3RemovedIsApprover(t *testing.T) {
 
 func TestMultisigDeleteSelf2Of2(t *testing.T) {
 	ctx := context.Background()
-	v := vm.NewVMWithSingletons(ctx, t)
+	v := vm.NewVMWithSingletons(ctx, t, ipld.NewBlockStoreInMemory())
 	addrs := vm.CreateAccounts(ctx, t, v, 2, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
 
 	multisigParams := multisig.ConstructorParams{
@@ -171,7 +171,7 @@ func TestMultisigDeleteSelf2Of2(t *testing.T) {
 
 func TestMultisigSwapsSelf2Of3(t *testing.T) {
 	ctx := context.Background()
-	v := vm.NewVMWithSingletons(ctx, t)
+	v := vm.NewVMWithSingletons(ctx, t, ipld.NewBlockStoreInMemory())
 	addrs := vm.CreateAccounts(ctx, t, v, 4, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
 	alice := addrs[0]
 	bob := addrs[1]
@@ -248,7 +248,7 @@ func TestMultisigSwapsSelf2Of3(t *testing.T) {
 
 func TestMultisigDeleteSigner1Of2(t *testing.T) {
 	ctx := context.Background()
-	v := vm.NewVMWithSingletons(ctx, t)
+	v := vm.NewVMWithSingletons(ctx, t, ipld.NewBlockStoreInMemory())
 	addrs := vm.CreateAccounts(ctx, t, v, 2, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
 
 	multisigParams := multisig.ConstructorParams{
@@ -290,7 +290,7 @@ func TestMultisigDeleteSigner1Of2(t *testing.T) {
 
 func TestMultisigSwapsSelf1Of2(t *testing.T) {
 	ctx := context.Background()
-	v := vm.NewVMWithSingletons(ctx, t)
+	v := vm.NewVMWithSingletons(ctx, t, ipld.NewBlockStoreInMemory())
 	addrs := vm.CreateAccounts(ctx, t, v, 3, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
 	alice := addrs[0]
 	bob := addrs[1]

--- a/actors/test/power_scenario_test.go
+++ b/actors/test/power_scenario_test.go
@@ -11,12 +11,13 @@ import (
 	"github.com/filecoin-project/specs-actors/v3/actors/builtin"
 	"github.com/filecoin-project/specs-actors/v3/actors/builtin/miner"
 	"github.com/filecoin-project/specs-actors/v3/actors/builtin/power"
+	"github.com/filecoin-project/specs-actors/v3/support/ipld"
 	vm "github.com/filecoin-project/specs-actors/v3/support/vm"
 )
 
 func TestCreateMiner(t *testing.T) {
 	ctx := context.Background()
-	v := vm.NewVMWithSingletons(ctx, t)
+	v := vm.NewVMWithSingletons(ctx, t, ipld.NewBlockStoreInMemory())
 	addrs := vm.CreateAccounts(ctx, t, v, 1, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
 
 	params := power.CreateMinerParams{
@@ -67,7 +68,7 @@ func TestCreateMiner(t *testing.T) {
 
 func TestOnEpochTickEnd(t *testing.T) {
 	ctx := context.Background()
-	v := vm.NewVMWithSingletons(ctx, t)
+	v := vm.NewVMWithSingletons(ctx, t, ipld.NewBlockStoreInMemory())
 	addrs := vm.CreateAccounts(ctx, t, v, 1, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
 
 	// create a miner

--- a/actors/test/terminate_sectors_scenario_test.go
+++ b/actors/test/terminate_sectors_scenario_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/filecoin-project/specs-actors/v3/actors/builtin/power"
 	"github.com/filecoin-project/specs-actors/v3/actors/builtin/verifreg"
 	"github.com/filecoin-project/specs-actors/v3/actors/runtime/proof"
+	"github.com/filecoin-project/specs-actors/v3/support/ipld"
 	tutil "github.com/filecoin-project/specs-actors/v3/support/testing"
 	vm "github.com/filecoin-project/specs-actors/v3/support/vm"
 )
@@ -23,7 +24,7 @@ import (
 // This scenario hits all Market Actor methods.
 func TestTerminateSectors(t *testing.T) {
 	ctx := context.Background()
-	v := vm.NewVMWithSingletons(ctx, t)
+	v := vm.NewVMWithSingletons(ctx, t, ipld.NewBlockStoreInMemory())
 	addrs := vm.CreateAccounts(ctx, t, v, 4, big.Mul(big.NewInt(10_000), vm.FIL), 93837778)
 	owner, verifier, unverifiedClient, verifiedClient := addrs[0], addrs[1], addrs[2], addrs[3]
 	worker := owner

--- a/actors/util/adt/store.go
+++ b/actors/util/adt/store.go
@@ -25,6 +25,11 @@ func WrapStore(ctx context.Context, store ipldcbor.IpldStore) Store {
 	}
 }
 
+// Adapts a block store as an ADT store.
+func WrapBlockStore(ctx context.Context, bs ipldcbor.IpldBlockstore) Store {
+	return WrapStore(ctx, ipldcbor.NewCborStore(bs))
+}
+
 type wstore struct {
 	ctx context.Context
 	ipldcbor.IpldStore

--- a/support/agent/cases_test.go
+++ b/support/agent/cases_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
+	cbor "github.com/ipfs/go-ipld-cbor"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/filecoin-project/specs-actors/v3/actors/builtin/power"
 	"github.com/filecoin-project/specs-actors/v3/actors/states"
 	"github.com/filecoin-project/specs-actors/v3/support/agent"
+	"github.com/filecoin-project/specs-actors/v3/support/ipld"
 	vm_test "github.com/filecoin-project/specs-actors/v3/support/vm"
 )
 
@@ -26,7 +28,7 @@ func TestCreate20Miners(t *testing.T) {
 
 	rnd := rand.New(rand.NewSource(42))
 
-	sim := agent.NewSim(ctx, t, agent.SimConfig{Seed: rnd.Int63()})
+	sim := agent.NewSim(ctx, t, newBlockStore, agent.SimConfig{Seed: rnd.Int63()})
 	accounts := vm_test.CreateAccounts(ctx, t, sim.GetVM(), minerCount, initialBalance, rnd.Int63())
 	sim.AddAgent(agent.NewMinerGenerator(
 		accounts,
@@ -74,7 +76,7 @@ func Test500Epochs(t *testing.T) {
 
 	// set up sim
 	rnd := rand.New(rand.NewSource(42))
-	sim := agent.NewSim(ctx, t, agent.SimConfig{
+	sim := agent.NewSim(ctx, t, newBlockStore, agent.SimConfig{
 		Seed:             rnd.Int63(),
 		CheckpointEpochs: 1000,
 	})
@@ -152,7 +154,7 @@ func TestCommitPowerAndCheckInvariants(t *testing.T) {
 	minerCount := 1
 
 	rnd := rand.New(rand.NewSource(42))
-	sim := agent.NewSim(ctx, t, agent.SimConfig{Seed: rnd.Int63()})
+	sim := agent.NewSim(ctx, t, newBlockStore, agent.SimConfig{Seed: rnd.Int63()})
 	accounts := vm_test.CreateAccounts(ctx, t, sim.GetVM(), minerCount, initialBalance, rnd.Int63())
 	sim.AddAgent(agent.NewMinerGenerator(
 		accounts,
@@ -207,7 +209,7 @@ func TestCommitAndCheckReadWriteStats(t *testing.T) {
 
 	// set up sim
 	rnd := rand.New(rand.NewSource(42))
-	sim := agent.NewSim(ctx, t, agent.SimConfig{
+	sim := agent.NewSim(ctx, t, newBlockStore, agent.SimConfig{
 		Seed:             rnd.Int63(),
 		CheckpointEpochs: 1000,
 	})
@@ -284,7 +286,7 @@ func TestCreateDeals(t *testing.T) {
 
 	// set up sim
 	rnd := rand.New(rand.NewSource(42))
-	sim := agent.NewSim(ctx, t, agent.SimConfig{Seed: rnd.Int63()})
+	sim := agent.NewSim(ctx, t, newBlockStore, agent.SimConfig{Seed: rnd.Int63()})
 
 	// create miners
 	workerAccounts := vm_test.CreateAccounts(ctx, t, sim.GetVM(), minerCount, initialBalance, rnd.Int63())
@@ -357,7 +359,7 @@ func TestCCUpgrades(t *testing.T) {
 
 	// set up sim
 	rnd := rand.New(rand.NewSource(42))
-	sim := agent.NewSim(ctx, t, agent.SimConfig{Seed: rnd.Int63()})
+	sim := agent.NewSim(ctx, t, newBlockStore, agent.SimConfig{Seed: rnd.Int63()})
 
 	// create miners
 	workerAccounts := vm_test.CreateAccounts(ctx, t, sim.GetVM(), minerCount, initialBalance, rnd.Int63())
@@ -428,6 +430,10 @@ func TestCCUpgrades(t *testing.T) {
 				sim.MessageCount, deals, upgrades)
 		}
 	}
+}
+
+func newBlockStore() cbor.IpldBlockstore {
+	return ipld.NewBlockStoreInMemory()
 }
 
 func printCallStats(method vm_test.MethodKey, stats *vm_test.CallStats, indent string) { // nolint:unused

--- a/support/vm/testing.go
+++ b/support/vm/testing.go
@@ -13,6 +13,7 @@ import (
 	"github.com/filecoin-project/go-state-types/dline"
 	"github.com/filecoin-project/go-state-types/exitcode"
 	"github.com/ipfs/go-cid"
+	ipldcbor "github.com/ipfs/go-ipld-cbor"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -31,7 +32,6 @@ import (
 	"github.com/filecoin-project/specs-actors/v3/actors/states"
 	"github.com/filecoin-project/specs-actors/v3/actors/util/adt"
 	"github.com/filecoin-project/specs-actors/v3/actors/util/smoothing"
-	"github.com/filecoin-project/specs-actors/v3/support/ipld"
 	actor_testing "github.com/filecoin-project/specs-actors/v3/support/testing"
 )
 
@@ -51,18 +51,13 @@ func init() {
 //
 
 // Creates a new VM and initializes all singleton actors plus a root verifier account.
-func NewVMWithSingletons(ctx context.Context, t *testing.T) *VM {
-	store := ipld.NewADTStore(ctx)
-	return NewCustomStoreVMWithSingletons(ctx, store, t)
-}
-
-// Creates a new VM and initializes all singleton actors plus a root verifier account.
-func NewCustomStoreVMWithSingletons(ctx context.Context, store adt.Store, t testing.TB) *VM {
+func NewVMWithSingletons(ctx context.Context, t testing.TB, bs ipldcbor.IpldBlockstore) *VM {
 	lookup := map[cid.Cid]runtime.VMActor{}
 	for _, ba := range exported.BuiltinActors() {
 		lookup[ba.Code()] = ba
 	}
 
+	store := adt.WrapBlockStore(ctx, bs)
 	vm := NewVM(ctx, lookup, store)
 
 	initializeActor(ctx, t, vm, &system.State{}, builtin.SystemActorCodeID, builtin.SystemActorAddr, big.Zero())


### PR DESCRIPTION
This PR refactors VM and Sim construction to always take the block store (or a blockstore factory) as parameter. This enables injection of a synchronized blockstore when it's needed, avoiding wrappers at other layers.

The existing `TestParallelMigrationCalls` works around this by constructing state manually rather than using the VM (copy-paste from `NewVMWithSingletons`). In order to use this, we need to make a similar change on the `v2` release branch, which I will follow-up with.

I needed this for profiling #1338, the test for which I could not check in for lack of the necessary changes in `v2`.