### PR TITLE
feat: Use constant consensus fault reward

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -1744,8 +1744,9 @@ func (a Actor) ReportConsensusFault(rt Runtime, params *ReportConsensusFaultPara
 	rewardStats := requestCurrentEpochBlockReward(rt)
 	// The policy amounts we should burn and send to reporter
 	// These may differ from actual funds send when miner goes into fee debt
-	faultPenalty := ConsensusFaultPenalty(rewardStats.ThisEpochRewardSmoothed.Estimate())
-	slasherReward := RewardForConsensusSlashReport(faultAge, faultPenalty)
+	thisEpochReward := rewardStats.ThisEpochRewardSmoothed.Estimate()
+	faultPenalty := ConsensusFaultPenalty(thisEpochReward)
+	slasherReward := RewardForConsensusSlashReport(thisEpochReward)
 	pledgeDelta := big.Zero()
 
 	// The amounts actually sent to burnt funds and reporter

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -5810,13 +5810,13 @@ func (h *actorHarness) reportConsensusFault(rt *mock.Runtime, from addr.Address,
 	}
 	rt.ExpectSend(builtin.RewardActorAddr, builtin.MethodsReward.ThisEpochReward, nil, big.Zero(), &currentReward, exitcode.Ok)
 
-	penaltyTotal := miner.ConsensusFaultPenalty(h.epochRewardSmooth.Estimate())
-	// slash reward
-	rwd := miner.RewardForConsensusSlashReport(1, penaltyTotal)
-	rt.ExpectSend(from, builtin.MethodSend, nil, rwd, nil, exitcode.Ok)
+	thisEpochReward := h.epochRewardSmooth.Estimate()
+	penaltyTotal := miner.ConsensusFaultPenalty(thisEpochReward)
+	rewardTotal := miner.RewardForConsensusSlashReport(thisEpochReward)
+	rt.ExpectSend(from, builtin.MethodSend, nil, rewardTotal, nil, exitcode.Ok)
 
 	// pay fault fee
-	toBurn := big.Sub(penaltyTotal, rwd)
+	toBurn := big.Sub(penaltyTotal, rewardTotal)
 	rt.ExpectSend(builtin.BurntFundsActorAddr, builtin.MethodSend, nil, toBurn, nil, exitcode.Ok)
 
 	rt.Call(h.a.ReportConsensusFault, params)

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -274,7 +274,7 @@ func SectorDealsMax(size abi.SectorSize) uint64 {
 }
 
 // Default share of block reward allocated as reward to the consensus fault reporter.
-// Applied as epochReward / consensusFaultReporterDefaultShare
+// Applied as epochReward / (expectedLeadersPerEpoch * consensusFaultReporterDefaultShare)
 const consensusFaultReporterDefaultShare int64 = 4
 
 // Specification for a linear vesting schedule.
@@ -295,7 +295,10 @@ var RewardVestingSpec = VestSpec{ // PARAM_SPEC
 
 // When an actor reports a consensus fault, they earn a share of the penalty paid by the miner.
 func RewardForConsensusSlashReport(epochReward abi.TokenAmount) abi.TokenAmount {
-	return big.Div(epochReward, big.NewInt(consensusFaultReporterDefaultShare))
+	return big.Div(epochReward,
+		big.Mul(big.NewInt(builtin.ExpectedLeadersPerEpoch),
+			big.NewInt(consensusFaultReporterDefaultShare)),
+	)
 }
 
 // The reward given for successfully disputing a window post.


### PR DESCRIPTION
Fixes #1382 and applies FIP-0011.

Adjust consensus fault reward as described in https://github.com/filecoin-project/FIPs/blob/6db88a7d5cdf26462f130b78d6e05b56e39442ad/FIPS/fip-0011.md.