### PR TITLE
[v2] Inject blockstore into VM and sim.

### DIFF
--- a/actors/migration/nv7/test/correct_power_accounting_test.go
+++ b/actors/migration/nv7/test/correct_power_accounting_test.go
@@ -21,13 +21,14 @@ import (
 	"github.com/filecoin-project/specs-actors/v2/actors/runtime"
 	"github.com/filecoin-project/specs-actors/v2/actors/runtime/proof"
 	"github.com/filecoin-project/specs-actors/v2/actors/states"
+	"github.com/filecoin-project/specs-actors/v2/support/ipld"
 	tutil "github.com/filecoin-project/specs-actors/v2/support/testing"
 	vm "github.com/filecoin-project/specs-actors/v2/support/vm"
 )
 
 func TestMigrationPowerAccountingIssue(t *testing.T) {
 	ctx := context.Background()
-	v, err := vm.NewVMWithSingletons(ctx, t).WithNetworkVersion(network.Version6)
+	v, err := vm.NewVMWithSingletons(ctx, t, ipld.NewBlockStoreInMemory()).WithNetworkVersion(network.Version6)
 	require.NoError(t, err)
 
 	addrs := vm.CreateAccounts(ctx, t, v, 1, big.Mul(big.NewInt(100_000), vm.FIL), 93837778)

--- a/actors/test/commit_post_test.go
+++ b/actors/test/commit_post_test.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/filecoin-project/specs-actors/v2/actors/states"
-
 	"github.com/filecoin-project/go-bitfield"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
@@ -18,13 +16,15 @@ import (
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin/miner"
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin/power"
 	"github.com/filecoin-project/specs-actors/v2/actors/runtime/proof"
+	"github.com/filecoin-project/specs-actors/v2/actors/states"
+	"github.com/filecoin-project/specs-actors/v2/support/ipld"
 	tutil "github.com/filecoin-project/specs-actors/v2/support/testing"
 	vm "github.com/filecoin-project/specs-actors/v2/support/vm"
 )
 
 func TestCommitPoStFlow(t *testing.T) {
 	ctx := context.Background()
-	v := vm.NewVMWithSingletons(ctx, t)
+	v := vm.NewVMWithSingletons(ctx, t, ipld.NewBlockStoreInMemory())
 	addrs := vm.CreateAccounts(ctx, t, v, 1, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
 
 	minerBalance := big.Mul(big.NewInt(10_000), vm.FIL)

--- a/actors/test/committed_capacity_scenario_test.go
+++ b/actors/test/committed_capacity_scenario_test.go
@@ -16,13 +16,14 @@ import (
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin/power"
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin/verifreg"
 	"github.com/filecoin-project/specs-actors/v2/actors/runtime/proof"
+	"github.com/filecoin-project/specs-actors/v2/support/ipld"
 	tutil "github.com/filecoin-project/specs-actors/v2/support/testing"
 	vm "github.com/filecoin-project/specs-actors/v2/support/vm"
 )
 
 func TestReplaceCommittedCapacitySectorWithDealLadenSector(t *testing.T) {
 	ctx := context.Background()
-	v := vm.NewVMWithSingletons(ctx, t)
+	v := vm.NewVMWithSingletons(ctx, t, ipld.NewBlockStoreInMemory())
 	addrs := vm.CreateAccounts(ctx, t, v, 4, big.Mul(big.NewInt(10_000), vm.FIL), 93837778)
 	worker, verifier, unverifiedClient, verifiedClient := addrs[0], addrs[1], addrs[2], addrs[3]
 

--- a/actors/test/cron_catches_expiries_scenario_test.go
+++ b/actors/test/cron_catches_expiries_scenario_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin/miner"
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin/power"
 	"github.com/filecoin-project/specs-actors/v2/actors/runtime/proof"
+	"github.com/filecoin-project/specs-actors/v2/support/ipld"
 	tutil "github.com/filecoin-project/specs-actors/v2/support/testing"
 	vm "github.com/filecoin-project/specs-actors/v2/support/vm"
 )
@@ -22,7 +23,7 @@ var fakeChainRandomness = []byte("not really random")
 
 func TestCronCatchedCCExpirationsAtDeadlineBoundary(t *testing.T) {
 	ctx := context.Background()
-	v := vm.NewVMWithSingletons(ctx, t)
+	v := vm.NewVMWithSingletons(ctx, t, ipld.NewBlockStoreInMemory())
 	addrs := vm.CreateAccounts(ctx, t, v, 2, big.Mul(big.NewInt(10_000), vm.FIL), 93837778)
 	worker, unverifiedClient := addrs[0], addrs[1]
 

--- a/actors/test/market_withdrawal_test.go
+++ b/actors/test/market_withdrawal_test.go
@@ -10,12 +10,13 @@ import (
 
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin/market"
+	"github.com/filecoin-project/specs-actors/v2/support/ipld"
 	vm "github.com/filecoin-project/specs-actors/v2/support/vm"
 )
 
 func TestMarketWithdraw(t *testing.T) {
 	ctx := context.Background()
-	v := vm.NewVMWithSingletons(ctx, t)
+	v := vm.NewVMWithSingletons(ctx, t, ipld.NewBlockStoreInMemory())
 	initialBalance := big.Mul(big.NewInt(6), big.NewInt(1e18))
 	addrs := vm.CreateAccounts(ctx, t, v, 1, initialBalance, 93837778)
 	caller := addrs[0]

--- a/actors/test/multisig_delete_self_test.go
+++ b/actors/test/multisig_delete_self_test.go
@@ -5,23 +5,23 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/exitcode"
 	"github.com/filecoin-project/go-state-types/network"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
 	init_ "github.com/filecoin-project/specs-actors/v2/actors/builtin/init"
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin/multisig"
+	"github.com/filecoin-project/specs-actors/v2/support/ipld"
 	vm "github.com/filecoin-project/specs-actors/v2/support/vm"
 )
 
 func TestV5MultisigDeleteSigner1Of2(t *testing.T) {
 	ctx := context.Background()
-	v := vm.NewVMWithSingletons(ctx, t)
+	v := vm.NewVMWithSingletons(ctx, t, ipld.NewBlockStoreInMemory())
 	v, err := v.WithNetworkVersion(network.Version5)
 	require.NoError(t, err)
 	addrs := vm.CreateAccounts(ctx, t, v, 2, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
@@ -68,7 +68,7 @@ func TestV5MultisigDeleteSigner1Of2(t *testing.T) {
 
 func TestV5MultisigDeleteSelf2Of3RemovedIsProposer(t *testing.T) {
 	ctx := context.Background()
-	v := vm.NewVMWithSingletons(ctx, t)
+	v := vm.NewVMWithSingletons(ctx, t, ipld.NewBlockStoreInMemory())
 	v, err := v.WithNetworkVersion(network.Version5)
 	require.NoError(t, err)
 	addrs := vm.CreateAccounts(ctx, t, v, 3, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
@@ -121,7 +121,7 @@ func TestV5MultisigDeleteSelf2Of3RemovedIsProposer(t *testing.T) {
 
 func TestV5MultisigDeleteSelf2Of3RemovedIsApprover(t *testing.T) {
 	ctx := context.Background()
-	v := vm.NewVMWithSingletons(ctx, t)
+	v := vm.NewVMWithSingletons(ctx, t, ipld.NewBlockStoreInMemory())
 	v, err := v.WithNetworkVersion(network.Version5)
 	require.NoError(t, err)
 	addrs := vm.CreateAccounts(ctx, t, v, 3, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
@@ -174,7 +174,7 @@ func TestV5MultisigDeleteSelf2Of3RemovedIsApprover(t *testing.T) {
 
 func TestV5MultisigDeleteSelf2Of2(t *testing.T) {
 	ctx := context.Background()
-	v := vm.NewVMWithSingletons(ctx, t)
+	v := vm.NewVMWithSingletons(ctx, t, ipld.NewBlockStoreInMemory())
 	v, err := v.WithNetworkVersion(network.Version5)
 	require.NoError(t, err)
 	addrs := vm.CreateAccounts(ctx, t, v, 2, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
@@ -225,7 +225,7 @@ func TestV5MultisigDeleteSelf2Of2(t *testing.T) {
 
 func TestV5MultisigSwapsSelf1Of2(t *testing.T) {
 	ctx := context.Background()
-	v := vm.NewVMWithSingletons(ctx, t)
+	v := vm.NewVMWithSingletons(ctx, t, ipld.NewBlockStoreInMemory())
 	v, err := v.WithNetworkVersion(network.Version5)
 	require.NoError(t, err)
 	addrs := vm.CreateAccounts(ctx, t, v, 3, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
@@ -277,7 +277,7 @@ func TestV5MultisigSwapsSelf1Of2(t *testing.T) {
 
 func TestV5MultisigSwapsSelf2Of3(t *testing.T) {
 	ctx := context.Background()
-	v := vm.NewVMWithSingletons(ctx, t)
+	v := vm.NewVMWithSingletons(ctx, t, ipld.NewBlockStoreInMemory())
 	v, err := v.WithNetworkVersion(network.Version5)
 	require.NoError(t, err)
 	addrs := vm.CreateAccounts(ctx, t, v, 4, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
@@ -356,7 +356,7 @@ func TestV5MultisigSwapsSelf2Of3(t *testing.T) {
 
 func TestMultisigDeleteSigner1Of2(t *testing.T) {
 	ctx := context.Background()
-	v := vm.NewVMWithSingletons(ctx, t)
+	v := vm.NewVMWithSingletons(ctx, t, ipld.NewBlockStoreInMemory())
 	addrs := vm.CreateAccounts(ctx, t, v, 2, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
 
 	multisigParams := multisig.ConstructorParams{
@@ -398,7 +398,7 @@ func TestMultisigDeleteSigner1Of2(t *testing.T) {
 
 func TestMultisigSwapsSelf1Of2(t *testing.T) {
 	ctx := context.Background()
-	v := vm.NewVMWithSingletons(ctx, t)
+	v := vm.NewVMWithSingletons(ctx, t, ipld.NewBlockStoreInMemory())
 	addrs := vm.CreateAccounts(ctx, t, v, 3, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
 	alice := addrs[0]
 	bob := addrs[1]

--- a/actors/test/power_scenario_test.go
+++ b/actors/test/power_scenario_test.go
@@ -11,12 +11,13 @@ import (
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin/miner"
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin/power"
+	"github.com/filecoin-project/specs-actors/v2/support/ipld"
 	vm "github.com/filecoin-project/specs-actors/v2/support/vm"
 )
 
 func TestCreateMiner(t *testing.T) {
 	ctx := context.Background()
-	v := vm.NewVMWithSingletons(ctx, t)
+	v := vm.NewVMWithSingletons(ctx, t, ipld.NewBlockStoreInMemory())
 	addrs := vm.CreateAccounts(ctx, t, v, 1, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
 
 	params := power.CreateMinerParams{
@@ -67,7 +68,7 @@ func TestCreateMiner(t *testing.T) {
 
 func TestOnEpochTickEnd(t *testing.T) {
 	ctx := context.Background()
-	v := vm.NewVMWithSingletons(ctx, t)
+	v := vm.NewVMWithSingletons(ctx, t, ipld.NewBlockStoreInMemory())
 	addrs := vm.CreateAccounts(ctx, t, v, 1, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
 
 	// create a miner

--- a/actors/test/terminate_sectors_scenario_test.go
+++ b/actors/test/terminate_sectors_scenario_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin/power"
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin/verifreg"
 	"github.com/filecoin-project/specs-actors/v2/actors/runtime/proof"
+	"github.com/filecoin-project/specs-actors/v2/support/ipld"
 	tutil "github.com/filecoin-project/specs-actors/v2/support/testing"
 	vm "github.com/filecoin-project/specs-actors/v2/support/vm"
 )
@@ -23,7 +24,7 @@ import (
 // This scenario hits all Market Actor methods.
 func TestTerminateSectors(t *testing.T) {
 	ctx := context.Background()
-	v := vm.NewVMWithSingletons(ctx, t)
+	v := vm.NewVMWithSingletons(ctx, t, ipld.NewBlockStoreInMemory())
 	addrs := vm.CreateAccounts(ctx, t, v, 4, big.Mul(big.NewInt(10_000), vm.FIL), 93837778)
 	owner, verifier, unverifiedClient, verifiedClient := addrs[0], addrs[1], addrs[2], addrs[3]
 	worker := owner

--- a/support/agent/cases_test.go
+++ b/support/agent/cases_test.go
@@ -9,14 +9,12 @@ import (
 
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
-	cbor "github.com/ipfs/go-ipld-cbor"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin/power"
 	"github.com/filecoin-project/specs-actors/v2/actors/states"
-	"github.com/filecoin-project/specs-actors/v2/actors/util/adt"
 	"github.com/filecoin-project/specs-actors/v2/support/agent"
 	"github.com/filecoin-project/specs-actors/v2/support/ipld"
 	"github.com/filecoin-project/specs-actors/v2/support/vm"
@@ -29,7 +27,7 @@ func TestCreate20Miners(t *testing.T) {
 
 	rnd := rand.New(rand.NewSource(42))
 
-	sim := agent.NewSim(ctx, t, ipld.NewADTStore(ctx), agent.SimConfig{Seed: rnd.Int63()})
+	sim := agent.NewSim(ctx, t, ipld.NewBlockStoreInMemory(), agent.SimConfig{Seed: rnd.Int63()})
 	accounts := vm_test.CreateAccounts(ctx, t, sim.GetVM(), minerCount, initialBalance, rnd.Int63())
 	sim.AddAgent(agent.NewMinerGenerator(
 		accounts,
@@ -70,7 +68,7 @@ func TestCommitPowerAndCheckInvariants(t *testing.T) {
 	minerCount := 1
 
 	rnd := rand.New(rand.NewSource(42))
-	sim := agent.NewSim(ctx, t, ipld.NewADTStore(ctx), agent.SimConfig{Seed: rnd.Int63()})
+	sim := agent.NewSim(ctx, t, ipld.NewBlockStoreInMemory(), agent.SimConfig{Seed: rnd.Int63()})
 	accounts := vm_test.CreateAccounts(ctx, t, sim.GetVM(), minerCount, initialBalance, rnd.Int63())
 	sim.AddAgent(agent.NewMinerGenerator(
 		accounts,
@@ -121,7 +119,7 @@ func TestCommitAndCheckReadWriteStats(t *testing.T) {
 	cumulativeStats := make(vm_test.StatsByCall)
 
 	// configure simulation
-	store, storeMetrics := metricsADTStore(ctx)
+	store := ipld.NewMetricsStore(ipld.NewBlockStoreInMemory())
 	rnd := rand.New(rand.NewSource(42))
 	sim := agent.NewSim(ctx, t, store, agent.SimConfig{Seed: rnd.Int63()})
 	accounts := vm_test.CreateAccounts(ctx, t, sim.GetVM(), minerCount, initialBalance, rnd.Int63())
@@ -137,7 +135,7 @@ func TestCommitAndCheckReadWriteStats(t *testing.T) {
 		1.0, // create miner probibility of 1 means a new miner is created every tick
 		rnd.Int63(),
 	))
-	sim.GetVM().SetStatsSource(storeMetrics)
+	sim.GetVM().SetStatsSource(store)
 
 	var pwrSt power.State
 	for i := 0; i < 20_000; i++ {
@@ -147,7 +145,7 @@ func TestCommitAndCheckReadWriteStats(t *testing.T) {
 			require.NoError(t, sim.GetVM().GetState(builtin.StoragePowerActorAddr, &pwrSt))
 			fmt.Printf("Power at %d: raw: %v  qa: %v  cmtRaw: %v  cmtQa: %v  cnsMnrs: %d  puts: %d  gets: %d\n",
 				sim.GetVM().GetEpoch(), pwrSt.TotalRawBytePower, pwrSt.TotalQualityAdjPower, pwrSt.TotalBytesCommitted,
-				pwrSt.TotalQABytesCommitted, pwrSt.MinerAboveMinPowerCount, storeMetrics.Writes, storeMetrics.Reads)
+				pwrSt.TotalQABytesCommitted, pwrSt.MinerAboveMinPowerCount, store.Writes, store.Reads)
 		}
 
 		cumulativeStats.MergeAllStats(sim.GetCallStats())
@@ -173,9 +171,4 @@ func printCallStats(method vm_test.MethodKey, stats *vm_test.CallStats, indent s
 	for m, s := range stats.SubStats {
 		printCallStats(m, s, indent+"  ")
 	}
-}
-
-func metricsADTStore(ctx context.Context) (adt.Store, *ipld.MetricsStore) { // nolint:unused
-	ms := ipld.NewMetricsStore(ipld.NewBlockStoreInMemory())
-	return adt.WrapStore(ctx, cbor.NewCborStore(ms)), ms
 }

--- a/support/agent/sim.go
+++ b/support/agent/sim.go
@@ -11,6 +11,7 @@ import (
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/cbor"
 	"github.com/filecoin-project/go-state-types/exitcode"
+	ipldcbor "github.com/ipfs/go-ipld-cbor"
 	"github.com/pkg/errors"
 
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
@@ -59,8 +60,8 @@ type SimConfig struct {
 	CreateMinerProbability float32
 }
 
-func NewSim(ctx context.Context, t testing.TB, store adt.Store, config SimConfig) *Sim {
-	v := vm.NewCustomStoreVMWithSingletons(ctx, store, t)
+func NewSim(ctx context.Context, t testing.TB, bs ipldcbor.IpldBlockstore, config SimConfig) *Sim {
+	v := vm.NewVMWithSingletons(ctx, t, bs)
 	return &Sim{
 		Config: config,
 		Agents: []Agent{},

--- a/support/vm/testing.go
+++ b/support/vm/testing.go
@@ -13,6 +13,7 @@ import (
 	"github.com/filecoin-project/go-state-types/dline"
 	"github.com/filecoin-project/go-state-types/exitcode"
 	"github.com/ipfs/go-cid"
+	ipldcbor "github.com/ipfs/go-ipld-cbor"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -31,7 +32,6 @@ import (
 	"github.com/filecoin-project/specs-actors/v2/actors/states"
 	"github.com/filecoin-project/specs-actors/v2/actors/util/adt"
 	"github.com/filecoin-project/specs-actors/v2/actors/util/smoothing"
-	"github.com/filecoin-project/specs-actors/v2/support/ipld"
 	actor_testing "github.com/filecoin-project/specs-actors/v2/support/testing"
 )
 
@@ -51,18 +51,13 @@ func init() {
 //
 
 // Creates a new VM and initializes all singleton actors plus a root verifier account.
-func NewVMWithSingletons(ctx context.Context, t *testing.T) *VM {
-	store := ipld.NewADTStore(ctx)
-	return NewCustomStoreVMWithSingletons(ctx, store, t)
-}
-
-// Creates a new VM and initializes all singleton actors plus a root verifier account.
-func NewCustomStoreVMWithSingletons(ctx context.Context, store adt.Store, t testing.TB) *VM {
+func NewVMWithSingletons(ctx context.Context, t testing.TB, bs ipldcbor.IpldBlockstore) *VM {
 	lookup := map[cid.Cid]runtime.VMActor{}
 	for _, ba := range exported.BuiltinActors() {
 		lookup[ba.Code()] = ba
 	}
 
+	store := adt.WrapStore(ctx, ipldcbor.NewCborStore(bs))
 	vm := NewVM(ctx, lookup, store)
 
 	emptyMapCID, err := adt.MakeEmptyMap(vm.store).Root()


### PR DESCRIPTION
This PR refactors VM and Sim construction to always take the block store (or a blockstore factory) as parameter. This enables injection of a synchronized blockstore when it's needed, avoiding wrappers at other layers.

See also #1342. This version is a bit simpler because the sim is less developed in v2.

I've confirmed that, after this, I can use `vm2.NewVMWithSingletons` to construct the state for the parallel migration test in v3.