### PR TITLE
Use sync blockstores for migration tests

### DIFF
--- a/actors/migration/nv9/test/modify_pending_proposals_test.go
+++ b/actors/migration/nv9/test/modify_pending_proposals_test.go
@@ -20,6 +20,8 @@ import (
 	market2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/market"
 	power2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/power"
 	vm2 "github.com/filecoin-project/specs-actors/v2/support/vm"
+	ipld2 "github.com/filecoin-project/specs-actors/v2/support/ipld"
+
 
 	builtin3 "github.com/filecoin-project/specs-actors/v3/actors/builtin"
 	exported3 "github.com/filecoin-project/specs-actors/v3/actors/builtin/exported"
@@ -34,7 +36,7 @@ import (
 func TestUpdatePendingDealsMigration(t *testing.T) {
 	ctx := context.Background()
 	log := TestLogger{t}
-	v := vm2.NewVMWithSingletons(ctx, t)
+	v := vm2.NewVMWithSingletons(ctx, t, ipld2.NewSyncBlockStoreInMemory())
 	addrs := vm2.CreateAccounts(ctx, t, v, 10, big.Mul(big.NewInt(100_000), vm2.FIL), 93837778)
 	worker := addrs[0]
 

--- a/actors/migration/nv9/test/parallel_migration_test.go
+++ b/actors/migration/nv9/test/parallel_migration_test.go
@@ -4,23 +4,12 @@ import (
 	"context"
 	"testing"
 
-	addr "github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
-	"github.com/filecoin-project/go-state-types/big"
-	"github.com/filecoin-project/go-state-types/cbor"
-	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
-	account2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/account"
-	cron2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/cron"
-	init2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/init"
-	market2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/market"
-	power2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/power"
-	reward2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/reward"
-	system2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/system"
-	verifreg2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/verifreg"
-	states2 "github.com/filecoin-project/specs-actors/v2/actors/states"
 	adt2 "github.com/filecoin-project/specs-actors/v2/actors/util/adt"
 	ipld2 "github.com/filecoin-project/specs-actors/v2/support/ipld"
+	vm2 "github.com/filecoin-project/specs-actors/v2/support/vm"
 	cid "github.com/ipfs/go-cid"
+	cbor "github.com/ipfs/go-ipld-cbor"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -29,65 +18,16 @@ import (
 )
 
 func TestParallelMigrationCalls(t *testing.T) {
-	// Construct simple prior state tree over a locking store
+	// Construct simple prior state tree over a synchronized store
 	ctx := context.Background()
 	log := TestLogger{t}
-	syncStore := ipld2.NewSyncADTStore(ctx)
-	initializeActor := func(ctx context.Context, t *testing.T, actors *states2.Tree, state cbor.Marshaler, code cid.Cid, a addr.Address, balance abi.TokenAmount) {
-		stateCID, err := actors.Store.Put(ctx, state)
-		require.NoError(t, err)
-		actor := &states2.Actor{
-			Head:    stateCID,
-			Code:    code,
-			Balance: balance,
-		}
-		err = actors.SetActor(a, actor)
-		require.NoError(t, err)
-	}
-	actorsIn, err := states2.NewTree(syncStore)
-	require.NoError(t, err)
-
-	emptyMapCID, err := adt2.MakeEmptyMap(syncStore).Root()
-	require.NoError(t, err)
-	emptyArray := adt2.MakeEmptyArray(syncStore)
-	emptyArrayCID, err := emptyArray.Root()
-	require.NoError(t, err)
-	emptyMultimapCID, err := adt2.MakeEmptyMultimap(syncStore).Root()
-	require.NoError(t, err)
-
-	initializeActor(ctx, t, actorsIn, &system2.State{}, builtin2.SystemActorCodeID, builtin2.SystemActorAddr, big.Zero())
-
-	initState := init2.ConstructState(emptyMapCID, "scenarios")
-	initializeActor(ctx, t, actorsIn, initState, builtin2.InitActorCodeID, builtin2.InitActorAddr, big.Zero())
-
-	rewardState := reward2.ConstructState(abi.NewStoragePower(0))
-	initializeActor(ctx, t, actorsIn, rewardState, builtin2.RewardActorCodeID, builtin2.RewardActorAddr, builtin2.TotalFilecoin)
-
-	cronState := cron2.ConstructState(cron2.BuiltInEntries())
-	initializeActor(ctx, t, actorsIn, cronState, builtin2.CronActorCodeID, builtin2.CronActorAddr, big.Zero())
-
-	powerState := power2.ConstructState(emptyMapCID, emptyMultimapCID)
-	initializeActor(ctx, t, actorsIn, powerState, builtin2.StoragePowerActorCodeID, builtin2.StoragePowerActorAddr, big.Zero())
-
-	marketState := market2.ConstructState(emptyArrayCID, emptyMapCID, emptyMultimapCID)
-	initializeActor(ctx, t, actorsIn, marketState, builtin2.StorageMarketActorCodeID, builtin2.StorageMarketActorAddr, big.Zero())
-
-	// this will need to be replaced with the address of a multisig actor for the verified registry to be tested accurately
-	verifregRoot, err := addr.NewIDAddress(80)
-	require.NoError(t, err)
-	initializeActor(ctx, t, actorsIn, &account2.State{Address: verifregRoot}, builtin2.AccountActorCodeID, verifregRoot, big.Zero())
-	vrState := verifreg2.ConstructState(emptyMapCID, verifregRoot)
-	initializeActor(ctx, t, actorsIn, vrState, builtin2.VerifiedRegistryActorCodeID, builtin2.VerifiedRegistryActorAddr, big.Zero())
-
-	// burnt funds
-	initializeActor(ctx, t, actorsIn, &account2.State{Address: builtin2.BurntFundsActorAddr}, builtin2.AccountActorCodeID, builtin2.BurntFundsActorAddr, big.Zero())
-
-	startRoot, err := actorsIn.Flush()
-	require.NoError(t, err)
+	bs := ipld2.NewSyncBlockStoreInMemory()
+	vm := vm2.NewVMWithSingletons(ctx, t, bs)
 
 	// Run migration
-
-	endRootSerial, err := nv9.MigrateStateTree(ctx, syncStore, startRoot, abi.ChainEpoch(0), nv9.Config{MaxWorkers: 1}, log)
+	adtStore := adt2.WrapStore(ctx, cbor.NewCborStore(bs))
+	startRoot := vm.StateRoot()
+	endRootSerial, err := nv9.MigrateStateTree(ctx, adtStore, startRoot, abi.ChainEpoch(0), nv9.Config{MaxWorkers: 1}, log)
 	require.NoError(t, err)
 
 	// Migrate in parallel
@@ -95,12 +35,12 @@ func TestParallelMigrationCalls(t *testing.T) {
 	grp, ctx := errgroup.WithContext(ctx)
 	grp.Go(func() error {
 		var err1 error
-		endRootParallel1, err1 = nv9.MigrateStateTree(ctx, syncStore, startRoot, abi.ChainEpoch(0), nv9.Config{MaxWorkers: 2}, log)
+		endRootParallel1, err1 = nv9.MigrateStateTree(ctx, adtStore, startRoot, abi.ChainEpoch(0), nv9.Config{MaxWorkers: 2}, log)
 		return err1
 	})
 	grp.Go(func() error {
 		var err2 error
-		endRootParallel2, err2 = nv9.MigrateStateTree(ctx, syncStore, startRoot, abi.ChainEpoch(0), nv9.Config{MaxWorkers: 2}, log)
+		endRootParallel2, err2 = nv9.MigrateStateTree(ctx, adtStore, startRoot, abi.ChainEpoch(0), nv9.Config{MaxWorkers: 2}, log)
 		return err2
 	})
 	require.NoError(t, grp.Wait())

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/filecoin-project/go-hamt-ipld/v3 v3.0.0-20201203140949-5cdbb5191437
 	github.com/filecoin-project/go-state-types v0.0.0-20201102161440-c8033295a1fc
 	github.com/filecoin-project/specs-actors v0.9.13
-	github.com/filecoin-project/specs-actors/v2 v2.3.4-0.20210105003919-86a2de3f95c4
+	github.com/filecoin-project/specs-actors/v2 v2.3.4
 	github.com/ipfs/go-block-format v0.0.2
 	github.com/ipfs/go-cid v0.0.7
 	github.com/ipfs/go-ipld-cbor v0.0.4

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/filecoin-project/go-hamt-ipld/v3 v3.0.0-20201203140949-5cdbb5191437
 	github.com/filecoin-project/go-state-types v0.0.0-20201102161440-c8033295a1fc
 	github.com/filecoin-project/specs-actors v0.9.13
-	github.com/filecoin-project/specs-actors/v2 v2.3.0
+	github.com/filecoin-project/specs-actors/v2 v2.3.4-0.20210105003919-86a2de3f95c4
 	github.com/ipfs/go-block-format v0.0.2
 	github.com/ipfs/go-cid v0.0.7
 	github.com/ipfs/go-ipld-cbor v0.0.4

--- a/go.sum
+++ b/go.sum
@@ -26,10 +26,8 @@ github.com/filecoin-project/go-state-types v0.0.0-20201102161440-c8033295a1fc h1
 github.com/filecoin-project/go-state-types v0.0.0-20201102161440-c8033295a1fc/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
 github.com/filecoin-project/specs-actors v0.9.13 h1:rUEOQouefi9fuVY/2HOroROJlZbOzWYXXeIh41KF2M4=
 github.com/filecoin-project/specs-actors v0.9.13/go.mod h1:TS1AW/7LbG+615j4NsjMK1qlpAwaFsG9w0V2tg2gSao=
-github.com/filecoin-project/specs-actors/v2 v2.3.0 h1:V7lHeF2ylfFi84F4y80u5FE4BpPHYGvB71kLrhXkJto=
-github.com/filecoin-project/specs-actors/v2 v2.3.0/go.mod h1:UuJQLoTx/HPvvWeqlIFmC/ywlOLHNe8SNQ3OunFbu2Y=
-github.com/filecoin-project/specs-actors/v2 v2.3.4-0.20210105003919-86a2de3f95c4 h1:UYg8ql43OPvqWGyK1M3vy+nhjqko79OAVS+v22dEKHk=
-github.com/filecoin-project/specs-actors/v2 v2.3.4-0.20210105003919-86a2de3f95c4/go.mod h1:UuJQLoTx/HPvvWeqlIFmC/ywlOLHNe8SNQ3OunFbu2Y=
+github.com/filecoin-project/specs-actors/v2 v2.3.4 h1:NZK2oMCcA71wNsUzDBmLQyRMzcCnX9tDGvwZ53G67j8=
+github.com/filecoin-project/specs-actors/v2 v2.3.4/go.mod h1:UuJQLoTx/HPvvWeqlIFmC/ywlOLHNe8SNQ3OunFbu2Y=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/filecoin-project/specs-actors v0.9.13 h1:rUEOQouefi9fuVY/2HOroROJlZbO
 github.com/filecoin-project/specs-actors v0.9.13/go.mod h1:TS1AW/7LbG+615j4NsjMK1qlpAwaFsG9w0V2tg2gSao=
 github.com/filecoin-project/specs-actors/v2 v2.3.0 h1:V7lHeF2ylfFi84F4y80u5FE4BpPHYGvB71kLrhXkJto=
 github.com/filecoin-project/specs-actors/v2 v2.3.0/go.mod h1:UuJQLoTx/HPvvWeqlIFmC/ywlOLHNe8SNQ3OunFbu2Y=
+github.com/filecoin-project/specs-actors/v2 v2.3.4-0.20210105003919-86a2de3f95c4 h1:UYg8ql43OPvqWGyK1M3vy+nhjqko79OAVS+v22dEKHk=
+github.com/filecoin-project/specs-actors/v2 v2.3.4-0.20210105003919-86a2de3f95c4/go.mod h1:UuJQLoTx/HPvvWeqlIFmC/ywlOLHNe8SNQ3OunFbu2Y=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=


### PR DESCRIPTION
Injects a sync blockstore into the VM (since #1343), thus allowing `TestParallelMigrationCalls` to use the `NewVMWithSingletons` method to construct state. Migration tests should generally use a sync blockstore since the migration method is now concurrent even with `MaxWorkers` set to `1` (#1338).

TODO:
- [x] Land #1342 and rebase on master
- [x] Land #1343, tag a release and update this `go.mod`