### PR TITLE
allocate a new slice when combining options

### DIFF
--- a/actors/migration/nv10/util.go
+++ b/actors/migration/nv10/util.go
@@ -25,7 +25,9 @@ func migrateHAMTRaw(ctx context.Context, store cbor.IpldStore, root cid.Cid, new
 		return cid.Undef, err
 	}
 
-	newOpts := append(adt3.DefaultHamtOptions, hamt3.UseTreeBitWidth(newBitwidth))
+	var newOpts []hamt3.Option
+	newOpts = append(newOpts, adt3.DefaultHamtOptions...)
+	newOpts = append(newOpts, hamt3.UseTreeBitWidth(newBitwidth))
 	outRootNode, err := hamt3.NewNode(store, newOpts...)
 	if err != nil {
 		return cid.Undef, err
@@ -51,7 +53,9 @@ func migrateAMTRaw(ctx context.Context, store cbor.IpldStore, root cid.Cid, newB
 		return cid.Undef, err
 	}
 
-	newOpts := append(adt3.DefaultAmtOptions, amt3.UseTreeBitWidth(uint(newBitwidth)))
+	var newOpts []amt3.Option
+	newOpts = append(newOpts, adt3.DefaultAmtOptions...)
+	newOpts = append(newOpts, amt3.UseTreeBitWidth(uint(newBitwidth)))
 	outRootNode, err := amt3.NewAMT(store, newOpts...)
 	if err != nil {
 		return cid.Undef, err
@@ -73,7 +77,9 @@ func migrateHAMTHAMTRaw(ctx context.Context, store cbor.IpldStore, root cid.Cid,
 		return cid.Undef, err
 	}
 
-	newOptsOuter := append(adt3.DefaultHamtOptions, hamt3.UseTreeBitWidth(newOuterBitwidth))
+	var newOptsOuter []hamt3.Option
+	newOptsOuter = append(newOptsOuter, adt3.DefaultHamtOptions...)
+	newOptsOuter = append(newOptsOuter, hamt3.UseTreeBitWidth(newOuterBitwidth))
 	outRootNodeOuter, err := hamt3.NewNode(store, newOptsOuter...)
 	if err != nil {
 		return cid.Undef, err
@@ -106,7 +112,9 @@ func migrateHAMTAMTRaw(ctx context.Context, store cbor.IpldStore, root cid.Cid, 
 	if err != nil {
 		return cid.Undef, err
 	}
-	newOptsOuter := append(adt3.DefaultHamtOptions, hamt3.UseTreeBitWidth(newOuterBitwidth))
+	var newOptsOuter []hamt3.Option
+	newOptsOuter = append(newOptsOuter, adt3.DefaultHamtOptions...)
+	newOptsOuter = append(newOptsOuter, hamt3.UseTreeBitWidth(newOuterBitwidth))
 	outRootNodeOuter, err := hamt3.NewNode(store, newOptsOuter...)
 	if err != nil {
 		return cid.Undef, err

--- a/actors/util/adt/array.go
+++ b/actors/util/adt/array.go
@@ -21,7 +21,9 @@ type Array struct {
 
 // AsArray interprets a store as an AMT-based array with root `r`.
 func AsArray(s Store, r cid.Cid, bitwidth int) (*Array, error) {
-	options := append(DefaultAmtOptions, amt.UseTreeBitWidth(uint(bitwidth)))
+	options := make([]amt.Option, 0, len(DefaultAmtOptions)+1)
+	options = append(options, DefaultAmtOptions...)
+	options = append(options, amt.UseTreeBitWidth(uint(bitwidth)))
 	root, err := amt.LoadAMT(s.Context(), s, r, options...)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to root: %w", err)
@@ -35,7 +37,9 @@ func AsArray(s Store, r cid.Cid, bitwidth int) (*Array, error) {
 
 // Creates a new array backed by an empty AMT.
 func MakeEmptyArray(s Store, bitwidth int) (*Array, error) {
-	options := append(DefaultAmtOptions, amt.UseTreeBitWidth(uint(bitwidth)))
+	options := make([]amt.Option, 0, len(DefaultAmtOptions)+1)
+	options = append(options, DefaultAmtOptions...)
+	options = append(options, amt.UseTreeBitWidth(uint(bitwidth)))
 	root, err := amt.NewAMT(s, options...)
 	if err != nil {
 		return nil, err

--- a/actors/util/adt/map.go
+++ b/actors/util/adt/map.go
@@ -32,7 +32,9 @@ type Map struct {
 // The HAMT is interpreted with branching factor 2^bitwidth.
 // We could drop this parameter if https://github.com/filecoin-project/go-hamt-ipld/issues/79 is implemented.
 func AsMap(s Store, root cid.Cid, bitwidth int) (*Map, error) {
-	options := append(DefaultHamtOptions, hamt.UseTreeBitWidth(bitwidth))
+	options := make([]hamt.Option, 0, len(DefaultHamtOptions)+1)
+	options = append(options, DefaultHamtOptions...)
+	options = append(options, hamt.UseTreeBitWidth(bitwidth))
 	nd, err := hamt.LoadNode(s.Context(), s, root, options...)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to load hamt node: %w", err)
@@ -47,7 +49,9 @@ func AsMap(s Store, root cid.Cid, bitwidth int) (*Map, error) {
 
 // Creates a new map backed by an empty HAMT.
 func MakeEmptyMap(s Store, bitwidth int) (*Map, error) {
-	options := append(DefaultHamtOptions, hamt.UseTreeBitWidth(bitwidth))
+	options := make([]hamt.Option, 0, len(DefaultHamtOptions)+1)
+	options = append(options, DefaultHamtOptions...)
+	options = append(options, hamt.UseTreeBitWidth(bitwidth))
 	nd, err := hamt.NewNode(s, options...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The existing code _should_ be fine as the "defaults" slice shouldn't have any extra capacity. But if, for some reason, it _did_, the append would not be thread-safe.