### PR TITLE
Migration on simulated network

### DIFF
--- a/actors/migration/nv10/test/modify_pending_proposals_test.go
+++ b/actors/migration/nv10/test/modify_pending_proposals_test.go
@@ -34,7 +34,7 @@ import (
 
 func TestUpdatePendingDealsMigration(t *testing.T) {
 	ctx := context.Background()
-	log := nv9.TestLogger{TB: t}
+	log := nv10.TestLogger{TB: t}
 	v := vm2.NewVMWithSingletons(ctx, t, ipld2.NewSyncBlockStoreInMemory())
 	addrs := vm2.CreateAccounts(ctx, t, v, 10, big.Mul(big.NewInt(100_000), vm2.FIL), 93837778)
 	worker := addrs[0]

--- a/actors/migration/nv10/test/modify_pending_proposals_test.go
+++ b/actors/migration/nv10/test/modify_pending_proposals_test.go
@@ -19,9 +19,8 @@ import (
 	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
 	market2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/market"
 	power2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/power"
-	vm2 "github.com/filecoin-project/specs-actors/v2/support/vm"
 	ipld2 "github.com/filecoin-project/specs-actors/v2/support/ipld"
-
+	vm2 "github.com/filecoin-project/specs-actors/v2/support/vm"
 
 	builtin3 "github.com/filecoin-project/specs-actors/v3/actors/builtin"
 	exported3 "github.com/filecoin-project/specs-actors/v3/actors/builtin/exported"
@@ -35,7 +34,7 @@ import (
 
 func TestUpdatePendingDealsMigration(t *testing.T) {
 	ctx := context.Background()
-	log := TestLogger{t}
+	log := nv9.TestLogger{TB: t}
 	v := vm2.NewVMWithSingletons(ctx, t, ipld2.NewSyncBlockStoreInMemory())
 	addrs := vm2.CreateAccounts(ctx, t, v, 10, big.Mul(big.NewInt(100_000), vm2.FIL), 93837778)
 	worker := addrs[0]

--- a/actors/migration/nv10/test/parallel_migration_test.go
+++ b/actors/migration/nv10/test/parallel_migration_test.go
@@ -20,7 +20,7 @@ import (
 func TestParallelMigrationCalls(t *testing.T) {
 	// Construct simple prior state tree over a synchronized store
 	ctx := context.Background()
-	log := TestLogger{t}
+	log := nv9.TestLogger{TB: t}
 	bs := ipld2.NewSyncBlockStoreInMemory()
 	vm := vm2.NewVMWithSingletons(ctx, t, bs)
 

--- a/actors/migration/nv10/test/parallel_migration_test.go
+++ b/actors/migration/nv10/test/parallel_migration_test.go
@@ -20,7 +20,7 @@ import (
 func TestParallelMigrationCalls(t *testing.T) {
 	// Construct simple prior state tree over a synchronized store
 	ctx := context.Background()
-	log := nv9.TestLogger{TB: t}
+	log := nv10.TestLogger{TB: t}
 	bs := ipld2.NewSyncBlockStoreInMemory()
 	vm := vm2.NewVMWithSingletons(ctx, t, bs)
 

--- a/actors/migration/nv10/util.go
+++ b/actors/migration/nv10/util.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"context"
 	"sync"
+	"testing"
 
 	amt2 "github.com/filecoin-project/go-amt-ipld/v2"
 	amt3 "github.com/filecoin-project/go-amt-ipld/v3"
 	hamt2 "github.com/filecoin-project/go-hamt-ipld/v2"
 	hamt3 "github.com/filecoin-project/go-hamt-ipld/v3"
+	"github.com/filecoin-project/go-state-types/rt"
 	adt2 "github.com/filecoin-project/specs-actors/v2/actors/util/adt"
 	cid "github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
@@ -186,4 +188,12 @@ func (m *MemMigrationCache) Update(other *MemMigrationCache) {
 		m.MigrationMap.Store(key, value)
 		return true
 	})
+}
+
+type TestLogger struct {
+	TB testing.TB
+}
+
+func (t TestLogger) Log(_ rt.LogLevel, msg string, args ...interface{}) {
+	t.TB.Logf(msg, args...)
 }

--- a/actors/states/check.go
+++ b/actors/states/check.go
@@ -159,7 +159,6 @@ func CheckStateInvariants(tree *Tree, expectedBalanceTotal abi.TokenAmount, prio
 
 func CheckMinersAgainstPower(acc *builtin.MessageAccumulator, minerSummaries map[addr.Address]*miner.StateSummary, powerSummary *power.StateSummary) {
 	for addr, minerSummary := range minerSummaries { // nolint:nomaprange
-
 		// check claim
 		claim, ok := powerSummary.Claims[addr]
 		acc.Require(ok, "miner %v has no power claim", addr)
@@ -174,6 +173,7 @@ func CheckMinersAgainstPower(acc *builtin.MessageAccumulator, minerSummaries map
 		// check crons
 		crons, ok := powerSummary.Crons[addr]
 		if !ok {
+			acc.Addf("miner %s has no cron events, at least one proving period cron expected", addr)
 			continue
 		}
 

--- a/actors/util/adt/store.go
+++ b/actors/util/adt/store.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/filecoin-project/go-state-types/cbor"
 	"github.com/filecoin-project/go-state-types/exitcode"
+	adt2 "github.com/filecoin-project/specs-actors/v2/actors/util/adt"
 	cid "github.com/ipfs/go-cid"
 	ipldcbor "github.com/ipfs/go-ipld-cbor"
 
@@ -12,10 +13,11 @@ import (
 )
 
 // Store defines an interface required to back the ADTs in this package.
-type Store interface {
-	Context() context.Context
-	ipldcbor.IpldStore
-}
+// type Store interface {
+// 	Context() context.Context
+// 	ipldcbor.IpldStore
+// }
+type Store = adt2.Store
 
 // Adapts a vanilla IPLD store as an ADT store.
 func WrapStore(ctx context.Context, store ipldcbor.IpldStore) Store {

--- a/actors/util/adt/store.go
+++ b/actors/util/adt/store.go
@@ -12,11 +12,6 @@ import (
 	vmr "github.com/filecoin-project/specs-actors/v3/actors/runtime"
 )
 
-// Store defines an interface required to back the ADTs in this package.
-// type Store interface {
-// 	Context() context.Context
-// 	ipldcbor.IpldStore
-// }
 type Store = adt2.Store
 
 // Adapts a vanilla IPLD store as an ADT store.

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,6 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/whyrusleeping/cbor-gen v0.0.0-20210118024343-169e9d70c0c2
 	github.com/xorcare/golden v0.6.0
-	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 )

--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/filecoin-project/go-hamt-ipld/v3 v3.0.1
 	github.com/filecoin-project/go-state-types v0.1.0
 	github.com/filecoin-project/specs-actors v0.9.13
-	github.com/filecoin-project/specs-actors/v2 v2.3.4
 	github.com/ipfs/go-block-format v0.0.3
+	github.com/filecoin-project/specs-actors/v2 v2.3.5-0.20210114162132-5b58b773f4fb
 	github.com/ipfs/go-cid v0.0.7
 	github.com/ipfs/go-ipld-cbor v0.0.5
 	github.com/kr/pretty v0.2.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/filecoin-project/go-hamt-ipld/v3 v3.0.1
 	github.com/filecoin-project/go-state-types v0.1.0
 	github.com/filecoin-project/specs-actors v0.9.13
-	github.com/ipfs/go-block-format v0.0.3
 	github.com/filecoin-project/specs-actors/v2 v2.3.5-0.20210114162132-5b58b773f4fb
+	github.com/ipfs/go-block-format v0.0.3
 	github.com/ipfs/go-cid v0.0.7
 	github.com/ipfs/go-ipld-cbor v0.0.5
 	github.com/kr/pretty v0.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -162,6 +162,7 @@ golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKG
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190219092855-153ac476189d/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/filecoin-project/go-state-types v0.1.0 h1:9r2HCSMMCmyMfGyMKxQtv0GKp6V
 github.com/filecoin-project/go-state-types v0.1.0/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
 github.com/filecoin-project/specs-actors v0.9.13 h1:rUEOQouefi9fuVY/2HOroROJlZbOzWYXXeIh41KF2M4=
 github.com/filecoin-project/specs-actors v0.9.13/go.mod h1:TS1AW/7LbG+615j4NsjMK1qlpAwaFsG9w0V2tg2gSao=
-github.com/filecoin-project/specs-actors/v2 v2.3.4 h1:NZK2oMCcA71wNsUzDBmLQyRMzcCnX9tDGvwZ53G67j8=
-github.com/filecoin-project/specs-actors/v2 v2.3.4/go.mod h1:UuJQLoTx/HPvvWeqlIFmC/ywlOLHNe8SNQ3OunFbu2Y=
+github.com/filecoin-project/specs-actors/v2 v2.3.5-0.20210114162132-5b58b773f4fb h1:orr/sMzrDZUPAveRE+paBdu1kScIUO5zm+HYeh+VlhA=
+github.com/filecoin-project/specs-actors/v2 v2.3.5-0.20210114162132-5b58b773f4fb/go.mod h1:LljnY2Mn2homxZsmokJZCpRuhOPxfXhvcek5gWkmqAc=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,7 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -162,8 +163,6 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20201207232520-09787c993a3a h1:DcqTD9SDLc+1P/r1EmRBwnVsrOwW+kk2vWf9n+1sGhs=
-golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190219092855-153ac476189d/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/support/agent/cases_test.go
+++ b/support/agent/cases_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/filecoin-project/specs-actors/v3/actors/builtin"
 	"github.com/filecoin-project/specs-actors/v3/actors/builtin/exported"
 	"github.com/filecoin-project/specs-actors/v3/actors/builtin/power"
-	"github.com/filecoin-project/specs-actors/v3/actors/migration/nv9"
+	"github.com/filecoin-project/specs-actors/v3/actors/migration/nv10"
 	"github.com/filecoin-project/specs-actors/v3/actors/states"
 	"github.com/filecoin-project/specs-actors/v3/actors/util/adt"
 	"github.com/filecoin-project/specs-actors/v3/support/agent"
@@ -231,7 +231,7 @@ func TestMigration(t *testing.T) {
 	sim := agent.NewSimWithVM(ctx, t, v, v2VMFactory, agent.ComputePowerTableV2, blkStore, newBlockStore, v2MinerFactory, agent.SimConfig{
 		Seed:             rnd.Int63(),
 		CheckpointEpochs: 1000,
-	})
+	}, agent.CreateMinerParamsV2)
 
 	// create miners
 	workerAccounts := vm_test2.CreateAccounts(ctx, t, v, minerCount, initialBalance, rnd.Int63())
@@ -291,9 +291,9 @@ func TestMigration(t *testing.T) {
 
 	// Migrate
 	v2 := sim.GetVM()
-	log := nv9.TestLogger{TB: t}
+	log := nv10.TestLogger{TB: t}
 	priorEpoch := v2.GetEpoch() - 1 // on tick sim internally creates new vm with epoch set to the next one
-	nextRoot, err := nv9.MigrateStateTree(ctx, v2.Store(), v2.StateRoot(), priorEpoch, nv9.Config{MaxWorkers: 1}, log, nv9.NewMemMigrationCache())
+	nextRoot, err := nv10.MigrateStateTree(ctx, v2.Store(), v2.StateRoot(), priorEpoch, nv10.Config{MaxWorkers: 1}, log, nv10.NewMemMigrationCache())
 	require.NoError(t, err)
 
 	lookup := map[cid.Cid]rt.VMActor{}
@@ -321,7 +321,7 @@ func TestMigration(t *testing.T) {
 			Root: root,
 		}, nil
 	}
-	sim.SwapVM(v3, agent.VMFactoryFunc(v3VMFactory), v3MinerFactory, agent.ComputePowerTableV3)
+	sim.SwapVM(v3, agent.VMFactoryFunc(v3VMFactory), v3MinerFactory, agent.ComputePowerTableV3, agent.CreateMinerParamsV3)
 
 	// Run v3 for 5000 epochs
 	for i := 0; i < 5000; i++ {

--- a/support/agent/cases_test.go
+++ b/support/agent/cases_test.go
@@ -9,13 +9,21 @@ import (
 
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/rt"
+	power2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/power"
+	states2 "github.com/filecoin-project/specs-actors/v2/actors/states"
+	vm_test2 "github.com/filecoin-project/specs-actors/v2/support/vm"
+	cid "github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/specs-actors/v3/actors/builtin"
+	"github.com/filecoin-project/specs-actors/v3/actors/builtin/exported"
 	"github.com/filecoin-project/specs-actors/v3/actors/builtin/power"
+	"github.com/filecoin-project/specs-actors/v3/actors/migration/nv9"
 	"github.com/filecoin-project/specs-actors/v3/actors/states"
+	"github.com/filecoin-project/specs-actors/v3/actors/util/adt"
 	"github.com/filecoin-project/specs-actors/v3/support/agent"
 	"github.com/filecoin-project/specs-actors/v3/support/ipld"
 	vm_test "github.com/filecoin-project/specs-actors/v3/support/vm"
@@ -29,7 +37,7 @@ func TestCreate20Miners(t *testing.T) {
 	rnd := rand.New(rand.NewSource(42))
 
 	sim := agent.NewSim(ctx, t, newBlockStore, agent.SimConfig{Seed: rnd.Int63()})
-	accounts := vm_test.CreateAccounts(ctx, t, sim.GetVM(), minerCount, initialBalance, rnd.Int63())
+	accounts := vm_test.CreateAccounts(ctx, t, sim.GetVM().(*vm_test.VM), minerCount, initialBalance, rnd.Int63())
 	sim.AddAgent(agent.NewMinerGenerator(
 		accounts,
 		agent.MinerAgentConfig{
@@ -82,7 +90,7 @@ func Test500Epochs(t *testing.T) {
 	})
 
 	// create miners
-	workerAccounts := vm_test.CreateAccounts(ctx, t, sim.GetVM(), minerCount, initialBalance, rnd.Int63())
+	workerAccounts := vm_test.CreateAccounts(ctx, t, sim.GetVM().(*vm_test.VM), minerCount, initialBalance, rnd.Int63())
 	sim.AddAgent(agent.NewMinerGenerator(
 		workerAccounts,
 		agent.MinerAgentConfig{
@@ -99,7 +107,7 @@ func Test500Epochs(t *testing.T) {
 		rnd.Int63(),
 	))
 
-	clientAccounts := vm_test.CreateAccounts(ctx, t, sim.GetVM(), clientCount, initialBalance, rnd.Int63())
+	clientAccounts := vm_test.CreateAccounts(ctx, t, sim.GetVM().(*vm_test.VM), clientCount, initialBalance, rnd.Int63())
 	dealAgents := agent.AddDealClientsForAccounts(sim, clientAccounts, rnd.Int63(), agent.DealClientConfig{
 		DealRate:         .05,
 		MinPieceSize:     1 << 29,
@@ -122,10 +130,10 @@ func Test500Epochs(t *testing.T) {
 				deals += da.DealCount
 			}
 
-			stateTree, err := sim.GetVM().GetStateTree()
+			stateTree, err := sim.GetVM().(*vm_test.VM).GetStateTree()
 			require.NoError(t, err)
 
-			totalBalance, err := sim.GetVM().GetTotalActorBalance()
+			totalBalance, err := sim.GetVM().(*vm_test.VM).GetTotalActorBalance()
 			require.NoError(t, err)
 
 			acc, err := states.CheckStateInvariants(stateTree, totalBalance, sim.GetVM().GetEpoch()-1)
@@ -139,8 +147,8 @@ func Test500Epochs(t *testing.T) {
 
 			fmt.Printf("Power at %d: raw: %v  cmtRaw: %v  cmtSecs: %d  msgs: %d  deals: %d  gets: %d  puts: %d  write bytes: %d  read bytes: %d\n",
 				epoch, pwrSt.TotalRawBytePower, pwrSt.TotalBytesCommitted, sectorCount.Uint64(),
-				sim.MessageCount, deals, sim.GetVM().StoreReads(), sim.GetVM().StoreWrites(),
-				sim.GetVM().StoreReadBytes(), sim.GetVM().StoreWriteBytes())
+				sim.MessageCount, deals, sim.GetVM().(*vm_test.VM).StoreReads(), sim.GetVM().(*vm_test.VM).StoreWrites(),
+				sim.GetVM().(*vm_test.VM).StoreReadBytes(), sim.GetVM().(*vm_test.VM).StoreWriteBytes())
 		}
 
 		cumulativeStats.MergeAllStats(sim.GetCallStats())
@@ -155,7 +163,7 @@ func TestCommitPowerAndCheckInvariants(t *testing.T) {
 
 	rnd := rand.New(rand.NewSource(42))
 	sim := agent.NewSim(ctx, t, newBlockStore, agent.SimConfig{Seed: rnd.Int63()})
-	accounts := vm_test.CreateAccounts(ctx, t, sim.GetVM(), minerCount, initialBalance, rnd.Int63())
+	accounts := vm_test.CreateAccounts(ctx, t, sim.GetVM().(*vm_test.VM), minerCount, initialBalance, rnd.Int63())
 	sim.AddAgent(agent.NewMinerGenerator(
 		accounts,
 		agent.MinerAgentConfig{
@@ -177,7 +185,150 @@ func TestCommitPowerAndCheckInvariants(t *testing.T) {
 
 		epoch := sim.GetVM().GetEpoch()
 		if epoch%100 == 0 {
-			stateTree, err := sim.GetVM().GetStateTree()
+			stateTree, err := sim.GetVM().(*vm_test.VM).GetStateTree()
+			require.NoError(t, err)
+
+			totalBalance, err := sim.GetVM().(*vm_test.VM).GetTotalActorBalance()
+			require.NoError(t, err)
+
+			acc, err := states.CheckStateInvariants(stateTree, totalBalance, sim.GetVM().GetEpoch()-1)
+			require.NoError(t, err)
+			require.True(t, acc.IsEmpty(), strings.Join(acc.Messages(), "\n"))
+
+			require.NoError(t, sim.GetVM().GetState(builtin.StoragePowerActorAddr, &pwrSt))
+
+			// assume each sector is 32Gb
+			sectorCount := big.Div(pwrSt.TotalBytesCommitted, big.NewInt(32<<30))
+
+			fmt.Printf("Power at %d: raw: %v  cmtRaw: %v  cmtSecs: %d  cnsMnrs: %d avgWins: %.3f  msgs: %d\n",
+				epoch, pwrSt.TotalRawBytePower, pwrSt.TotalBytesCommitted, sectorCount.Uint64(),
+				pwrSt.MinerAboveMinPowerCount, float64(sim.WinCount)/float64(epoch), sim.MessageCount)
+		}
+	}
+}
+
+func TestMigration(t *testing.T) {
+	//t.Skip("slow")
+	ctx := context.Background()
+	initialBalance := big.Mul(big.NewInt(1e8), big.NewInt(1e18))
+	minerCount := 10
+	clientCount := 9
+
+	blkStore := newBlockStore()
+	v := vm_test2.NewVMWithSingletons(ctx, t, blkStore)
+	v2VMFactory := func(ctx context.Context, impl vm_test2.ActorImplLookup, store adt.Store, stateRoot cid.Cid, epoch abi.ChainEpoch) (agent.SimVM, error) {
+		return vm_test2.NewVMAtEpoch(ctx, impl, store, stateRoot, epoch)
+	}
+	v2MinerFactory := func(ctx context.Context, root cid.Cid) (agent.SimMinerState, error) {
+		return &agent.MinerStateV2{
+			Ctx:  ctx,
+			Root: root,
+		}, nil
+	}
+
+	// set up sim
+	rnd := rand.New(rand.NewSource(42))
+	sim := agent.NewSimWithVM(ctx, t, v, v2VMFactory, agent.ComputePowerTableV2, blkStore, newBlockStore, v2MinerFactory, agent.SimConfig{
+		Seed:             rnd.Int63(),
+		CheckpointEpochs: 1000,
+	})
+
+	// create miners
+	workerAccounts := vm_test2.CreateAccounts(ctx, t, v, minerCount, initialBalance, rnd.Int63())
+	sim.AddAgent(agent.NewMinerGenerator(
+		workerAccounts,
+		agent.MinerAgentConfig{
+			PrecommitRate:    2.0,
+			FaultRate:        0.00001,
+			RecoveryRate:     0.0001,
+			UpgradeSectors:   true,
+			ProofType:        abi.RegisteredSealProof_StackedDrg32GiBV1_1,
+			StartingBalance:  big.Div(initialBalance, big.NewInt(2)),
+			MinMarketBalance: big.NewInt(1e18),
+			MaxMarketBalance: big.NewInt(2e18),
+		},
+		1.0, // create miner probability of 1 means a new miner is created every tick
+		rnd.Int63(),
+	))
+
+	clientAccounts := vm_test2.CreateAccounts(ctx, t, v, clientCount, initialBalance, rnd.Int63())
+	agent.AddDealClientsForAccounts(sim, clientAccounts, rnd.Int63(), agent.DealClientConfig{
+		DealRate:         .05,
+		MinPieceSize:     1 << 29,
+		MaxPieceSize:     32 << 30,
+		MinStoragePrice:  big.Zero(),
+		MaxStoragePrice:  abi.NewTokenAmount(200_000_000),
+		MinMarketBalance: big.NewInt(1e18),
+		MaxMarketBalance: big.NewInt(2e18),
+	})
+
+	// Run v2 for 5000 epochs
+	var pwrSt power2.State
+	for i := 0; i < 5000; i++ {
+		require.NoError(t, sim.Tick())
+		epoch := sim.GetVM().GetEpoch()
+		if epoch%100 == 0 {
+			stateTree, err := states2.LoadTree(sim.GetVM().Store(), sim.GetVM().StateRoot())
+			require.NoError(t, err)
+
+			totalBalance, err := sim.GetVM().GetTotalActorBalance()
+			require.NoError(t, err)
+
+			acc, err := states2.CheckStateInvariants(stateTree, totalBalance, sim.GetVM().GetEpoch()-1)
+			require.NoError(t, err)
+			require.True(t, acc.IsEmpty(), strings.Join(acc.Messages(), "\n"))
+
+			require.NoError(t, sim.GetVM().GetState(builtin.StoragePowerActorAddr, &pwrSt))
+
+			// assume each sector is 32Gb
+			sectorCount := big.Div(pwrSt.TotalBytesCommitted, big.NewInt(32<<30))
+
+			fmt.Printf("Power at %d: raw: %v  cmtRaw: %v  cmtSecs: %d  cnsMnrs: %d avgWins: %.3f  msgs: %d\n",
+				epoch, pwrSt.TotalRawBytePower, pwrSt.TotalBytesCommitted, sectorCount.Uint64(),
+				pwrSt.MinerAboveMinPowerCount, float64(sim.WinCount)/float64(epoch), sim.MessageCount)
+		}
+	}
+
+	// Migrate
+	v2 := sim.GetVM()
+	log := nv9.TestLogger{TB: t}
+	priorEpoch := v2.GetEpoch() - 1 // on tick sim internally creates new vm with epoch set to the next one
+	nextRoot, err := nv9.MigrateStateTree(ctx, v2.Store(), v2.StateRoot(), priorEpoch, nv9.Config{MaxWorkers: 1}, log, nv9.NewMemMigrationCache())
+	require.NoError(t, err)
+
+	lookup := map[cid.Cid]rt.VMActor{}
+	for _, ba := range exported.BuiltinActors() {
+		lookup[ba.Code()] = ba
+	}
+
+	v3, err := vm_test.NewVMAtEpoch(ctx, lookup, v2.Store(), nextRoot, priorEpoch+1)
+	require.NoError(t, err)
+
+	stateTree, err := v3.GetStateTree()
+	require.NoError(t, err)
+	totalBalance, err := v3.GetTotalActorBalance()
+	require.NoError(t, err)
+	msgs, err := states.CheckStateInvariants(stateTree, totalBalance, priorEpoch)
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(msgs.Messages()), strings.Join(msgs.Messages(), "\n"))
+
+	v3VMFactory := func(ctx context.Context, impl vm_test2.ActorImplLookup, store adt.Store, stateRoot cid.Cid, epoch abi.ChainEpoch) (agent.SimVM, error) {
+		return vm_test.NewVMAtEpoch(ctx, vm_test.ActorImplLookup(impl), store, stateRoot, epoch)
+	}
+	v3MinerFactory := func(ctx context.Context, root cid.Cid) (agent.SimMinerState, error) {
+		return &agent.MinerStateV3{
+			Ctx:  ctx,
+			Root: root,
+		}, nil
+	}
+	sim.SwapVM(v3, agent.VMFactoryFunc(v3VMFactory), v3MinerFactory, agent.ComputePowerTableV3)
+
+	// Run v3 for 5000 epochs
+	for i := 0; i < 5000; i++ {
+		require.NoError(t, sim.Tick())
+		epoch := sim.GetVM().GetEpoch()
+		if epoch%100 == 0 {
+			stateTree, err := states.LoadTree(sim.GetVM().Store(), sim.GetVM().StateRoot())
 			require.NoError(t, err)
 
 			totalBalance, err := sim.GetVM().GetTotalActorBalance()
@@ -197,6 +348,7 @@ func TestCommitPowerAndCheckInvariants(t *testing.T) {
 				pwrSt.MinerAboveMinPowerCount, float64(sim.WinCount)/float64(epoch), sim.MessageCount)
 		}
 	}
+
 }
 
 func TestCommitAndCheckReadWriteStats(t *testing.T) {
@@ -215,7 +367,7 @@ func TestCommitAndCheckReadWriteStats(t *testing.T) {
 	})
 
 	// create miners
-	workerAccounts := vm_test.CreateAccounts(ctx, t, sim.GetVM(), minerCount, initialBalance, rnd.Int63())
+	workerAccounts := vm_test.CreateAccounts(ctx, t, sim.GetVM().(*vm_test.VM), minerCount, initialBalance, rnd.Int63())
 	sim.AddAgent(agent.NewMinerGenerator(
 		workerAccounts,
 		agent.MinerAgentConfig{
@@ -232,7 +384,7 @@ func TestCommitAndCheckReadWriteStats(t *testing.T) {
 		rnd.Int63(),
 	))
 
-	clientAccounts := vm_test.CreateAccounts(ctx, t, sim.GetVM(), clientCount, initialBalance, rnd.Int63())
+	clientAccounts := vm_test.CreateAccounts(ctx, t, sim.GetVM().(*vm_test.VM), clientCount, initialBalance, rnd.Int63())
 	dealAgents := agent.AddDealClientsForAccounts(sim, clientAccounts, rnd.Int63(), agent.DealClientConfig{
 		DealRate:         .05,
 		MinPieceSize:     1 << 29,
@@ -262,8 +414,8 @@ func TestCommitAndCheckReadWriteStats(t *testing.T) {
 
 			fmt.Printf("Power at %d: raw: %v  cmtRaw: %v  cmtSecs: %d  msgs: %d  deals: %d  gets: %d  puts: %d  write bytes: %d  read bytes: %d\n",
 				epoch, pwrSt.TotalRawBytePower, pwrSt.TotalBytesCommitted, sectorCount.Uint64(),
-				sim.MessageCount, deals, sim.GetVM().StoreReads(), sim.GetVM().StoreWrites(),
-				sim.GetVM().StoreReadBytes(), sim.GetVM().StoreWriteBytes())
+				sim.MessageCount, deals, sim.GetVM().(*vm_test.VM).StoreReads(), sim.GetVM().(*vm_test.VM).StoreWrites(),
+				sim.GetVM().(*vm_test.VM).StoreReadBytes(), sim.GetVM().(*vm_test.VM).StoreWriteBytes())
 		}
 
 		cumulativeStats.MergeAllStats(sim.GetCallStats())
@@ -289,7 +441,7 @@ func TestCreateDeals(t *testing.T) {
 	sim := agent.NewSim(ctx, t, newBlockStore, agent.SimConfig{Seed: rnd.Int63()})
 
 	// create miners
-	workerAccounts := vm_test.CreateAccounts(ctx, t, sim.GetVM(), minerCount, initialBalance, rnd.Int63())
+	workerAccounts := vm_test.CreateAccounts(ctx, t, sim.GetVM().(*vm_test.VM), minerCount, initialBalance, rnd.Int63())
 	sim.AddAgent(agent.NewMinerGenerator(
 		workerAccounts,
 		agent.MinerAgentConfig{
@@ -305,7 +457,7 @@ func TestCreateDeals(t *testing.T) {
 		rnd.Int63(),
 	))
 
-	clientAccounts := vm_test.CreateAccounts(ctx, t, sim.GetVM(), clientCount, initialBalance, rnd.Int63())
+	clientAccounts := vm_test.CreateAccounts(ctx, t, sim.GetVM().(*vm_test.VM), clientCount, initialBalance, rnd.Int63())
 	dealAgents := agent.AddDealClientsForAccounts(sim, clientAccounts, rnd.Int63(), agent.DealClientConfig{
 		DealRate:         .01,
 		MinPieceSize:     1 << 29,
@@ -322,10 +474,10 @@ func TestCreateDeals(t *testing.T) {
 
 		epoch := sim.GetVM().GetEpoch()
 		if epoch%100 == 0 {
-			stateTree, err := sim.GetVM().GetStateTree()
+			stateTree, err := sim.GetVM().(*vm_test.VM).GetStateTree()
 			require.NoError(t, err)
 
-			totalBalance, err := sim.GetVM().GetTotalActorBalance()
+			totalBalance, err := sim.GetVM().(*vm_test.VM).GetTotalActorBalance()
 			require.NoError(t, err)
 
 			acc, err := states.CheckStateInvariants(stateTree, totalBalance, sim.GetVM().GetEpoch()-1)
@@ -362,7 +514,7 @@ func TestCCUpgrades(t *testing.T) {
 	sim := agent.NewSim(ctx, t, newBlockStore, agent.SimConfig{Seed: rnd.Int63()})
 
 	// create miners
-	workerAccounts := vm_test.CreateAccounts(ctx, t, sim.GetVM(), minerCount, initialBalance, rnd.Int63())
+	workerAccounts := vm_test.CreateAccounts(ctx, t, sim.GetVM().(*vm_test.VM), minerCount, initialBalance, rnd.Int63())
 	sim.AddAgent(agent.NewMinerGenerator(
 		workerAccounts,
 		agent.MinerAgentConfig{
@@ -379,7 +531,7 @@ func TestCCUpgrades(t *testing.T) {
 		rnd.Int63(),
 	))
 
-	clientAccounts := vm_test.CreateAccounts(ctx, t, sim.GetVM(), clientCount, initialBalance, rnd.Int63())
+	clientAccounts := vm_test.CreateAccounts(ctx, t, sim.GetVM().(*vm_test.VM), clientCount, initialBalance, rnd.Int63())
 	agent.AddDealClientsForAccounts(sim, clientAccounts, rnd.Int63(), agent.DealClientConfig{
 		DealRate:         .01,
 		MinPieceSize:     1 << 29,
@@ -396,10 +548,10 @@ func TestCCUpgrades(t *testing.T) {
 
 		epoch := sim.GetVM().GetEpoch()
 		if epoch%100 == 0 {
-			stateTree, err := sim.GetVM().GetStateTree()
+			stateTree, err := sim.GetVM().(*vm_test.VM).GetStateTree()
 			require.NoError(t, err)
 
-			totalBalance, err := sim.GetVM().GetTotalActorBalance()
+			totalBalance, err := sim.GetVM().(*vm_test.VM).GetTotalActorBalance()
 			require.NoError(t, err)
 
 			acc, err := states.CheckStateInvariants(stateTree, totalBalance, sim.GetVM().GetEpoch()-1)

--- a/support/agent/cases_test.go
+++ b/support/agent/cases_test.go
@@ -208,7 +208,7 @@ func TestCommitPowerAndCheckInvariants(t *testing.T) {
 }
 
 func TestMigration(t *testing.T) {
-	//t.Skip("slow")
+	t.Skip("slow")
 	ctx := context.Background()
 	initialBalance := big.Mul(big.NewInt(1e8), big.NewInt(1e18))
 	minerCount := 10

--- a/support/agent/miner_agent.go
+++ b/support/agent/miner_agent.go
@@ -134,9 +134,15 @@ func (ma *MinerAgent) Tick(s SimState) ([]message, error) {
 	// between PreCommits. For now always assume we have enough funds for the PreCommit deposit.
 	if err := ma.preCommitEvents.Tick(func() error {
 		// can't create precommit if in fee debt
-		if st, err := ma.getState(s); err != nil {
+		mSt, err := s.MinerState(ma.IDAddress)
+		if err != nil {
 			return err
-		} else if st.FeeDebt.GreaterThan(big.Zero()) {
+		}
+		feeDebt, err := mSt.FeeDebt(s.Store())
+		if err != nil {
+			return err
+		}
+		if feeDebt.GreaterThan(big.Zero()) {
 			return nil
 		}
 
@@ -252,8 +258,8 @@ func (ma *MinerAgent) createPreCommit(s SimState, currentEpoch abi.ChainEpoch) (
 		if err != nil {
 			return message{}, err
 		}
-		if sinfo.Expiration > expiration {
-			params.Expiration = sinfo.Expiration
+		if sinfo.Expiration() > expiration {
+			params.Expiration = sinfo.Expiration()
 		}
 
 		dlInfo, pIdx, err := ma.dlInfoForSector(s, upgradeNumber)
@@ -521,21 +527,20 @@ func (ma *MinerAgent) updateMarketBalance() []message {
 
 // looks up sector deadline and partition so we can start adding it to PoSts
 func (ma *MinerAgent) registerSector(v SimState, sectorNumber abi.SectorNumber, committedCapacity bool, upgrade bool) error {
-	var st miner.State
-	err := v.GetState(ma.IDAddress, &st)
+	mSt, err := v.MinerState(ma.IDAddress)
 	if err != nil {
 		return err
 	}
 
 	// first check for sector
-	if found, err := st.HasSectorNo(v.Store(), sectorNumber); err != nil {
+	if found, err := mSt.HasSectorNo(v.Store(), sectorNumber); err != nil {
 		return err
 	} else if !found {
 		fmt.Printf("failed to register sector %d, did proof verification fail?\n", sectorNumber)
 		return nil
 	}
 
-	dlIdx, pIdx, err := st.FindSector(v.Store(), sectorNumber)
+	dlIdx, pIdx, err := mSt.FindSector(v.Store(), sectorNumber)
 	if err != nil {
 		return err
 	}
@@ -570,14 +575,17 @@ func (ma *MinerAgent) registerSector(v SimState, sectorNumber abi.SectorNumber, 
 
 // schedule a proof within the deadline's bounds
 func (ma *MinerAgent) scheduleSyncAndNextProof(v SimState, dlIdx uint64) error {
-	var st miner.State
-	err := v.GetState(ma.IDAddress, &st)
+	mSt, err := v.MinerState(ma.IDAddress)
 	if err != nil {
 		return err
 	}
 
 	// find next proving window for this deadline
-	deadlineStart := st.ProvingPeriodStart + abi.ChainEpoch(dlIdx)*miner.WPoStChallengeWindow
+	provingPeriodStart, err := mSt.ProvingPeriodStart(v.Store())
+	if err != nil {
+		return err
+	}
+	deadlineStart := provingPeriodStart + abi.ChainEpoch(dlIdx)*miner.WPoStChallengeWindow
 	if deadlineStart-miner.WPoStChallengeWindow < v.GetEpoch() {
 		deadlineStart += miner.WPoStProvingPeriod
 	}
@@ -663,13 +671,12 @@ func (ma *MinerAgent) recoveryMessage(dlIdx uint64, pIdx uint64, recoveryNumber 
 
 // This function updates all sectors in deadline that have newly expired
 func (ma *MinerAgent) syncMinerState(s SimState, dlIdx uint64) error {
-	st, err := ma.getState(s)
+	mSt, err := s.MinerState(ma.IDAddress)
 	if err != nil {
 		return err
-
 	}
 
-	dl, err := ma.loadDeadlineState(s, st, dlIdx)
+	dl, err := mSt.LoadDeadlineState(s.Store(), dlIdx)
 	if err != nil {
 		return err
 	}
@@ -681,7 +688,7 @@ func (ma *MinerAgent) syncMinerState(s SimState, dlIdx uint64) error {
 		if err != nil {
 			return err
 		}
-		newExpired, err := bitfield.IntersectBitField(part.sectors, partState.Terminated)
+		newExpired, err := bitfield.IntersectBitField(part.sectors, partState.Terminated())
 		if err != nil {
 			return err
 		}
@@ -727,51 +734,34 @@ func filterSlice(ns []uint64, toRemove map[uint64]bool) []uint64 {
 	return nextLive
 }
 
-func (ma *MinerAgent) loadDeadlineState(s SimState, st miner.State, dlIdx uint64) (*miner.Deadline, error) {
-	dls, err := st.LoadDeadlines(s.Store())
+func (ma *MinerAgent) sectorInfo(v SimState, sectorNumber uint64) (SimSectorInfo, error) {
+	mSt, err := v.MinerState(ma.IDAddress)
 	if err != nil {
 		return nil, err
 	}
 
-	return dls.LoadDeadline(s.Store(), dlIdx)
-}
-
-func (ma *MinerAgent) getState(s SimState) (miner.State, error) {
-	var st miner.State
-	err := s.GetState(ma.IDAddress, &st)
-	if err != nil {
-		return miner.State{}, err
-	}
-	return st, err
-}
-
-func (ma *MinerAgent) sectorInfo(v SimState, sectorNumber uint64) (*miner.SectorOnChainInfo, error) {
-	var st miner.State
-	err := v.GetState(ma.IDAddress, &st)
+	sector, err := mSt.LoadSectorInfo(v.Store(), sectorNumber)
 	if err != nil {
 		return nil, err
 	}
-
-	sectors, err := st.LoadSectorInfos(v.Store(), bitfield.NewFromSet([]uint64{uint64(sectorNumber)}))
-	if err != nil {
-		return nil, err
-	}
-	return sectors[0], nil
+	return sector, nil
 }
 
 func (ma *MinerAgent) dlInfoForSector(v SimState, sectorNumber uint64) (*dline.Info, uint64, error) {
-	var st miner.State
-	err := v.GetState(ma.IDAddress, &st)
+	mSt, err := v.MinerState(ma.IDAddress)
 	if err != nil {
 		return nil, 0, err
 	}
 
-	dlIdx, pIdx, err := st.FindSector(v.Store(), abi.SectorNumber(sectorNumber))
+	dlIdx, pIdx, err := mSt.FindSector(v.Store(), abi.SectorNumber(sectorNumber))
 	if err != nil {
 		return nil, 0, err
 	}
 
-	dlInfo := st.DeadlineInfo(v.GetEpoch())
+	dlInfo, err := mSt.DeadlineInfo(v.Store(), v.GetEpoch())
+	if err != nil {
+		return nil, 0, err
+	}
 	sectorDLInfo := miner.NewDeadlineInfo(dlInfo.PeriodStart, dlIdx, v.GetEpoch()).NextNotElapsed()
 	return sectorDLInfo, pIdx, nil
 }

--- a/support/agent/miner_generator.go
+++ b/support/agent/miner_generator.go
@@ -7,8 +7,10 @@ import (
 	"github.com/filecoin-project/go-state-types/cbor"
 	"github.com/pkg/errors"
 
+	power2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/power"
 	"github.com/filecoin-project/specs-actors/v3/actors/builtin"
 	"github.com/filecoin-project/specs-actors/v3/actors/builtin/power"
+	power3 "github.com/filecoin-project/specs-actors/v3/actors/builtin/power"
 )
 
 // MinerGenerator adds miner agents to the simulation at a configured rate.
@@ -34,7 +36,7 @@ func NewMinerGenerator(accounts []address.Address, config MinerAgentConfig, crea
 	}
 }
 
-func (mg *MinerGenerator) Tick(_ SimState) ([]message, error) {
+func (mg *MinerGenerator) Tick(s SimState) ([]message, error) {
 	var msgs []message
 	if mg.minersCreated >= len(mg.accounts) {
 		return msgs, nil
@@ -44,7 +46,7 @@ func (mg *MinerGenerator) Tick(_ SimState) ([]message, error) {
 		if mg.minersCreated < len(mg.accounts) {
 			addr := mg.accounts[mg.minersCreated]
 			mg.minersCreated++
-			msg, err := mg.createMiner(addr, mg.config)
+			msg, err := mg.createMiner(addr, mg.config, s)
 			if err != nil {
 				return err
 			}
@@ -55,8 +57,8 @@ func (mg *MinerGenerator) Tick(_ SimState) ([]message, error) {
 	return msgs, err
 }
 
-func (mg *MinerGenerator) createMiner(owner address.Address, cfg MinerAgentConfig) (message, error) {
-	windowPoStProofType, err := cfg.ProofType.RegisteredWindowPoStProof()
+func (mg *MinerGenerator) createMiner(owner address.Address, cfg MinerAgentConfig, s SimState) (message, error) {
+	params, err := s.CreateMinerParams(owner, owner, cfg.ProofType)
 	if err != nil {
 		return message{}, err
 	}
@@ -65,24 +67,29 @@ func (mg *MinerGenerator) createMiner(owner address.Address, cfg MinerAgentConfi
 		To:     builtin.StoragePowerActorAddr,
 		Value:  mg.config.StartingBalance, // miner gets all account funds
 		Method: builtin.MethodsPower.CreateMiner,
-		Params: &power.CreateMinerParams{
-			Owner:                owner,
-			Worker:               owner,
-			WindowPoStProofType:  windowPoStProofType,
-		},
+		Params: params,
 		ReturnHandler: func(s SimState, msg message, ret cbor.Marshaler) error {
 			createMinerRet, ok := ret.(*power.CreateMinerReturn)
 			if !ok {
 				return errors.Errorf("create miner return has wrong type: %v", ret)
 			}
 
-			params := msg.Params.(*power.CreateMinerParams)
-			if !ok {
-				return errors.Errorf("create miner params has wrong type: %v", msg.Params)
+			var worker, owner address.Address
+			params, okV3 := msg.Params.(*power3.CreateMinerParams)
+			if !okV3 {
+				params, okV2 := msg.Params.(*power2.CreateMinerParams)
+				if !okV2 {
+					return errors.Errorf("create miner params has wrong type: %v", msg.Params)
+				}
+				worker = params.Worker
+				owner = params.Owner
+			} else {
+				worker = params.Worker
+				owner = params.Owner
 			}
 
 			// register agent as both a miner and deal provider
-			minerAgent := NewMinerAgent(params.Owner, params.Worker, createMinerRet.IDAddress, createMinerRet.RobustAddress, mg.rnd.Int63(), cfg)
+			minerAgent := NewMinerAgent(owner, worker, createMinerRet.IDAddress, createMinerRet.RobustAddress, mg.rnd.Int63(), cfg)
 			s.AddAgent(minerAgent)
 			s.AddDealProvider(minerAgent)
 			return nil

--- a/support/agent/miner_state.go
+++ b/support/agent/miner_state.go
@@ -1,0 +1,242 @@
+package agent
+
+import (
+	"context"
+
+	"github.com/filecoin-project/go-bitfield"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/dline"
+	miner2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/miner"
+	miner3 "github.com/filecoin-project/specs-actors/v3/actors/builtin/miner"
+	"github.com/filecoin-project/specs-actors/v3/actors/util/adt"
+	cid "github.com/ipfs/go-cid"
+)
+
+type MinerStateV2 struct {
+	Root cid.Cid
+	Ctx  context.Context
+	st   *miner2.State
+}
+
+func (m *MinerStateV2) state(store adt.Store) (*miner2.State, error) {
+	if m.st == nil {
+		var st miner2.State
+		err := store.Get(m.Ctx, m.Root, &st)
+		if err != nil {
+			return nil, err
+		}
+		m.st = &st
+	}
+	return m.st, nil
+}
+
+func (m *MinerStateV2) HasSectorNo(store adt.Store, sectorNo abi.SectorNumber) (bool, error) {
+	st, err := m.state(store)
+	if err != nil {
+		return false, err
+	}
+	return st.HasSectorNo(store, sectorNo)
+}
+
+func (m *MinerStateV2) FindSector(store adt.Store, sectorNo abi.SectorNumber) (uint64, uint64, error) {
+	st, err := m.state(store)
+	if err != nil {
+		return 0, 0, err
+	}
+	return st.FindSector(store, sectorNo)
+}
+
+func (m *MinerStateV2) ProvingPeriodStart(store adt.Store) (abi.ChainEpoch, error) {
+	st, err := m.state(store)
+	if err != nil {
+		return 0, err
+	}
+	return st.ProvingPeriodStart, nil
+}
+
+func (m *MinerStateV2) LoadSectorInfo(store adt.Store, sectorNo uint64) (SimSectorInfo, error) {
+	st, err := m.state(store)
+	if err != nil {
+		return nil, err
+	}
+	sectors, err := st.LoadSectorInfos(store, bitfield.NewFromSet([]uint64{uint64(sectorNo)}))
+	if err != nil {
+		return nil, err
+	}
+	return &SectorInfoV2{info: sectors[0]}, nil
+}
+
+func (m *MinerStateV2) DeadlineInfo(store adt.Store, currEpoch abi.ChainEpoch) (*dline.Info, error) {
+	st, err := m.state(store)
+	if err != nil {
+		return nil, err
+	}
+	return st.DeadlineInfo(currEpoch), nil
+}
+
+func (m *MinerStateV2) FeeDebt(store adt.Store) (abi.TokenAmount, error) {
+	st, err := m.state(store)
+	if err != nil {
+		return big.Zero(), err
+	}
+	return st.FeeDebt, nil
+}
+
+func (m *MinerStateV2) LoadDeadlineState(store adt.Store, dlIdx uint64) (SimDeadlineState, error) {
+	st, err := m.state(store)
+	if err != nil {
+		return nil, err
+	}
+	dls, err := st.LoadDeadlines(store)
+	if err != nil {
+		return nil, err
+	}
+	dline, err := dls.LoadDeadline(store, dlIdx)
+	if err != nil {
+		return nil, err
+	}
+	return &DeadlineStateV2{deadline: dline}, nil
+}
+
+type DeadlineStateV2 struct {
+	deadline *miner2.Deadline
+}
+
+func (d *DeadlineStateV2) LoadPartition(store adt.Store, partIdx uint64) (SimPartitionState, error) {
+	part, err := d.deadline.LoadPartition(store, partIdx)
+	if err != nil {
+		return nil, err
+	}
+	return &PartitionStateV2{partition: part}, nil
+}
+
+type PartitionStateV2 struct {
+	partition *miner2.Partition
+}
+
+func (p *PartitionStateV2) Terminated() bitfield.BitField {
+	return p.partition.Terminated
+}
+
+type SectorInfoV2 struct {
+	info *miner2.SectorOnChainInfo
+}
+
+func (s *SectorInfoV2) Expiration() abi.ChainEpoch {
+	return s.info.Expiration
+}
+
+type MinerStateV3 struct {
+	Root cid.Cid
+	st   *miner3.State
+	Ctx  context.Context
+}
+
+func (m *MinerStateV3) state(store adt.Store) (*miner3.State, error) {
+	if m.st == nil {
+		var st miner3.State
+		err := store.Get(m.Ctx, m.Root, &st)
+		if err != nil {
+			return nil, err
+		}
+		m.st = &st
+	}
+	return m.st, nil
+}
+
+func (m *MinerStateV3) HasSectorNo(store adt.Store, sectorNo abi.SectorNumber) (bool, error) {
+	st, err := m.state(store)
+	if err != nil {
+		return false, err
+	}
+	return st.HasSectorNo(store, sectorNo)
+}
+
+func (m *MinerStateV3) FindSector(store adt.Store, sectorNo abi.SectorNumber) (uint64, uint64, error) {
+	st, err := m.state(store)
+	if err != nil {
+		return 0, 0, err
+	}
+	return st.FindSector(store, sectorNo)
+}
+
+func (m *MinerStateV3) ProvingPeriodStart(store adt.Store) (abi.ChainEpoch, error) {
+	st, err := m.state(store)
+	if err != nil {
+		return 0, err
+	}
+	return st.ProvingPeriodStart, nil
+}
+
+func (m *MinerStateV3) LoadSectorInfo(store adt.Store, sectorNo uint64) (SimSectorInfo, error) {
+	st, err := m.state(store)
+	if err != nil {
+		return nil, err
+	}
+	sectors, err := st.LoadSectorInfos(store, bitfield.NewFromSet([]uint64{uint64(sectorNo)}))
+	if err != nil {
+		return nil, err
+	}
+	return &SectorInfoV3{info: sectors[0]}, nil
+}
+
+func (m *MinerStateV3) DeadlineInfo(store adt.Store, currEpoch abi.ChainEpoch) (*dline.Info, error) {
+	st, err := m.state(store)
+	if err != nil {
+		return nil, err
+	}
+	return st.DeadlineInfo(currEpoch), nil
+}
+
+func (m *MinerStateV3) FeeDebt(store adt.Store) (abi.TokenAmount, error) {
+	st, err := m.state(store)
+	if err != nil {
+		return big.Zero(), err
+	}
+	return st.FeeDebt, nil
+}
+
+func (m *MinerStateV3) LoadDeadlineState(store adt.Store, dlIdx uint64) (SimDeadlineState, error) {
+	st, err := m.state(store)
+	if err != nil {
+		return nil, err
+	}
+	dls, err := st.LoadDeadlines(store)
+	if err != nil {
+		return nil, err
+	}
+	dline, err := dls.LoadDeadline(store, dlIdx)
+	if err != nil {
+		return nil, err
+	}
+	return &DeadlineStateV3{deadline: dline}, nil
+}
+
+type DeadlineStateV3 struct {
+	deadline *miner3.Deadline
+}
+
+func (d *DeadlineStateV3) LoadPartition(store adt.Store, partIdx uint64) (SimPartitionState, error) {
+	part, err := d.deadline.LoadPartition(store, partIdx)
+	if err != nil {
+		return nil, err
+	}
+	return &PartitionStateV3{partition: part}, nil
+}
+
+type PartitionStateV3 struct {
+	partition *miner3.Partition
+}
+
+func (p *PartitionStateV3) Terminated() bitfield.BitField {
+	return p.partition.Terminated
+}
+
+type SectorInfoV3 struct {
+	info *miner3.SectorOnChainInfo
+}
+
+func (s *SectorInfoV3) Expiration() abi.ChainEpoch {
+	return s.info.Expiration
+}

--- a/support/vm/invocation_context.go
+++ b/support/vm/invocation_context.go
@@ -16,6 +16,7 @@ import (
 	"github.com/filecoin-project/go-state-types/exitcode"
 	"github.com/filecoin-project/go-state-types/network"
 	"github.com/filecoin-project/go-state-types/rt"
+	vm2 "github.com/filecoin-project/specs-actors/v2/support/vm"
 	"github.com/ipfs/go-cid"
 	"github.com/minio/blake2b-simd"
 	"github.com/pkg/errors"
@@ -69,7 +70,7 @@ func newInvocationContext(rt *VM, topLevel *topLevelContext, msg InternalMessage
 		allowSideEffects: true,
 		callerValidated:  false,
 		stateUsedObjs:    map[cbor.Marshaler]cid.Cid{},
-		stats:            NewCallStats(topLevel.statsSource),
+		stats:            vm2.NewCallStats(topLevel.statsSource),
 	}
 }
 

--- a/support/vm/stats.go
+++ b/support/vm/stats.go
@@ -1,120 +1,38 @@
 package vm_test
 
 import (
-	"github.com/filecoin-project/go-state-types/abi"
-	"github.com/ipfs/go-cid"
+	vm2 "github.com/filecoin-project/specs-actors/v2/support/vm"
 )
 
-type StatsSource interface {
-	WriteCount() uint64
-	ReadCount() uint64
-	WriteSize() uint64
-	ReadSize() uint64
-}
+// type StatsSource interface {
+// 	WriteCount() uint64
+// 	ReadCount() uint64
+// 	WriteSize() uint64
+// 	ReadSize() uint64
+// }
+type StatsSource = vm2.StatsSource
 
-type StatsByCall map[MethodKey]*CallStats
+// type StatsByCall map[MethodKey]*CallStats
+type StatsByCall = vm2.StatsByCall
 
-type MethodKey struct {
-	Code   cid.Cid
-	Method abi.MethodNum
-}
+// type MethodKey struct {
+// 	Code   cid.Cid
+// 	Method abi.MethodNum
+// }
+type MethodKey = vm2.MethodKey
 
-func (sbc StatsByCall) MergeStats(code cid.Cid, methodNum abi.MethodNum, newStats *CallStats) {
-	key := MethodKey{code, methodNum}
-	stats, ok := sbc[key]
-	if !ok {
-		sbc[key] = newStats
-	} else {
-		stats.MergeStats(newStats)
-	}
-}
+// type CallStats struct {
+// 	Reads       uint64
+// 	Writes      uint64
+// 	ReadBytes   uint64
+// 	WriteBytes  uint64
+// 	Calls       uint64
+// 	statsSource StatsSource
+// 	SubStats    StatsByCall
 
-func (sbc StatsByCall) MergeAllStats(other StatsByCall) {
-	for key, stats := range other { // nolint:nomaprange
-		sbc.MergeStats(key.Code, key.Method, stats)
-	}
-}
-
-type CallStats struct {
-	Reads       uint64
-	Writes      uint64
-	ReadBytes   uint64
-	WriteBytes  uint64
-	Calls       uint64
-	statsSource StatsSource
-	SubStats    StatsByCall
-
-	startReads      uint64
-	startWrites     uint64
-	startReadBytes  uint64
-	startWriteBytes uint64
-}
-
-func NewCallStats(statsSource StatsSource) *CallStats {
-	var startReads, startWrites, startReadBytes, startWriteBytes uint64
-	if statsSource != nil {
-		startReads = statsSource.ReadCount()
-		startWrites = statsSource.WriteCount()
-		startReadBytes = statsSource.ReadSize()
-		startWriteBytes = statsSource.WriteSize()
-	}
-	return &CallStats{
-		Reads:           0,
-		Writes:          0,
-		ReadBytes:       0,
-		WriteBytes:      0,
-		Calls:           0,
-		statsSource:     statsSource,
-		SubStats:        nil,
-		startReads:      startReads,
-		startWrites:     startWrites,
-		startReadBytes:  startReadBytes,
-		startWriteBytes: startWriteBytes,
-	}
-}
-
-func (s *CallStats) Capture() {
-	if s.statsSource == nil {
-		return
-	}
-
-	s.Calls++
-	s.Writes = s.statsSource.WriteCount() - s.startWrites
-	s.Reads = s.statsSource.ReadCount() - s.startReads
-	s.WriteBytes = s.statsSource.WriteSize() - s.startWriteBytes
-	s.ReadBytes = s.statsSource.ReadSize() - s.startReadBytes
-}
-
-// assume stats have same method type and that other will be discarded after this call
-func (s *CallStats) MergeStats(other *CallStats) {
-	s.Calls += other.Calls
-	s.Reads += other.Reads
-	s.Writes += other.Writes
-	s.WriteBytes += other.WriteBytes
-	s.ReadBytes += other.WriteBytes
-
-	if other.SubStats == nil {
-		return
-	}
-
-	if s.SubStats == nil {
-		s.SubStats = other.SubStats
-		return
-	}
-
-	for method, stats := range other.SubStats { // nolint:nomaprange
-		sub, ok := s.SubStats[method]
-		if !ok {
-			s.SubStats[method] = stats
-		} else {
-			sub.MergeStats(stats)
-		}
-	}
-}
-
-func (s *CallStats) MergeSubStat(code cid.Cid, methodNum abi.MethodNum, newStats *CallStats) {
-	if s.SubStats == nil {
-		s.SubStats = make(StatsByCall)
-	}
-	s.SubStats.MergeStats(code, methodNum, newStats)
-}
+// 	startReads      uint64
+// 	startWrites     uint64
+// 	startReadBytes  uint64
+// 	startWriteBytes uint64
+// }
+type CallStats = vm2.CallStats

--- a/support/vm/vm.go
+++ b/support/vm/vm.go
@@ -11,6 +11,7 @@ import (
 	"github.com/filecoin-project/go-state-types/exitcode"
 	"github.com/filecoin-project/go-state-types/network"
 	"github.com/filecoin-project/go-state-types/rt"
+	vm2 "github.com/filecoin-project/specs-actors/v2/support/vm"
 	"github.com/ipfs/go-cid"
 	"github.com/pkg/errors"
 
@@ -52,7 +53,8 @@ type VM struct {
 
 // VM types
 
-type ActorImplLookup map[cid.Cid]runtime.VMActor
+// type ActorImplLookup map[cid.Cid]runtime.VMActor
+type ActorImplLookup vm2.ActorImplLookup
 
 type InternalMessage struct {
 	from   address.Address
@@ -353,6 +355,12 @@ func (vm *VM) ApplyMessage(from, to address.Address, value abi.TokenAmount, meth
 		if err := vm.rollback(priorRoot); err != nil {
 			panic(err)
 		}
+	} else {
+		// persist changes from final invocation if call is ok
+		if _, err := vm.checkpoint(); err != nil {
+			panic(err)
+		}
+
 	}
 
 	return ret.inner, exitCode
@@ -422,6 +430,10 @@ func (vm *VM) GetCirculatingSupply() abi.TokenAmount {
 	return vm.circSupply
 }
 
+func (vm *VM) GetActorImpls() map[cid.Cid]rt.VMActor {
+	return vm.ActorImpls
+}
+
 // transfer debits money from one account and credits it to another.
 // avoid calling this method with a zero amount else it will perform unnecessary actor loading.
 //
@@ -487,6 +499,10 @@ func (vm *VM) getActorImpl(code cid.Cid) runtime.VMActor {
 
 func (vm *VM) SetStatsSource(s StatsSource) {
 	vm.statsSource = s
+}
+
+func (vm *VM) GetStatsSource() StatsSource {
+	return vm.statsSource
 }
 
 func (vm *VM) StoreReads() uint64 {


### PR DESCRIPTION
Use the new simulation framework to 1) generate realistic entropy within a state for migrating 2) continue simulating after migration to demonstrate common case network operations continue working on the migrated state.
- [x] Simulate state and then migrate
- [x] Continue simulating after the migration