### PR TITLE
migration: add methods to the cache to clone/update

### DIFF
--- a/actors/migration/nv10/util_test.go
+++ b/actors/migration/nv10/util_test.go
@@ -1,0 +1,55 @@
+package nv10_test
+
+import (
+	"testing"
+
+	"github.com/filecoin-project/specs-actors/v3/actors/migration/nv10"
+	atesting "github.com/filecoin-project/specs-actors/v3/support/testing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemMigrationCache(t *testing.T) {
+	cache := nv10.NewMemMigrationCache()
+	cid1 := atesting.MakeCID("foo", nil)
+	cid2 := atesting.MakeCID("bar", nil)
+	require.NoError(t, cache.Write("first", cid1))
+
+	// We see the key we wrote.
+	found, result, err := cache.Read("first")
+	require.True(t, found)
+	require.NoError(t, err)
+	require.Equal(t, cid1, result)
+
+	// Make sure we can't find random keys.
+	found, _, err = cache.Read("other")
+	require.False(t, found)
+	require.NoError(t, err)
+
+	newCache := cache.Clone()
+	require.NoError(t, newCache.Write("second", cid2))
+
+	// We see both keys.
+	found, result, err = newCache.Read("first")
+	require.True(t, found)
+	require.NoError(t, err)
+	require.Equal(t, cid1, result)
+
+	found, result, err = newCache.Read("second")
+	require.True(t, found)
+	require.NoError(t, err)
+	require.Equal(t, cid2, result)
+
+	// But the original cache was not updated.
+	found, _, err = cache.Read("second")
+	require.False(t, found)
+	require.NoError(t, err)
+
+	// Now write back to the original cache.
+	cache.Update(newCache)
+
+	// And make sure that worked.
+	found, result, err = cache.Read("second")
+	require.True(t, found)
+	require.NoError(t, err)
+	require.Equal(t, cid2, result)
+}


### PR DESCRIPTION
This lets us:

1. Clone the cache before pre-migrating.
2. Update the original cache when done pre-migrating.

Otherwise, if we fail when pre-migrating, we may give a cache to the final migration that references blocks that were never actually written to disk.

(also, switch to referencing the cache by pointer)