### PR TITLE
Replace miner on-chain seal proof type with window/winning PoSt proof types

### DIFF
--- a/actors/builtin/miner/cbor_gen.go
+++ b/actors/builtin/miner/cbor_gen.go
@@ -303,7 +303,7 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
-var lengthBufMinerInfo = []byte{140}
+var lengthBufMinerInfo = []byte{139}
 
 func (t *MinerInfo) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -391,17 +391,6 @@ func (t *MinerInfo) MarshalCBOR(w io.Writer) error {
 		}
 	}
 
-	// t.WinningPoStProofType (abi.RegisteredPoStProof) (int64)
-	if t.WinningPoStProofType >= 0 {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.WinningPoStProofType)); err != nil {
-			return err
-		}
-	} else {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.WinningPoStProofType-1)); err != nil {
-			return err
-		}
-	}
-
 	// t.SectorSize (abi.SectorSize) (uint64)
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.SectorSize)); err != nil {
@@ -446,7 +435,7 @@ func (t *MinerInfo) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 12 {
+	if extra != 11 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -608,31 +597,6 @@ func (t *MinerInfo) UnmarshalCBOR(r io.Reader) error {
 		}
 
 		t.WindowPoStProofType = abi.RegisteredPoStProof(extraI)
-	}
-	// t.WinningPoStProofType (abi.RegisteredPoStProof) (int64)
-	{
-		maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
-		var extraI int64
-		if err != nil {
-			return err
-		}
-		switch maj {
-		case cbg.MajUnsignedInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 positive overflow")
-			}
-		case cbg.MajNegativeInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 negative oveflow")
-			}
-			extraI = -1 - extraI
-		default:
-			return fmt.Errorf("wrong type for int64 field: %d", maj)
-		}
-
-		t.WinningPoStProofType = abi.RegisteredPoStProof(extraI)
 	}
 	// t.SectorSize (abi.SectorSize) (uint64)
 

--- a/actors/builtin/miner/cbor_gen.go
+++ b/actors/builtin/miner/cbor_gen.go
@@ -303,7 +303,7 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
-var lengthBufMinerInfo = []byte{139}
+var lengthBufMinerInfo = []byte{140}
 
 func (t *MinerInfo) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -380,13 +380,24 @@ func (t *MinerInfo) MarshalCBOR(w io.Writer) error {
 		}
 	}
 
-	// t.SealProofType (abi.RegisteredSealProof) (int64)
-	if t.SealProofType >= 0 {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.SealProofType)); err != nil {
+	// t.WindowPoStProofType (abi.RegisteredPoStProof) (int64)
+	if t.WindowPoStProofType >= 0 {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.WindowPoStProofType)); err != nil {
 			return err
 		}
 	} else {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.SealProofType-1)); err != nil {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.WindowPoStProofType-1)); err != nil {
+			return err
+		}
+	}
+
+	// t.WinningPoStProofType (abi.RegisteredPoStProof) (int64)
+	if t.WinningPoStProofType >= 0 {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.WinningPoStProofType)); err != nil {
+			return err
+		}
+	} else {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.WinningPoStProofType-1)); err != nil {
 			return err
 		}
 	}
@@ -435,7 +446,7 @@ func (t *MinerInfo) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 11 {
+	if extra != 12 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -573,7 +584,7 @@ func (t *MinerInfo) UnmarshalCBOR(r io.Reader) error {
 		}
 	}
 
-	// t.SealProofType (abi.RegisteredSealProof) (int64)
+	// t.WindowPoStProofType (abi.RegisteredPoStProof) (int64)
 	{
 		maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
 		var extraI int64
@@ -596,7 +607,32 @@ func (t *MinerInfo) UnmarshalCBOR(r io.Reader) error {
 			return fmt.Errorf("wrong type for int64 field: %d", maj)
 		}
 
-		t.SealProofType = abi.RegisteredSealProof(extraI)
+		t.WindowPoStProofType = abi.RegisteredPoStProof(extraI)
+	}
+	// t.WinningPoStProofType (abi.RegisteredPoStProof) (int64)
+	{
+		maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+		var extraI int64
+		if err != nil {
+			return err
+		}
+		switch maj {
+		case cbg.MajUnsignedInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 positive overflow")
+			}
+		case cbg.MajNegativeInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 negative oveflow")
+			}
+			extraI = -1 - extraI
+		default:
+			return fmt.Errorf("wrong type for int64 field: %d", maj)
+		}
+
+		t.WinningPoStProofType = abi.RegisteredPoStProof(extraI)
 	}
 	// t.SectorSize (abi.SectorSize) (uint64)
 

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -115,7 +115,7 @@ func (a Actor) Constructor(rt Runtime, params *ConstructorParams) *abi.EmptyValu
 	deadlineIndex := currentDeadlineIndex(currEpoch, periodStart)
 	builtin.RequireState(rt, deadlineIndex < WPoStPeriodDeadlines, "computed proving deadline index %d invalid", deadlineIndex)
 
-	info, err := ConstructMinerInfo(owner, worker, controlAddrs, params.PeerId, params.Multiaddrs, params.WindowPoStProofType, params.WinningPoStProofType)
+	info, err := ConstructMinerInfo(owner, worker, controlAddrs, params.PeerId, params.Multiaddrs, params.WindowPoStProofType)
 	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to construct initial miner info")
 	infoCid := rt.StorePut(info)
 

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -99,10 +99,6 @@ func (a Actor) Constructor(rt Runtime, params *ConstructorParams) *abi.EmptyValu
 	checkControlAddresses(rt, params.ControlAddrs)
 	checkPeerInfo(rt, params.PeerId, params.Multiaddrs)
 
-	if !CanPreCommitSealProof(params.SealProofType, rt.NetworkVersion()) {
-		rt.Abortf(exitcode.ErrIllegalArgument, "proof type %d not allowed for new miner actors", params.SealProofType)
-	}
-
 	owner := resolveControlAddress(rt, params.OwnerAddr)
 	worker := resolveWorkerAddress(rt, params.WorkerAddr)
 	controlAddrs := make([]addr.Address, 0, len(params.ControlAddrs))
@@ -119,7 +115,7 @@ func (a Actor) Constructor(rt Runtime, params *ConstructorParams) *abi.EmptyValu
 	deadlineIndex := currentDeadlineIndex(currEpoch, periodStart)
 	builtin.RequireState(rt, deadlineIndex < WPoStPeriodDeadlines, "computed proving deadline index %d invalid", deadlineIndex)
 
-	info, err := ConstructMinerInfo(owner, worker, controlAddrs, params.PeerId, params.Multiaddrs, params.SealProofType)
+	info, err := ConstructMinerInfo(owner, worker, controlAddrs, params.PeerId, params.Multiaddrs, params.WindowPoStProofType, params.WinningPoStProofType)
 	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to construct initial miner info")
 	infoCid := rt.StorePut(info)
 
@@ -365,12 +361,10 @@ func (a Actor) SubmitWindowedPoSt(rt Runtime, params *SubmitWindowedPoStParams) 
 		//
 		// This can be 0 if the miner isn't actually proving anything,
 		// just skipping all sectors.
-		windowPoStProofType, err := info.SealProofType.RegisteredWindowPoStProof()
-		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to determine window PoSt type")
 		if len(params.Proofs) != 1 {
 			rt.Abortf(exitcode.ErrIllegalArgument, "expected exactly one proof, got %d", len(params.Proofs))
-		} else if params.Proofs[0].PoStProof != windowPoStProofType {
-			rt.Abortf(exitcode.ErrIllegalArgument, "expected proof of type %s, got proof of type %s", windowPoStProofType, params.Proofs[0])
+		} else if params.Proofs[0].PoStProof != info.WindowPoStProofType {
+			rt.Abortf(exitcode.ErrIllegalArgument, "expected proof of type %s, got proof of type %s", info.WindowPoStProofType, params.Proofs[0])
 		}
 
 		// Validate that the miner didn't try to prove too many partitions at once.
@@ -575,16 +569,14 @@ func (a Actor) PreCommitSector(rt Runtime, params *PreCommitSectorParams) *abi.E
 			rt.Abortf(exitcode.ErrForbidden, "precommit not allowed during active consensus fault")
 		}
 
-		// From network version 7, the pre-commit seal type must have the same Window PoSt proof type as the miner's
-		// recorded seal type has, rather than be exactly the same seal type.
+		// From network version 7, the pre-commit seal type must have the same Window PoSt proof type as the miner,
+		// rather than be exactly the same seal type.
 		// This permits a transition window from V1 to V1_1 seal types (which share Window PoSt proof type).
-		minerWPoStProof, err := info.SealProofType.RegisteredWindowPoStProof()
-		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to lookup Window PoSt proof type for miner seal proof %d", info.SealProofType)
 		sectorWPoStProof, err := params.SealProof.RegisteredWindowPoStProof()
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalArgument, "failed to lookup Window PoSt proof type for sector seal proof %d", params.SealProof)
-		if sectorWPoStProof != minerWPoStProof {
+		if sectorWPoStProof != info.WindowPoStProofType {
 			rt.Abortf(exitcode.ErrIllegalArgument, "sector Window PoSt proof type %d must match miner Window PoSt proof type %d (seal proof type %d)",
-				sectorWPoStProof, minerWPoStProof, params.SealProof)
+				sectorWPoStProof, info.WindowPoStProofType, params.SealProof)
 		}
 
 		dealCountMax := SectorDealsMax(info.SectorSize)

--- a/actors/builtin/miner/miner_state_test.go
+++ b/actors/builtin/miner/miner_state_test.go
@@ -893,7 +893,6 @@ func constructStateHarness(t *testing.T, periodBoundary abi.ChainEpoch) *stateHa
 	worker := tutils.NewBLSAddr(t, 2)
 
 	testWindowPoStProofType := abi.RegisteredPoStProof_StackedDrgWindow2KiBV1
-	testWinningPoStProofType := abi.RegisteredPoStProof_StackedDrgWinning2KiBV1
 
 	sectorSize, err := testWindowPoStProofType.SectorSize()
 	require.NoError(t, err)
@@ -908,7 +907,6 @@ func constructStateHarness(t *testing.T, periodBoundary abi.ChainEpoch) *stateHa
 		PeerId:                     abi.PeerID("peer"),
 		Multiaddrs:                 testMultiaddrs,
 		WindowPoStProofType:        testWindowPoStProofType,
-		WinningPoStProofType:       testWinningPoStProofType,
 		SectorSize:                 sectorSize,
 		WindowPoStPartitionSectors: partitionSectors,
 	}

--- a/actors/builtin/miner/miner_state_test.go
+++ b/actors/builtin/miner/miner_state_test.go
@@ -892,12 +892,13 @@ func constructStateHarness(t *testing.T, periodBoundary abi.ChainEpoch) *stateHa
 	owner := tutils.NewBLSAddr(t, 1)
 	worker := tutils.NewBLSAddr(t, 2)
 
-	testSealProofType := abi.RegisteredSealProof_StackedDrg2KiBV1_1
+	testWindowPoStProofType := abi.RegisteredPoStProof_StackedDrgWindow2KiBV1
+	testWinningPoStProofType := abi.RegisteredPoStProof_StackedDrgWinning2KiBV1
 
-	sectorSize, err := testSealProofType.SectorSize()
+	sectorSize, err := testWindowPoStProofType.SectorSize()
 	require.NoError(t, err)
 
-	partitionSectors, err := builtin.SealProofWindowPoStPartitionSectors(testSealProofType)
+	partitionSectors, err := builtin.PoStProofWindowPoStPartitionSectors(testWindowPoStProofType)
 	require.NoError(t, err)
 
 	info := miner.MinerInfo{
@@ -906,7 +907,8 @@ func constructStateHarness(t *testing.T, periodBoundary abi.ChainEpoch) *stateHa
 		PendingWorkerKey:           nil,
 		PeerId:                     abi.PeerID("peer"),
 		Multiaddrs:                 testMultiaddrs,
-		SealProofType:              testSealProofType,
+		WindowPoStProofType:        testWindowPoStProofType,
+		WinningPoStProofType:       testWinningPoStProofType,
 		SectorSize:                 sectorSize,
 		WindowPoStPartitionSectors: partitionSectors,
 	}

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -84,13 +84,12 @@ func TestConstruction(t *testing.T) {
 	t.Run("simple construction", func(t *testing.T) {
 		rt := builder.Build(t)
 		params := miner.ConstructorParams{
-			OwnerAddr:            owner,
-			WorkerAddr:           worker,
-			ControlAddrs:         controlAddrs,
-			WindowPoStProofType:  abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
-			WinningPoStProofType: abi.RegisteredPoStProof_StackedDrgWinning32GiBV1,
-			PeerId:               testPid,
-			Multiaddrs:           testMultiaddrs,
+			OwnerAddr:           owner,
+			WorkerAddr:          worker,
+			ControlAddrs:        controlAddrs,
+			WindowPoStProofType: abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
+			PeerId:              testPid,
+			Multiaddrs:          testMultiaddrs,
 		}
 
 		provingPeriodStart := abi.ChainEpoch(-2222) // This is just set from running the code.
@@ -117,7 +116,6 @@ func TestConstruction(t *testing.T) {
 		assert.Equal(t, params.PeerId, info.PeerId)
 		assert.Equal(t, params.Multiaddrs, info.Multiaddrs)
 		assert.Equal(t, abi.RegisteredPoStProof_StackedDrgWindow32GiBV1, info.WindowPoStProofType)
-		assert.Equal(t, abi.RegisteredPoStProof_StackedDrgWinning32GiBV1, info.WinningPoStProofType)
 		assert.Equal(t, abi.SectorSize(1<<35), info.SectorSize)
 		assert.Equal(t, uint64(2349), info.WindowPoStPartitionSectors)
 
@@ -160,11 +158,10 @@ func TestConstruction(t *testing.T) {
 		rt.AddIDAddress(control2, control2Id)
 
 		params := miner.ConstructorParams{
-			OwnerAddr:            owner,
-			WorkerAddr:           worker,
-			ControlAddrs:         []addr.Address{control1, control2},
-			WindowPoStProofType:  abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
-			WinningPoStProofType: abi.RegisteredPoStProof_StackedDrgWinning32GiBV1,
+			OwnerAddr:           owner,
+			WorkerAddr:          worker,
+			ControlAddrs:        []addr.Address{control1, control2},
+			WindowPoStProofType: abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
 		}
 
 		provingPeriodStart := abi.ChainEpoch(-2222) // This is just set from running the code.
@@ -193,11 +190,10 @@ func TestConstruction(t *testing.T) {
 		rt.SetAddressActorType(control1, builtin.PaymentChannelActorCodeID)
 
 		params := miner.ConstructorParams{
-			OwnerAddr:            owner,
-			WorkerAddr:           worker,
-			ControlAddrs:         []addr.Address{control1},
-			WindowPoStProofType:  abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
-			WinningPoStProofType: abi.RegisteredPoStProof_StackedDrgWinning32GiBV1,
+			OwnerAddr:           owner,
+			WorkerAddr:          worker,
+			ControlAddrs:        []addr.Address{control1},
+			WindowPoStProofType: abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
 		}
 
 		rt.ExpectValidateCallerAddr(builtin.InitActorAddr)
@@ -213,12 +209,11 @@ func TestConstruction(t *testing.T) {
 		rt := builder.Build(t)
 		pid := [miner.MaxPeerIDLength + 1]byte{1, 2, 3, 4}
 		params := miner.ConstructorParams{
-			OwnerAddr:            owner,
-			WorkerAddr:           worker,
-			WindowPoStProofType:  abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
-			WinningPoStProofType: abi.RegisteredPoStProof_StackedDrgWinning32GiBV1,
-			PeerId:               pid[:],
-			Multiaddrs:           testMultiaddrs,
+			OwnerAddr:           owner,
+			WorkerAddr:          worker,
+			WindowPoStProofType: abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
+			PeerId:              pid[:],
+			Multiaddrs:          testMultiaddrs,
 		}
 
 		rt.ExpectValidateCallerAddr(builtin.InitActorAddr)
@@ -237,12 +232,11 @@ func TestConstruction(t *testing.T) {
 		}
 
 		params := miner.ConstructorParams{
-			OwnerAddr:            owner,
-			WorkerAddr:           worker,
-			WindowPoStProofType:  abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
-			WinningPoStProofType: abi.RegisteredPoStProof_StackedDrgWinning32GiBV1,
-			PeerId:               testPid,
-			ControlAddrs:         controlAddrs,
+			OwnerAddr:           owner,
+			WorkerAddr:          worker,
+			WindowPoStProofType: abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
+			PeerId:              testPid,
+			ControlAddrs:        controlAddrs,
 		}
 
 		rt.ExpectValidateCallerAddr(builtin.InitActorAddr)
@@ -259,12 +253,11 @@ func TestConstruction(t *testing.T) {
 			maddrs[i] = []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}
 		}
 		params := miner.ConstructorParams{
-			OwnerAddr:            owner,
-			WorkerAddr:           worker,
-			WindowPoStProofType:  abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
-			WinningPoStProofType: abi.RegisteredPoStProof_StackedDrgWinning32GiBV1,
-			PeerId:               testPid,
-			Multiaddrs:           maddrs,
+			OwnerAddr:           owner,
+			WorkerAddr:          worker,
+			WindowPoStProofType: abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
+			PeerId:              testPid,
+			Multiaddrs:          maddrs,
 		}
 
 		rt.ExpectValidateCallerAddr(builtin.InitActorAddr)
@@ -281,12 +274,11 @@ func TestConstruction(t *testing.T) {
 			{1},
 		}
 		params := miner.ConstructorParams{
-			OwnerAddr:            owner,
-			WorkerAddr:           worker,
-			WindowPoStProofType:  abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
-			WinningPoStProofType: abi.RegisteredPoStProof_StackedDrgWinning32GiBV1,
-			PeerId:               testPid,
-			Multiaddrs:           maddrs,
+			OwnerAddr:           owner,
+			WorkerAddr:          worker,
+			WindowPoStProofType: abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
+			PeerId:              testPid,
+			Multiaddrs:          maddrs,
 		}
 
 		rt.ExpectValidateCallerAddr(builtin.InitActorAddr)
@@ -294,20 +286,6 @@ func TestConstruction(t *testing.T) {
 		rt.ExpectAbortContainsMessage(exitcode.ErrIllegalArgument, "invalid empty multiaddr", func() {
 			rt.Call(actor.Constructor, &params)
 		})
-	})
-
-	t.Run("checks PoSt proof compatibility", func(t *testing.T) {
-		actor := newHarness(t, 0)
-		builder := builderForHarness(actor)
-		rt := builder.Build(t)
-		actor.setProofType(abi.RegisteredSealProof_StackedDrg32GiBV1)
-		actor.winningPostProofType = abi.RegisteredPoStProof_StackedDrgWinning64GiBV1
-		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
-			actor.constructAndVerify(rt)
-		})
-		rt.Reset()
-		actor.setProofType(abi.RegisteredSealProof_StackedDrg32GiBV1_1)
-		actor.constructAndVerify(rt)
 	})
 }
 
@@ -4459,13 +4437,12 @@ type actorHarness struct {
 
 	controlAddrs []addr.Address
 
-	sealProofType        abi.RegisteredSealProof
-	windowPostProofType  abi.RegisteredPoStProof
-	winningPostProofType abi.RegisteredPoStProof
-	sectorSize           abi.SectorSize
-	partitionSize        uint64
-	periodOffset         abi.ChainEpoch
-	nextSectorNo         abi.SectorNumber
+	sealProofType       abi.RegisteredSealProof
+	windowPostProofType abi.RegisteredPoStProof
+	sectorSize          abi.SectorSize
+	partitionSize       uint64
+	periodOffset        abi.ChainEpoch
+	nextSectorNo        abi.SectorNumber
 
 	networkPledge   abi.TokenAmount
 	networkRawPower abi.StoragePower
@@ -4516,22 +4493,19 @@ func (h *actorHarness) setProofType(proof abi.RegisteredSealProof) {
 	h.sealProofType = proof
 	h.windowPostProofType, err = proof.RegisteredWindowPoStProof()
 	require.NoError(h.t, err)
-	h.winningPostProofType, err = proof.RegisteredWinningPoStProof()
-	require.NoError(h.t, err)
 	h.sectorSize, err = proof.SectorSize()
 	require.NoError(h.t, err)
-	h.partitionSize, err = builtin.SealProofWindowPoStPartitionSectors(proof)
+	h.partitionSize, err = builtin.PoStProofWindowPoStPartitionSectors(h.windowPostProofType)
 	require.NoError(h.t, err)
 }
 
 func (h *actorHarness) constructAndVerify(rt *mock.Runtime) {
 	params := miner.ConstructorParams{
-		OwnerAddr:            h.owner,
-		WorkerAddr:           h.worker,
-		ControlAddrs:         h.controlAddrs,
-		WindowPoStProofType:  h.windowPostProofType,
-		WinningPoStProofType: h.winningPostProofType,
-		PeerId:               testPid,
+		OwnerAddr:           h.owner,
+		WorkerAddr:          h.worker,
+		ControlAddrs:        h.controlAddrs,
+		WindowPoStProofType: h.windowPostProofType,
+		PeerId:              testPid,
 	}
 
 	rt.ExpectValidateCallerAddr(builtin.InitActorAddr)

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -84,12 +84,13 @@ func TestConstruction(t *testing.T) {
 	t.Run("simple construction", func(t *testing.T) {
 		rt := builder.Build(t)
 		params := miner.ConstructorParams{
-			OwnerAddr:     owner,
-			WorkerAddr:    worker,
-			ControlAddrs:  controlAddrs,
-			SealProofType: abi.RegisteredSealProof_StackedDrg32GiBV1_1,
-			PeerId:        testPid,
-			Multiaddrs:    testMultiaddrs,
+			OwnerAddr:            owner,
+			WorkerAddr:           worker,
+			ControlAddrs:         controlAddrs,
+			WindowPoStProofType:  abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
+			WinningPoStProofType: abi.RegisteredPoStProof_StackedDrgWinning32GiBV1,
+			PeerId:               testPid,
+			Multiaddrs:           testMultiaddrs,
 		}
 
 		provingPeriodStart := abi.ChainEpoch(-2222) // This is just set from running the code.
@@ -115,7 +116,8 @@ func TestConstruction(t *testing.T) {
 		assert.Equal(t, params.ControlAddrs, info.ControlAddresses)
 		assert.Equal(t, params.PeerId, info.PeerId)
 		assert.Equal(t, params.Multiaddrs, info.Multiaddrs)
-		assert.Equal(t, abi.RegisteredSealProof_StackedDrg32GiBV1_1, info.SealProofType)
+		assert.Equal(t, abi.RegisteredPoStProof_StackedDrgWindow32GiBV1, info.WindowPoStProofType)
+		assert.Equal(t, abi.RegisteredPoStProof_StackedDrgWinning32GiBV1, info.WinningPoStProofType)
 		assert.Equal(t, abi.SectorSize(1<<35), info.SectorSize)
 		assert.Equal(t, uint64(2349), info.WindowPoStPartitionSectors)
 
@@ -158,10 +160,11 @@ func TestConstruction(t *testing.T) {
 		rt.AddIDAddress(control2, control2Id)
 
 		params := miner.ConstructorParams{
-			OwnerAddr:     owner,
-			WorkerAddr:    worker,
-			ControlAddrs:  []addr.Address{control1, control2},
-			SealProofType: abi.RegisteredSealProof_StackedDrg32GiBV1_1,
+			OwnerAddr:            owner,
+			WorkerAddr:           worker,
+			ControlAddrs:         []addr.Address{control1, control2},
+			WindowPoStProofType:  abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
+			WinningPoStProofType: abi.RegisteredPoStProof_StackedDrgWinning32GiBV1,
 		}
 
 		provingPeriodStart := abi.ChainEpoch(-2222) // This is just set from running the code.
@@ -190,10 +193,11 @@ func TestConstruction(t *testing.T) {
 		rt.SetAddressActorType(control1, builtin.PaymentChannelActorCodeID)
 
 		params := miner.ConstructorParams{
-			OwnerAddr:     owner,
-			WorkerAddr:    worker,
-			ControlAddrs:  []addr.Address{control1},
-			SealProofType: abi.RegisteredSealProof_StackedDrg2KiBV1_1,
+			OwnerAddr:            owner,
+			WorkerAddr:           worker,
+			ControlAddrs:         []addr.Address{control1},
+			WindowPoStProofType:  abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
+			WinningPoStProofType: abi.RegisteredPoStProof_StackedDrgWinning32GiBV1,
 		}
 
 		rt.ExpectValidateCallerAddr(builtin.InitActorAddr)
@@ -209,11 +213,12 @@ func TestConstruction(t *testing.T) {
 		rt := builder.Build(t)
 		pid := [miner.MaxPeerIDLength + 1]byte{1, 2, 3, 4}
 		params := miner.ConstructorParams{
-			OwnerAddr:     owner,
-			WorkerAddr:    worker,
-			SealProofType: abi.RegisteredSealProof_StackedDrg32GiBV1_1,
-			PeerId:        pid[:],
-			Multiaddrs:    testMultiaddrs,
+			OwnerAddr:            owner,
+			WorkerAddr:           worker,
+			WindowPoStProofType:  abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
+			WinningPoStProofType: abi.RegisteredPoStProof_StackedDrgWinning32GiBV1,
+			PeerId:               pid[:],
+			Multiaddrs:           testMultiaddrs,
 		}
 
 		rt.ExpectValidateCallerAddr(builtin.InitActorAddr)
@@ -232,11 +237,12 @@ func TestConstruction(t *testing.T) {
 		}
 
 		params := miner.ConstructorParams{
-			OwnerAddr:     owner,
-			WorkerAddr:    worker,
-			SealProofType: abi.RegisteredSealProof_StackedDrg32GiBV1_1,
-			PeerId:        testPid,
-			ControlAddrs:  controlAddrs,
+			OwnerAddr:            owner,
+			WorkerAddr:           worker,
+			WindowPoStProofType:  abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
+			WinningPoStProofType: abi.RegisteredPoStProof_StackedDrgWinning32GiBV1,
+			PeerId:               testPid,
+			ControlAddrs:         controlAddrs,
 		}
 
 		rt.ExpectValidateCallerAddr(builtin.InitActorAddr)
@@ -253,11 +259,12 @@ func TestConstruction(t *testing.T) {
 			maddrs[i] = []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}
 		}
 		params := miner.ConstructorParams{
-			OwnerAddr:     owner,
-			WorkerAddr:    worker,
-			SealProofType: abi.RegisteredSealProof_StackedDrg32GiBV1_1,
-			PeerId:        testPid,
-			Multiaddrs:    maddrs,
+			OwnerAddr:            owner,
+			WorkerAddr:           worker,
+			WindowPoStProofType:  abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
+			WinningPoStProofType: abi.RegisteredPoStProof_StackedDrgWinning32GiBV1,
+			PeerId:               testPid,
+			Multiaddrs:           maddrs,
 		}
 
 		rt.ExpectValidateCallerAddr(builtin.InitActorAddr)
@@ -274,11 +281,12 @@ func TestConstruction(t *testing.T) {
 			{1},
 		}
 		params := miner.ConstructorParams{
-			OwnerAddr:     owner,
-			WorkerAddr:    worker,
-			SealProofType: abi.RegisteredSealProof_StackedDrg32GiBV1_1,
-			PeerId:        testPid,
-			Multiaddrs:    maddrs,
+			OwnerAddr:            owner,
+			WorkerAddr:           worker,
+			WindowPoStProofType:  abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
+			WinningPoStProofType: abi.RegisteredPoStProof_StackedDrgWinning32GiBV1,
+			PeerId:               testPid,
+			Multiaddrs:           maddrs,
 		}
 
 		rt.ExpectValidateCallerAddr(builtin.InitActorAddr)
@@ -288,12 +296,12 @@ func TestConstruction(t *testing.T) {
 		})
 	})
 
-	t.Run("checks seal proof version", func(t *testing.T) {
+	t.Run("checks PoSt proof compatibility", func(t *testing.T) {
 		actor := newHarness(t, 0)
 		builder := builderForHarness(actor)
-		// From version 8, only V1_1 accepted
 		rt := builder.Build(t)
 		actor.setProofType(abi.RegisteredSealProof_StackedDrg32GiBV1)
+		actor.winningPostProofType = abi.RegisteredPoStProof_StackedDrgWinning64GiBV1
 		rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 			actor.constructAndVerify(rt)
 		})
@@ -1944,7 +1952,7 @@ func TestWindowPost(t *testing.T) {
 				Index:   pIdx,
 				Skipped: bf(uint64(sector.SectorNumber)),
 			}},
-			Proofs:           makePoStProofs(actor.postProofType),
+			Proofs:           makePoStProofs(actor.windowPostProofType),
 			ChainCommitEpoch: dlinfo.Challenge,
 			ChainCommitRand:  commitRand,
 		}
@@ -2313,9 +2321,8 @@ func TestProveCommit(t *testing.T) {
 		// Set balance to exactly cover locked funds.
 		st := getState(rt)
 		rt.SetBalance(big.Sum(st.PreCommitDeposits, st.InitialPledge, st.LockedFunds))
-		info := actor.getInfo(rt)
 
-		rt.SetEpoch(precommitEpoch + miner.MaxProveCommitDuration[info.SealProofType] - 1)
+		rt.SetEpoch(precommitEpoch + miner.MaxProveCommitDuration[actor.sealProofType] - 1)
 		rt.ExpectAbort(exitcode.ErrInsufficientFunds, func() {
 			actor.proveCommitSectorAndConfirm(rt, precommit, makeProveCommit(actor.nextSectorNo), proveCommitConf{})
 		})
@@ -2344,8 +2351,7 @@ func TestProveCommit(t *testing.T) {
 		sectorNoB := actor.nextSectorNo
 
 		// handle both prove commits in the same epoch
-		info := actor.getInfo(rt)
-		rt.SetEpoch(precommitEpoch + miner.MaxProveCommitDuration[info.SealProofType] - 1)
+		rt.SetEpoch(precommitEpoch + miner.MaxProveCommitDuration[actor.sealProofType] - 1)
 
 		actor.proveCommitSector(rt, preCommitA, makeProveCommit(sectorNoA))
 		actor.proveCommitSector(rt, preCommitB, makeProveCommit(sectorNoB))
@@ -4453,12 +4459,13 @@ type actorHarness struct {
 
 	controlAddrs []addr.Address
 
-	sealProofType abi.RegisteredSealProof
-	postProofType abi.RegisteredPoStProof
-	sectorSize    abi.SectorSize
-	partitionSize uint64
-	periodOffset  abi.ChainEpoch
-	nextSectorNo  abi.SectorNumber
+	sealProofType        abi.RegisteredSealProof
+	windowPostProofType  abi.RegisteredPoStProof
+	winningPostProofType abi.RegisteredPoStProof
+	sectorSize           abi.SectorSize
+	partitionSize        uint64
+	periodOffset         abi.ChainEpoch
+	nextSectorNo         abi.SectorNumber
 
 	networkPledge   abi.TokenAmount
 	networkRawPower abi.StoragePower
@@ -4488,11 +4495,9 @@ func newHarness(t testing.TB, provingPeriodOffset abi.ChainEpoch) *actorHarness 
 
 		controlAddrs: controlAddrs,
 
-		sealProofType: 0, // Initialized in setProofType
-		sectorSize:    0, // Initialized in setProofType
-		partitionSize: 0, // Initialized in setProofType
-		periodOffset:  provingPeriodOffset,
-		nextSectorNo:  100,
+		// Proof types and metadata initialized in setProofType
+		periodOffset: provingPeriodOffset,
+		nextSectorNo: 100,
 
 		networkPledge:   big.Mul(rwd, big.NewIntUnsigned(1000)),
 		networkRawPower: pwr,
@@ -4509,7 +4514,9 @@ func newHarness(t testing.TB, provingPeriodOffset abi.ChainEpoch) *actorHarness 
 func (h *actorHarness) setProofType(proof abi.RegisteredSealProof) {
 	var err error
 	h.sealProofType = proof
-	h.postProofType, err = proof.RegisteredWindowPoStProof()
+	h.windowPostProofType, err = proof.RegisteredWindowPoStProof()
+	require.NoError(h.t, err)
+	h.winningPostProofType, err = proof.RegisteredWinningPoStProof()
 	require.NoError(h.t, err)
 	h.sectorSize, err = proof.SectorSize()
 	require.NoError(h.t, err)
@@ -4519,11 +4526,12 @@ func (h *actorHarness) setProofType(proof abi.RegisteredSealProof) {
 
 func (h *actorHarness) constructAndVerify(rt *mock.Runtime) {
 	params := miner.ConstructorParams{
-		OwnerAddr:     h.owner,
-		WorkerAddr:    h.worker,
-		ControlAddrs:  h.controlAddrs,
-		SealProofType: h.sealProofType,
-		PeerId:        testPid,
+		OwnerAddr:            h.owner,
+		WorkerAddr:           h.worker,
+		ControlAddrs:         h.controlAddrs,
+		WindowPoStProofType:  h.windowPostProofType,
+		WinningPoStProofType: h.winningPostProofType,
+		PeerId:               testPid,
 	}
 
 	rt.ExpectValidateCallerAddr(builtin.InitActorAddr)
@@ -5086,7 +5094,7 @@ func (h *actorHarness) submitWindowPoSt(rt *mock.Runtime, deadline *dline.Info, 
 
 	rt.ExpectValidateCallerAddr(append(h.controlAddrs, h.owner, h.worker)...)
 
-	proofs := makePoStProofs(h.postProofType)
+	proofs := makePoStProofs(h.windowPostProofType)
 	challengeRand := abi.SealRandomness([]byte{10, 11, 12, 13})
 
 	// only sectors that are not skipped and not existing non-recovered faults will be verified

--- a/actors/builtin/miner/testing.go
+++ b/actors/builtin/miner/testing.go
@@ -22,7 +22,6 @@ type StateSummary struct {
 	FaultyPower          PowerPair
 	Deals                map[abi.DealID]DealSummary
 	WindowPoStProofType  abi.RegisteredPoStProof
-	WinningPoStProofType abi.RegisteredPoStProof
 }
 
 // Checks internal invariants of init state.
@@ -30,11 +29,10 @@ func CheckStateInvariants(st *State, store adt.Store, balance abi.TokenAmount) (
 	acc := &builtin.MessageAccumulator{}
 	sectorSize := abi.SectorSize(0)
 	minerSummary := &StateSummary{
-		LivePower:            NewPowerPairZero(),
-		ActivePower:          NewPowerPairZero(),
-		FaultyPower:          NewPowerPairZero(),
-		WindowPoStProofType:  0,
-		WinningPoStProofType: 0,
+		LivePower:           NewPowerPairZero(),
+		ActivePower:         NewPowerPairZero(),
+		FaultyPower:         NewPowerPairZero(),
+		WindowPoStProofType: 0,
 	}
 
 	// Load data from linked structures.
@@ -44,7 +42,6 @@ func CheckStateInvariants(st *State, store adt.Store, balance abi.TokenAmount) (
 		return minerSummary, acc
 	} else {
 		minerSummary.WindowPoStProofType = info.WindowPoStProofType
-		minerSummary.WinningPoStProofType = info.WinningPoStProofType
 		sectorSize = info.SectorSize
 		CheckMinerInfo(info, acc)
 	}
@@ -665,13 +662,6 @@ func CheckMinerInfo(info *MinerInfo, acc *builtin.MessageAccumulator) {
 	if found {
 		acc.Require(windowPoStProofInfo.SectorSize == info.SectorSize,
 			"sector size %d is wrong for Window PoSt proof type %d: %d", info.SectorSize, info.WindowPoStProofType, windowPoStProofInfo.SectorSize)
-	}
-
-	winningPoStProofInfo, found := abi.PoStProofInfos[info.WinningPoStProofType]
-	acc.Require(found, "miner has unrecognized Window PoSt proof type %d", info.WinningPoStProofType)
-	if found {
-		acc.Require(winningPoStProofInfo.SectorSize == info.SectorSize,
-			"sector size %d is wrong for Winning PoSt proof type %d: %d", info.SectorSize, info.WinningPoStProofType, winningPoStProofInfo.SectorSize)
 	}
 
 	poStProofPolicy, found := builtin.PoStProofPolicies[info.WindowPoStProofType]

--- a/actors/builtin/power/cbor_gen.go
+++ b/actors/builtin/power/cbor_gen.go
@@ -539,7 +539,7 @@ func (t *CronEvent) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
-var lengthBufCreateMinerParams = []byte{134}
+var lengthBufCreateMinerParams = []byte{133}
 
 func (t *CreateMinerParams) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -569,17 +569,6 @@ func (t *CreateMinerParams) MarshalCBOR(w io.Writer) error {
 		}
 	} else {
 		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.WindowPoStProofType-1)); err != nil {
-			return err
-		}
-	}
-
-	// t.WinningPoStProofType (abi.RegisteredPoStProof) (int64)
-	if t.WinningPoStProofType >= 0 {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.WinningPoStProofType)); err != nil {
-			return err
-		}
-	} else {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.WinningPoStProofType-1)); err != nil {
 			return err
 		}
 	}
@@ -635,7 +624,7 @@ func (t *CreateMinerParams) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 6 {
+	if extra != 5 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -681,31 +670,6 @@ func (t *CreateMinerParams) UnmarshalCBOR(r io.Reader) error {
 		}
 
 		t.WindowPoStProofType = abi.RegisteredPoStProof(extraI)
-	}
-	// t.WinningPoStProofType (abi.RegisteredPoStProof) (int64)
-	{
-		maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
-		var extraI int64
-		if err != nil {
-			return err
-		}
-		switch maj {
-		case cbg.MajUnsignedInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 positive overflow")
-			}
-		case cbg.MajNegativeInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 negative oveflow")
-			}
-			extraI = -1 - extraI
-		default:
-			return fmt.Errorf("wrong type for int64 field: %d", maj)
-		}
-
-		t.WinningPoStProofType = abi.RegisteredPoStProof(extraI)
 	}
 	// t.Peer ([]uint8) (slice)
 
@@ -868,7 +832,7 @@ func (t *CurrentTotalPowerReturn) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
-var lengthBufMinerConstructorParams = []byte{135}
+var lengthBufMinerConstructorParams = []byte{134}
 
 func (t *MinerConstructorParams) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -912,17 +876,6 @@ func (t *MinerConstructorParams) MarshalCBOR(w io.Writer) error {
 		}
 	} else {
 		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.WindowPoStProofType-1)); err != nil {
-			return err
-		}
-	}
-
-	// t.WinningPoStProofType (abi.RegisteredPoStProof) (int64)
-	if t.WinningPoStProofType >= 0 {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.WinningPoStProofType)); err != nil {
-			return err
-		}
-	} else {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.WinningPoStProofType-1)); err != nil {
 			return err
 		}
 	}
@@ -978,7 +931,7 @@ func (t *MinerConstructorParams) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 7 {
+	if extra != 6 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -1053,31 +1006,6 @@ func (t *MinerConstructorParams) UnmarshalCBOR(r io.Reader) error {
 		}
 
 		t.WindowPoStProofType = abi.RegisteredPoStProof(extraI)
-	}
-	// t.WinningPoStProofType (abi.RegisteredPoStProof) (int64)
-	{
-		maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
-		var extraI int64
-		if err != nil {
-			return err
-		}
-		switch maj {
-		case cbg.MajUnsignedInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 positive overflow")
-			}
-		case cbg.MajNegativeInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 negative oveflow")
-			}
-			extraI = -1 - extraI
-		default:
-			return fmt.Errorf("wrong type for int64 field: %d", maj)
-		}
-
-		t.WinningPoStProofType = abi.RegisteredPoStProof(extraI)
 	}
 	// t.PeerId ([]uint8) (slice)
 

--- a/actors/builtin/power/power_actor.go
+++ b/actors/builtin/power/power_actor.go
@@ -61,13 +61,12 @@ var _ runtime.VMActor = Actor{}
 // Storage miner actor constructor params are defined here so the power actor can send them to the init actor
 // to instantiate miners.
 // Changed since v2:
-// - Seal proof type replaced with PoSt proof types
+// - Seal proof type replaced with PoSt proof type
 type MinerConstructorParams struct {
 	OwnerAddr            addr.Address
 	WorkerAddr           addr.Address
 	ControlAddrs         []addr.Address
 	WindowPoStProofType  abi.RegisteredPoStProof
-	WinningPoStProofType abi.RegisteredPoStProof
 	PeerId               abi.PeerID
 	Multiaddrs           []abi.Multiaddrs
 }
@@ -91,7 +90,6 @@ type CreateMinerParams struct {
 	Owner                addr.Address
 	Worker               addr.Address
 	WindowPoStProofType  abi.RegisteredPoStProof
-	WinningPoStProofType abi.RegisteredPoStProof
 	Peer                 abi.PeerID
 	Multiaddrs           []abi.Multiaddrs
 }
@@ -109,7 +107,6 @@ func (a Actor) CreateMiner(rt Runtime, params *CreateMinerParams) *CreateMinerRe
 		OwnerAddr:  params.Owner,
 		WorkerAddr: params.Worker,
 		WindowPoStProofType: params.WindowPoStProofType,
-		WinningPoStProofType: params.WinningPoStProofType,
 		PeerId:        params.Peer,
 		Multiaddrs:    params.Multiaddrs,
 	}

--- a/actors/builtin/power/power_state.go
+++ b/actors/builtin/power/power_state.go
@@ -70,7 +70,7 @@ type State struct {
 
 type Claim struct {
 	// Miner's proof type used to determine minimum miner size
-	SealProofType abi.RegisteredSealProof
+	WindowPoStProofType abi.RegisteredPoStProof
 
 	// Sum of raw byte power for a miner's sectors.
 	RawBytePower abi.StoragePower
@@ -131,7 +131,7 @@ func (st *State) MinerNominalPowerMeetsConsensusMinimum(s adt.Store, miner addr.
 	}
 
 	minerNominalPower := claim.RawBytePower
-	minerMinPower, err := builtin.ConsensusMinerMinPower(claim.SealProofType)
+	minerMinPower, err := builtin.ConsensusMinerMinPower(claim.WindowPoStProofType)
 	if err != nil {
 		return false, errors.Wrap(err, "could not get miner min power from proof type")
 	}
@@ -191,12 +191,12 @@ func (st *State) addToClaim(claims *adt.Map, miner addr.Address, power abi.Stora
 	st.TotalBytesCommitted = big.Add(st.TotalBytesCommitted, power)
 
 	newClaim := Claim{
-		SealProofType:   oldClaim.SealProofType,
-		RawBytePower:    big.Add(oldClaim.RawBytePower, power),
-		QualityAdjPower: big.Add(oldClaim.QualityAdjPower, qapower),
+		WindowPoStProofType: oldClaim.WindowPoStProofType,
+		RawBytePower:        big.Add(oldClaim.RawBytePower, power),
+		QualityAdjPower:     big.Add(oldClaim.QualityAdjPower, qapower),
 	}
 
-	minPower, err := builtin.ConsensusMinerMinPower(oldClaim.SealProofType)
+	minPower, err := builtin.ConsensusMinerMinPower(oldClaim.WindowPoStProofType)
 	if err != nil {
 		return fmt.Errorf("could not get consensus miner min power: %w", err)
 	}
@@ -232,8 +232,8 @@ func (st *State) addToClaim(claims *adt.Map, miner addr.Address, power abi.Stora
 	return setClaim(claims, miner, &newClaim)
 }
 
-func (st *State) updateStatsForNewMiner(sealProof abi.RegisteredSealProof) error {
-	minPower, err := builtin.ConsensusMinerMinPower(sealProof)
+func (st *State) updateStatsForNewMiner(windowPoStProof abi.RegisteredPoStProof) error {
+	minPower, err := builtin.ConsensusMinerMinPower(windowPoStProof)
 	if err != nil {
 		return fmt.Errorf("could not get consensus miner min power: %w", err)
 	}

--- a/actors/builtin/power/testing.go
+++ b/actors/builtin/power/testing.go
@@ -112,7 +112,7 @@ func CheckClaimInvariants(st *State, store adt.Store, acc *builtin.MessageAccumu
 		committedRawPower = big.Add(committedRawPower, claim.RawBytePower)
 		committedQAPower = big.Add(committedQAPower, claim.QualityAdjPower)
 
-		minPower, err := builtin.ConsensusMinerMinPower(claim.SealProofType)
+		minPower, err := builtin.ConsensusMinerMinPower(claim.WindowPoStProofType)
 		acc.Require(err == nil, "could not get consensus miner min power for miner %v: %v", addr, err)
 		if err != nil {
 			return nil // noted above
@@ -169,8 +169,10 @@ func CheckProofValidationInvariants(st *State, store adt.Store, claims ClaimsByA
 
 			var info proof.SealVerifyInfo
 			err = arr.ForEach(&info, func(i int64) error {
-				acc.Require(claim.SealProofType == info.SealProof, "miner submitted proof with proof type %d different from claim %d",
-					info.SealProof, claim.SealProofType)
+				sectorWindowPoStProofType, err := info.SealProof.RegisteredWindowPoStProof()
+				acc.RequireNoError(err, "failed to get PoSt proof type for seal proof %d", info.SealProof)
+				acc.Require(claim.WindowPoStProofType == sectorWindowPoStProofType, "miner submitted proof with proof type %d different from claim %d",
+					sectorWindowPoStProofType, claim.WindowPoStProofType)
 				proofs[addr] = append(proofs[addr], info)
 				return nil
 			})

--- a/actors/builtin/sector.go
+++ b/actors/builtin/sector.go
@@ -8,7 +8,6 @@ import (
 // Policy values associated with a seal proof type.
 type SealProofPolicy struct {
 	SectorMaxLifetime      stabi.ChainEpoch
-	ConsensusMinerMinPower stabi.StoragePower
 }
 
 // For all Stacked DRG sectors, the max is 5 years
@@ -17,44 +16,34 @@ const EpochsInFiveYears = stabi.ChainEpoch(5 * EpochsInYear)
 var SealProofPolicies = map[stabi.RegisteredSealProof]*SealProofPolicy{
 	stabi.RegisteredSealProof_StackedDrg2KiBV1: {
 		SectorMaxLifetime:      EpochsInFiveYears,
-		ConsensusMinerMinPower: stabi.NewStoragePower(0),
 	},
 	stabi.RegisteredSealProof_StackedDrg8MiBV1: {
 		SectorMaxLifetime:      EpochsInFiveYears,
-		ConsensusMinerMinPower: stabi.NewStoragePower(16 << 20),
 	},
 	stabi.RegisteredSealProof_StackedDrg512MiBV1: {
 		SectorMaxLifetime:      EpochsInFiveYears,
-		ConsensusMinerMinPower: stabi.NewStoragePower(1 << 30),
 	},
 	stabi.RegisteredSealProof_StackedDrg32GiBV1: {
 		SectorMaxLifetime:      EpochsInFiveYears,
-		ConsensusMinerMinPower: stabi.NewStoragePower(10 << 40),
 	},
 	stabi.RegisteredSealProof_StackedDrg64GiBV1: {
 		SectorMaxLifetime:      EpochsInFiveYears,
-		ConsensusMinerMinPower: stabi.NewStoragePower(20 << 40),
 	},
 
 	stabi.RegisteredSealProof_StackedDrg2KiBV1_1: {
 		SectorMaxLifetime:      EpochsInFiveYears,
-		ConsensusMinerMinPower: stabi.NewStoragePower(0),
 	},
 	stabi.RegisteredSealProof_StackedDrg8MiBV1_1: {
 		SectorMaxLifetime:      EpochsInFiveYears,
-		ConsensusMinerMinPower: stabi.NewStoragePower(16 << 20),
 	},
 	stabi.RegisteredSealProof_StackedDrg512MiBV1_1: {
 		SectorMaxLifetime:      EpochsInFiveYears,
-		ConsensusMinerMinPower: stabi.NewStoragePower(1 << 30),
 	},
 	stabi.RegisteredSealProof_StackedDrg32GiBV1_1: {
 		SectorMaxLifetime:      EpochsInFiveYears,
-		ConsensusMinerMinPower: stabi.NewStoragePower(10 << 40),
 	},
 	stabi.RegisteredSealProof_StackedDrg64GiBV1_1: {
 		SectorMaxLifetime:      EpochsInFiveYears,
-		ConsensusMinerMinPower: stabi.NewStoragePower(20 << 40),
 	},
 }
 
@@ -85,8 +74,8 @@ func SealProofSectorMaximumLifetime(p stabi.RegisteredSealProof) (stabi.ChainEpo
 // - Ensures that a specific soundness for the power table
 // Note: We may be able to reduce this in the future, addressing consensus faults with more complicated penalties,
 // sybil generation with crypto-economic mechanism, and PoSt soundness by increasing the challenges for small miners.
-func ConsensusMinerMinPower(p stabi.RegisteredSealProof) (stabi.StoragePower, error) {
-	info, ok := SealProofPolicies[p]
+func ConsensusMinerMinPower(p stabi.RegisteredPoStProof) (stabi.StoragePower, error) {
+	info, ok := PoStProofPolicies[p]
 	if !ok {
 		return stabi.NewStoragePower(0), errors.Errorf("unsupported proof type: %v", p)
 	}
@@ -96,6 +85,7 @@ func ConsensusMinerMinPower(p stabi.RegisteredSealProof) (stabi.StoragePower, er
 // Policy values associated with a PoSt proof type.
 type PoStProofPolicy struct {
 	WindowPoStPartitionSectors uint64
+	ConsensusMinerMinPower stabi.StoragePower
 }
 
 // Partition sizes must match those used by the proofs library.
@@ -103,18 +93,23 @@ type PoStProofPolicy struct {
 var PoStProofPolicies = map[stabi.RegisteredPoStProof]*PoStProofPolicy{
 	stabi.RegisteredPoStProof_StackedDrgWindow2KiBV1: {
 		WindowPoStPartitionSectors: 2,
+		ConsensusMinerMinPower: stabi.NewStoragePower(0),
 	},
 	stabi.RegisteredPoStProof_StackedDrgWindow8MiBV1: {
 		WindowPoStPartitionSectors: 2,
+		ConsensusMinerMinPower: stabi.NewStoragePower(16 << 20),
 	},
 	stabi.RegisteredPoStProof_StackedDrgWindow512MiBV1: {
 		WindowPoStPartitionSectors: 2,
+		ConsensusMinerMinPower: stabi.NewStoragePower(1 << 30),
 	},
 	stabi.RegisteredPoStProof_StackedDrgWindow32GiBV1: {
 		WindowPoStPartitionSectors: 2349,
+		ConsensusMinerMinPower: stabi.NewStoragePower(10 << 40),
 	},
 	stabi.RegisteredPoStProof_StackedDrgWindow64GiBV1: {
 		WindowPoStPartitionSectors: 2300,
+		ConsensusMinerMinPower: stabi.NewStoragePower(20 << 40),
 	},
 	// Winning PoSt proof types omitted.
 }

--- a/actors/migration/nv9/miner.go
+++ b/actors/migration/nv9/miner.go
@@ -93,10 +93,6 @@ func (m *minerMigrator) migrateInfo(ctx context.Context, store cbor.IpldStore, c
 	if err != nil {
 		return cid.Undef, err
 	}
-	winningPoStProof, err := oldInfo.SealProofType.RegisteredWinningPoStProof()
-	if err != nil {
-		return cid.Undef, err
-	}
 
 	newInfo := miner3.MinerInfo{
 		Owner:                      oldInfo.Owner,
@@ -106,7 +102,6 @@ func (m *minerMigrator) migrateInfo(ctx context.Context, store cbor.IpldStore, c
 		PeerId:                     oldInfo.PeerId,
 		Multiaddrs:                 oldInfo.Multiaddrs,
 		WindowPoStProofType:        windowPoStProof,
-		WinningPoStProofType:       winningPoStProof,
 		SectorSize:                 oldInfo.SectorSize,
 		WindowPoStPartitionSectors: oldInfo.WindowPoStPartitionSectors,
 		ConsensusFaultElapsed:      oldInfo.ConsensusFaultElapsed,

--- a/actors/migration/nv9/power.go
+++ b/actors/migration/nv9/power.go
@@ -3,12 +3,14 @@ package nv9
 import (
 	"context"
 
+	adt2 "github.com/filecoin-project/specs-actors/actors/util/adt"
 	power2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/power"
 	cid "github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
 
 	builtin3 "github.com/filecoin-project/specs-actors/v3/actors/builtin"
 	power3 "github.com/filecoin-project/specs-actors/v3/actors/builtin/power"
+	adt3 "github.com/filecoin-project/specs-actors/v3/actors/util/adt"
 	smoothing3 "github.com/filecoin-project/specs-actors/v3/actors/util/smoothing"
 )
 
@@ -29,7 +31,7 @@ func (m powerMigrator) migrateState(ctx context.Context, store cbor.IpldStore, i
 		proofValidationBatchOut = &proofValidationBatchOutCID
 	}
 
-	claimsOut, err := migrateHAMTRaw(ctx, store, inState.Claims, builtin3.DefaultHamtBitwidth)
+	claimsOut, err := m.migrateClaims(ctx, store, inState.Claims)
 	if err != nil {
 		return nil, err
 	}
@@ -65,4 +67,30 @@ func (m powerMigrator) migrateState(ctx context.Context, store cbor.IpldStore, i
 
 func (m powerMigrator) migratedCodeCID() cid.Cid {
 	return builtin3.StoragePowerActorCodeID
+}
+
+func (m powerMigrator) migrateClaims(ctx context.Context, store cbor.IpldStore, root cid.Cid) (cid.Cid, error) {
+	astore := adt3.WrapStore(ctx, store)
+	inClaims, err := adt2.AsMap(astore, root)
+	if err != nil {
+		return cid.Undef, err
+	}
+	outClaims := adt3.MakeEmptyMap(astore, builtin3.DefaultHamtBitwidth)
+
+	var inClaim power2.Claim
+	if err = inClaims.ForEach(&inClaim, func(key string) error {
+		postProof, err := inClaim.SealProofType.RegisteredWindowPoStProof()
+		if err != nil {
+			return err
+		}
+		outClaim := power3.Claim{
+			WindowPoStProofType: postProof,
+			RawBytePower:        inClaim.RawBytePower,
+			QualityAdjPower:     inClaim.QualityAdjPower,
+		}
+		return outClaims.Put(StringKey(key), &outClaim)
+	}); err != nil {
+		return cid.Undef, err
+	}
+	return outClaims.Root()
 }

--- a/actors/migration/nv9/test/modify_pending_proposals_test.go
+++ b/actors/migration/nv9/test/modify_pending_proposals_test.go
@@ -208,7 +208,7 @@ func publishV3Deal(t *testing.T, v *vm3.VM, provider, dealClient, minerID addr.A
 	}
 
 	publishDealParams := market3.PublishStorageDealsParams{
-		Deals: []market2.ClientDealProposal{{
+		Deals: []market3.ClientDealProposal{{
 			Proposal:        deal,
 			ClientSignature: crypto.Signature{},
 		}},

--- a/actors/states/check.go
+++ b/actors/states/check.go
@@ -167,8 +167,8 @@ func CheckMinersAgainstPower(acc *builtin.MessageAccumulator, minerSummaries map
 			claimPower := miner.NewPowerPair(claim.RawBytePower, claim.QualityAdjPower)
 			acc.Require(minerSummary.ActivePower.Equals(claimPower),
 				"miner %v computed active power %v does not match claim %v", addr, minerSummary.ActivePower, claimPower)
-			acc.Require(minerSummary.SealProofType == claim.SealProofType,
-				"miner seal proof type %d does not match claim proof type %d", minerSummary.SealProofType, claim.SealProofType)
+			acc.Require(minerSummary.WindowPoStProofType == claim.WindowPoStProofType,
+				"miner seal proof type %d does not match claim proof type %d", minerSummary.WindowPoStProofType, claim.WindowPoStProofType)
 		}
 
 		// check crons

--- a/actors/states/election_test.go
+++ b/actors/states/election_test.go
@@ -141,7 +141,6 @@ func TestMinerEligibleAtLookback(t *testing.T) {
 
 func constructMinerState(ctx context.Context, t *testing.T, store adt.Store, owner address.Address) *miner.State {
 	proofType := abi.RegisteredPoStProof_StackedDrgWindow32GiBV1
-	winningPoStProofType := abi.RegisteredPoStProof_StackedDrgWinning32GiBV1
 	ssize, err := proofType.SectorSize()
 	require.NoError(t, err)
 	psize, err := builtin.PoStProofWindowPoStPartitionSectors(proofType)
@@ -155,7 +154,6 @@ func constructMinerState(ctx context.Context, t *testing.T, store adt.Store, own
 		PeerId:                     nil,
 		Multiaddrs:                 [][]byte{},
 		WindowPoStProofType:        proofType,
-		WinningPoStProofType:       winningPoStProofType,
 		SectorSize:                 ssize,
 		WindowPoStPartitionSectors: psize,
 		ConsensusFaultElapsed:      0,

--- a/actors/states/election_test.go
+++ b/actors/states/election_test.go
@@ -22,7 +22,7 @@ import (
 func TestMinerEligibleForElection(t *testing.T) {
 	ctx := context.Background()
 	store := ipld.NewADTStore(ctx)
-	proofType := abi.RegisteredSealProof_StackedDrg32GiBV1_1
+	proofType := abi.RegisteredPoStProof_StackedDrgWindow32GiBV1
 	pwr := abi.NewStoragePower(1)
 
 	owner := tutil.NewIDAddr(t, 100)
@@ -80,53 +80,53 @@ func TestMinerEligibleForElection(t *testing.T) {
 func TestMinerEligibleAtLookback(t *testing.T) {
 	ctx := context.Background()
 	store := ipld.NewADTStore(ctx)
-	proofType := abi.RegisteredSealProof_StackedDrg32GiBV1_1
+	windowPoStProofType := abi.RegisteredPoStProof_StackedDrgWindow32GiBV1
 	maddr := tutil.NewIDAddr(t, 101)
 
 	t.Run("power does not meet minimum", func(t *testing.T) {
 		// get minimums
-		pow32GiBMin, err := builtin.ConsensusMinerMinPower(proofType)
+		pow32GiBMin, err := builtin.ConsensusMinerMinPower(windowPoStProofType)
 		require.NoError(t, err)
-		pow64GiBMin, err := builtin.ConsensusMinerMinPower(abi.RegisteredSealProof_StackedDrg64GiBV1_1)
+		pow64GiBMin, err := builtin.ConsensusMinerMinPower(abi.RegisteredPoStProof_StackedDrgWindow64GiBV1)
 		require.NoError(t, err)
 
 		for _, tc := range []struct {
 			consensusMiners int64
-			minerProof      abi.RegisteredSealProof
+			minerProof      abi.RegisteredPoStProof
 			power           abi.StoragePower
 			eligible        bool
 		}{{
 			// below consensus minimum miners, power only needs to be positive to be eligible
 			consensusMiners: 0,
-			minerProof:      proofType,
+			minerProof:      windowPoStProofType,
 			power:           big.Zero(),
 			eligible:        false,
 		}, {
 			consensusMiners: 0,
-			minerProof:      proofType,
+			minerProof:      windowPoStProofType,
 			power:           big.NewInt(1),
 			eligible:        true,
 		}, {
 			// with enough miners above minimum, power must be at or above consensus min
 			consensusMiners: power.ConsensusMinerMinMiners,
-			minerProof:      proofType,
+			minerProof:      windowPoStProofType,
 			power:           big.Sub(pow32GiBMin, big.NewInt(1)),
 			eligible:        false,
 		}, {
 			consensusMiners: power.ConsensusMinerMinMiners,
-			minerProof:      proofType,
+			minerProof:      windowPoStProofType,
 			power:           pow32GiBMin,
 			eligible:        true,
 		}, {
 			// bigger sector size requires higher minimum
 			consensusMiners: power.ConsensusMinerMinMiners,
-			minerProof:      abi.RegisteredSealProof_StackedDrg64GiBV1_1,
+			minerProof:      abi.RegisteredPoStProof_StackedDrgWindow64GiBV1,
 			power:           pow32GiBMin,
 			eligible:        false,
 		}, {
 			// bigger sector size requires higher minimum
 			consensusMiners: power.ConsensusMinerMinMiners,
-			minerProof:      abi.RegisteredSealProof_StackedDrg64GiBV1_1,
+			minerProof:      abi.RegisteredPoStProof_StackedDrgWindow64GiBV1,
 			power:           pow64GiBMin,
 			eligible:        true,
 		}} {
@@ -140,10 +140,11 @@ func TestMinerEligibleAtLookback(t *testing.T) {
 }
 
 func constructMinerState(ctx context.Context, t *testing.T, store adt.Store, owner address.Address) *miner.State {
-	proofType := abi.RegisteredSealProof_StackedDrg32GiBV1_1
+	proofType := abi.RegisteredPoStProof_StackedDrgWindow32GiBV1
+	winningPoStProofType := abi.RegisteredPoStProof_StackedDrgWinning32GiBV1
 	ssize, err := proofType.SectorSize()
 	require.NoError(t, err)
-	psize, err := builtin.SealProofWindowPoStPartitionSectors(proofType)
+	psize, err := builtin.PoStProofWindowPoStPartitionSectors(proofType)
 	require.NoError(t, err)
 
 	info := miner.MinerInfo{
@@ -153,7 +154,8 @@ func constructMinerState(ctx context.Context, t *testing.T, store adt.Store, own
 		PendingWorkerKey:           nil,
 		PeerId:                     nil,
 		Multiaddrs:                 [][]byte{},
-		SealProofType:              proofType,
+		WindowPoStProofType:        proofType,
+		WinningPoStProofType:       winningPoStProofType,
 		SectorSize:                 ssize,
 		WindowPoStPartitionSectors: psize,
 		ConsensusFaultElapsed:      0,
@@ -169,14 +171,14 @@ func constructMinerState(ctx context.Context, t *testing.T, store adt.Store, own
 	return st
 }
 
-func constructPowerStateWithMiner(t *testing.T, store adt.Store, maddr address.Address, pwr abi.StoragePower, proof abi.RegisteredSealProof) *power.State {
+func constructPowerStateWithMiner(t *testing.T, store adt.Store, maddr address.Address, pwr abi.StoragePower, proof abi.RegisteredPoStProof) *power.State {
 	pSt, err := power.ConstructState(store)
 	require.NoError(t, err)
 
 	claims, err := adt.AsMap(store, pSt.Claims, builtin.DefaultHamtBitwidth)
 	require.NoError(t, err)
 
-	claim := &power.Claim{SealProofType: proof, RawBytePower: pwr, QualityAdjPower: pwr}
+	claim := &power.Claim{WindowPoStProofType: proof, RawBytePower: pwr, QualityAdjPower: pwr}
 
 	err = claims.Put(abi.AddrKey(maddr), claim)
 	require.NoError(t, err)

--- a/actors/test/commit_post_test.go
+++ b/actors/test/commit_post_test.go
@@ -35,7 +35,6 @@ func TestCommitPoStFlow(t *testing.T) {
 		Owner:                addrs[0],
 		Worker:               addrs[0],
 		WindowPoStProofType:  abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
-		WinningPoStProofType: abi.RegisteredPoStProof_StackedDrgWinning32GiBV1,
 		Peer:                 abi.PeerID("not really a peer id"),
 	}
 	ret := vm.ApplyOk(t, v, addrs[0], builtin.StoragePowerActorAddr, minerBalance, builtin.MethodsPower.CreateMiner, &params)

--- a/actors/test/commit_post_test.go
+++ b/actors/test/commit_post_test.go
@@ -32,10 +32,11 @@ func TestCommitPoStFlow(t *testing.T) {
 
 	// create miner
 	params := power.CreateMinerParams{
-		Owner:         addrs[0],
-		Worker:        addrs[0],
-		SealProofType: sealProof,
-		Peer:          abi.PeerID("not really a peer id"),
+		Owner:                addrs[0],
+		Worker:               addrs[0],
+		WindowPoStProofType:  abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
+		WinningPoStProofType: abi.RegisteredPoStProof_StackedDrgWinning32GiBV1,
+		Peer:                 abi.PeerID("not really a peer id"),
 	}
 	ret := vm.ApplyOk(t, v, addrs[0], builtin.StoragePowerActorAddr, minerBalance, builtin.MethodsPower.CreateMiner, &params)
 

--- a/actors/test/committed_capacity_scenario_test.go
+++ b/actors/test/committed_capacity_scenario_test.go
@@ -37,7 +37,6 @@ func TestReplaceCommittedCapacitySectorWithDealLadenSector(t *testing.T) {
 		Owner:                worker,
 		Worker:               worker,
 		WindowPoStProofType:  abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
-		WinningPoStProofType: abi.RegisteredPoStProof_StackedDrgWinning32GiBV1,
 		Peer:                 abi.PeerID("not really a peer id"),
 	}
 	ret := vm.ApplyOk(t, v, addrs[0], builtin.StoragePowerActorAddr, minerBalance, builtin.MethodsPower.CreateMiner, &params)

--- a/actors/test/committed_capacity_scenario_test.go
+++ b/actors/test/committed_capacity_scenario_test.go
@@ -34,10 +34,11 @@ func TestReplaceCommittedCapacitySectorWithDealLadenSector(t *testing.T) {
 
 	// create miner
 	params := power.CreateMinerParams{
-		Owner:         worker,
-		Worker:        worker,
-		SealProofType: sealProof,
-		Peer:          abi.PeerID("not really a peer id"),
+		Owner:                worker,
+		Worker:               worker,
+		WindowPoStProofType:  abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
+		WinningPoStProofType: abi.RegisteredPoStProof_StackedDrgWinning32GiBV1,
+		Peer:                 abi.PeerID("not really a peer id"),
 	}
 	ret := vm.ApplyOk(t, v, addrs[0], builtin.StoragePowerActorAddr, minerBalance, builtin.MethodsPower.CreateMiner, &params)
 

--- a/actors/test/cron_catches_expiries_scenario_test.go
+++ b/actors/test/cron_catches_expiries_scenario_test.go
@@ -37,7 +37,6 @@ func TestCronCatchedCCExpirationsAtDeadlineBoundary(t *testing.T) {
 		Owner:                worker,
 		Worker:               worker,
 		WindowPoStProofType:  abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
-		WinningPoStProofType: abi.RegisteredPoStProof_StackedDrgWinning32GiBV1,
 		Peer:                 abi.PeerID("not really a peer id"),
 	}
 	ret := vm.ApplyOk(t, v, worker, builtin.StoragePowerActorAddr, minerBalance, builtin.MethodsPower.CreateMiner, &params)

--- a/actors/test/cron_catches_expiries_scenario_test.go
+++ b/actors/test/cron_catches_expiries_scenario_test.go
@@ -34,10 +34,11 @@ func TestCronCatchedCCExpirationsAtDeadlineBoundary(t *testing.T) {
 
 	// create miner
 	params := power.CreateMinerParams{
-		Owner:         worker,
-		Worker:        worker,
-		SealProofType: sealProof,
-		Peer:          abi.PeerID("not really a peer id"),
+		Owner:                worker,
+		Worker:               worker,
+		WindowPoStProofType:  abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
+		WinningPoStProofType: abi.RegisteredPoStProof_StackedDrgWinning32GiBV1,
+		Peer:                 abi.PeerID("not really a peer id"),
 	}
 	ret := vm.ApplyOk(t, v, worker, builtin.StoragePowerActorAddr, minerBalance, builtin.MethodsPower.CreateMiner, &params)
 

--- a/actors/test/power_scenario_test.go
+++ b/actors/test/power_scenario_test.go
@@ -24,7 +24,6 @@ func TestCreateMiner(t *testing.T) {
 		Owner:                addrs[0],
 		Worker:               addrs[0],
 		WindowPoStProofType:  abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
-		WinningPoStProofType: abi.RegisteredPoStProof_StackedDrgWinning32GiBV1,
 		Peer:                 abi.PeerID("not really a peer id"),
 	}
 	ret := vm.ApplyOk(t, v, addrs[0], builtin.StoragePowerActorAddr, big.NewInt(1e10), builtin.MethodsPower.CreateMiner, &params)
@@ -53,7 +52,6 @@ func TestCreateMiner(t *testing.T) {
 					OwnerAddr:            params.Owner,
 					WorkerAddr:           params.Worker,
 					WindowPoStProofType:  params.WindowPoStProofType,
-					WinningPoStProofType: params.WinningPoStProofType,
 					PeerId:               params.Peer,
 				}),
 				SubInvocations: []vm.ExpectInvocation{{
@@ -74,7 +72,7 @@ func TestOnEpochTickEnd(t *testing.T) {
 
 	// create a miner
 	params := power.CreateMinerParams{Owner: addrs[0], Worker: addrs[0],
-		WindowPoStProofType: abi.RegisteredPoStProof_StackedDrgWindow32GiBV1, WinningPoStProofType: abi.RegisteredPoStProof_StackedDrgWinning32GiBV1,
+		WindowPoStProofType: abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
 		Peer: abi.PeerID("pid")}
 	ret := vm.ApplyOk(t, v, addrs[0], builtin.StoragePowerActorAddr, big.NewInt(1e10), builtin.MethodsPower.CreateMiner, &params)
 

--- a/actors/test/power_scenario_test.go
+++ b/actors/test/power_scenario_test.go
@@ -21,10 +21,11 @@ func TestCreateMiner(t *testing.T) {
 	addrs := vm.CreateAccounts(ctx, t, v, 1, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
 
 	params := power.CreateMinerParams{
-		Owner:         addrs[0],
-		Worker:        addrs[0],
-		SealProofType: abi.RegisteredSealProof_StackedDrg32GiBV1_1,
-		Peer:          abi.PeerID("not really a peer id"),
+		Owner:                addrs[0],
+		Worker:               addrs[0],
+		WindowPoStProofType:  abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
+		WinningPoStProofType: abi.RegisteredPoStProof_StackedDrgWinning32GiBV1,
+		Peer:                 abi.PeerID("not really a peer id"),
 	}
 	ret := vm.ApplyOk(t, v, addrs[0], builtin.StoragePowerActorAddr, big.NewInt(1e10), builtin.MethodsPower.CreateMiner, &params)
 
@@ -49,13 +50,13 @@ func TestCreateMiner(t *testing.T) {
 				To:     minerAddrs.IDAddress,
 				Method: builtin.MethodConstructor,
 				Params: vm.ExpectObject(&miner.ConstructorParams{
-					OwnerAddr:     params.Owner,
-					WorkerAddr:    params.Worker,
-					SealProofType: params.SealProofType,
-					PeerId:        params.Peer,
+					OwnerAddr:            params.Owner,
+					WorkerAddr:           params.Worker,
+					WindowPoStProofType:  params.WindowPoStProofType,
+					WinningPoStProofType: params.WinningPoStProofType,
+					PeerId:               params.Peer,
 				}),
 				SubInvocations: []vm.ExpectInvocation{{
-
 					// Miner calls back to power actor to enroll its cron event
 					To:             builtin.StoragePowerActorAddr,
 					Method:         builtin.MethodsPower.EnrollCronEvent,
@@ -72,7 +73,9 @@ func TestOnEpochTickEnd(t *testing.T) {
 	addrs := vm.CreateAccounts(ctx, t, v, 1, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
 
 	// create a miner
-	params := power.CreateMinerParams{Owner: addrs[0], Worker: addrs[0], SealProofType: abi.RegisteredSealProof_StackedDrg32GiBV1_1, Peer: abi.PeerID("pid")}
+	params := power.CreateMinerParams{Owner: addrs[0], Worker: addrs[0],
+		WindowPoStProofType: abi.RegisteredPoStProof_StackedDrgWindow32GiBV1, WinningPoStProofType: abi.RegisteredPoStProof_StackedDrgWinning32GiBV1,
+		Peer: abi.PeerID("pid")}
 	ret := vm.ApplyOk(t, v, addrs[0], builtin.StoragePowerActorAddr, big.NewInt(1e10), builtin.MethodsPower.CreateMiner, &params)
 
 	ret, ok := ret.(*power.CreateMinerReturn)

--- a/actors/test/terminate_sectors_scenario_test.go
+++ b/actors/test/terminate_sectors_scenario_test.go
@@ -39,7 +39,6 @@ func TestTerminateSectors(t *testing.T) {
 		Owner:                owner,
 		Worker:               worker,
 		WindowPoStProofType:  abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
-		WinningPoStProofType: abi.RegisteredPoStProof_StackedDrgWinning32GiBV1,
 		Peer:                 abi.PeerID("not really a peer id"),
 	})
 

--- a/actors/test/terminate_sectors_scenario_test.go
+++ b/actors/test/terminate_sectors_scenario_test.go
@@ -36,10 +36,11 @@ func TestTerminateSectors(t *testing.T) {
 
 	// create miner
 	ret := vm.ApplyOk(t, v, addrs[0], builtin.StoragePowerActorAddr, minerBalance, builtin.MethodsPower.CreateMiner, &power.CreateMinerParams{
-		Owner:         owner,
-		Worker:        worker,
-		SealProofType: sealProof,
-		Peer:          abi.PeerID("not really a peer id"),
+		Owner:                owner,
+		Worker:               worker,
+		WindowPoStProofType:  abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
+		WinningPoStProofType: abi.RegisteredPoStProof_StackedDrgWinning32GiBV1,
+		Peer:                 abi.PeerID("not really a peer id"),
 	})
 
 	minerAddrs, ok := ret.(*power.CreateMinerReturn)

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -131,13 +131,13 @@ func main() {
 		power.Claim{},
 		power.CronEvent{},
 		// method params and returns
-		//power.CreateMinerParams{}, // Aliased from v0
+		power.CreateMinerParams{},
 		//power.CreateMinerReturn{}, // Aliased from v0
 		//power.EnrollCronEventParams{}, // Aliased from v0
 		//power.UpdateClaimedPowerParams{}, // Aliased from v0
 		power.CurrentTotalPowerReturn{},
 		// other types
-		// power.MinerConstructorParams{}, // Aliased from v2
+		power.MinerConstructorParams{},
 	); err != nil {
 		panic(err)
 	}

--- a/support/agent/deal_client_agent.go
+++ b/support/agent/deal_client_agent.go
@@ -12,10 +12,10 @@ import (
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/cbor"
 	"github.com/filecoin-project/go-state-types/crypto"
-	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
-	"github.com/filecoin-project/specs-actors/v2/actors/builtin/market"
-	"github.com/filecoin-project/specs-actors/v2/actors/builtin/power"
-	"github.com/filecoin-project/specs-actors/v2/actors/builtin/reward"
+	"github.com/filecoin-project/specs-actors/v3/actors/builtin"
+	"github.com/filecoin-project/specs-actors/v3/actors/builtin/market"
+	"github.com/filecoin-project/specs-actors/v3/actors/builtin/power"
+	"github.com/filecoin-project/specs-actors/v3/actors/builtin/reward"
 	"github.com/ipfs/go-cid"
 )
 

--- a/support/agent/miner_generator.go
+++ b/support/agent/miner_generator.go
@@ -60,10 +60,6 @@ func (mg *MinerGenerator) createMiner(owner address.Address, cfg MinerAgentConfi
 	if err != nil {
 		return message{}, err
 	}
-	winningPoStProofType, err := cfg.ProofType.RegisteredWinningPoStProof()
-	if err != nil {
-		return message{}, err
-	}
 	return message{
 		From:   owner,
 		To:     builtin.StoragePowerActorAddr,
@@ -73,7 +69,6 @@ func (mg *MinerGenerator) createMiner(owner address.Address, cfg MinerAgentConfi
 			Owner:                owner,
 			Worker:               owner,
 			WindowPoStProofType:  windowPoStProofType,
-			WinningPoStProofType: winningPoStProofType,
 		},
 		ReturnHandler: func(s SimState, msg message, ret cbor.Marshaler) error {
 			createMinerRet, ok := ret.(*power.CreateMinerReturn)

--- a/support/agent/miner_generator.go
+++ b/support/agent/miner_generator.go
@@ -1,14 +1,14 @@
 package agent
 
 import (
-	"github.com/pkg/errors"
 	"math/rand"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/cbor"
+	"github.com/pkg/errors"
 
-	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
-	"github.com/filecoin-project/specs-actors/v2/actors/builtin/power"
+	"github.com/filecoin-project/specs-actors/v3/actors/builtin"
+	"github.com/filecoin-project/specs-actors/v3/actors/builtin/power"
 )
 
 // MinerGenerator adds miner agents to the simulation at a configured rate.
@@ -44,23 +44,36 @@ func (mg *MinerGenerator) Tick(_ SimState) ([]message, error) {
 		if mg.minersCreated < len(mg.accounts) {
 			addr := mg.accounts[mg.minersCreated]
 			mg.minersCreated++
-			msgs = append(msgs, mg.createMiner(addr, mg.config))
+			msg, err := mg.createMiner(addr, mg.config)
+			if err != nil {
+				return err
+			}
+			msgs = append(msgs, msg)
 		}
 		return nil
 	})
 	return msgs, err
 }
 
-func (mg *MinerGenerator) createMiner(owner address.Address, cfg MinerAgentConfig) message {
+func (mg *MinerGenerator) createMiner(owner address.Address, cfg MinerAgentConfig) (message, error) {
+	windowPoStProofType, err := cfg.ProofType.RegisteredWindowPoStProof()
+	if err != nil {
+		return message{}, err
+	}
+	winningPoStProofType, err := cfg.ProofType.RegisteredWinningPoStProof()
+	if err != nil {
+		return message{}, err
+	}
 	return message{
 		From:   owner,
 		To:     builtin.StoragePowerActorAddr,
 		Value:  mg.config.StartingBalance, // miner gets all account funds
 		Method: builtin.MethodsPower.CreateMiner,
 		Params: &power.CreateMinerParams{
-			Owner:         owner,
-			Worker:        owner,
-			SealProofType: cfg.ProofType,
+			Owner:                owner,
+			Worker:               owner,
+			WindowPoStProofType:  windowPoStProofType,
+			WinningPoStProofType: winningPoStProofType,
 		},
 		ReturnHandler: func(s SimState, msg message, ret cbor.Marshaler) error {
 			createMinerRet, ok := ret.(*power.CreateMinerReturn)
@@ -79,5 +92,5 @@ func (mg *MinerGenerator) createMiner(owner address.Address, cfg MinerAgentConfi
 			s.AddDealProvider(minerAgent)
 			return nil
 		},
-	}
+	}, nil
 }


### PR DESCRIPTION
The seal proof type isn't the right thing to store in miner state. Many miners have sectors committed with two different seal proof types (but sharing a common Window/Winning PoSt proof type). This PR replaces the seal proof type with the Window/Winning PoSt proof types. It was basically only used for looking up those PoSt proof types anyway.

Reviewers: start with the miner state and actor, then power state and actor. Most of the rest is just noise.

Notes:
- Actors does not use WinningPoSt. I've opted to store it for presumed convenience for nodes, but we could drop if if there were a reliable Window -> Winning PoSt mapping (currently very simple), and save some noise
- I thus selected the Window PoSt proof type for the power claim and consensus minimum power calculation
- There were some existing errors where a v2 package was imported but a v3 one should have been

I nearly forgot to implement the migration, which was easy because the miner info is loaded via CID; I was saved by `TestUpdatePendingDealsMigration` which attempts to publish another deal after migration. We need a more general migration test that uses the sim to build some state, migrates, then continues the sim to exercise the migrated state.

Closes #1329. This issue has some discussion about possible downstream integration challenges.