### PR TITLE
feat: Allow VerifiedClient DataCap to be topped up

### DIFF
--- a/actors/builtin/verifreg/verified_registry_actor.go
+++ b/actors/builtin/verifreg/verified_registry_actor.go
@@ -182,18 +182,19 @@ func (a Actor) AddVerifiedClient(rt runtime.Runtime, params *AddVerifiedClientPa
 		err = verifiers.Put(abi.AddrKey(verifier), &newVerifierCap)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to update new verifier cap (%d) for %v", newVerifierCap, verifier)
 
-		// This is a one-time, upfront allocation.
-		// This allowance cannot be changed by calls to AddVerifiedClient as long as the client has not been removed.
-		// If parties need more allowance, they need to create a new verified client or use up the the current allowance
-		// and then create a new verified client.
-		found, err = verifiedClients.Get(abi.AddrKey(client), nil)
+		var clientCap DataCap
+		found, err = verifiedClients.Get(abi.AddrKey(client), &clientCap)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to get verified client %v", client)
-		if found {
-			rt.Abortf(exitcode.ErrIllegalArgument, "verified client already exists: %v", client)
-		}
 
-		err = verifiedClients.Put(abi.AddrKey(client), &params.Allowance)
-		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to add verified client %v with cap %d", client, params.Allowance)
+		// if verified client exists, add allowance to existing cap
+		// otherwise, create new client with allownace
+		if found {
+			clientCap = big.Add(clientCap, params.Allowance)
+		} else {
+			clientCap = params.Allowance
+		}
+		err = verifiedClients.Put(abi.AddrKey(client), &clientCap)
+		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to add verified client %v with cap %d", client, clientCap)
 
 		st.Verifiers, err = verifiers.Root()
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to flush verifiers")


### PR DESCRIPTION
Implements [FIP-0012](https://github.com/filecoin-project/FIPs/blob/5ab54f271a87b3c759c21dc36948c033f105ac4d/FIPS/fip-0012.md) and fixes #1325.

Thoughts on these changes:
- The mock runtime `addVerifiedClient` function is now overloaded to support an optional `expectedAllowance` arg to be used in the cases where VerifiedClients will now have more than what was initially allotted. This makes the verification of an `expectedAllownace` a concern on the caller rather than letting the function reflect on its internal before/after state to verify correctness. I'd personally prefer the latter to keep the call simple, but there were errors when I attempted to access the runtime map for the "before" state of the Client's DataCap allowance. (An example of that is at https://gist.github.com/placer14/f2134a4064373607da44b48b4f338d69.)
- This change will mix all Verifier's allowances together for each Client address. If there were ever a need to know how DataCap is used on a per-Verifier basis, we would be eliminating that option here.
- The unit test which protects that a VerifiedClient can be referred to be its ID and non-ID addr is also protecting its ability to be topped-up. If it's preferred that these behaviors are protected by separate tests, I can, but felt the redundancy was unnecessary and left them combined.
- This change does not limit the DataCap upper bound and expects that DataCap boundaries are already protected where necessary.