### PR TITLE
Add caching for premigration

### DIFF
--- a/actors/migration/nv9/init.go
+++ b/actors/migration/nv9/init.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	init2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/init"
+	cid "github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
 
 	builtin3 "github.com/filecoin-project/specs-actors/v3/actors/builtin"
@@ -30,7 +31,11 @@ func (m initMigrator) migrateState(ctx context.Context, store cbor.IpldStore, in
 	}
 	newHead, err := store.Put(ctx, &outState)
 	return &actorMigrationResult{
-		newCodeCID: builtin3.InitActorCodeID,
+		newCodeCID: m.migratedCodeCID(),
 		newHead:    newHead,
 	}, err
+}
+
+func (m initMigrator) migratedCodeCID() cid.Cid {
+	return builtin3.InitActorCodeID
 }

--- a/actors/migration/nv9/market.go
+++ b/actors/migration/nv9/market.go
@@ -63,9 +63,13 @@ func (m marketMigrator) migrateState(ctx context.Context, store cbor.IpldStore, 
 
 	newHead, err := store.Put(ctx, &outState)
 	return &actorMigrationResult{
-		newCodeCID: builtin3.StorageMarketActorCodeID,
+		newCodeCID: m.migratedCodeCID(),
 		newHead:    newHead,
 	}, err
+}
+
+func (m marketMigrator) migratedCodeCID() cid.Cid {
+	return builtin3.StorageMarketActorCodeID
 }
 
 func (a marketMigrator) MapPendingProposals(ctx context.Context, store cbor.IpldStore, pendingProposalsRoot cid.Cid) (cid.Cid, error) {

--- a/actors/migration/nv9/miner.go
+++ b/actors/migration/nv9/miner.go
@@ -58,9 +58,13 @@ func (m minerMigrator) migrateState(ctx context.Context, store cbor.IpldStore, i
 	}
 	newHead, err := store.Put(ctx, &outState)
 	return &actorMigrationResult{
-		newCodeCID: builtin3.StorageMinerActorCodeID,
+		newCodeCID: m.migratedCodeCID(),
 		newHead:    newHead,
 	}, err
+}
+
+func (m minerMigrator) migratedCodeCID() cid.Cid {
+	return builtin3.StorageMinerActorCodeID
 }
 
 func (m *minerMigrator) migrateDeadlines(ctx context.Context, store cbor.IpldStore, deadlines cid.Cid) (cid.Cid, error) {

--- a/actors/migration/nv9/multisig.go
+++ b/actors/migration/nv9/multisig.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	multisig2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/multisig"
+	cid "github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
 
 	builtin3 "github.com/filecoin-project/specs-actors/v3/actors/builtin"
@@ -34,7 +35,11 @@ func (m multisigMigrator) migrateState(ctx context.Context, store cbor.IpldStore
 	}
 	newHead, err := store.Put(ctx, &outState)
 	return &actorMigrationResult{
-		newCodeCID: builtin3.MultisigActorCodeID,
+		newCodeCID: m.migratedCodeCID(),
 		newHead:    newHead,
 	}, err
+}
+
+func (m multisigMigrator) migratedCodeCID() cid.Cid {
+	return builtin3.MultisigActorCodeID
 }

--- a/actors/migration/nv9/paych.go
+++ b/actors/migration/nv9/paych.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	paych2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/paych"
+	cid "github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
 
 	builtin3 "github.com/filecoin-project/specs-actors/v3/actors/builtin"
@@ -33,7 +34,11 @@ func (m paychMigrator) migrateState(ctx context.Context, store cbor.IpldStore, i
 	}
 	newHead, err := store.Put(ctx, &outState)
 	return &actorMigrationResult{
-		newCodeCID: builtin3.PaymentChannelActorCodeID,
+		newCodeCID: m.migratedCodeCID(),
 		newHead:    newHead,
 	}, err
+}
+
+func (m paychMigrator) migratedCodeCID() cid.Cid {
+	return builtin3.PaymentChannelActorCodeID
 }

--- a/actors/migration/nv9/power.go
+++ b/actors/migration/nv9/power.go
@@ -58,7 +58,11 @@ func (m powerMigrator) migrateState(ctx context.Context, store cbor.IpldStore, i
 	}
 	newHead, err := store.Put(ctx, &outState)
 	return &actorMigrationResult{
-		newCodeCID: builtin3.StoragePowerActorCodeID,
+		newCodeCID: m.migratedCodeCID(),
 		newHead:    newHead,
 	}, err
+}
+
+func (m powerMigrator) migratedCodeCID() cid.Cid {
+	return builtin3.StoragePowerActorCodeID
 }

--- a/actors/migration/nv9/test/modify_pending_proposals_test.go
+++ b/actors/migration/nv9/test/modify_pending_proposals_test.go
@@ -74,7 +74,7 @@ func TestUpdatePendingDealsMigration(t *testing.T) {
 	}
 
 	// run migration
-	nextRoot, err := nv9.MigrateStateTree(ctx, v.Store(), v.StateRoot(), v.GetEpoch(), nv9.Config{MaxWorkers: 1}, log)
+	nextRoot, err := nv9.MigrateStateTree(ctx, v.Store(), v.StateRoot(), v.GetEpoch(), nv9.Config{MaxWorkers: 1}, log, nv9.NewMemMigrationCache())
 	require.NoError(t, err)
 
 	lookup := map[cid.Cid]rt.VMActor{}

--- a/actors/migration/nv9/test/parallel_migration_test.go
+++ b/actors/migration/nv9/test/parallel_migration_test.go
@@ -27,7 +27,7 @@ func TestParallelMigrationCalls(t *testing.T) {
 	// Run migration
 	adtStore := adt2.WrapStore(ctx, cbor.NewCborStore(bs))
 	startRoot := vm.StateRoot()
-	endRootSerial, err := nv9.MigrateStateTree(ctx, adtStore, startRoot, abi.ChainEpoch(0), nv9.Config{MaxWorkers: 1}, log)
+	endRootSerial, err := nv9.MigrateStateTree(ctx, adtStore, startRoot, abi.ChainEpoch(0), nv9.Config{MaxWorkers: 1}, log, nv9.NewMemMigrationCache())
 	require.NoError(t, err)
 
 	// Migrate in parallel
@@ -35,12 +35,12 @@ func TestParallelMigrationCalls(t *testing.T) {
 	grp, ctx := errgroup.WithContext(ctx)
 	grp.Go(func() error {
 		var err1 error
-		endRootParallel1, err1 = nv9.MigrateStateTree(ctx, adtStore, startRoot, abi.ChainEpoch(0), nv9.Config{MaxWorkers: 2}, log)
+		endRootParallel1, err1 = nv9.MigrateStateTree(ctx, adtStore, startRoot, abi.ChainEpoch(0), nv9.Config{MaxWorkers: 2}, log, nv9.NewMemMigrationCache())
 		return err1
 	})
 	grp.Go(func() error {
 		var err2 error
-		endRootParallel2, err2 = nv9.MigrateStateTree(ctx, adtStore, startRoot, abi.ChainEpoch(0), nv9.Config{MaxWorkers: 2}, log)
+		endRootParallel2, err2 = nv9.MigrateStateTree(ctx, adtStore, startRoot, abi.ChainEpoch(0), nv9.Config{MaxWorkers: 2}, log, nv9.NewMemMigrationCache())
 		return err2
 	})
 	require.NoError(t, grp.Wait())

--- a/actors/migration/nv9/top.go
+++ b/actors/migration/nv9/top.go
@@ -47,15 +47,15 @@ type Logger interface {
 type MigrationCacheKey string
 
 func ActorHeadKey(addr address.Address, head cid.Cid) MigrationCacheKey {
-	return MigrationCacheKey(fmt.Sprintf("%s-h-%s", addr.String(), head.String()))
+	return MigrationCacheKey(addr.String() + "-h-" + head.String())
 }
 
 func DeadlineKey(dlCid cid.Cid) MigrationCacheKey {
-	return MigrationCacheKey(fmt.Sprintf("d-%s", dlCid.String()))
+	return MigrationCacheKey("d-" + dlCid.String())
 }
 
 func SectorsRootKey(sCid cid.Cid) MigrationCacheKey {
-	return MigrationCacheKey(fmt.Sprintf("s-%s", sCid))
+	return MigrationCacheKey("s-" + sCid.String())
 }
 
 // MigrationCache stores and loads cached data. Its implementation must be threadsafe

--- a/actors/migration/nv9/top.go
+++ b/actors/migration/nv9/top.go
@@ -129,7 +129,6 @@ func MigrateStateTree(ctx context.Context, store cbor.IpldStore, actorsRootIn ci
 				cache:          cache,
 				actorMigration: migrations[actorIn.Code],
 			}
-			fmt.Printf("creating job on %s\n", addr)
 			select {
 			case jobCh <- nextInput:
 			case <-ctx.Done():
@@ -152,7 +151,6 @@ func MigrateStateTree(ctx context.Context, store cbor.IpldStore, actorsRootIn ci
 		grp.Go(func() error {
 			defer workerWg.Done()
 			for job := range jobCh {
-				fmt.Printf("running job on %s\n", job.Address)
 				result, err := job.run(ctx, store, priorEpoch)
 				if err != nil {
 					return err

--- a/actors/migration/nv9/verifreg.go
+++ b/actors/migration/nv9/verifreg.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	verifreg2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/verifreg"
+	cid "github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
 
 	builtin3 "github.com/filecoin-project/specs-actors/v3/actors/builtin"
@@ -35,7 +36,11 @@ func (m verifregMigrator) migrateState(ctx context.Context, store cbor.IpldStore
 
 	newHead, err := store.Put(ctx, &outState)
 	return &actorMigrationResult{
-		newCodeCID: builtin3.VerifiedRegistryActorCodeID,
+		newCodeCID: m.migratedCodeCID(),
 		newHead:    newHead,
 	}, err
+}
+
+func (m verifregMigrator) migratedCodeCID() cid.Cid {
+	return builtin3.VerifiedRegistryActorCodeID
 }


### PR DESCRIPTION
The design proposed here is a hierarchical cache.  The `MigrationCache` stores all per actor address `MigrationAddressCache`s.  Each `MigrationAddressCache` maps cids to cids.  Neither cache needs to be threadsafe for use in a single migration.  Caches should only be used in one migration at a time -- the premigration should finish completely before using a populated cache in another migration.  If this is a problem for lotus integration caches can be made threadsafe or we can revisit this design.

The toplevel migration reads and writes back from address cache.  This PR tweaks the actorMigration interface to avoid making every actor migrator do its own caching.

TODO
~test with two migrations in serial.~
- [x] add miner deadline and sector amt root cids to miner actor caches

~partial sectors amt caching~