### PR TITLE
Replace sector extensiblility by lifetime setting

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -1171,7 +1171,7 @@ func (a Actor) ExtendSectorExpiration(rt Runtime, params *ExtendSectorExpiration
 				builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load sectors in deadline %v partition %v", dlIdx, decl.Partition)
 				newSectors := make([]*SectorOnChainInfo, len(oldSectors))
 				for i, sector := range oldSectors {
-					if !CanExtendSealProofType(sector.SealProof) {
+					if !CanExtendSealProofType(sector.SealProof, rt.NetworkVersion()) {
 						rt.Abortf(exitcode.ErrForbidden, "cannot extend expiration for sector %v with unsupported seal type %v",
 							sector.SectorNumber, sector.SealProof)
 					}
@@ -2124,7 +2124,7 @@ func validateExpiration(rt Runtime, activation, expiration abi.ChainEpoch, sealP
 	}
 
 	// total sector lifetime cannot exceed SectorMaximumLifetime for the sector's seal proof
-	maxLifetime, err := builtin.SealProofSectorMaximumLifetime(sealProof)
+	maxLifetime, err := builtin.SealProofSectorMaximumLifetime(sealProof, rt.NetworkVersion())
 	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalArgument, "unrecognized seal proof type %d", sealProof)
 	if expiration-activation > maxLifetime {
 		rt.Abortf(exitcode.ErrIllegalArgument, "invalid expiration %d, total sector lifetime (%d) cannot exceed %d after activation %d",

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -3019,7 +3019,7 @@ func TestExtendSectorExpiration(t *testing.T) {
 		// and prove it once to activate it.
 		advanceAndSubmitPoSts(rt, actor, sector)
 
-		maxLifetime, err := builtin.SealProofSectorMaximumLifetime(sector.SealProof)
+		maxLifetime, err := builtin.SealProofSectorMaximumLifetime(sector.SealProof, network.VersionMax)
 		require.NoError(t, err)
 
 		st := getState(rt)

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -147,16 +147,19 @@ func CanPreCommitSealProof(s abi.RegisteredSealProof, nv network.Version) bool {
 }
 
 // List of proof types for which sector lifetime may be extended.
-// From network version 7, sectors sealed with the V1 seal proof types cannot be extended.
+// From network version 7 to version 10, sectors sealed with the V1 seal proof types cannot be extended.
 var ExtensibleProofTypes = map[abi.RegisteredSealProof]struct{}{
 	abi.RegisteredSealProof_StackedDrg32GiBV1_1: {},
 	abi.RegisteredSealProof_StackedDrg64GiBV1_1: {},
 }
 
 // Checks whether a seal proof type is supported for new miners and sectors.
-func CanExtendSealProofType(s abi.RegisteredSealProof) bool {
-	_, ok := ExtensibleProofTypes[s]
-	return ok
+func CanExtendSealProofType(s abi.RegisteredSealProof, nv network.Version) bool {
+	if nv >= network.Version7 && nv <= network.Version10 {
+		_, ok := ExtensibleProofTypes[s]
+		return ok
+	}
+	return true
 }
 
 // Maximum delay to allow between sector pre-commit and subsequent proof.

--- a/actors/builtin/sector.go
+++ b/actors/builtin/sector.go
@@ -2,48 +2,88 @@ package builtin
 
 import (
 	stabi "github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/network"
 	"github.com/pkg/errors"
 )
 
 // Policy values associated with a seal proof type.
 type SealProofPolicy struct {
-	SectorMaxLifetime      stabi.ChainEpoch
+	SectorMaxLifetime stabi.ChainEpoch
 }
 
-// For all Stacked DRG sectors, the max is 5 years
+// For V1 Stacked DRG sectors, the max is 540 days since Network Version 11
+// 	according to https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0014.md
+const EpochsIn540Days = stabi.ChainEpoch(540 * EpochsInDay)
+
+// For V1_1 Stacked DRG sectors, the max is 5 years
 const EpochsInFiveYears = stabi.ChainEpoch(5 * EpochsInYear)
 
-var SealProofPolicies = map[stabi.RegisteredSealProof]*SealProofPolicy{
+var SealProofPoliciesV0 = map[stabi.RegisteredSealProof]*SealProofPolicy{
 	stabi.RegisteredSealProof_StackedDrg2KiBV1: {
-		SectorMaxLifetime:      EpochsInFiveYears,
+		SectorMaxLifetime: EpochsInFiveYears,
 	},
 	stabi.RegisteredSealProof_StackedDrg8MiBV1: {
-		SectorMaxLifetime:      EpochsInFiveYears,
+		SectorMaxLifetime: EpochsInFiveYears,
 	},
 	stabi.RegisteredSealProof_StackedDrg512MiBV1: {
-		SectorMaxLifetime:      EpochsInFiveYears,
+		SectorMaxLifetime: EpochsInFiveYears,
 	},
 	stabi.RegisteredSealProof_StackedDrg32GiBV1: {
-		SectorMaxLifetime:      EpochsInFiveYears,
+		SectorMaxLifetime: EpochsInFiveYears,
 	},
 	stabi.RegisteredSealProof_StackedDrg64GiBV1: {
-		SectorMaxLifetime:      EpochsInFiveYears,
+		SectorMaxLifetime: EpochsInFiveYears,
 	},
 
 	stabi.RegisteredSealProof_StackedDrg2KiBV1_1: {
-		SectorMaxLifetime:      EpochsInFiveYears,
+		SectorMaxLifetime: EpochsInFiveYears,
 	},
 	stabi.RegisteredSealProof_StackedDrg8MiBV1_1: {
-		SectorMaxLifetime:      EpochsInFiveYears,
+		SectorMaxLifetime: EpochsInFiveYears,
 	},
 	stabi.RegisteredSealProof_StackedDrg512MiBV1_1: {
-		SectorMaxLifetime:      EpochsInFiveYears,
+		SectorMaxLifetime: EpochsInFiveYears,
 	},
 	stabi.RegisteredSealProof_StackedDrg32GiBV1_1: {
-		SectorMaxLifetime:      EpochsInFiveYears,
+		SectorMaxLifetime: EpochsInFiveYears,
 	},
 	stabi.RegisteredSealProof_StackedDrg64GiBV1_1: {
-		SectorMaxLifetime:      EpochsInFiveYears,
+		SectorMaxLifetime: EpochsInFiveYears,
+	},
+}
+
+// 540-day maximum life time setting for V1 since network version 11
+var SealProofPoliciesV11 = map[stabi.RegisteredSealProof]*SealProofPolicy{
+	stabi.RegisteredSealProof_StackedDrg2KiBV1: {
+		SectorMaxLifetime: EpochsIn540Days,
+	},
+	stabi.RegisteredSealProof_StackedDrg8MiBV1: {
+		SectorMaxLifetime: EpochsIn540Days,
+	},
+	stabi.RegisteredSealProof_StackedDrg512MiBV1: {
+		SectorMaxLifetime: EpochsIn540Days,
+	},
+	stabi.RegisteredSealProof_StackedDrg32GiBV1: {
+		SectorMaxLifetime: EpochsIn540Days,
+	},
+	stabi.RegisteredSealProof_StackedDrg64GiBV1: {
+		SectorMaxLifetime: EpochsIn540Days,
+	},
+
+	stabi.RegisteredSealProof_StackedDrg2KiBV1_1: {
+		SectorMaxLifetime: EpochsInFiveYears,
+	},
+	stabi.RegisteredSealProof_StackedDrg8MiBV1_1: {
+		SectorMaxLifetime: EpochsInFiveYears,
+	},
+	stabi.RegisteredSealProof_StackedDrg512MiBV1_1: {
+		SectorMaxLifetime: EpochsInFiveYears,
+	},
+	stabi.RegisteredSealProof_StackedDrg32GiBV1_1: {
+		SectorMaxLifetime: EpochsInFiveYears,
+	},
+	stabi.RegisteredSealProof_StackedDrg64GiBV1_1: {
+		SectorMaxLifetime: EpochsInFiveYears,
 	},
 }
 
@@ -58,8 +98,16 @@ func SealProofWindowPoStPartitionSectors(p stabi.RegisteredSealProof) (uint64, e
 }
 
 // SectorMaximumLifetime is the maximum duration a sector sealed with this proof may exist between activation and expiration
-func SealProofSectorMaximumLifetime(p stabi.RegisteredSealProof) (stabi.ChainEpoch, error) {
-	info, ok := SealProofPolicies[p]
+func SealProofSectorMaximumLifetime(p stabi.RegisteredSealProof, nv network.Version) (stabi.ChainEpoch, error) {
+	var info *SealProofPolicy
+	var ok bool
+
+	if nv < network.Version11 {
+		info, ok = SealProofPoliciesV0[p]
+	} else {
+		info, ok = SealProofPoliciesV11[p]
+	}
+
 	if !ok {
 		return 0, errors.Errorf("unsupported proof type: %v", p)
 	}
@@ -85,7 +133,7 @@ func ConsensusMinerMinPower(p stabi.RegisteredPoStProof) (stabi.StoragePower, er
 // Policy values associated with a PoSt proof type.
 type PoStProofPolicy struct {
 	WindowPoStPartitionSectors uint64
-	ConsensusMinerMinPower stabi.StoragePower
+	ConsensusMinerMinPower     stabi.StoragePower
 }
 
 // Partition sizes must match those used by the proofs library.
@@ -93,23 +141,23 @@ type PoStProofPolicy struct {
 var PoStProofPolicies = map[stabi.RegisteredPoStProof]*PoStProofPolicy{
 	stabi.RegisteredPoStProof_StackedDrgWindow2KiBV1: {
 		WindowPoStPartitionSectors: 2,
-		ConsensusMinerMinPower: stabi.NewStoragePower(0),
+		ConsensusMinerMinPower:     stabi.NewStoragePower(0),
 	},
 	stabi.RegisteredPoStProof_StackedDrgWindow8MiBV1: {
 		WindowPoStPartitionSectors: 2,
-		ConsensusMinerMinPower: stabi.NewStoragePower(16 << 20),
+		ConsensusMinerMinPower:     stabi.NewStoragePower(16 << 20),
 	},
 	stabi.RegisteredPoStProof_StackedDrgWindow512MiBV1: {
 		WindowPoStPartitionSectors: 2,
-		ConsensusMinerMinPower: stabi.NewStoragePower(1 << 30),
+		ConsensusMinerMinPower:     stabi.NewStoragePower(1 << 30),
 	},
 	stabi.RegisteredPoStProof_StackedDrgWindow32GiBV1: {
 		WindowPoStPartitionSectors: 2349,
-		ConsensusMinerMinPower: stabi.NewStoragePower(10 << 40),
+		ConsensusMinerMinPower:     stabi.NewStoragePower(10 << 40),
 	},
 	stabi.RegisteredPoStProof_StackedDrgWindow64GiBV1: {
 		WindowPoStPartitionSectors: 2300,
-		ConsensusMinerMinPower: stabi.NewStoragePower(20 << 40),
+		ConsensusMinerMinPower:     stabi.NewStoragePower(20 << 40),
 	},
 	// Winning PoSt proof types omitted.
 }


### PR DESCRIPTION
This PR is to change the sector extension disability to the sector maximum lifetime limitation, currently the change just reflect on the V1 proof-type sectors as per the proposal in https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0014.md

What's more, this change also simplified the logic of the limitation of sector extension, could apply to further proof types too.

_Note: this PR is to replace #1384  using just one commit to make it cleaner._ 