### PR TITLE
test: remove side-effects from runtime builder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   golang:
     docker:
-      - image: circleci/golang:1.13
+      - image: circleci/golang:1.15
 
 commands:
   install-deps:

--- a/actors/builtin/account/account_test.go
+++ b/actors/builtin/account/account_test.go
@@ -1,7 +1,6 @@
 package account_test
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -30,7 +29,7 @@ func TestAccountactor(t *testing.T) {
 	actor := account.Actor{}
 
 	receiver := tutil.NewIDAddr(t, 100)
-	builder := mock.NewBuilder(context.Background(), receiver).WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
+	builder := mock.NewBuilder(receiver).WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
 
 	testCases := []constructorTestCase{
 		{

--- a/actors/builtin/cron/cron_test.go
+++ b/actors/builtin/cron/cron_test.go
@@ -1,7 +1,6 @@
 package cron_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/filecoin-project/go-state-types/abi"
@@ -23,7 +22,7 @@ func TestConstructor(t *testing.T) {
 	actor := cronHarness{cron.Actor{}, t}
 
 	receiver := tutil.NewIDAddr(t, 100)
-	builder := mock.NewBuilder(context.Background(), receiver).WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
+	builder := mock.NewBuilder(receiver).WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
 
 	t.Run("construct with empty entries", func(t *testing.T) {
 		rt := builder.Build(t)
@@ -65,7 +64,7 @@ func TestEpochTick(t *testing.T) {
 	actor := cronHarness{cron.Actor{}, t}
 
 	receiver := tutil.NewIDAddr(t, 100)
-	builder := mock.NewBuilder(context.Background(), receiver).WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
+	builder := mock.NewBuilder(receiver).WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
 
 	t.Run("epoch tick with empty entries", func(t *testing.T) {
 		rt := builder.Build(t)

--- a/actors/builtin/init/init_test.go
+++ b/actors/builtin/init/init_test.go
@@ -1,7 +1,6 @@
 package init_test
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -27,7 +26,7 @@ func TestConstructor(t *testing.T) {
 	actor := initHarness{init_.Actor{}, t}
 
 	receiver := tutil.NewIDAddr(t, 1000)
-	builder := mock.NewBuilder(context.Background(), receiver).WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
+	builder := mock.NewBuilder(receiver).WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
 	rt := builder.Build(t)
 	actor.constructAndVerify(rt)
 	actor.checkState(rt)
@@ -38,7 +37,7 @@ func TestExec(t *testing.T) {
 
 	receiver := tutil.NewIDAddr(t, 1000)
 	anne := tutil.NewIDAddr(t, 1001)
-	builder := mock.NewBuilder(context.Background(), receiver).WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
+	builder := mock.NewBuilder(receiver).WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
 
 	t.Run("abort actors that cannot call exec", func(t *testing.T) {
 		rt := builder.Build(t)

--- a/actors/builtin/market/market_test.go
+++ b/actors/builtin/market/market_test.go
@@ -2,7 +2,6 @@ package market_test
 
 import (
 	"bytes"
-	"context"
 	"encoding/binary"
 	"errors"
 	"strings"
@@ -46,7 +45,7 @@ func TestExports(t *testing.T) {
 
 func TestRemoveAllError(t *testing.T) {
 	marketActor := tutil.NewIDAddr(t, 100)
-	builder := mock.NewBuilder(context.Background(), marketActor)
+	builder := mock.NewBuilder(marketActor)
 	rt := builder.Build(t)
 	store := adt.AsStore(rt)
 
@@ -70,7 +69,7 @@ func TestMarketActor(t *testing.T) {
 	t.Run("simple construction", func(t *testing.T) {
 		actor := market.Actor{}
 		receiver := tutil.NewIDAddr(t, 100)
-		builder := mock.NewBuilder(context.Background(), receiver).
+		builder := mock.NewBuilder(receiver).
 			WithCaller(builtin.SystemActorAddr, builtin.InitActorCodeID)
 
 		rt := builder.Build(t)
@@ -3199,7 +3198,7 @@ func generateDealProposal(client, provider address.Address, startEpoch, endEpoch
 }
 
 func basicMarketSetup(t *testing.T, owner, provider, worker, client address.Address) (*mock.Runtime, *marketActorTestHarness) {
-	builder := mock.NewBuilder(context.Background(), builtin.StorageMarketActorAddr).
+	builder := mock.NewBuilder(builtin.StorageMarketActorAddr).
 		WithCaller(builtin.SystemActorAddr, builtin.InitActorCodeID).
 		WithBalance(big.Mul(big.NewInt(10), big.NewInt(1e18)), big.Zero()).
 		WithActorType(owner, builtin.AccountActorCodeID).

--- a/actors/builtin/miner/bitfield_queue_test.go
+++ b/actors/builtin/miner/bitfield_queue_test.go
@@ -1,7 +1,6 @@
 package miner_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/filecoin-project/go-address"
@@ -236,7 +235,7 @@ func TestBitfieldQueue(t *testing.T) {
 }
 
 func emptyBitfieldQueueWithQuantizing(t *testing.T, quant miner.QuantSpec, bitwidth int) miner.BitfieldQueue {
-	rt := mock.NewBuilder(context.Background(), address.Undef).Build(t)
+	rt := mock.NewBuilder(address.Undef).Build(t)
 	store := adt.AsStore(rt)
 	emptyArray, err := adt.StoreEmptyArray(store, bitwidth)
 	require.NoError(t, err)

--- a/actors/builtin/miner/expiration_queue_test.go
+++ b/actors/builtin/miner/expiration_queue_test.go
@@ -1,7 +1,6 @@
 package miner_test
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -752,7 +751,7 @@ func requireNoExpirationGroupsBefore(t *testing.T, epoch abi.ChainEpoch, queue m
 }
 
 func emptyExpirationQueueWithQuantizing(t *testing.T, quant miner.QuantSpec, bitwidth int) miner.ExpirationQueue {
-	rt := mock.NewBuilder(context.Background(), address.Undef).Build(t)
+	rt := mock.NewBuilder(address.Undef).Build(t)
 	store := adt.AsStore(rt)
 	emptyArray, err := adt.StoreEmptyArray(store, testAmtBitwidth)
 	require.NoError(t, err)

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -6176,7 +6176,7 @@ func immediatelyVestingFunds(rt *mock.Runtime, st *miner.State) big.Int {
 // Construction helpers, etc
 //
 
-func builderForHarness(actor *actorHarness) *mock.RuntimeBuilder {
+func builderForHarness(actor *actorHarness) mock.RuntimeBuilder {
 	rb := mock.NewBuilder(context.Background(), actor.receiver).
 		WithActorType(actor.owner, builtin.AccountActorCodeID).
 		WithActorType(actor.worker, builtin.AccountActorCodeID).

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -3,7 +3,6 @@ package miner_test
 
 import (
 	"bytes"
-	"context"
 	"encoding/binary"
 	"fmt"
 	"strings"
@@ -73,7 +72,7 @@ func TestConstruction(t *testing.T) {
 	controlAddrs := []addr.Address{tutil.NewIDAddr(t, 999), tutil.NewIDAddr(t, 998)}
 
 	receiver := tutil.NewIDAddr(t, 1000)
-	builder := mock.NewBuilder(context.Background(), receiver).
+	builder := mock.NewBuilder(receiver).
 		WithActorType(owner, builtin.AccountActorCodeID).
 		WithActorType(worker, builtin.AccountActorCodeID).
 		WithActorType(controlAddrs[0], builtin.AccountActorCodeID).
@@ -6177,7 +6176,7 @@ func immediatelyVestingFunds(rt *mock.Runtime, st *miner.State) big.Int {
 //
 
 func builderForHarness(actor *actorHarness) mock.RuntimeBuilder {
-	rb := mock.NewBuilder(context.Background(), actor.receiver).
+	rb := mock.NewBuilder(actor.receiver).
 		WithActorType(actor.owner, builtin.AccountActorCodeID).
 		WithActorType(actor.worker, builtin.AccountActorCodeID).
 		WithHasher(fixedHasher(uint64(actor.periodOffset)))

--- a/actors/builtin/multisig/multisig_test.go
+++ b/actors/builtin/multisig/multisig_test.go
@@ -2,7 +2,6 @@ package multisig_test
 
 import (
 	"bytes"
-	"context"
 	"strings"
 	"testing"
 
@@ -39,7 +38,7 @@ func TestConstruction(t *testing.T) {
 
 	charlie := tutil.NewIDAddr(t, 103)
 
-	builder := mock.NewBuilder(context.Background(), receiver).WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID)
+	builder := mock.NewBuilder(receiver).WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID)
 
 	t.Run("simple construction", func(t *testing.T) {
 		rt := builder.Build(t)
@@ -174,7 +173,7 @@ func TestConstruction(t *testing.T) {
 	})
 
 	t.Run("fail to construct multisig if a signer is not resolvable to an ID address", func(t *testing.T) {
-		builder := mock.NewBuilder(context.Background(), receiver).WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID)
+		builder := mock.NewBuilder(receiver).WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID)
 		rt := builder.Build(t)
 		params := multisig.ConstructorParams{
 			Signers:               []addr.Address{anneNonId, bob, charlie},
@@ -234,7 +233,7 @@ func TestVesting(t *testing.T) {
 	const unlockDuration = abi.ChainEpoch(10)
 	var multisigInitialBalance = abi.NewTokenAmount(100)
 
-	builder := mock.NewBuilder(context.Background(), receiver).
+	builder := mock.NewBuilder(receiver).
 		WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID).
 		WithEpoch(0).
 		WithBalance(multisigInitialBalance, multisigInitialBalance).
@@ -419,7 +418,7 @@ func TestPropose(t *testing.T) {
 	var fakeParams = builtin.CBORBytes([]byte{1, 2, 3, 4})
 	var signers = []addr.Address{anne, bob}
 
-	builder := mock.NewBuilder(context.Background(), receiver).WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID)
+	builder := mock.NewBuilder(receiver).WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID)
 
 	t.Run("simple propose", func(t *testing.T) {
 		const numApprovals = uint64(2)
@@ -536,7 +535,7 @@ func TestApprove(t *testing.T) {
 	var fakeParams = builtin.CBORBytes([]byte{1, 2, 3, 4})
 	var signers = []addr.Address{anne, bob}
 
-	builder := mock.NewBuilder(context.Background(), receiver).
+	builder := mock.NewBuilder(receiver).
 		WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID).
 		WithHasher(blake2b.Sum256)
 
@@ -911,7 +910,7 @@ func TestCancel(t *testing.T) {
 	var sendValue = abi.NewTokenAmount(10)
 	var signers = []addr.Address{anne, bob}
 
-	builder := mock.NewBuilder(context.Background(), receiver).
+	builder := mock.NewBuilder(receiver).
 		WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID).
 		WithHasher(blake2b.Sum256)
 
@@ -1185,7 +1184,7 @@ func TestAddSigner(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			builder := mock.NewBuilder(context.Background(), multisigWalletAdd).WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID)
+			builder := mock.NewBuilder(multisigWalletAdd).WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID)
 			rt := builder.Build(t)
 			for src, target := range tc.idAddrsMapping {
 				rt.AddIDAddress(src, target)
@@ -1238,7 +1237,7 @@ func TestRemoveSigner(t *testing.T) {
 	const noUnlockDuration = abi.ChainEpoch(0)
 
 	actor := msActorHarness{multisig.Actor{}, t}
-	builder := mock.NewBuilder(context.Background(), receiver).WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID)
+	builder := mock.NewBuilder(receiver).WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID)
 
 	testCases := []removeSignerTestCase{
 		{
@@ -1479,7 +1478,7 @@ func TestSwapSigners(t *testing.T) {
 	const numApprovals = uint64(1)
 
 	actor := msActorHarness{multisig.Actor{}, t}
-	builder := mock.NewBuilder(context.Background(), receiver).WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID)
+	builder := mock.NewBuilder(receiver).WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID)
 
 	testCases := []swapTestCase{
 		{
@@ -1685,7 +1684,7 @@ func TestChangeThreshold(t *testing.T) {
 		},
 	}
 
-	builder := mock.NewBuilder(context.Background(), multisigWalletAdd).WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID)
+	builder := mock.NewBuilder(multisigWalletAdd).WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID)
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			rt := builder.Build(t)
@@ -1742,7 +1741,7 @@ func TestLockBalance(t *testing.T) {
 	anne := tutil.NewIDAddr(t, 101)
 	bob := tutil.NewIDAddr(t, 102)
 
-	builder := mock.NewBuilder(context.Background(), receiver).
+	builder := mock.NewBuilder(receiver).
 		WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID).
 		WithEpoch(0).
 		WithHasher(blake2b.Sum256)
@@ -1896,7 +1895,7 @@ func TestLockBalance(t *testing.T) {
 		})
 		rt.Reset()
 	})
-	
+
 	t.Run("checks preconditions", func(t *testing.T) {
 		rt := builder.Build(t)
 

--- a/actors/builtin/paych/paych_test.go
+++ b/actors/builtin/paych/paych_test.go
@@ -1,7 +1,6 @@
 package paych_test
 
 import (
-	"context"
 	"fmt"
 	"math"
 	"reflect"
@@ -30,7 +29,6 @@ func TestExports(t *testing.T) {
 }
 
 func TestPaymentChannelActor_Constructor(t *testing.T) {
-	ctx := context.Background()
 	paychAddr := tutil.NewIDAddr(t, 100)
 	payerAddr := tutil.NewIDAddr(t, 101)
 	payeeAddr := tutil.NewIDAddr(t, 102)
@@ -39,7 +37,7 @@ func TestPaymentChannelActor_Constructor(t *testing.T) {
 	actor := pcActorHarness{Actor{}, t, paychAddr, payerAddr, payeeAddr}
 
 	t.Run("can create a payment channel actor", func(t *testing.T) {
-		builder := mock.NewBuilder(ctx, paychAddr).
+		builder := mock.NewBuilder(paychAddr).
 			WithCaller(callerAddr, builtin.InitActorCodeID).
 			WithActorType(payerAddr, builtin.AccountActorCodeID).
 			WithActorType(payeeAddr, builtin.AccountActorCodeID)
@@ -55,7 +53,7 @@ func TestPaymentChannelActor_Constructor(t *testing.T) {
 		payeeAddr := tutil.NewIDAddr(t, 103)
 		payeeNonId := tutil.NewBLSAddr(t, 104)
 
-		builder := mock.NewBuilder(ctx, paychAddr).
+		builder := mock.NewBuilder(paychAddr).
 			WithCaller(callerAddr, builtin.InitActorCodeID).
 			WithActorType(payerAddr, builtin.AccountActorCodeID).
 			WithActorType(payeeAddr, builtin.AccountActorCodeID)
@@ -92,7 +90,7 @@ func TestPaymentChannelActor_Constructor(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			builder := mock.NewBuilder(ctx, paychAddr).
+			builder := mock.NewBuilder(paychAddr).
 				WithCaller(callerAddr, builtin.InitActorCodeID).
 				WithActorType(paychAddr, builtin.PaymentChannelActorCodeID).
 				WithActorType(payerAddr, tc.toCode).
@@ -109,7 +107,7 @@ func TestPaymentChannelActor_Constructor(t *testing.T) {
 		to := tutil.NewIDAddr(t, 101)
 		nonIdAddr := tutil.NewBLSAddr(t, 501)
 
-		rt := mock.NewBuilder(ctx, paychAddr).
+		rt := mock.NewBuilder(paychAddr).
 			WithCaller(callerAddr, builtin.InitActorCodeID).
 			WithActorType(to, builtin.AccountActorCodeID).Build(t)
 
@@ -125,7 +123,7 @@ func TestPaymentChannelActor_Constructor(t *testing.T) {
 		from := tutil.NewIDAddr(t, 5555)
 		nonIdAddr := tutil.NewBLSAddr(t, 501)
 
-		rt := mock.NewBuilder(ctx, paychAddr).
+		rt := mock.NewBuilder(paychAddr).
 			WithCaller(callerAddr, builtin.InitActorCodeID).
 			WithActorType(from, builtin.AccountActorCodeID).Build(t)
 
@@ -138,7 +136,7 @@ func TestPaymentChannelActor_Constructor(t *testing.T) {
 	})
 
 	t.Run("fails if actor does not exist with: no code for address", func(t *testing.T) {
-		builder := mock.NewBuilder(ctx, paychAddr).
+		builder := mock.NewBuilder(paychAddr).
 			WithCaller(callerAddr, builtin.InitActorCodeID).
 			WithActorType(payerAddr, builtin.AccountActorCodeID)
 		rt := builder.Build(t)
@@ -150,7 +148,6 @@ func TestPaymentChannelActor_Constructor(t *testing.T) {
 }
 
 func TestPaymentChannelActor_CreateLane(t *testing.T) {
-	ctx := context.Background()
 	initActorAddr := tutil.NewIDAddr(t, 100)
 	paychNonId := tutil.NewBLSAddr(t, 201)
 	paychAddr := tutil.NewIDAddr(t, 101)
@@ -233,7 +230,7 @@ func TestPaymentChannelActor_CreateLane(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			hasher := func(data []byte) [32]byte { return [32]byte{} }
 
-			builder := mock.NewBuilder(ctx, paychAddr).
+			builder := mock.NewBuilder(paychAddr).
 				WithBalance(payChBalance, abi.NewTokenAmount(tc.received)).
 				WithEpoch(abi.ChainEpoch(tc.epoch)).
 				WithCaller(initActorAddr, builtin.InitActorCodeID).
@@ -330,11 +327,10 @@ func getLaneState(t *testing.T, rt *mock.Runtime, rcid cid.Cid, lane uint64) *La
 }
 
 func TestActor_UpdateChannelStateRedeem(t *testing.T) {
-	ctx := context.Background()
 	newVoucherAmt := big.NewInt(9)
 
 	t.Run("redeeming voucher updates correctly with one lane", func(t *testing.T) {
-		rt, actor, sv := requireCreateChannelWithLanes(t, ctx, 1)
+		rt, actor, sv := requireCreateChannelWithLanes(t, 1)
 		var st1 State
 		rt.GetState(&st1)
 
@@ -367,7 +363,7 @@ func TestActor_UpdateChannelStateRedeem(t *testing.T) {
 	})
 
 	t.Run("redeems voucher for correct lane", func(t *testing.T) {
-		rt, actor, sv := requireCreateChannelWithLanes(t, ctx, 3)
+		rt, actor, sv := requireCreateChannelWithLanes(t, 3)
 		var st1, st2 State
 		rt.GetState(&st1)
 
@@ -400,7 +396,7 @@ func TestActor_UpdateChannelStateRedeem(t *testing.T) {
 	})
 
 	t.Run("redeeming voucher fails on nonce reuse", func(t *testing.T) {
-		rt, actor, sv := requireCreateChannelWithLanes(t, ctx, 1)
+		rt, actor, sv := requireCreateChannelWithLanes(t, 1)
 		var st1 State
 		rt.GetState(&st1)
 
@@ -426,7 +422,7 @@ func TestActor_UpdateChannelStateRedeem(t *testing.T) {
 func TestActor_UpdateChannelStateMergeSuccess(t *testing.T) {
 	// Check that a lane merge correctly updates lane states
 	numLanes := 3
-	rt, actor, sv := requireCreateChannelWithLanes(t, context.Background(), numLanes)
+	rt, actor, sv := requireCreateChannelWithLanes(t, numLanes)
 
 	var st1 State
 	rt.GetState(&st1)
@@ -498,7 +494,7 @@ func TestActor_UpdateChannelStateMergeFailure(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			rt, actor, sv := requireCreateChannelWithLanes(t, context.Background(), 2)
+			rt, actor, sv := requireCreateChannelWithLanes(t, 2)
 			if tc.balance > 0 {
 				rt.SetBalance(abi.NewTokenAmount(tc.balance))
 			}
@@ -525,7 +521,7 @@ func TestActor_UpdateChannelStateMergeFailure(t *testing.T) {
 		})
 	}
 	t.Run("When lane doesn't exist, fails with: voucher specifies invalid merge lane 999", func(t *testing.T) {
-		rt, actor, sv := requireCreateChannelWithLanes(t, context.Background(), 2)
+		rt, actor, sv := requireCreateChannelWithLanes(t, 2)
 
 		var st1 State
 		rt.GetState(&st1)
@@ -548,7 +544,7 @@ func TestActor_UpdateChannelStateMergeFailure(t *testing.T) {
 	})
 
 	t.Run("Lane ID over max fails", func(t *testing.T) {
-		rt, actor, sv := requireCreateChannelWithLanes(t, context.Background(), 1)
+		rt, actor, sv := requireCreateChannelWithLanes(t, 1)
 
 		var st1 State
 		rt.GetState(&st1)
@@ -578,7 +574,7 @@ func TestActor_UpdateChannelStateExtra(t *testing.T) {
 	}
 
 	t.Run("Succeeds if extra call succeeds", func(t *testing.T) {
-		rt, actor1, sv1 := requireCreateChannelWithLanes(t, context.Background(), 1)
+		rt, actor1, sv1 := requireCreateChannelWithLanes(t, 1)
 		var st1 State
 		rt.GetState(&st1)
 		rt.SetCaller(st1.From, builtin.AccountActorCodeID)
@@ -594,7 +590,7 @@ func TestActor_UpdateChannelStateExtra(t *testing.T) {
 		actor1.checkState(rt)
 	})
 	t.Run("If Extra call fails, fails with: spend voucher verification failed", func(t *testing.T) {
-		rt, actor1, sv1 := requireCreateChannelWithLanes(t, context.Background(), 1)
+		rt, actor1, sv1 := requireCreateChannelWithLanes(t, 1)
 		var st1 State
 		rt.GetState(&st1)
 		rt.SetCaller(st1.From, builtin.AccountActorCodeID)
@@ -613,7 +609,7 @@ func TestActor_UpdateChannelStateExtra(t *testing.T) {
 }
 
 func TestActor_UpdateChannelStateSettling(t *testing.T) {
-	rt, actor, sv := requireCreateChannelWithLanes(t, context.Background(), 1)
+	rt, actor, sv := requireCreateChannelWithLanes(t, 1)
 
 	ep := abi.ChainEpoch(10)
 	rt.SetEpoch(ep)
@@ -667,7 +663,7 @@ func TestActor_UpdateChannelStateSettling(t *testing.T) {
 
 func TestActor_UpdateChannelStateSecretPreimage(t *testing.T) {
 	t.Run("Succeeds with correct secret", func(t *testing.T) {
-		rt, actor, sv := requireCreateChannelWithLanes(t, context.Background(), 1)
+		rt, actor, sv := requireCreateChannelWithLanes(t, 1)
 		var st State
 		rt.GetState(&st)
 
@@ -691,7 +687,7 @@ func TestActor_UpdateChannelStateSecretPreimage(t *testing.T) {
 	})
 
 	t.Run("If bad secret preimage, fails with: incorrect secret!", func(t *testing.T) {
-		rt, actor, sv := requireCreateChannelWithLanes(t, context.Background(), 1)
+		rt, actor, sv := requireCreateChannelWithLanes(t, 1)
 		var st State
 		rt.GetState(&st)
 		ucp := &UpdateChannelStateParams{
@@ -712,7 +708,7 @@ func TestActor_Settle(t *testing.T) {
 	ep := abi.ChainEpoch(10)
 
 	t.Run("Settle adjusts SettlingAt", func(t *testing.T) {
-		rt, actor, _ := requireCreateChannelWithLanes(t, context.Background(), 1)
+		rt, actor, _ := requireCreateChannelWithLanes(t, 1)
 		rt.SetEpoch(ep)
 		var st State
 		rt.GetState(&st)
@@ -729,7 +725,7 @@ func TestActor_Settle(t *testing.T) {
 	})
 
 	t.Run("settle fails if called twice: channel already settling", func(t *testing.T) {
-		rt, actor, _ := requireCreateChannelWithLanes(t, context.Background(), 1)
+		rt, actor, _ := requireCreateChannelWithLanes(t, 1)
 		rt.SetEpoch(ep)
 		var st State
 		rt.GetState(&st)
@@ -745,7 +741,7 @@ func TestActor_Settle(t *testing.T) {
 	})
 
 	t.Run("Settle changes SettleHeight again if MinSettleHeight is less", func(t *testing.T) {
-		rt, actor, sv := requireCreateChannelWithLanes(t, context.Background(), 1)
+		rt, actor, sv := requireCreateChannelWithLanes(t, 1)
 		rt.SetEpoch(ep)
 		var st State
 		rt.GetState(&st)
@@ -776,7 +772,7 @@ func TestActor_Settle(t *testing.T) {
 	})
 
 	t.Run("Voucher invalid after settling", func(t *testing.T) {
-		rt, actor, sv := requireCreateChannelWithLanes(t, context.Background(), 1)
+		rt, actor, sv := requireCreateChannelWithLanes(t, 1)
 		rt.SetEpoch(ep)
 		var st State
 		rt.GetState(&st)
@@ -799,7 +795,7 @@ func TestActor_Settle(t *testing.T) {
 
 func TestActor_Collect(t *testing.T) {
 	t.Run("Happy path", func(t *testing.T) {
-		rt, actor, _ := requireCreateChannelWithLanes(t, context.Background(), 1)
+		rt, actor, _ := requireCreateChannelWithLanes(t, 1)
 		currEpoch := abi.ChainEpoch(10)
 		rt.SetEpoch(currEpoch)
 		var st State
@@ -838,7 +834,7 @@ func TestActor_Collect(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			rt, actor, _ := requireCreateChannelWithLanes(t, context.Background(), 1)
+			rt, actor, _ := requireCreateChannelWithLanes(t, 1)
 			currEpoch := abi.ChainEpoch(10)
 			rt.SetEpoch(currEpoch)
 			var st State
@@ -884,7 +880,7 @@ type laneParams struct {
 	merges      []Merge
 }
 
-func requireCreateChannelWithLanes(t *testing.T, ctx context.Context, numLanes int) (*mock.Runtime, *pcActorHarness, *SignedVoucher) {
+func requireCreateChannelWithLanes(t *testing.T, numLanes int) (*mock.Runtime, *pcActorHarness, *SignedVoucher) {
 	paychAddr := tutil.NewIDAddr(t, 100)
 	payerAddr := tutil.NewIDAddr(t, 102)
 	payeeAddr := tutil.NewIDAddr(t, 103)
@@ -894,7 +890,7 @@ func requireCreateChannelWithLanes(t *testing.T, ctx context.Context, numLanes i
 	curEpoch := 2
 	hasher := func(data []byte) [32]byte { return [32]byte{} }
 
-	builder := mock.NewBuilder(ctx, paychAddr).
+	builder := mock.NewBuilder(paychAddr).
 		WithBalance(balance, received).
 		WithEpoch(abi.ChainEpoch(curEpoch)).
 		WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID).

--- a/actors/builtin/power/power_test.go
+++ b/actors/builtin/power/power_test.go
@@ -2,7 +2,6 @@ package power_test
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -38,7 +37,7 @@ func TestConstruction(t *testing.T) {
 	miner := tutil.NewIDAddr(t, 103)
 	actr := tutil.NewActorAddr(t, "actor")
 
-	builder := mock.NewBuilder(context.Background(), builtin.StoragePowerActorAddr).WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
+	builder := mock.NewBuilder(builtin.StoragePowerActorAddr).WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
 
 	t.Run("simple construction", func(t *testing.T) {
 		rt := builder.Build(t)
@@ -274,7 +273,7 @@ func TestPowerAndPledgeAccounting(t *testing.T) {
 	// Subtests implicitly rely on ConsensusMinerMinMiners = 3
 	require.Equal(t, 4, power.ConsensusMinerMinMiners, "power.ConsensusMinerMinMiners has changed requiring update to this test")
 
-	builder := mock.NewBuilder(context.Background(), builtin.StoragePowerActorAddr).
+	builder := mock.NewBuilder(builtin.StoragePowerActorAddr).
 		WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
 
 	t.Run("power & pledge accounted below threshold", func(t *testing.T) {
@@ -529,7 +528,7 @@ func TestUpdatePledgeTotal(t *testing.T) {
 	actor := newHarness(t)
 	owner := tutil.NewIDAddr(t, 101)
 	miner := tutil.NewIDAddr(t, 111)
-	builder := mock.NewBuilder(context.Background(), builtin.StoragePowerActorAddr).
+	builder := mock.NewBuilder(builtin.StoragePowerActorAddr).
 		WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
 
 	t.Run("update pledge total aborts if miner has no claim", func(t *testing.T) {
@@ -552,7 +551,7 @@ func TestCron(t *testing.T) {
 	miner2 := tutil.NewIDAddr(t, 102)
 	owner := tutil.NewIDAddr(t, 103)
 
-	builder := mock.NewBuilder(context.Background(), builtin.StoragePowerActorAddr).WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
+	builder := mock.NewBuilder(builtin.StoragePowerActorAddr).WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
 
 	t.Run("calls reward actor", func(t *testing.T) {
 		rt := builder.Build(t)
@@ -793,7 +792,7 @@ func TestSubmitPoRepForBulkVerify(t *testing.T) {
 	actor := newHarness(t)
 	miner := tutil.NewIDAddr(t, 101)
 	owner := tutil.NewIDAddr(t, 101)
-	builder := mock.NewBuilder(context.Background(), builtin.StoragePowerActorAddr).WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
+	builder := mock.NewBuilder(builtin.StoragePowerActorAddr).WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
 
 	t.Run("registers porep and charges gas", func(t *testing.T) {
 		rt := builder.Build(t)
@@ -1242,7 +1241,7 @@ func (h *spActorHarness) getEnrolledCronTicks(rt *mock.Runtime, epoch abi.ChainE
 }
 
 func basicPowerSetup(t *testing.T) (*mock.Runtime, *spActorHarness) {
-	builder := mock.NewBuilder(context.Background(), builtin.StoragePowerActorAddr).WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
+	builder := mock.NewBuilder(builtin.StoragePowerActorAddr).WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
 	rt := builder.Build(t)
 	h := newHarness(t)
 	h.constructAndVerify(rt)

--- a/actors/builtin/reward/reward_test.go
+++ b/actors/builtin/reward/reward_test.go
@@ -1,7 +1,6 @@
 package reward_test
 
 import (
-	"context"
 	"testing"
 
 	address "github.com/filecoin-project/go-address"
@@ -27,7 +26,7 @@ func TestConstructor(t *testing.T) {
 	actor := rewardHarness{reward.Actor{}, t}
 
 	t.Run("construct with 0 power", func(t *testing.T) {
-		rt := mock.NewBuilder(context.Background(), builtin.RewardActorAddr).
+		rt := mock.NewBuilder(builtin.RewardActorAddr).
 			WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID).
 			Build(t)
 		startRealizedPower := abi.NewStoragePower(0)
@@ -41,7 +40,7 @@ func TestConstructor(t *testing.T) {
 		assert.Equal(t, reward.BaselineInitialValue, st.EffectiveBaselinePower)
 	})
 	t.Run("construct with less power than baseline", func(t *testing.T) {
-		rt := mock.NewBuilder(context.Background(), builtin.RewardActorAddr).
+		rt := mock.NewBuilder(builtin.RewardActorAddr).
 			WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID).
 			Build(t)
 		startRealizedPower := big.Lsh(abi.NewStoragePower(1), 39)
@@ -53,7 +52,7 @@ func TestConstructor(t *testing.T) {
 		assert.NotEqual(t, big.Zero(), st.ThisEpochReward)
 	})
 	t.Run("construct with more power than baseline", func(t *testing.T) {
-		rt := mock.NewBuilder(context.Background(), builtin.RewardActorAddr).
+		rt := mock.NewBuilder(builtin.RewardActorAddr).
 			WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID).
 			Build(t)
 		startRealizedPower := reward.BaselineInitialValue
@@ -62,7 +61,7 @@ func TestConstructor(t *testing.T) {
 		rwrd := st.ThisEpochReward
 
 		// start with 2x power
-		rt = mock.NewBuilder(context.Background(), builtin.RewardActorAddr).
+		rt = mock.NewBuilder(builtin.RewardActorAddr).
 			WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID).
 			Build(t)
 		startRealizedPower = big.Mul(reward.BaselineInitialValue, big.NewInt(2))
@@ -77,7 +76,7 @@ func TestConstructor(t *testing.T) {
 func TestAwardBlockReward(t *testing.T) {
 	actor := rewardHarness{reward.Actor{}, t}
 	winner := tutil.NewIDAddr(t, 1000)
-	builder := mock.NewBuilder(context.Background(), builtin.RewardActorAddr).
+	builder := mock.NewBuilder(builtin.RewardActorAddr).
 		WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
 
 	t.Run("rejects gas reward exceeding balance", func(t *testing.T) {
@@ -220,7 +219,7 @@ func TestAwardBlockReward(t *testing.T) {
 func TestThisEpochReward(t *testing.T) {
 	t.Run("successfully fetch reward for this epoch", func(t *testing.T) {
 		actor := rewardHarness{reward.Actor{}, t}
-		builder := mock.NewBuilder(context.Background(), builtin.RewardActorAddr).
+		builder := mock.NewBuilder(builtin.RewardActorAddr).
 			WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
 		rt := builder.Build(t)
 		power := abi.NewStoragePower(1 << 50)
@@ -236,7 +235,7 @@ func TestThisEpochReward(t *testing.T) {
 
 func TestSuccessiveKPIUpdates(t *testing.T) {
 	actor := rewardHarness{reward.Actor{}, t}
-	builder := mock.NewBuilder(context.Background(), builtin.RewardActorAddr).
+	builder := mock.NewBuilder(builtin.RewardActorAddr).
 		WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
 	rt := builder.Build(t)
 	power := abi.NewStoragePower(1 << 50)

--- a/actors/builtin/system/system_test.go
+++ b/actors/builtin/system/system_test.go
@@ -1,7 +1,6 @@
 package system_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -16,7 +15,7 @@ func TestExports(t *testing.T) {
 }
 
 func TestConstruction(t *testing.T) {
-	rt := mock.NewBuilder(context.Background(), builtin.SystemActorAddr).Build(t)
+	rt := mock.NewBuilder(builtin.SystemActorAddr).Build(t)
 	a := system.Actor{}
 
 	rt.ExpectValidateCallerAddr(builtin.SystemActorAddr)

--- a/actors/builtin/verifreg/verified_registry_test.go
+++ b/actors/builtin/verifreg/verified_registry_test.go
@@ -26,15 +26,11 @@ func TestExports(t *testing.T) {
 func TestConstruction(t *testing.T) {
 	receiver := tutil.NewIDAddr(t, 100)
 
-	runtimeSetup := func() *mock.RuntimeBuilder {
-		builder := mock.NewBuilder(context.Background(), receiver).
-			WithCaller(builtin.SystemActorAddr, builtin.InitActorCodeID)
-
-		return builder
-	}
+	builder := mock.NewBuilder(context.Background(), receiver).
+		WithCaller(builtin.SystemActorAddr, builtin.InitActorCodeID)
 
 	t.Run("successful construction with root ID address", func(t *testing.T) {
-		rt := runtimeSetup().Build(t)
+		rt := builder.Build(t)
 		raddr := tutil.NewIDAddr(t, 101)
 
 		actor := verifRegActorTestHarness{t: t, rootkey: raddr}
@@ -51,7 +47,7 @@ func TestConstruction(t *testing.T) {
 	})
 
 	t.Run("non-ID address root is resolved to an ID address for construction", func(t *testing.T) {
-		rt := runtimeSetup().Build(t)
+		rt := builder.Build(t)
 
 		raddr := tutil.NewBLSAddr(t, 101)
 		rootIdAddr := tutil.NewIDAddr(t, 201)
@@ -72,7 +68,7 @@ func TestConstruction(t *testing.T) {
 	})
 
 	t.Run("fails if root cannot be resolved to an ID address", func(t *testing.T) {
-		rt := runtimeSetup().Build(t)
+		rt := builder.Build(t)
 		actor := verifreg.Actor{}
 		rt.ExpectValidateCallerAddr(builtin.SystemActorAddr)
 
@@ -973,4 +969,3 @@ func mkVerifierParams(a address.Address, allowance verifreg.DataCap) *verifreg.A
 func mkClientParams(a address.Address, cap verifreg.DataCap) *verifreg.AddVerifiedClientParams {
 	return &verifreg.AddVerifiedClientParams{Address: a, Allowance: cap}
 }
-

--- a/actors/builtin/verifreg/verified_registry_test.go
+++ b/actors/builtin/verifreg/verified_registry_test.go
@@ -1,7 +1,6 @@
 package verifreg_test
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -26,7 +25,7 @@ func TestExports(t *testing.T) {
 func TestConstruction(t *testing.T) {
 	receiver := tutil.NewIDAddr(t, 100)
 
-	builder := mock.NewBuilder(context.Background(), receiver).
+	builder := mock.NewBuilder(receiver).
 		WithCaller(builtin.SystemActorAddr, builtin.InitActorCodeID)
 
 	t.Run("successful construction with root ID address", func(t *testing.T) {
@@ -775,7 +774,7 @@ type verifRegActorTestHarness struct {
 }
 
 func basicVerifRegSetup(t *testing.T, root address.Address) (*mock.Runtime, *verifRegActorTestHarness) {
-	builder := mock.NewBuilder(context.Background(), builtin.StorageMarketActorAddr).
+	builder := mock.NewBuilder(builtin.StorageMarketActorAddr).
 		WithCaller(builtin.SystemActorAddr, builtin.InitActorCodeID).
 		WithActorType(root, builtin.VerifiedRegistryActorCodeID)
 

--- a/actors/util/adt/array_test.go
+++ b/actors/util/adt/array_test.go
@@ -1,7 +1,6 @@
 package adt_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/filecoin-project/go-address"
@@ -12,7 +11,7 @@ import (
 )
 
 func TestArrayNotFound(t *testing.T) {
-	rt := mock.NewBuilder(context.Background(), address.Undef).Build(t)
+	rt := mock.NewBuilder(address.Undef).Build(t)
 	store := adt.AsStore(rt)
 	arr, err := adt.MakeEmptyArray(store, 3)
 	require.NoError(t, err)

--- a/actors/util/adt/balancetable_test.go
+++ b/actors/util/adt/balancetable_test.go
@@ -1,7 +1,6 @@
 package adt_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/filecoin-project/go-address"
@@ -18,7 +17,7 @@ import (
 
 func TestBalanceTable(t *testing.T) {
 	buildBalanceTable := func() *adt.BalanceTable {
-		rt := mock.NewBuilder(context.Background(), address.Undef).Build(t)
+		rt := mock.NewBuilder(address.Undef).Build(t)
 		store := adt.AsStore(rt)
 		emptyMap, err := adt.MakeEmptyMap(store, builtin.DefaultHamtBitwidth)
 		require.NoError(t, err)
@@ -128,7 +127,7 @@ func TestBalanceTable(t *testing.T) {
 
 func TestSubtractWithMinimum(t *testing.T) {
 	buildBalanceTable := func() *adt.BalanceTable {
-		rt := mock.NewBuilder(context.Background(), address.Undef).Build(t)
+		rt := mock.NewBuilder(address.Undef).Build(t)
 		store := adt.AsStore(rt)
 		emptyMap, err := adt.MakeEmptyMap(store, builtin.DefaultHamtBitwidth)
 		require.NoError(t, err)

--- a/support/mock/builder.go
+++ b/support/mock/builder.go
@@ -17,10 +17,9 @@ type RuntimeBuilder struct {
 }
 
 // Initializes a new builder with a receiving actor address.
-func NewBuilder(ctx context.Context, receiver addr.Address) RuntimeBuilder {
+func NewBuilder(receiver addr.Address) RuntimeBuilder {
 	var b RuntimeBuilder
 	b.add(func(rt *Runtime) {
-		rt.ctx = ctx
 		rt.receiver = receiver
 	})
 	return b
@@ -28,8 +27,11 @@ func NewBuilder(ctx context.Context, receiver addr.Address) RuntimeBuilder {
 
 // Builds a new runtime object with the configured values.
 func (b RuntimeBuilder) Build(t testing.TB) *Runtime {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
 	m := &Runtime{
-		ctx:               context.Background(),
+		ctx:               ctx,
 		epoch:             0,
 		networkVersion:    network.VersionMax,
 		caller:            addr.Address{},

--- a/support/mock/builder.go
+++ b/support/mock/builder.go
@@ -13,16 +13,25 @@ import (
 
 // Build for fluent initialization of a mock runtime.
 type RuntimeBuilder struct {
-	rt *Runtime
+	options []func(rt *Runtime)
 }
 
 // Initializes a new builder with a receiving actor address.
-func NewBuilder(ctx context.Context, receiver addr.Address) *RuntimeBuilder {
+func NewBuilder(ctx context.Context, receiver addr.Address) RuntimeBuilder {
+	var b RuntimeBuilder
+	b.add(func(rt *Runtime) {
+		rt.ctx = ctx
+		rt.receiver = receiver
+	})
+	return b
+}
+
+// Builds a new runtime object with the configured values.
+func (b RuntimeBuilder) Build(t testing.TB) *Runtime {
 	m := &Runtime{
-		ctx:               ctx,
+		ctx:               context.Background(),
 		epoch:             0,
 		networkVersion:    network.VersionMax,
-		receiver:          receiver,
 		caller:            addr.Address{},
 		callerType:        cid.Undef,
 		miner:             addr.Address{},
@@ -39,7 +48,7 @@ func NewBuilder(ctx context.Context, receiver addr.Address) *RuntimeBuilder {
 		actorCodeCIDs: make(map[addr.Address]cid.Cid),
 		newActorAddr:  addr.Undef,
 
-		t:                        nil, // Initialized at Build()
+		t:                        t,
 		expectValidateCallerAny:  false,
 		expectValidateCallerAddr: nil,
 		expectValidateCallerType: nil,
@@ -48,56 +57,63 @@ func NewBuilder(ctx context.Context, receiver addr.Address) *RuntimeBuilder {
 		expectSends:      make([]*expectedMessage, 0),
 		expectVerifySigs: make([]*expectVerifySig, 0),
 	}
-	return &RuntimeBuilder{m}
-}
-
-// Builds a new runtime object with the configured values.
-func (b *RuntimeBuilder) Build(t testing.TB) *Runtime {
-	cpy := *b.rt
-
-	// Deep copy the mutable values.
-	cpy.store = make(map[cid.Cid][]byte)
-	for k, v := range b.rt.store { //nolint:nomaprange
-		cpy.store[k] = v
+	for _, opt := range b.options {
+		opt(m)
 	}
-
-	cpy.t = t
-	return &cpy
+	return m
 }
 
-func (b *RuntimeBuilder) WithEpoch(epoch abi.ChainEpoch) *RuntimeBuilder {
-	b.rt.epoch = epoch
+func (b *RuntimeBuilder) add(cb func(*Runtime)) {
+	b.options = append(b.options, cb)
+}
+
+func (b RuntimeBuilder) WithEpoch(epoch abi.ChainEpoch) RuntimeBuilder {
+	b.add(func(rt *Runtime) {
+		rt.epoch = epoch
+	})
 	return b
 }
 
-func (b *RuntimeBuilder) WithCaller(address addr.Address, code cid.Cid) *RuntimeBuilder {
-	b.rt.caller = address
-	b.rt.callerType = code
+func (b RuntimeBuilder) WithCaller(address addr.Address, code cid.Cid) RuntimeBuilder {
+	b.add(func(rt *Runtime) {
+		rt.caller = address
+		rt.callerType = code
+	})
 	return b
 }
 
-func (b *RuntimeBuilder) WithMiner(miner addr.Address) *RuntimeBuilder {
-	b.rt.miner = miner
+func (b RuntimeBuilder) WithMiner(miner addr.Address) RuntimeBuilder {
+	b.add(func(rt *Runtime) {
+		rt.miner = miner
+	})
 	return b
 }
 
-func (b *RuntimeBuilder) WithBalance(balance, received abi.TokenAmount) *RuntimeBuilder {
-	b.rt.balance = balance
-	b.rt.valueReceived = received
+func (b RuntimeBuilder) WithBalance(balance, received abi.TokenAmount) RuntimeBuilder {
+	b.add(func(rt *Runtime) {
+		rt.balance = balance
+		rt.valueReceived = received
+	})
 	return b
 }
 
-func (b *RuntimeBuilder) WithNetworkVersion(version network.Version) *RuntimeBuilder {
-	b.rt.networkVersion = version
+func (b RuntimeBuilder) WithNetworkVersion(version network.Version) RuntimeBuilder {
+	b.add(func(rt *Runtime) {
+		rt.networkVersion = version
+	})
 	return b
 }
 
-func (b *RuntimeBuilder) WithActorType(addr addr.Address, code cid.Cid) *RuntimeBuilder {
-	b.rt.actorCodeCIDs[addr] = code
+func (b RuntimeBuilder) WithActorType(addr addr.Address, code cid.Cid) RuntimeBuilder {
+	b.add(func(rt *Runtime) {
+		rt.actorCodeCIDs[addr] = code
+	})
 	return b
 }
 
-func (b *RuntimeBuilder) WithHasher(f func(data []byte) [32]byte) *RuntimeBuilder {
-	b.rt.hashfunc = f
+func (b RuntimeBuilder) WithHasher(f func(data []byte) [32]byte) RuntimeBuilder {
+	b.add(func(rt *Runtime) {
+		rt.hashfunc = f
+	})
 	return b
 }

--- a/support/mock/mockrt_state_test.go
+++ b/support/mock/mockrt_state_test.go
@@ -1,7 +1,6 @@
 package mock
 
 import (
-	"context"
 	"io"
 	"testing"
 
@@ -59,7 +58,6 @@ func (s State) UnmarshalCBOR(r io.Reader) error {
 
 var _ runtime.VMActor = FakeActor{}
 
-
 func (a FakeActor) Constructor(rt runtime.Runtime, mutate *cbg.CborBool) *abi.EmptyValue {
 	st := State{Value: 0}
 	rt.StateCreate(&st)
@@ -111,11 +109,10 @@ func (a FakeActor) TransactionStateTwice(rt runtime.Runtime, mutate *cbg.CborBoo
 	return nil
 }
 
-
 func TestIllegalStateModifications(t *testing.T) {
 	actor := FakeActor{}
 	receiver := tutil.NewIDAddr(t, 100)
-	builder := NewBuilder(context.Background(), receiver).WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID)
+	builder := NewBuilder(receiver).WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID)
 
 	t.Run("construction", func(t *testing.T) {
 		rt := builder.Build(t)
@@ -176,4 +173,3 @@ func TestIllegalStateModifications(t *testing.T) {
 		})
 	})
 }
-


### PR DESCRIPTION
Otherwise, reusing the builder can have strange side-effects when running multiple tests.