### PR TITLE
Make sure the deadline is _really_ dead before skipping it during the deadline cron.

### DIFF
--- a/actors/builtin/miner/deadline_state.go
+++ b/actors/builtin/miner/deadline_state.go
@@ -209,7 +209,6 @@ func (d *Deadline) PartitionsSnapshotArray(store adt.Store) (*adt.Array, error) 
 	return arr, nil
 }
 
-
 func (d *Deadline) OptimisticProofsSnapshotArray(store adt.Store) (*adt.Array, error) {
 	arr, err := adt.AsArray(store, d.OptimisticPoStSubmissionsSnapshot, DeadlineOptimisticPoStSubmissionsAmtBitwidth)
 	if err != nil {

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -105,7 +105,7 @@ type MinerInfo struct {
 	// The proof type used for Window PoSt for this miner.
 	// A miner may commit sectors with different seal proof types (but compatible sector size and
 	// corresponding PoSt proof types).
-	WindowPoStProofType  abi.RegisteredPoStProof
+	WindowPoStProofType abi.RegisteredPoStProof
 
 	// Amount of space in each sector committed by this miner.
 	// This is computed from the proof type and represented here redundantly.

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -1131,9 +1131,9 @@ func (st *State) AdvanceDeadline(store adt.Store, currEpoch abi.ChainEpoch) (*Ad
 	previouslyFaultyPower := deadline.FaultyPower
 
 	// No live sectors in this deadline, nothing to do.
-	if deadline.LiveSectors == 0 {
-		// We should do some more checks here. See:
-		// Fix: https://github.com/filecoin-project/specs-actors/issues/1348
+	if live, err := deadline.IsLive(); err != nil {
+		return nil, xerrors.Errorf("failed to determine if miner is live: %w", err)
+	} else if !live {
 		return &AdvanceDeadlineResult{
 			pledgeDelta,
 			powerDelta,

--- a/actors/builtin/miner/testing.go
+++ b/actors/builtin/miner/testing.go
@@ -17,11 +17,11 @@ type DealSummary struct {
 }
 
 type StateSummary struct {
-	LivePower            PowerPair
-	ActivePower          PowerPair
-	FaultyPower          PowerPair
-	Deals                map[abi.DealID]DealSummary
-	WindowPoStProofType  abi.RegisteredPoStProof
+	LivePower           PowerPair
+	ActivePower         PowerPair
+	FaultyPower         PowerPair
+	Deals               map[abi.DealID]DealSummary
+	WindowPoStProofType abi.RegisteredPoStProof
 }
 
 // Checks internal invariants of init state.

--- a/actors/builtin/miner/testing.go
+++ b/actors/builtin/miner/testing.go
@@ -201,6 +201,18 @@ func CheckDeadlineStateInvariants(deadline *Deadline, store adt.Store, quant Qua
 	})
 	acc.RequireNoError(err, "error iterating partitions")
 
+	// Check invariants on partitions proven.
+	{
+		if lastProof, err := deadline.PartitionsPoSted.Last(); err != nil {
+			if err != bitfield.ErrNoBitsSet {
+				acc.Addf("error determining the last partition proven: %v", err)
+			}
+		} else {
+			acc.Require(partitionCount >= (lastProof+1), "expected at least %d partitions, found %d", lastProof+1, partitionCount)
+			acc.Require(deadline.LiveSectors > 0, "expected at least one live sector when partitions have been proven")
+		}
+	}
+
 	// Check partitions snapshot to make sure we take the snapshot after
 	// dealing with recovering power and unproven power.
 	partitionsSnapshot, err := deadline.PartitionsSnapshotArray(store)

--- a/actors/migration/nv10/miner.go
+++ b/actors/migration/nv10/miner.go
@@ -147,14 +147,14 @@ func (m *minerMigrator) migrateDeadlines(ctx context.Context, store cbor.IpldSto
 				return cid.Undef, xerrors.Errorf("bitfield queue: %w", err)
 			}
 
-		outDeadline := *deadlineTemplate
-		outDeadline.Partitions = partitions
-		outDeadline.ExpirationsEpochs = expirationEpochs
-		outDeadline.PartitionsPoSted = inDeadline.PostSubmissions
-		outDeadline.EarlyTerminations = inDeadline.EarlyTerminations
-		outDeadline.LiveSectors = inDeadline.LiveSectors
-		outDeadline.TotalSectors = inDeadline.TotalSectors
-		outDeadline.FaultyPower = miner3.PowerPair(inDeadline.FaultyPower)
+			outDeadline := *deadlineTemplate
+			outDeadline.Partitions = partitions
+			outDeadline.ExpirationsEpochs = expirationEpochs
+			outDeadline.PartitionsPoSted = inDeadline.PostSubmissions
+			outDeadline.EarlyTerminations = inDeadline.EarlyTerminations
+			outDeadline.LiveSectors = inDeadline.LiveSectors
+			outDeadline.TotalSectors = inDeadline.TotalSectors
+			outDeadline.FaultyPower = miner3.PowerPair(inDeadline.FaultyPower)
 
 			return store.Put(ctx, &outDeadline)
 		})


### PR DESCRIPTION
We check:

* There are live sectors (the obvious test).
* There are no proven partitions (shouldn't be possible, but might as well check).
* The partitions haven't changed since last time (dead for at least one proving period).
* There are no optimistic proofs in the snapshot (dead for at least one proving period).

This means all "dead" partitions should be "normalized" (partitions = partitionsSnapshot, etc.). If, for example, a miner decides to "compact" a dead partition, the deadline cron will run for that partition exactly once in order to re-normalize it.

This change also fixes any incorrect PartitionsPoSted bitfields during the state upgrade.

fixes #1348