### PR TITLE
Aggregate PoRep

### DIFF
--- a/actors/builtin/methods.go
+++ b/actors/builtin/methods.go
@@ -101,7 +101,8 @@ var MethodsMiner = struct {
 	ChangeOwnerAddress       abi.MethodNum
 	DisputeWindowedPoSt      abi.MethodNum
 	PreCommitSectorBatch     abi.MethodNum
-}{MethodConstructor, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25}
+	ProveCommitAggregate     abi.MethodNum
+}{MethodConstructor, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}
 
 var MethodsVerifiedRegistry = struct {
 	Constructor       abi.MethodNum

--- a/actors/builtin/miner/cbor_gen.go
+++ b/actors/builtin/miner/cbor_gen.go
@@ -2483,6 +2483,90 @@ func (t *WindowedPoSt) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
+var lengthBufProveCommitAggregateParams = []byte{130}
+
+func (t *ProveCommitAggregateParams) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write(lengthBufProveCommitAggregateParams); err != nil {
+		return err
+	}
+
+	scratch := make([]byte, 9)
+
+	// t.SectorNumbers (bitfield.BitField) (struct)
+	if err := t.SectorNumbers.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.AggregateProof ([]uint8) (slice)
+	if len(t.AggregateProof) > cbg.ByteArrayMaxLen {
+		return xerrors.Errorf("Byte array in field t.AggregateProof was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajByteString, uint64(len(t.AggregateProof))); err != nil {
+		return err
+	}
+
+	if _, err := w.Write(t.AggregateProof[:]); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *ProveCommitAggregateParams) UnmarshalCBOR(r io.Reader) error {
+	*t = ProveCommitAggregateParams{}
+
+	br := cbg.GetPeeker(r)
+	scratch := make([]byte, 8)
+
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 2 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.SectorNumbers (bitfield.BitField) (struct)
+
+	{
+
+		if err := t.SectorNumbers.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.SectorNumbers: %w", err)
+		}
+
+	}
+	// t.AggregateProof ([]uint8) (slice)
+
+	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+
+	if extra > cbg.ByteArrayMaxLen {
+		return fmt.Errorf("t.AggregateProof: byte array too large (%d)", extra)
+	}
+	if maj != cbg.MajByteString {
+		return fmt.Errorf("expected byte array")
+	}
+
+	if extra > 0 {
+		t.AggregateProof = make([]uint8, extra)
+	}
+
+	if _, err := io.ReadFull(br, t.AggregateProof[:]); err != nil {
+		return err
+	}
+	return nil
+}
+
 var lengthBufPreCommitSectorBatchParams = []byte{129}
 
 func (t *PreCommitSectorBatchParams) MarshalCBOR(w io.Writer) error {

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -376,6 +376,31 @@ func (st *State) GetPrecommittedSector(store adt.Store, sectorNo abi.SectorNumbe
 	return &info, found, nil
 }
 
+// Load all precommits or fail trying
+func (st *State) GetAllPrecommittedSectors(store adt.Store, sectorNos bitfield.BitField) ([]*SectorPreCommitOnChainInfo, error) {
+	precommits := make([]*SectorPreCommitOnChainInfo, 0)
+	precommitted, err := adt.AsMap(store, st.PreCommittedSectors, builtin.DefaultHamtBitwidth)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := sectorNos.ForEach(func(sectorNo uint64) error {
+		var info SectorPreCommitOnChainInfo
+		found, err := precommitted.Get(SectorKey(abi.SectorNumber(sectorNo)), &info)
+		if err != nil {
+			return err
+		}
+		if !found {
+			return xc.ErrNotFound.Wrapf("sector %d not found", sectorNo)
+		}
+		precommits = append(precommits, &info)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return precommits, nil
+}
+
 // This method gets and returns the requested pre-committed sectors, skipping
 // missing sectors.
 func (st *State) FindPrecommittedSectors(store adt.Store, sectorNos ...abi.SectorNumber) ([]*SectorPreCommitOnChainInfo, error) {

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -171,11 +171,11 @@ var MaxProveCommitDuration = map[abi.RegisteredSealProof]abi.ChainEpoch{
 	abi.RegisteredSealProof_StackedDrg512MiBV1: builtin.EpochsInDay + PreCommitChallengeDelay,
 	abi.RegisteredSealProof_StackedDrg64GiBV1:  builtin.EpochsInDay + PreCommitChallengeDelay,
 
-	abi.RegisteredSealProof_StackedDrg32GiBV1_1:  builtin.EpochsInDay + PreCommitChallengeDelay, // PARAM_SPEC
-	abi.RegisteredSealProof_StackedDrg2KiBV1_1:   builtin.EpochsInDay + PreCommitChallengeDelay,
-	abi.RegisteredSealProof_StackedDrg8MiBV1_1:   builtin.EpochsInDay + PreCommitChallengeDelay,
-	abi.RegisteredSealProof_StackedDrg512MiBV1_1: builtin.EpochsInDay + PreCommitChallengeDelay,
-	abi.RegisteredSealProof_StackedDrg64GiBV1_1:  builtin.EpochsInDay + PreCommitChallengeDelay,
+	abi.RegisteredSealProof_StackedDrg32GiBV1_1:  6*builtin.EpochsInDay + PreCommitChallengeDelay, // PARAM_SPEC
+	abi.RegisteredSealProof_StackedDrg2KiBV1_1:   6*builtin.EpochsInDay + PreCommitChallengeDelay,
+	abi.RegisteredSealProof_StackedDrg8MiBV1_1:   6*builtin.EpochsInDay + PreCommitChallengeDelay,
+	abi.RegisteredSealProof_StackedDrg512MiBV1_1: 6*builtin.EpochsInDay + PreCommitChallengeDelay,
+	abi.RegisteredSealProof_StackedDrg64GiBV1_1:  6*builtin.EpochsInDay + PreCommitChallengeDelay,
 }
 
 // The maximum number of sector pre-commitments in a single batch.
@@ -310,3 +310,7 @@ func RewardForDisputedWindowPoSt(proofType abi.RegisteredPoStProof, disputedPowe
 	// This is currently just the base. In the future, the fee may scale based on the disputed power.
 	return BaseRewardForDisputedWindowPoSt
 }
+
+const MaxAggregatedSectors = 819
+const MinAggregatedSectors = 1
+const MaxAggregateProofSize = 192000

--- a/actors/builtin/power/policy.go
+++ b/actors/builtin/power/policy.go
@@ -10,4 +10,3 @@ const ConsensusMinerMinMiners = 4 // PARAM_SPEC
 // This limits the number of proof partitions we may need to load in the cron call path.
 // Onboarding 1EiB/year requires at least 32 prove-commits per epoch.
 const MaxMinerProveCommitsPerEpoch = 200 // PARAM_SPEC
-

--- a/actors/builtin/power/power_actor.go
+++ b/actors/builtin/power/power_actor.go
@@ -63,12 +63,12 @@ var _ runtime.VMActor = Actor{}
 // Changed since v2:
 // - Seal proof type replaced with PoSt proof type
 type MinerConstructorParams struct {
-	OwnerAddr            addr.Address
-	WorkerAddr           addr.Address
-	ControlAddrs         []addr.Address
-	WindowPoStProofType  abi.RegisteredPoStProof
-	PeerId               abi.PeerID
-	Multiaddrs           []abi.Multiaddrs
+	OwnerAddr           addr.Address
+	WorkerAddr          addr.Address
+	ControlAddrs        []addr.Address
+	WindowPoStProofType abi.RegisteredPoStProof
+	PeerId              abi.PeerID
+	Multiaddrs          []abi.Multiaddrs
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -87,11 +87,11 @@ func (a Actor) Constructor(rt Runtime, _ *abi.EmptyValue) *abi.EmptyValue {
 // Changed since v2:
 // - Seal proof type replaced with PoSt proof types
 type CreateMinerParams struct {
-	Owner                addr.Address
-	Worker               addr.Address
-	WindowPoStProofType  abi.RegisteredPoStProof
-	Peer                 abi.PeerID
-	Multiaddrs           []abi.Multiaddrs
+	Owner               addr.Address
+	Worker              addr.Address
+	WindowPoStProofType abi.RegisteredPoStProof
+	Peer                abi.PeerID
+	Multiaddrs          []abi.Multiaddrs
 }
 
 //type CreateMinerReturn struct {
@@ -104,11 +104,11 @@ func (a Actor) CreateMiner(rt Runtime, params *CreateMinerParams) *CreateMinerRe
 	rt.ValidateImmediateCallerType(builtin.CallerTypesSignable...)
 
 	ctorParams := MinerConstructorParams{
-		OwnerAddr:  params.Owner,
-		WorkerAddr: params.Worker,
+		OwnerAddr:           params.Owner,
+		WorkerAddr:          params.Worker,
 		WindowPoStProofType: params.WindowPoStProofType,
-		PeerId:        params.Peer,
-		Multiaddrs:    params.Multiaddrs,
+		PeerId:              params.Peer,
+		Multiaddrs:          params.Multiaddrs,
 	}
 	ctorParamBuf := new(bytes.Buffer)
 	err := ctorParams.MarshalCBOR(ctorParamBuf)

--- a/actors/builtin/power/power_test.go
+++ b/actors/builtin/power/power_test.go
@@ -97,11 +97,11 @@ func TestCreateMinerFailures(t *testing.T) {
 		rt, ac := basicPowerSetup(t)
 
 		createMinerParams := &power.CreateMinerParams{
-			Owner:                owner,
-			Worker:               owner,
-			WindowPoStProofType:  windowPoStProofType,
-			Peer:                 peer,
-			Multiaddrs:           mAddr,
+			Owner:               owner,
+			Worker:              owner,
+			WindowPoStProofType: windowPoStProofType,
+			Peer:                peer,
+			Multiaddrs:          mAddr,
 		}
 
 		// owner send CreateMiner to Actor
@@ -1083,18 +1083,18 @@ func verifyEmptyMap(t testing.TB, rt *mock.Runtime, cid cid.Cid) {
 
 type spActorHarness struct {
 	power.Actor
-	t                *testing.T
-	minerSeq         int
-	sealProof        abi.RegisteredSealProof
-	windowPoStProof  abi.RegisteredPoStProof
+	t               *testing.T
+	minerSeq        int
+	sealProof       abi.RegisteredSealProof
+	windowPoStProof abi.RegisteredPoStProof
 }
 
 func newHarness(t *testing.T) *spActorHarness {
 	return &spActorHarness{
-		Actor:            power.Actor{},
-		t:                t,
-		sealProof:        abi.RegisteredSealProof_StackedDrg32GiBV1_1,
-		windowPoStProof:  abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
+		Actor:           power.Actor{},
+		t:               t,
+		sealProof:       abi.RegisteredSealProof_StackedDrg32GiBV1_1,
+		windowPoStProof: abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
 	}
 }
 
@@ -1159,11 +1159,11 @@ func (h *spActorHarness) createMiner(rt *mock.Runtime, owner, worker, miner, rob
 	prevMinerCount := st.MinerCount
 
 	createMinerParams := &power.CreateMinerParams{
-		Owner:                owner,
-		Worker:               worker,
-		WindowPoStProofType:  windowPoStProofType,
-		Peer:                 peer,
-		Multiaddrs:           multiaddrs,
+		Owner:               owner,
+		Worker:              worker,
+		WindowPoStProofType: windowPoStProofType,
+		Peer:                peer,
+		Multiaddrs:          multiaddrs,
 	}
 
 	// owner send CreateMiner to Actor
@@ -1317,6 +1317,7 @@ func (h *spActorHarness) enrollCronEvent(rt *mock.Runtime, miner addr.Address, e
 }
 
 func (h *spActorHarness) submitPoRepForBulkVerify(rt *mock.Runtime, minerAddr addr.Address, sealInfo *proof.SealVerifyInfo) {
+	rt.ExpectGasCharged(power.GasOnSubmitVerifySeal)
 	rt.ExpectValidateCallerType(builtin.StorageMinerActorCodeID)
 	rt.SetCaller(minerAddr, builtin.StorageMinerActorCodeID)
 	rt.Call(h.Actor.SubmitPoRepForBulkVerify, sealInfo)
@@ -1349,11 +1350,11 @@ func (h *spActorHarness) checkState(rt *mock.Runtime) {
 
 func initCreateMinerBytes(t testing.TB, owner, worker addr.Address, peer abi.PeerID, multiaddrs []abi.Multiaddrs, windowPoStProofType abi.RegisteredPoStProof) []byte {
 	params := &power.MinerConstructorParams{
-		OwnerAddr:            owner,
-		WorkerAddr:           worker,
-		WindowPoStProofType:  windowPoStProofType,
-		PeerId:               peer,
-		Multiaddrs:           multiaddrs,
+		OwnerAddr:           owner,
+		WorkerAddr:          worker,
+		WindowPoStProofType: windowPoStProofType,
+		PeerId:              peer,
+		Multiaddrs:          multiaddrs,
 	}
 
 	buf := new(bytes.Buffer)

--- a/actors/runtime/proof/verify.go
+++ b/actors/runtime/proof/verify.go
@@ -1,7 +1,9 @@
 package proof
 
 import (
+	"github.com/filecoin-project/go-state-types/abi"
 	proof0 "github.com/filecoin-project/specs-actors/actors/runtime/proof"
+	"github.com/ipfs/go-cid"
 )
 
 ///
@@ -22,6 +24,24 @@ import (
 //	UnsealedCID cid.Cid `checked:"true"` // CommD
 //}
 type SealVerifyInfo = proof0.SealVerifyInfo
+
+type AggregateSealVerifyInfo struct {
+	Number                abi.SectorNumber
+	Randomness            abi.SealRandomness
+	InteractiveRandomness abi.InteractiveSealRandomness
+
+	// Safe because we get those from the miner actor
+	SealedCID   cid.Cid `checked:"true"` // CommR
+	UnsealedCID cid.Cid `checked:"true"` // CommD
+}
+
+type AggregateSealVerifyProofAndInfos struct {
+	Miner          abi.ActorID
+	SealProof      abi.RegisteredSealProof
+	AggregateProof abi.RegisteredAggregationProof
+	Proof          []byte
+	Infos          []AggregateSealVerifyInfo
+}
 
 ///
 /// PoSting

--- a/actors/runtime/runtime.go
+++ b/actors/runtime/runtime.go
@@ -182,6 +182,7 @@ type Syscalls interface {
 	VerifySeal(vi proof.SealVerifyInfo) error
 
 	BatchVerifySeals(vis map[addr.Address][]proof.SealVerifyInfo) (map[addr.Address][]bool, error)
+	VerifyAggregateSeals(aggregate proof.AggregateSealVerifyProofAndInfos) error
 
 	// Verifies a proof of spacetime.
 	VerifyPoSt(vi proof.WindowPoStVerifyInfo) error

--- a/actors/test/commit_post_test.go
+++ b/actors/test/commit_post_test.go
@@ -1,10 +1,12 @@
-package test_test
+package test
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-bitfield"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
@@ -330,4 +332,324 @@ func TestCommitPoStFlow(t *testing.T) {
 		assert.Equal(t, big.Zero(), networkStats.TotalBytesCommitted)
 		assert.True(t, networkStats.TotalPledgeCollateral.GreaterThan(big.Zero()))
 	})
+}
+
+func TestMeasurePoRepGas(t *testing.T) {
+
+	batchSize := 819
+	fmt.Printf("Batch Size = %d\n", batchSize)
+	printPoRepMsgGas(batchSize)
+
+	ctx := context.Background()
+	blkStore := ipld.NewBlockStoreInMemory()
+	metrics := ipld.NewMetricsBlockStore(blkStore)
+	v := vm.NewVMWithSingletons(ctx, t, metrics)
+	v.SetStatsSource(metrics)
+	addrs := vm.CreateAccounts(ctx, t, v, 1, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
+
+	minerBalance := big.Mul(big.NewInt(10_000), vm.FIL)
+	sealProof := abi.RegisteredSealProof_StackedDrg32GiBV1_1
+
+	// create miner
+	params := power.CreateMinerParams{
+		Owner:               addrs[0],
+		Worker:              addrs[0],
+		WindowPoStProofType: abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
+		Peer:                abi.PeerID("not really a peer id"),
+	}
+	ret := vm.ApplyOk(t, v, addrs[0], builtin.StoragePowerActorAddr, minerBalance, builtin.MethodsPower.CreateMiner, &params)
+	minerAddrs, ok := ret.(*power.CreateMinerReturn)
+	require.True(t, ok)
+
+	// advance vm so we can have seal randomness epoch in the past
+	v, err := v.WithEpoch(abi.ChainEpoch(200))
+	require.NoError(t, err)
+
+	//
+	// precommit sectors
+	//
+	sectorNumbers, _ := preCommitSectors(t, v, batchSize, addrs[0], minerAddrs.IDAddress, sealProof)
+
+	balances := vm.GetMinerBalances(t, v, minerAddrs.IDAddress)
+	assert.True(t, balances.PreCommitDeposit.GreaterThan(big.Zero()))
+
+	// advance time to max seal duration
+	proveTime := v.GetEpoch() + miner.MaxProveCommitDuration[sealProof]
+	v, _ = vm.AdvanceByDeadlineTillEpoch(t, v, minerAddrs.IDAddress, proveTime)
+
+	//
+	// prove and verify
+	//
+	v, err = v.WithEpoch(proveTime)
+	require.NoError(t, err)
+	sectorsProven := 0
+	crons := 0
+	// Prove sectors in batches of 200 to avoid going over the max 200 commits per miner per power cron invocation
+	for sectorsProven < batchSize {
+		sectorsToProveThisCron := min(batchSize-sectorsProven, power.MaxMinerProveCommitsPerEpoch)
+		for i := 0; i < sectorsToProveThisCron; i++ {
+			// Prove commit sector at a valid epoch
+			proveCommitParams := miner.ProveCommitSectorParams{
+				SectorNumber: sectorNumbers[i+sectorsProven],
+			}
+			vm.ApplyOk(t, v, addrs[0], minerAddrs.RobustAddress, big.Zero(), builtin.MethodsMiner.ProveCommitSector, &proveCommitParams)
+
+			vm.ExpectInvocation{
+				To:     minerAddrs.IDAddress,
+				Method: builtin.MethodsMiner.ProveCommitSector,
+				Params: vm.ExpectObject(&proveCommitParams),
+				SubInvocations: []vm.ExpectInvocation{
+					{To: builtin.StorageMarketActorAddr, Method: builtin.MethodsMarket.ComputeDataCommitment},
+					{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.SubmitPoRepForBulkVerify},
+				},
+			}.Matches(t, v.Invocations()[sectorsProven+crons+i])
+		}
+		sectorsProven += sectorsToProveThisCron
+
+		proveCommitKey := vm.MethodKey{Code: builtin.StorageMinerActorCodeID, Method: builtin.MethodsMiner.ProveCommitSector}
+		stats := v.GetCallStats()
+		fmt.Printf("\n--------------------- Batch %d ---------------------\n", crons)
+		printCallStats(proveCommitKey, stats[proveCommitKey], "\n")
+
+		// In the same epoch, trigger cron to validate prove commits
+		vm.ApplyOk(t, v, builtin.SystemActorAddr, builtin.CronActorAddr, big.Zero(), builtin.MethodsCron.EpochTick, nil)
+		crons += 1
+		cronKey := vm.MethodKey{Code: builtin.CronActorCodeID, Method: builtin.MethodsCron.EpochTick}
+		stats = v.GetCallStats()
+		printCallStats(cronKey, stats[cronKey], "\n")
+
+		vm.ExpectInvocation{
+			To:     builtin.CronActorAddr,
+			Method: builtin.MethodsCron.EpochTick,
+			SubInvocations: []vm.ExpectInvocation{
+				{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.OnEpochTickEnd, SubInvocations: []vm.ExpectInvocation{
+					// expect confirm sector proofs valid because we prove committed,
+					// but not an on deferred cron event because this is not a deadline boundary
+					{To: minerAddrs.IDAddress, Method: builtin.MethodsMiner.ConfirmSectorProofsValid, SubInvocations: []vm.ExpectInvocation{
+						{To: builtin.RewardActorAddr, Method: builtin.MethodsReward.ThisEpochReward},
+						{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.CurrentTotalPower},
+						{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.UpdatePledgeTotal},
+					}},
+					{To: builtin.RewardActorAddr, Method: builtin.MethodsReward.UpdateNetworkKPI},
+				}},
+				{To: builtin.StorageMarketActorAddr, Method: builtin.MethodsMarket.CronTick},
+			},
+		}.Matches(t, v.Invocations()[sectorsProven+crons-1])
+
+	}
+
+	// precommit deposit is released, ipr is added
+	balances = vm.GetMinerBalances(t, v, minerAddrs.IDAddress)
+	assert.True(t, balances.InitialPledge.GreaterThan(big.Zero()))
+	assert.Equal(t, big.Zero(), balances.PreCommitDeposit)
+
+	// power is unproven so network stats are unchanged
+	networkStats := vm.GetNetworkStats(t, v)
+	assert.Equal(t, big.Zero(), networkStats.TotalBytesCommitted)
+	assert.True(t, networkStats.TotalPledgeCollateral.GreaterThan(big.Zero()))
+
+}
+
+func TestMeasureAggregatePorepGas(t *testing.T) {
+
+	batchSize := 819
+	fmt.Printf("batch size = %d\n", batchSize)
+
+	ctx := context.Background()
+	blkStore := ipld.NewBlockStoreInMemory()
+	metrics := ipld.NewMetricsBlockStore(blkStore)
+	v := vm.NewVMWithSingletons(ctx, t, metrics)
+	v.SetStatsSource(metrics)
+	addrs := vm.CreateAccounts(ctx, t, v, 1, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
+
+	minerBalance := big.Mul(big.NewInt(10_000), vm.FIL)
+	sealProof := abi.RegisteredSealProof_StackedDrg32GiBV1_1
+
+	// create miner
+	params := power.CreateMinerParams{
+		Owner:               addrs[0],
+		Worker:              addrs[0],
+		WindowPoStProofType: abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
+		Peer:                abi.PeerID("not really a peer id"),
+	}
+	ret := vm.ApplyOk(t, v, addrs[0], builtin.StoragePowerActorAddr, minerBalance, builtin.MethodsPower.CreateMiner, &params)
+	minerAddrs, ok := ret.(*power.CreateMinerReturn)
+	require.True(t, ok)
+
+	// advance vm so we can have seal randomness epoch in the past
+	v, err := v.WithEpoch(abi.ChainEpoch(200))
+	require.NoError(t, err)
+
+	//
+	// precommit sectors
+	//
+	sectorNumbers, _ := preCommitSectors(t, v, batchSize, addrs[0], minerAddrs.IDAddress, sealProof)
+	balances := vm.GetMinerBalances(t, v, minerAddrs.IDAddress)
+	assert.True(t, balances.PreCommitDeposit.GreaterThan(big.Zero()))
+
+	// advance time to max seal duration
+	proveTime := v.GetEpoch() + miner.MaxProveCommitDuration[sealProof]
+	v, _ = vm.AdvanceByDeadlineTillEpoch(t, v, minerAddrs.IDAddress, proveTime)
+
+	//
+	// prove and verify
+	//
+	v, err = v.WithEpoch(proveTime)
+	require.NoError(t, err)
+	intSectorNumbers := make([]uint64, len(sectorNumbers))
+	for i := range sectorNumbers {
+		intSectorNumbers[i] = uint64(sectorNumbers[i])
+	}
+	sectorNosBf := bitfield.NewFromSet(intSectorNumbers)
+
+	proveCommitAggregateParams := miner.ProveCommitAggregateParams{
+		SectorNumbers: sectorNosBf,
+	}
+	vm.ApplyOk(t, v, addrs[0], minerAddrs.RobustAddress, big.Zero(), builtin.MethodsMiner.ProveCommitAggregate, &proveCommitAggregateParams)
+	vm.ExpectInvocation{
+		To:     minerAddrs.IDAddress,
+		Method: builtin.MethodsMiner.ProveCommitAggregate,
+		Params: vm.ExpectObject(&proveCommitAggregateParams),
+		SubInvocations: []vm.ExpectInvocation{
+			{To: builtin.StorageMarketActorAddr, Method: builtin.MethodsMarket.ComputeDataCommitment},
+			{To: builtin.RewardActorAddr, Method: builtin.MethodsReward.ThisEpochReward},
+			{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.CurrentTotalPower},
+			{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.UpdatePledgeTotal},
+		},
+	}.Matches(t, v.Invocations()[0])
+
+	proveCommitAggrKey := vm.MethodKey{Code: builtin.StorageMinerActorCodeID, Method: builtin.MethodsMiner.ProveCommitAggregate}
+	stats := v.GetCallStats()
+	printCallStats(proveCommitAggrKey, stats[proveCommitAggrKey], "\n")
+
+	// In the same epoch, trigger cron to
+	vm.ApplyOk(t, v, builtin.SystemActorAddr, builtin.CronActorAddr, big.Zero(), builtin.MethodsCron.EpochTick, nil)
+
+	cronKey := vm.MethodKey{Code: builtin.CronActorCodeID, Method: builtin.MethodsCron.EpochTick}
+	stats = v.GetCallStats()
+	printCallStats(cronKey, stats[cronKey], "\n")
+
+	vm.ExpectInvocation{
+		To:     builtin.CronActorAddr,
+		Method: builtin.MethodsCron.EpochTick,
+		SubInvocations: []vm.ExpectInvocation{
+			{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.OnEpochTickEnd, SubInvocations: []vm.ExpectInvocation{
+				// expect no confirm sector proofs valid because we prove committed with aggregation.
+				// expect no on deferred cron event because this is not a deadline boundary
+				{To: builtin.RewardActorAddr, Method: builtin.MethodsReward.UpdateNetworkKPI},
+			}},
+			{To: builtin.StorageMarketActorAddr, Method: builtin.MethodsMarket.CronTick},
+		},
+	}.Matches(t, v.Invocations()[1])
+
+	// precommit deposit is released, ipr is added
+	balances = vm.GetMinerBalances(t, v, minerAddrs.IDAddress)
+	assert.True(t, balances.InitialPledge.GreaterThan(big.Zero()))
+	assert.Equal(t, big.Zero(), balances.PreCommitDeposit)
+
+	// power is unproven so network stats are unchanged
+	networkStats := vm.GetNetworkStats(t, v)
+	assert.Equal(t, big.Zero(), networkStats.TotalBytesCommitted)
+	assert.True(t, networkStats.TotalPledgeCollateral.GreaterThan(big.Zero()))
+
+}
+
+func preCommitSectors(t *testing.T, v *vm.VM, batchSize int, worker, mAddr address.Address, sealProof abi.RegisteredSealProof) ([]abi.SectorNumber, []*miner.SectorPreCommitOnChainInfo) {
+	sectorNumberBase := 100
+	precommits := []*miner.SectorPreCommitOnChainInfo{}
+	sectorNumbers := []abi.SectorNumber{}
+
+	invocsCommon := []vm.ExpectInvocation{
+		{To: builtin.RewardActorAddr, Method: builtin.MethodsReward.ThisEpochReward},
+		{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.CurrentTotalPower},
+	}
+	invocsFirst := append(invocsCommon, vm.ExpectInvocation{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.EnrollCronEvent})
+	for i := 0; i < batchSize; i++ {
+		sectorNumber := abi.SectorNumber(sectorNumberBase + i)
+		sealedCid := tutil.MakeCID(fmt.Sprintf("%d", sectorNumber), &miner.SealedCIDPrefix)
+
+		preCommitParams := miner.PreCommitSectorParams{
+			SealProof:     sealProof,
+			SectorNumber:  sectorNumber,
+			SealedCID:     sealedCid,
+			SealRandEpoch: v.GetEpoch() - 1,
+			DealIDs:       nil,
+			Expiration:    v.GetEpoch() + miner.MinSectorExpiration + miner.MaxProveCommitDuration[sealProof] + 100,
+		}
+		vm.ApplyOk(t, v, worker, mAddr, big.Zero(), builtin.MethodsMiner.PreCommitSector, &preCommitParams)
+		invocs := invocsCommon
+		if i == 0 {
+			invocs = invocsFirst
+		}
+		// assert successful precommit invocation
+		vm.ExpectInvocation{
+			To:             mAddr,
+			Method:         builtin.MethodsMiner.PreCommitSector,
+			Params:         vm.ExpectObject(&preCommitParams),
+			SubInvocations: invocs,
+		}.Matches(t, v.Invocations()[i])
+
+		// find information about precommited sector
+		var minerState miner.State
+		err := v.GetState(mAddr, &minerState)
+		require.NoError(t, err)
+
+		precommit, found, err := minerState.GetPrecommittedSector(v.Store(), sectorNumber)
+		require.NoError(t, err)
+		require.True(t, found)
+		precommits = append(precommits, precommit)
+		sectorNumbers = append(sectorNumbers, sectorNumber)
+	}
+	return sectorNumbers, precommits
+
+}
+
+func printCallStats(method vm.MethodKey, stats *vm.CallStats, indent string) { // nolint:unused
+	fmt.Printf("%s%v:%d: calls: %d  gets: %d  puts: %d  read: %d  written: %d  avg gets: %.2f, avg puts: %.2f\n",
+		indent, builtin.ActorNameByCode(method.Code), method.Method, stats.Calls, stats.Reads, stats.Writes,
+		stats.ReadBytes, stats.WriteBytes, float32(stats.Reads)/float32(stats.Calls),
+		float32(stats.Writes)/float32(stats.Calls))
+
+	gasGetObj := uint64(75242)
+	gasPutObj := uint64(84070)
+	gasPutPerByte := uint64(1)
+	gasStorageMultiplier := uint64(1300)
+	gasPerCall := uint64(29233)
+
+	ipldGas := stats.Reads*gasGetObj + stats.Writes*gasPutObj + stats.WriteBytes*gasPutPerByte*gasStorageMultiplier
+	callGas := stats.Calls * gasPerCall
+	fmt.Printf("%v:%d: ipld gas=%d call gas=%d\n", builtin.ActorNameByCode(method.Code), method.Method, ipldGas, callGas)
+
+	if stats.SubStats == nil {
+		return
+	}
+
+	for m, s := range stats.SubStats {
+		printCallStats(m, s, indent+"  ")
+	}
+}
+
+// Using gas params from filecoin v12 and assumptions about parameters to ProveCommitAggregate print an estimate
+// of the gas charged for the on chain ProveCommitAggregate message.
+func printPoRepMsgGas(batchSize int) {
+	// Ignore message fields and sector number bytes for both.
+	// Ignoring non-parma message fields under estimates both by the same amount
+	// Ignoring sector numbers/bitfields underestimates current porep compared to aggregate
+	// which is the right direction for finding a starting bound (we can optimize later)
+	onChainMessageComputeBase := 38863
+	onChainMessageStorageBase := 36
+	onChainMessageStoragePerByte := 1
+	storageGasMultiplier := 1300
+	msgBytes := 1920
+	msgGas := onChainMessageComputeBase + (onChainMessageStorageBase+onChainMessageStoragePerByte*msgBytes)*storageGasMultiplier
+
+	allMsgsGas := batchSize * msgGas
+	fmt.Printf("%d batchsize: all proof param byte gas: %d\n", batchSize, allMsgsGas)
+}
+
+func min(a, b int) int {
+	if a <= b {
+		return a
+	}
+	return b
 }

--- a/actors/test/committed_capacity_scenario_test.go
+++ b/actors/test/committed_capacity_scenario_test.go
@@ -1,4 +1,4 @@
-package test_test
+package test
 
 import (
 	"context"
@@ -34,10 +34,10 @@ func TestReplaceCommittedCapacitySectorWithDealLadenSector(t *testing.T) {
 
 	// create miner
 	params := power.CreateMinerParams{
-		Owner:                worker,
-		Worker:               worker,
-		WindowPoStProofType:  abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
-		Peer:                 abi.PeerID("not really a peer id"),
+		Owner:               worker,
+		Worker:              worker,
+		WindowPoStProofType: abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
+		Peer:                abi.PeerID("not really a peer id"),
 	}
 	ret := vm.ApplyOk(t, v, addrs[0], builtin.StoragePowerActorAddr, minerBalance, builtin.MethodsPower.CreateMiner, &params)
 

--- a/actors/test/common_test.go
+++ b/actors/test/common_test.go
@@ -1,4 +1,4 @@
-package test_test
+package test
 
 import (
 	"testing"

--- a/actors/test/cron_catches_expiries_scenario_test.go
+++ b/actors/test/cron_catches_expiries_scenario_test.go
@@ -1,4 +1,4 @@
-package test_test
+package test
 
 import (
 	"context"
@@ -34,10 +34,10 @@ func TestCronCatchedCCExpirationsAtDeadlineBoundary(t *testing.T) {
 
 	// create miner
 	params := power.CreateMinerParams{
-		Owner:                worker,
-		Worker:               worker,
-		WindowPoStProofType:  abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
-		Peer:                 abi.PeerID("not really a peer id"),
+		Owner:               worker,
+		Worker:              worker,
+		WindowPoStProofType: abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
+		Peer:                abi.PeerID("not really a peer id"),
 	}
 	ret := vm.ApplyOk(t, v, worker, builtin.StoragePowerActorAddr, minerBalance, builtin.MethodsPower.CreateMiner, &params)
 

--- a/actors/test/market_withdrawal_test.go
+++ b/actors/test/market_withdrawal_test.go
@@ -1,4 +1,4 @@
-package test_test
+package test
 
 import (
 	"context"

--- a/actors/test/power_scenario_test.go
+++ b/actors/test/power_scenario_test.go
@@ -1,4 +1,4 @@
-package test_test
+package test
 
 import (
 	"context"

--- a/actors/test/terminate_sectors_scenario_test.go
+++ b/actors/test/terminate_sectors_scenario_test.go
@@ -1,4 +1,4 @@
-package test_test
+package test
 
 import (
 	"context"
@@ -36,10 +36,10 @@ func TestTerminateSectors(t *testing.T) {
 
 	// create miner
 	ret := vm.ApplyOk(t, v, addrs[0], builtin.StoragePowerActorAddr, minerBalance, builtin.MethodsPower.CreateMiner, &power.CreateMinerParams{
-		Owner:                owner,
-		Worker:               worker,
-		WindowPoStProofType:  abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
-		Peer:                 abi.PeerID("not really a peer id"),
+		Owner:               owner,
+		Worker:              worker,
+		WindowPoStProofType: abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
+		Peer:                abi.PeerID("not really a peer id"),
 	})
 
 	minerAddrs, ok := ret.(*power.CreateMinerReturn)

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -152,7 +152,9 @@ func main() {
 		//market.ActivateDealsParams{}, // Aliased from v0
 		market.VerifyDealsForActivationParams{},
 		market.VerifyDealsForActivationReturn{},
-		//market.ComputeDataCommitmentParams{}, // Aliased from v0
+		market.SectorDataSpec{},
+		market.ComputeDataCommitmentParams{},
+		market.ComputeDataCommitmentReturn{},
 		//market.OnMinerSectorsTerminateParams{}, // Aliased from v0
 		// other types
 		//market.DealProposal{}, // Aliased from v0
@@ -188,6 +190,7 @@ func main() {
 		//miner.ChangePeerIDParams{}, // Aliased from v0
 		//miner.ChangeMultiaddrsParams{}, // Aliased from v0
 		//miner.ProveCommitSectorParams{}, // Aliased from v0
+		miner.ProveCommitAggregateParams{},
 		//miner.ChangeWorkerAddressParams{},  // Aliased from v0
 		//miner.ExtendSectorExpirationParams{}, // Aliased from v0
 		//miner.DeclareFaultsParams{}, // Aliased from v0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/filecoin-project/go-amt-ipld/v3 v3.0.0
 	github.com/filecoin-project/go-bitfield v0.2.3
 	github.com/filecoin-project/go-hamt-ipld/v3 v3.0.1
-	github.com/filecoin-project/go-state-types v0.1.0
+	github.com/filecoin-project/go-state-types v0.1.1-0.20210506134452-99b279731c48
 	github.com/filecoin-project/specs-actors v0.9.13
 	github.com/filecoin-project/specs-actors/v2 v2.3.5-0.20210114162132-5b58b773f4fb
 	github.com/filecoin-project/specs-actors/v3 v3.1.0

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,9 @@ github.com/filecoin-project/go-hamt-ipld/v3 v3.0.1 h1:zbzs46G7bOctkZ+JUX3xirrj0R
 github.com/filecoin-project/go-hamt-ipld/v3 v3.0.1/go.mod h1:gXpNmr3oQx8l3o7qkGyDjJjYSRX7hp/FGOStdqrWyDI=
 github.com/filecoin-project/go-state-types v0.0.0-20200928172055-2df22083d8ab/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
 github.com/filecoin-project/go-state-types v0.0.0-20201102161440-c8033295a1fc/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
-github.com/filecoin-project/go-state-types v0.1.0 h1:9r2HCSMMCmyMfGyMKxQtv0GKp6VT/m5GgVk8EhYbLJU=
 github.com/filecoin-project/go-state-types v0.1.0/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
+github.com/filecoin-project/go-state-types v0.1.1-0.20210506134452-99b279731c48 h1:Jc4OprDp3bRDxbsrXNHPwJabZJM3iDy+ri8/1e0ZnX4=
+github.com/filecoin-project/go-state-types v0.1.1-0.20210506134452-99b279731c48/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
 github.com/filecoin-project/specs-actors v0.9.13 h1:rUEOQouefi9fuVY/2HOroROJlZbOzWYXXeIh41KF2M4=
 github.com/filecoin-project/specs-actors v0.9.13/go.mod h1:TS1AW/7LbG+615j4NsjMK1qlpAwaFsG9w0V2tg2gSao=
 github.com/filecoin-project/specs-actors/v2 v2.3.5-0.20210114162132-5b58b773f4fb h1:orr/sMzrDZUPAveRE+paBdu1kScIUO5zm+HYeh+VlhA=

--- a/support/vm/invocation_context.go
+++ b/support/vm/invocation_context.go
@@ -202,6 +202,10 @@ func (ic *invocationContext) BatchVerifySeals(vis map[address.Address][]proof.Se
 	return ic.Syscalls().BatchVerifySeals(vis)
 }
 
+func (ic *invocationContext) VerifyAggregateSeals(agg proof.AggregateSealVerifyProofAndInfos) error {
+	return ic.Syscalls().VerifyAggregateSeals(agg)
+}
+
 func (ic *invocationContext) VerifyPoSt(vi proof.WindowPoStVerifyInfo) error {
 	return ic.Syscalls().VerifyPoSt(vi)
 }
@@ -487,6 +491,10 @@ func (s fakeSyscalls) BatchVerifySeals(vi map[address.Address][]proof.SealVerify
 		res[addr] = verified
 	}
 	return res, nil
+}
+
+func (s fakeSyscalls) VerifyAggregateSeals(agg proof.AggregateSealVerifyProofAndInfos) error {
+	return nil
 }
 
 func (s fakeSyscalls) VerifyPoSt(_ proof.WindowPoStVerifyInfo) error {


### PR DESCRIPTION
Changes needed for introducing aggregate porep verification into the network.

- [x] Implement `ProveCommitAggregate`
- [x] VM tests of `ProveCommit` and `ProveCommitAggregate` to measure gas costs
- [x] Batch market `ComputeDataCommitment` call to save gas
- [x] `ComputeDataCommitment` testing
- [x] Check power claim during `ProveCommitAggreagate` to retain safety properties protecting against programmer error in deadline code
- [ ] ~Accurate gas table~
- [ ] ~Final min and max aggregate batch parameters and max proof size parameter~
- [x] Extend sector precommit expiry
- [x] AggregateProofType for upgradeability
- [x] Unit (and or more extensive VM) tests of `ProveCommitAggregate`

--edit--
I'm calling final Gas and param estimation out of scope because we'll need to merge this into lotus to start gas rebalancing.  We will do the final parameter setting in another PR.

Closes #1257.