### PR TITLE
remove the newtype from the migration cache

### DIFF
--- a/actors/migration/nv10/top.go
+++ b/actors/migration/nv10/top.go
@@ -44,25 +44,23 @@ type Logger interface {
 	Log(level rt.LogLevel, msg string, args ...interface{})
 }
 
-type MigrationCacheKey string
-
-func ActorHeadKey(addr address.Address, head cid.Cid) MigrationCacheKey {
-	return MigrationCacheKey(addr.String() + "-h-" + head.String())
+func ActorHeadKey(addr address.Address, head cid.Cid) string {
+	return addr.String() + "-h-" + head.String()
 }
 
-func DeadlineKey(dlCid cid.Cid) MigrationCacheKey {
-	return MigrationCacheKey("d-" + dlCid.String())
+func DeadlineKey(dlCid cid.Cid) string {
+	return "d-" + dlCid.String()
 }
 
-func SectorsRootKey(sCid cid.Cid) MigrationCacheKey {
-	return MigrationCacheKey("s-" + sCid.String())
+func SectorsRootKey(sCid cid.Cid) string {
+	return "s-" + sCid.String()
 }
 
 // MigrationCache stores and loads cached data. Its implementation must be threadsafe
 type MigrationCache interface {
-	Write(key MigrationCacheKey, newCid cid.Cid) error
-	Read(key MigrationCacheKey) (bool, cid.Cid, error)
-	Load(key MigrationCacheKey, loadFunc func() (cid.Cid, error)) (cid.Cid, error)
+	Write(key string, newCid cid.Cid) error
+	Read(key string) (bool, cid.Cid, error)
+	Load(key string, loadFunc func() (cid.Cid, error)) (cid.Cid, error)
 }
 
 // Migrates the filecoin state tree starting from the global state tree and upgrading all actor state.

--- a/actors/migration/nv10/util.go
+++ b/actors/migration/nv10/util.go
@@ -139,12 +139,12 @@ func NewMemMigrationCache() MemMigrationCache {
 	}
 }
 
-func (m MemMigrationCache) Write(key MigrationCacheKey, c cid.Cid) error {
+func (m MemMigrationCache) Write(key string, c cid.Cid) error {
 	m.MigrationMap.Store(key, c)
 	return nil
 }
 
-func (m MemMigrationCache) Read(key MigrationCacheKey) (bool, cid.Cid, error) {
+func (m MemMigrationCache) Read(key string) (bool, cid.Cid, error) {
 	val, found := m.MigrationMap.Load(key)
 	if !found {
 		return false, cid.Undef, nil
@@ -157,7 +157,7 @@ func (m MemMigrationCache) Read(key MigrationCacheKey) (bool, cid.Cid, error) {
 	return true, c, nil
 }
 
-func (m MemMigrationCache) Load(key MigrationCacheKey, loadFunc func() (cid.Cid, error)) (cid.Cid, error) {
+func (m MemMigrationCache) Load(key string, loadFunc func() (cid.Cid, error)) (cid.Cid, error) {
 	found, c, err := m.Read(key)
 	if err != nil {
 		return cid.Undef, err


### PR DESCRIPTION
This makes it easier to abstract over the migration cache in lotus without directly referring to _this_ implementation.