### PR TITLE
Batched miner state manipulations for sector number allocation

### DIFF
--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -743,7 +743,7 @@ func (a Actor) PreCommitSector(rt Runtime, params *PreCommitSectorParams) *abi.E
 			rt.Abortf(exitcode.ErrIllegalArgument, "deals too large to fit in sector %d > %d", dealWeight.DealSpace, info.SectorSize)
 		}
 
-		err = st.AllocateSectorNumber(store, params.SectorNumber)
+		err = st.AllocateSectorNumbers(store, bitfield.NewFromSet([]uint64{uint64(params.SectorNumber)}), DenyCollisions)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to allocate sector id %d", params.SectorNumber)
 
 		// This sector check is redundant given the allocated sectors bitfield, but remains for safety.
@@ -1655,7 +1655,7 @@ func (a Actor) CompactSectorNumbers(rt Runtime, params *CompactSectorNumbersPara
 		info := getMinerInfo(rt, &st)
 		rt.ValidateImmediateCallerIs(append(info.ControlAddresses, info.Owner, info.Worker)...)
 
-		err := st.MaskSectorNumbers(store, params.MaskSectorNumbers)
+		err := st.AllocateSectorNumbers(store, params.MaskSectorNumbers, AllowCollisions)
 
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to mask sector numbers")
 	})

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -309,7 +309,7 @@ const (
 )
 
 // Marks a set of sector numbers has having been allocated.
-// If allowCollision is false, fails if the set intersects with the sector numbers already allocated.
+// If policy is `DenyCollisions`, fails if the set intersects with the sector numbers already allocated.
 func (st *State) AllocateSectorNumbers(store adt.Store, sectorNos bitfield.BitField, policy CollisionPolicy) error {
 	if lastSectorNo, err := sectorNos.Last(); err != nil {
 		return xc.ErrIllegalArgument.Wrapf("invalid sector bitfield: %w", err)

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -301,54 +301,48 @@ func (st *State) QuantSpecForDeadline(dlIdx uint64) QuantSpec {
 	return QuantSpecForDeadline(NewDeadlineInfo(st.ProvingPeriodStart, dlIdx, 0))
 }
 
-func (st *State) AllocateSectorNumber(store adt.Store, sectorNo abi.SectorNumber) error {
-	// This will likely already have been checked, but this is a good place
-	// to catch any mistakes.
-	if sectorNo > abi.MaxSectorNumber {
-		return xc.ErrIllegalArgument.Wrapf("sector number out of range: %d", sectorNo)
+type CollisionPolicy bool
+
+const (
+	DenyCollisions  = CollisionPolicy(false)
+	AllowCollisions = CollisionPolicy(true)
+)
+
+// Marks a set of sector numbers has having been allocated.
+// If allowCollision is false, fails if the set intersects with the sector numbers already allocated.
+func (st *State) AllocateSectorNumbers(store adt.Store, sectorNos bitfield.BitField, policy CollisionPolicy) error {
+	if lastSectorNo, err := sectorNos.Last(); err != nil {
+		return xc.ErrIllegalArgument.Wrapf("invalid sector bitfield: %w", err)
+	} else if lastSectorNo > abi.MaxSectorNumber {
+		return xc.ErrIllegalArgument.Wrapf("sector number %d exceeds max %d", lastSectorNo, abi.MaxSectorNumber)
 	}
 
-	var allocatedSectors bitfield.BitField
-	if err := store.Get(store.Context(), st.AllocatedSectors, &allocatedSectors); err != nil {
-		return xc.ErrIllegalState.Wrapf("failed to load allocated sectors bitfield: %w", err)
-	}
-	if allocated, err := allocatedSectors.IsSet(uint64(sectorNo)); err != nil {
-		return xc.ErrIllegalState.Wrapf("failed to lookup sector number in allocated sectors bitfield: %w", err)
-	} else if allocated {
-		return xc.ErrIllegalArgument.Wrapf("sector number %d has already been allocated", sectorNo)
-	}
-	allocatedSectors.Set(uint64(sectorNo))
-
-	if root, err := store.Put(store.Context(), allocatedSectors); err != nil {
-		return xc.ErrIllegalArgument.Wrapf("failed to store allocated sectors bitfield after adding sector %d: %w", sectorNo, err)
-	} else {
-		st.AllocatedSectors = root
-	}
-	return nil
-}
-
-func (st *State) MaskSectorNumbers(store adt.Store, sectorNos bitfield.BitField) error {
-	lastSectorNo, err := sectorNos.Last()
-	if err != nil {
-		return xc.ErrIllegalArgument.Wrapf("invalid mask bitfield: %w", err)
-	}
-
-	if lastSectorNo > abi.MaxSectorNumber {
-		return xc.ErrIllegalArgument.Wrapf("masked sector number %d exceeded max sector number", lastSectorNo)
-	}
-
-	var allocatedSectors bitfield.BitField
-	if err := store.Get(store.Context(), st.AllocatedSectors, &allocatedSectors); err != nil {
+	var priorAllocation bitfield.BitField
+	if err := store.Get(store.Context(), st.AllocatedSectors, &priorAllocation); err != nil {
 		return xc.ErrIllegalState.Wrapf("failed to load allocated sectors bitfield: %w", err)
 	}
 
-	allocatedSectors, err = bitfield.MergeBitFields(allocatedSectors, sectorNos)
+	if policy != AllowCollisions {
+		// NOTE: A fancy merge algorithm could extract this intersection while merging, below, saving
+		// one iteration of the runs.
+		collisions, err := bitfield.IntersectBitField(priorAllocation, sectorNos)
+		if err != nil {
+			return xerrors.Errorf("failed to intersect sector numbers: %w", err)
+		}
+		if empty, err := collisions.IsEmpty(); err != nil {
+			return xerrors.Errorf("failed to check if intersection is empty: %w", err)
+		} else if !empty {
+			return xc.ErrIllegalArgument.Wrapf("sector numbers %v already allocated", collisions)
+		}
+	}
+
+	newAllocation, err := bitfield.MergeBitFields(priorAllocation, sectorNos)
 	if err != nil {
 		return xc.ErrIllegalState.Wrapf("failed to merge allocated bitfield with mask: %w", err)
 	}
 
-	if root, err := store.Put(store.Context(), allocatedSectors); err != nil {
-		return xc.ErrIllegalArgument.Wrapf("failed to mask allocated sectors bitfield: %w", err)
+	if root, err := store.Put(store.Context(), newAllocation); err != nil {
+		return xc.ErrIllegalArgument.Wrapf("failed to store allocated sectors bitfield after adding %v: %w", sectorNos, err)
 	} else {
 		st.AllocatedSectors = root
 	}

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -308,7 +308,7 @@ const (
 	AllowCollisions = CollisionPolicy(true)
 )
 
-// Marks a set of sector numbers has having been allocated.
+// Marks a set of sector numbers as having been allocated.
 // If policy is `DenyCollisions`, fails if the set intersects with the sector numbers already allocated.
 func (st *State) AllocateSectorNumbers(store adt.Store, sectorNos bitfield.BitField, policy CollisionPolicy) error {
 	if lastSectorNo, err := sectorNos.Last(); err != nil {

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -628,13 +628,13 @@ func TestCommitments(t *testing.T) {
 		expiration := deadline.PeriodEnd() + defaultSectorExpiration*miner.WPoStProvingPeriod
 		actor.preCommitSector(rt, actor.makePreCommit(101, challengeEpoch, expiration, nil), preCommitConf{}, false)
 		// Duplicate pre-commit sector ID
-		rt.ExpectAbortContainsMessage(exitcode.ErrIllegalArgument, "already been allocated", func() {
+		rt.ExpectAbortContainsMessage(exitcode.ErrIllegalArgument, "already allocated", func() {
 			actor.preCommitSector(rt, actor.makePreCommit(101, challengeEpoch, expiration, nil), preCommitConf{}, false)
 		})
 		rt.Reset()
 
 		// Sector ID already committed
-		rt.ExpectAbortContainsMessage(exitcode.ErrIllegalArgument, "already been allocated", func() {
+		rt.ExpectAbortContainsMessage(exitcode.ErrIllegalArgument, "already allocated", func() {
 			actor.preCommitSector(rt, actor.makePreCommit(oldSector.SectorNumber, challengeEpoch, expiration, nil), preCommitConf{}, false)
 		})
 		rt.Reset()


### PR DESCRIPTION
This is broken out (1 of 2) of my work on #1241, batching pre-commits. During implementation I realised the essential similarity between allocating and masking sector numbers, so combined the state manipulation methods.