### PR TITLE
Implemented PreCommitSectorBatch method (FIP-0008)

### DIFF
--- a/actors/builtin/methods.go
+++ b/actors/builtin/methods.go
@@ -100,7 +100,8 @@ var MethodsMiner = struct {
 	RepayDebt                abi.MethodNum
 	ChangeOwnerAddress       abi.MethodNum
 	DisputeWindowedPoSt      abi.MethodNum
-}{MethodConstructor, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24}
+	PreCommitSectorBatch     abi.MethodNum
+}{MethodConstructor, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25}
 
 var MethodsVerifiedRegistry = struct {
 	Constructor       abi.MethodNum

--- a/actors/builtin/miner/cbor_gen.go
+++ b/actors/builtin/miner/cbor_gen.go
@@ -8,6 +8,7 @@ import (
 
 	address "github.com/filecoin-project/go-address"
 	abi "github.com/filecoin-project/go-state-types/abi"
+	miner "github.com/filecoin-project/specs-actors/actors/builtin/miner"
 	proof "github.com/filecoin-project/specs-actors/actors/runtime/proof"
 	cid "github.com/ipfs/go-cid"
 	cbg "github.com/whyrusleeping/cbor-gen"
@@ -2477,6 +2478,85 @@ func (t *WindowedPoSt) UnmarshalCBOR(r io.Reader) error {
 		}
 
 		t.Proofs[i] = v
+	}
+
+	return nil
+}
+
+var lengthBufPreCommitSectorBatchParams = []byte{129}
+
+func (t *PreCommitSectorBatchParams) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write(lengthBufPreCommitSectorBatchParams); err != nil {
+		return err
+	}
+
+	scratch := make([]byte, 9)
+
+	// t.Sectors ([]*miner.SectorPreCommitInfo) (slice)
+	if len(t.Sectors) > cbg.MaxLength {
+		return xerrors.Errorf("Slice value in field t.Sectors was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.Sectors))); err != nil {
+		return err
+	}
+	for _, v := range t.Sectors {
+		if err := v.MarshalCBOR(w); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *PreCommitSectorBatchParams) UnmarshalCBOR(r io.Reader) error {
+	*t = PreCommitSectorBatchParams{}
+
+	br := cbg.GetPeeker(r)
+	scratch := make([]byte, 8)
+
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 1 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.Sectors ([]*miner.SectorPreCommitInfo) (slice)
+
+	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("t.Sectors: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.Sectors = make([]*miner.SectorPreCommitInfo, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+
+		var v miner.SectorPreCommitInfo
+		if err := v.UnmarshalCBOR(br); err != nil {
+			return err
+		}
+
+		t.Sectors[i] = &v
 	}
 
 	return nil

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -660,7 +660,7 @@ type PreCommitSectorBatchParams struct {
 
 // Pledges the miner to seal and commit some new sectors.
 // The caller specifies sector numbers, sealed sector data CIDs, seal randomness epoch, expiration, and the IDs
-// of any storage marge deals contained in the sector data. The storage deal proposals must be already submitted
+// of any storage deals contained in the sector data. The storage deal proposals must be already submitted
 // to the storage market actor.
 // A pre-commitment may specify an existing committed-capacity sector that the committed sector will replace
 // when proven.

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -74,6 +74,7 @@ func (a Actor) Exports() []interface{} {
 		22:                        a.RepayDebt,
 		23:                        a.ChangeOwnerAddress,
 		24:                        a.DisputeWindowedPoSt,
+		25:                        a.PreCommitSectorBatch,
 	}
 }
 
@@ -643,65 +644,103 @@ func (a Actor) DisputeWindowedPoSt(rt Runtime, params *DisputeWindowedPoStParams
 //}
 type PreCommitSectorParams = miner0.SectorPreCommitInfo
 
-// Proposals must be posted on chain via sma.PublishStorageDeals before PreCommitSector.
-// Optimization: PreCommitSector could contain a list of deals that are not published yet.
+// Pledges to seal and commit a single sector.
+// See PreCommitSectorBatch for details.
+// This method may be deprecated and removed in the future.
 func (a Actor) PreCommitSector(rt Runtime, params *PreCommitSectorParams) *abi.EmptyValue {
+	// This is a direct method call to self, not a message send.
+	batchParams := &PreCommitSectorBatchParams{Sectors: []*miner0.SectorPreCommitInfo{params}}
+	a.PreCommitSectorBatch(rt, batchParams)
+	return nil
+}
+
+type PreCommitSectorBatchParams struct {
+	Sectors []*miner0.SectorPreCommitInfo
+}
+
+// Pledges the miner to seal and commit some new sectors.
+// The caller specifies sector numbers, sealed sector data CIDs, seal randomness epoch, expiration, and the IDs
+// of any storage marge deals contained in the sector data. The storage deal proposals must be already submitted
+// to the storage market actor.
+// A pre-commitment may specify an existing committed-capacity sector that the committed sector will replace
+// when proven.
+// This method calculates the sector's power, locks a pre-commit deposit for the sector, stores information about the
+// sector in state and waits for it to be proven or expire.
+func (a Actor) PreCommitSectorBatch(rt Runtime, params *PreCommitSectorBatchParams) *abi.EmptyValue {
 	nv := rt.NetworkVersion()
-	if !CanPreCommitSealProof(params.SealProof, nv) {
-		rt.Abortf(exitcode.ErrIllegalArgument, "unsupported seal proof type %v at network version %v", params.SealProof, nv)
-	}
-	if params.SectorNumber > abi.MaxSectorNumber {
-		rt.Abortf(exitcode.ErrIllegalArgument, "sector number %d out of range 0..(2^63-1)", params.SectorNumber)
-	}
-	if !params.SealedCID.Defined() {
-		rt.Abortf(exitcode.ErrIllegalArgument, "sealed CID undefined")
-	}
-	if params.SealedCID.Prefix() != SealedCIDPrefix {
-		rt.Abortf(exitcode.ErrIllegalArgument, "sealed CID had wrong prefix")
-	}
-	if params.SealRandEpoch >= rt.CurrEpoch() {
-		rt.Abortf(exitcode.ErrIllegalArgument, "seal challenge epoch %v must be before now %v", params.SealRandEpoch, rt.CurrEpoch())
+	currEpoch := rt.CurrEpoch()
+	if len(params.Sectors) == 0 {
+		rt.Abortf(exitcode.ErrIllegalArgument, "batch empty")
+	} else if len(params.Sectors) > PreCommitSectorBatchMaxSize {
+		rt.Abortf(exitcode.ErrIllegalArgument, "batch of %d too large, max %d", len(params.Sectors), PreCommitSectorBatchMaxSize)
 	}
 
-	challengeEarliest := rt.CurrEpoch() - MaxPreCommitRandomnessLookback
-	if params.SealRandEpoch < challengeEarliest {
-		rt.Abortf(exitcode.ErrIllegalArgument, "seal challenge epoch %v too old, must be after %v", params.SealRandEpoch, challengeEarliest)
-	}
+	// Check per-sector preconditions before opening state transaction or sending other messages.
+	challengeEarliest := currEpoch - MaxPreCommitRandomnessLookback
+	sectorsDeals := make([]market.SectorDeals, len(params.Sectors))
+	sectorNumbers := bitfield.New()
+	for i, precommit := range params.Sectors {
+		// Bitfied.IsSet() is fast when there are only locally-set values.
+		set, err := sectorNumbers.IsSet(uint64(precommit.SectorNumber))
+		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "error checking sector number")
+		if set {
+			rt.Abortf(exitcode.ErrIllegalArgument, "duplicate sector number %d", precommit.SectorNumber)
+		}
+		sectorNumbers.Set(uint64(precommit.SectorNumber))
 
-	// Require sector lifetime meets minimum by assuming activation happens at last epoch permitted for seal proof.
-	// This could make sector maximum lifetime validation more lenient if the maximum sector limit isn't hit first.
-	maxActivation := rt.CurrEpoch() + MaxProveCommitDuration[params.SealProof]
-	validateExpiration(rt, maxActivation, params.Expiration, params.SealProof)
+		if !CanPreCommitSealProof(precommit.SealProof, nv) {
+			rt.Abortf(exitcode.ErrIllegalArgument, "unsupported seal proof type %v at network version %v", precommit.SealProof, nv)
+		}
+		if precommit.SectorNumber > abi.MaxSectorNumber {
+			rt.Abortf(exitcode.ErrIllegalArgument, "sector number %d out of range 0..(2^63-1)", precommit.SectorNumber)
+		}
+		if !precommit.SealedCID.Defined() {
+			rt.Abortf(exitcode.ErrIllegalArgument, "sealed CID undefined")
+		}
+		if precommit.SealedCID.Prefix() != SealedCIDPrefix {
+			rt.Abortf(exitcode.ErrIllegalArgument, "sealed CID had wrong prefix")
+		}
+		if precommit.SealRandEpoch >= currEpoch {
+			rt.Abortf(exitcode.ErrIllegalArgument, "seal challenge epoch %v must be before now %v", precommit.SealRandEpoch, rt.CurrEpoch())
+		}
+		if precommit.SealRandEpoch < challengeEarliest {
+			rt.Abortf(exitcode.ErrIllegalArgument, "seal challenge epoch %v too old, must be after %v", precommit.SealRandEpoch, challengeEarliest)
+		}
 
-	if params.ReplaceCapacity && len(params.DealIDs) == 0 {
-		rt.Abortf(exitcode.ErrIllegalArgument, "cannot replace sector without committing deals")
-	}
-	if params.ReplaceSectorDeadline >= WPoStPeriodDeadlines {
-		rt.Abortf(exitcode.ErrIllegalArgument, "invalid deadline %d", params.ReplaceSectorDeadline)
-	}
-	if params.ReplaceSectorNumber > abi.MaxSectorNumber {
-		rt.Abortf(exitcode.ErrIllegalArgument, "invalid sector number %d", params.ReplaceSectorNumber)
+		// Require sector lifetime meets minimum by assuming activation happens at last epoch permitted for seal proof.
+		// This could make sector maximum lifetime validation more lenient if the maximum sector limit isn't hit first.
+		maxActivation := currEpoch + MaxProveCommitDuration[precommit.SealProof]
+		validateExpiration(rt, maxActivation, precommit.Expiration, precommit.SealProof)
+
+		if precommit.ReplaceCapacity && len(precommit.DealIDs) == 0 {
+			rt.Abortf(exitcode.ErrIllegalArgument, "cannot replace sector without committing deals")
+		}
+		if precommit.ReplaceSectorDeadline >= WPoStPeriodDeadlines {
+			rt.Abortf(exitcode.ErrIllegalArgument, "invalid deadline %d", precommit.ReplaceSectorDeadline)
+		}
+		if precommit.ReplaceSectorNumber > abi.MaxSectorNumber {
+			rt.Abortf(exitcode.ErrIllegalArgument, "invalid sector number %d", precommit.ReplaceSectorNumber)
+		}
+
+		sectorsDeals[i] = market.SectorDeals{
+			SectorExpiry: precommit.Expiration,
+			DealIDs:      precommit.DealIDs,
+		}
 	}
 
 	// gather information from other actors
-
 	rewardStats := requestCurrentEpochBlockReward(rt)
 	pwrTotal := requestCurrentTotalPower(rt)
-	dealWeights := requestDealWeights(rt, []market.SectorDeals{
-		{
-			SectorExpiry: params.Expiration,
-			DealIDs:      params.DealIDs,
-		},
-	})
-	if len(dealWeights.Sectors) == 0 {
-		rt.Abortf(exitcode.ErrIllegalState, "deal weight request returned no records")
+	dealWeights := requestDealWeights(rt, sectorsDeals)
+
+	if len(dealWeights.Sectors) != len(params.Sectors) {
+		rt.Abortf(exitcode.ErrIllegalState, "deal weight request returned %d records, expected %d",
+			len(dealWeights.Sectors), len(params.Sectors))
 	}
-	dealWeight := dealWeights.Sectors[0]
 
 	store := adt.AsStore(rt)
 	var st State
 	var err error
-	newlyVested := big.Zero()
 	feeToBurn := abi.NewTokenAmount(0)
 	var needsCron bool
 	rt.StateTransaction(&st, func() {
@@ -715,92 +754,97 @@ func (a Actor) PreCommitSector(rt Runtime, params *PreCommitSectorParams) *abi.E
 		info := getMinerInfo(rt, &st)
 		rt.ValidateImmediateCallerIs(append(info.ControlAddresses, info.Owner, info.Worker)...)
 
-		if ConsensusFaultActive(info, rt.CurrEpoch()) {
-			rt.Abortf(exitcode.ErrForbidden, "precommit not allowed during active consensus fault")
+		if ConsensusFaultActive(info, currEpoch) {
+			rt.Abortf(exitcode.ErrForbidden, "pre-commit not allowed during active consensus fault")
 		}
 
-		// From network version 7, the pre-commit seal type must have the same Window PoSt proof type as the miner,
-		// rather than be exactly the same seal type.
-		// This permits a transition window from V1 to V1_1 seal types (which share Window PoSt proof type).
-		sectorWPoStProof, err := params.SealProof.RegisteredWindowPoStProof()
-		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalArgument, "failed to lookup Window PoSt proof type for sector seal proof %d", params.SealProof)
-		if sectorWPoStProof != info.WindowPoStProofType {
-			rt.Abortf(exitcode.ErrIllegalArgument, "sector Window PoSt proof type %d must match miner Window PoSt proof type %d (seal proof type %d)",
-				sectorWPoStProof, info.WindowPoStProofType, params.SealProof)
-		}
-
+		chainInfos := make([]*SectorPreCommitOnChainInfo, len(params.Sectors))
+		totalDepositRequired := big.Zero()
+		expirations := map[abi.ChainEpoch][]uint64{}
 		dealCountMax := SectorDealsMax(info.SectorSize)
-		if uint64(len(params.DealIDs)) > dealCountMax {
-			rt.Abortf(exitcode.ErrIllegalArgument, "too many deals for sector %d > %d", len(params.DealIDs), dealCountMax)
+		for i, precommit := range params.Sectors {
+			// Sector must have the same Window PoSt proof type as the miner's recorded seal type.
+			sectorWPoStProof, err := precommit.SealProof.RegisteredWindowPoStProof()
+			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalArgument, "failed to lookup Window PoSt proof type for sector seal proof %d", precommit.SealProof)
+			if sectorWPoStProof != info.WindowPoStProofType {
+				rt.Abortf(exitcode.ErrIllegalArgument, "sector Window PoSt proof type %d must match miner Window PoSt proof type %d (seal proof type %d)",
+					sectorWPoStProof, info.WindowPoStProofType, precommit.SealProof)
+			}
+
+			if uint64(len(precommit.DealIDs)) > dealCountMax {
+				rt.Abortf(exitcode.ErrIllegalArgument, "too many deals for sector %d > %d", len(precommit.DealIDs), dealCountMax)
+			}
+
+			// Ensure total deal space does not exceed sector size.
+			dealWeight := dealWeights.Sectors[i]
+			if dealWeight.DealSpace > uint64(info.SectorSize) {
+				rt.Abortf(exitcode.ErrIllegalArgument, "deals too large to fit in sector %d > %d", dealWeight.DealSpace, info.SectorSize)
+			}
+
+			if precommit.ReplaceCapacity {
+				validateReplaceSector(rt, &st, store, precommit)
+			}
+
+			// Estimate the sector weight using the current epoch as an estimate for activation,
+			// and compute the pre-commit deposit using that weight.
+			// The sector's power will be recalculated when it's proven.
+			duration := precommit.Expiration - currEpoch
+			sectorWeight := QAPowerForWeight(info.SectorSize, duration, dealWeight.DealWeight, dealWeight.VerifiedDealWeight)
+			depositReq := PreCommitDepositForPower(rewardStats.ThisEpochRewardSmoothed, pwrTotal.QualityAdjPowerSmoothed, sectorWeight)
+
+			// Build on-chain record.
+			chainInfos[i] = &SectorPreCommitOnChainInfo{
+				Info:               SectorPreCommitInfo(*precommit),
+				PreCommitDeposit:   depositReq,
+				PreCommitEpoch:     currEpoch,
+				DealWeight:         dealWeight.DealWeight,
+				VerifiedDealWeight: dealWeight.VerifiedDealWeight,
+			}
+			totalDepositRequired = big.Add(totalDepositRequired, depositReq)
+
+			// Calculate pre-commit expiry
+			msd, ok := MaxProveCommitDuration[precommit.SealProof]
+			if !ok {
+				rt.Abortf(exitcode.ErrIllegalArgument, "no max seal duration set for proof type: %d", precommit.SealProof)
+			}
+			// The +1 here is critical for the batch verification of proofs. Without it, if a proof arrived exactly on the
+			// due epoch, ProveCommitSector would accept it, then the expiry event would remove it, and then
+			// ConfirmSectorProofsValid would fail to find it.
+			expiryBound := currEpoch + msd + 1
+			expirations[expiryBound] = append(expirations[expiryBound], uint64(precommit.SectorNumber))
 		}
 
-		// Ensure total deal space does not exceed sector size.
-		if dealWeight.DealSpace > uint64(info.SectorSize) {
-			rt.Abortf(exitcode.ErrIllegalArgument, "deals too large to fit in sector %d > %d", dealWeight.DealSpace, info.SectorSize)
+		// Batch update actor state.
+		if availableBalance.LessThan(totalDepositRequired) {
+			rt.Abortf(exitcode.ErrInsufficientFunds, "insufficient funds %v for pre-commit deposit: %v", availableBalance, totalDepositRequired)
 		}
+		err = st.AddPreCommitDeposit(totalDepositRequired)
+		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to add pre-commit deposit %v", totalDepositRequired)
 
-		err = st.AllocateSectorNumbers(store, bitfield.NewFromSet([]uint64{uint64(params.SectorNumber)}), DenyCollisions)
-		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to allocate sector id %d", params.SectorNumber)
+		err = st.AllocateSectorNumbers(store, sectorNumbers, DenyCollisions)
+		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to allocate sector ids %v", sectorNumbers)
 
-		// This sector check is redundant given the allocated sectors bitfield, but remains for safety.
-		sectorFound, err := st.HasSectorNo(store, params.SectorNumber)
-		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to check sector %v", params.SectorNumber)
-		if sectorFound {
-			rt.Abortf(exitcode.ErrIllegalState, "sector %v already committed", params.SectorNumber)
-		}
+		err = st.PutPrecommittedSectors(store, chainInfos...)
+		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to write pre-committed sectors")
 
-		if params.ReplaceCapacity {
-			validateReplaceSector(rt, &st, store, params)
-		}
-
-		duration := params.Expiration - rt.CurrEpoch()
-		sectorWeight := QAPowerForWeight(info.SectorSize, duration, dealWeight.DealWeight, dealWeight.VerifiedDealWeight)
-		depositReq := PreCommitDepositForPower(rewardStats.ThisEpochRewardSmoothed, pwrTotal.QualityAdjPowerSmoothed, sectorWeight)
-		if availableBalance.LessThan(depositReq) {
-			rt.Abortf(exitcode.ErrInsufficientFunds, "insufficient funds for pre-commit deposit: %v", depositReq)
-		}
-
-		err = st.AddPreCommitDeposit(depositReq)
-		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to add pre-commit deposit %v", depositReq)
-
-		if err := st.PutPrecommittedSectors(store, &SectorPreCommitOnChainInfo{
-			Info:               SectorPreCommitInfo(*params),
-			PreCommitDeposit:   depositReq,
-			PreCommitEpoch:     rt.CurrEpoch(),
-			DealWeight:         dealWeight.DealWeight,
-			VerifiedDealWeight: dealWeight.VerifiedDealWeight,
-		}); err != nil {
-			rt.Abortf(exitcode.ErrIllegalState, "failed to write pre-committed sector %v: %v", params.SectorNumber, err)
-		}
-		// add precommit expiry to the queue
-		msd, ok := MaxProveCommitDuration[params.SealProof]
-		if !ok {
-			rt.Abortf(exitcode.ErrIllegalArgument, "no max seal duration set for proof type: %d", params.SealProof)
-		}
-		// The +1 here is critical for the batch verification of proofs. Without it, if a proof arrived exactly on the
-		// due epoch, ProveCommitSector would accept it, then the expiry event would remove it, and then
-		// ConfirmSectorProofsValid would fail to find it.
-		expiryBound := rt.CurrEpoch() + msd + 1
-
-		err = st.AddPreCommitExpirations(store, map[abi.ChainEpoch][]uint64{expiryBound: {uint64(params.SectorNumber)}})
+		err = st.AddPreCommitExpirations(store, expirations)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to add pre-commit expiry to queue")
 
-		// activate miner cron
+		// Activate miner cron
 		needsCron = !st.DeadlineCronActive
 		st.DeadlineCronActive = true
 	})
+
 	burnFunds(rt, feeToBurn)
 	rt.StateReadonly(&st)
 	err = st.CheckBalanceInvariants(rt.CurrentBalance())
 	builtin.RequireNoErr(rt, err, ErrBalanceInvariantBroken, "balance invariants broken")
 	if needsCron {
-		newDlInfo := st.DeadlineInfo(rt.CurrEpoch())
+		newDlInfo := st.DeadlineInfo(currEpoch)
 		enrollCronEvent(rt, newDlInfo.Last(), &CronEventPayload{
 			EventType: CronEventProvingDeadline,
 		})
 	}
-
-	notifyPledgeChanged(rt, newlyVested.Neg())
 
 	return nil
 }
@@ -2149,7 +2193,7 @@ func validateExpiration(rt Runtime, activation, expiration abi.ChainEpoch, sealP
 	}
 }
 
-func validateReplaceSector(rt Runtime, st *State, store adt.Store, params *PreCommitSectorParams) {
+func validateReplaceSector(rt Runtime, st *State, store adt.Store, params *miner0.SectorPreCommitInfo) {
 	replaceSector, found, err := st.GetSector(store, params.ReplaceSectorNumber)
 	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load sector %v", params.SectorNumber)
 	if !found {

--- a/actors/builtin/miner/miner_commitment_test.go
+++ b/actors/builtin/miner/miner_commitment_test.go
@@ -520,6 +520,7 @@ func TestPreCommitBatch(t *testing.T) {
 			sectors := make([]*miner0.SectorPreCommitInfo, batchSize)
 			conf := preCommitBatchConf{
 				sectorWeights: make([]market.SectorWeights, batchSize),
+				firstForMiner: true,
 			}
 			deposits := make([]big.Int, batchSize)
 			for i := 0; i < batchSize; i++ {
@@ -545,7 +546,7 @@ func TestPreCommitBatch(t *testing.T) {
 
 			if test.exit != exitcode.Ok {
 				rt.ExpectAbortContainsMessage(test.exit, test.error, func() {
-					actor.preCommitSectorBatch(rt, &miner.PreCommitSectorBatchParams{Sectors: sectors}, conf, true)
+					actor.preCommitSectorBatch(rt, &miner.PreCommitSectorBatchParams{Sectors: sectors}, conf)
 
 					// State untouched.
 					st := getState(rt)
@@ -555,7 +556,7 @@ func TestPreCommitBatch(t *testing.T) {
 				})
 				return
 			}
-			precommits := actor.preCommitSectorBatch(rt, &miner.PreCommitSectorBatchParams{Sectors: sectors}, conf, true)
+			precommits := actor.preCommitSectorBatch(rt, &miner.PreCommitSectorBatchParams{Sectors: sectors}, conf)
 
 			// Check precommits
 			st := getState(rt)
@@ -607,7 +608,7 @@ func TestPreCommitBatch(t *testing.T) {
 		}
 
 		rt.ExpectAbortContainsMessage(exitcode.ErrIllegalArgument, "sector expiration", func() {
-			actor.preCommitSectorBatch(rt, &miner.PreCommitSectorBatchParams{Sectors: sectors}, preCommitBatchConf{}, true)
+			actor.preCommitSectorBatch(rt, &miner.PreCommitSectorBatchParams{Sectors: sectors}, preCommitBatchConf{firstForMiner: true})
 		})
 	})
 
@@ -628,7 +629,7 @@ func TestPreCommitBatch(t *testing.T) {
 			actor.makePreCommit(100, precommitEpoch-1, sectorExpiration, nil),
 		}
 		rt.ExpectAbortContainsMessage(exitcode.ErrIllegalArgument, "duplicate sector number 100", func() {
-			actor.preCommitSectorBatch(rt, &miner.PreCommitSectorBatchParams{Sectors: sectors}, preCommitBatchConf{}, true)
+			actor.preCommitSectorBatch(rt, &miner.PreCommitSectorBatchParams{Sectors: sectors}, preCommitBatchConf{firstForMiner: true})
 		})
 	})
 }
@@ -786,9 +787,10 @@ func TestProveCommit(t *testing.T) {
 				{DealSpace: dealSpace, DealWeight: dealWeight, VerifiedDealWeight: verifiedDealWeight},
 				{DealSpace: dealSpace, DealWeight: dealWeight, VerifiedDealWeight: verifiedDealWeight},
 			},
+			firstForMiner: true,
 		}
 
-		precommits := actor.preCommitSectorBatch(rt, &miner.PreCommitSectorBatchParams{Sectors: sectors}, conf, true)
+		precommits := actor.preCommitSectorBatch(rt, &miner.PreCommitSectorBatchParams{Sectors: sectors}, conf)
 
 		rt.SetEpoch(proveCommitEpoch)
 		noDealPower := miner.QAPowerForWeight(actor.sectorSize, sectorExpiration-proveCommitEpoch, big.Zero(), big.Zero())

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -311,12 +311,6 @@ const (
 // Marks a set of sector numbers as having been allocated.
 // If policy is `DenyCollisions`, fails if the set intersects with the sector numbers already allocated.
 func (st *State) AllocateSectorNumbers(store adt.Store, sectorNos bitfield.BitField, policy CollisionPolicy) error {
-	if lastSectorNo, err := sectorNos.Last(); err != nil {
-		return xc.ErrIllegalArgument.Wrapf("invalid sector bitfield: %w", err)
-	} else if lastSectorNo > abi.MaxSectorNumber {
-		return xc.ErrIllegalArgument.Wrapf("sector number %d exceeds max %d", lastSectorNo, abi.MaxSectorNumber)
-	}
-
 	var priorAllocation bitfield.BitField
 	if err := store.Get(store.Context(), st.AllocatedSectors, &priorAllocation); err != nil {
 		return xc.ErrIllegalState.Wrapf("failed to load allocated sectors bitfield: %w", err)

--- a/actors/builtin/miner/miner_state_test.go
+++ b/actors/builtin/miner/miner_state_test.go
@@ -798,7 +798,6 @@ func TestSectorNumberAllocation(t *testing.T) {
 
 		assert.NoError(t, allocate(harness, 0))
 		assert.NoError(t, allocate(harness, abi.MaxSectorNumber))
-		assert.Error(t, allocate(harness, abi.MaxSectorNumber+1))
 		expect(harness, bf(0, abi.MaxSectorNumber))
 	})
 
@@ -807,7 +806,7 @@ func TestSectorNumberAllocation(t *testing.T) {
 
 		assert.NoError(t, mask(harness, bf(0)))
 		assert.NoError(t, mask(harness, bf(abi.MaxSectorNumber)))
-		assert.Error(t, mask(harness, bf(abi.MaxSectorNumber+1)))
+		expect(harness, bf(0, abi.MaxSectorNumber))
 	})
 
 	t.Run("compaction with mask", func(t *testing.T) {

--- a/actors/builtin/miner/miner_state_test.go
+++ b/actors/builtin/miner/miner_state_test.go
@@ -1017,11 +1017,6 @@ func newPreCommitOnChain(sectorNo abi.SectorNumber, sealed cid.Cid, deposit abi.
 	}
 }
 
-const (
-	sectorSealRandEpochValue = abi.ChainEpoch(1)
-	sectorExpiration         = abi.ChainEpoch(1)
-)
-
 // returns a unique SectorOnChainInfo with each invocation with SectorNumber set to `sectorNo`.
 func newSectorOnChainInfo(sectorNo abi.SectorNumber, sealed cid.Cid, weight big.Int, activation abi.ChainEpoch) *miner.SectorOnChainInfo {
 	return &miner.SectorOnChainInfo{
@@ -1030,7 +1025,7 @@ func newSectorOnChainInfo(sectorNo abi.SectorNumber, sealed cid.Cid, weight big.
 		SealedCID:             sealed,
 		DealIDs:               nil,
 		Activation:            activation,
-		Expiration:            sectorExpiration,
+		Expiration:            abi.ChainEpoch(1),
 		DealWeight:            weight,
 		VerifiedDealWeight:    weight,
 		InitialPledge:         abi.NewTokenAmount(0),
@@ -1047,8 +1042,8 @@ func newSectorPreCommitInfo(sectorNo abi.SectorNumber, sealed cid.Cid) *miner.Se
 		SealProof:     abi.RegisteredSealProof_StackedDrg32GiBV1_1,
 		SectorNumber:  sectorNo,
 		SealedCID:     sealed,
-		SealRandEpoch: sectorSealRandEpochValue,
+		SealRandEpoch: abi.ChainEpoch(1),
 		DealIDs:       nil,
-		Expiration:    sectorExpiration,
+		Expiration:    abi.ChainEpoch(1),
 	}
 }

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -178,6 +178,10 @@ var MaxProveCommitDuration = map[abi.RegisteredSealProof]abi.ChainEpoch{
 	abi.RegisteredSealProof_StackedDrg64GiBV1_1:  builtin.EpochsInDay + PreCommitChallengeDelay,
 }
 
+// The maximum number of sector pre-commitments in a single batch.
+// 32 sectors per epoch would support a single miner onboarding 1EiB of 32GiB sectors in 1 year.
+const PreCommitSectorBatchMaxSize = 32
+
 // Maximum delay between challenge and pre-commitment.
 // This prevents a miner sealing sectors far in advance of committing them to the chain, thus committing to a
 // particular chain.

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -200,6 +200,7 @@ func main() {
 		//miner.CompactSectorNumbersParams{}, // Aliased from v0
 		//miner.CronEventPayload{}, // Aliased from v0
 		// miner.DisputeWindowedPoStParams{}, // Aliased from v3
+		miner.PreCommitSectorBatchParams{},
 		// other types
 		//miner.FaultDeclaration{}, // Aliased from v0
 		//miner.RecoveryDeclaration{}, // Aliased from v0


### PR DESCRIPTION
Implements a new `PreCommitSectorBatch` method, as specified by [FIP-0008](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0008.md) ([discussion](https://github.com/filecoin-project/FIPs/issues/25))

The non-batched `PreCommitSector` method remains, but should be considered deprecated. The implementation delegates internally to the batched method. This consumes less gas than before this change (due to removal of redundant checks in the batched method) but is slightly less efficient at runtime than a strictly-optimized singleton method could be. I expect it to be removed in the future.