### PR TITLE
Move VM from package vm_test to vm, because it's not tests.

### DIFF
--- a/actors/test/commit_post_test.go
+++ b/actors/test/commit_post_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/filecoin-project/specs-actors/v5/actors/states"
 	"github.com/filecoin-project/specs-actors/v5/support/ipld"
 	tutil "github.com/filecoin-project/specs-actors/v5/support/testing"
-	vm "github.com/filecoin-project/specs-actors/v5/support/vm"
+	"github.com/filecoin-project/specs-actors/v5/support/vm"
 )
 
 func TestCommitPoStFlow(t *testing.T) {

--- a/actors/test/committed_capacity_scenario_test.go
+++ b/actors/test/committed_capacity_scenario_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/filecoin-project/specs-actors/v5/actors/runtime/proof"
 	"github.com/filecoin-project/specs-actors/v5/support/ipld"
 	tutil "github.com/filecoin-project/specs-actors/v5/support/testing"
-	vm "github.com/filecoin-project/specs-actors/v5/support/vm"
+	"github.com/filecoin-project/specs-actors/v5/support/vm"
 )
 
 func TestReplaceCommittedCapacitySectorWithDealLadenSector(t *testing.T) {

--- a/actors/test/common_test.go
+++ b/actors/test/common_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/filecoin-project/specs-actors/v5/actors/builtin"
 	"github.com/filecoin-project/specs-actors/v5/actors/builtin/market"
 	tutil "github.com/filecoin-project/specs-actors/v5/support/testing"
-	vm "github.com/filecoin-project/specs-actors/v5/support/vm"
+	"github.com/filecoin-project/specs-actors/v5/support/vm"
 )
 
 func publishDeal(t *testing.T, v *vm.VM, provider, dealClient, minerID addr.Address, dealLabel string,

--- a/actors/test/cron_catches_expiries_scenario_test.go
+++ b/actors/test/cron_catches_expiries_scenario_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/filecoin-project/specs-actors/v5/actors/runtime/proof"
 	"github.com/filecoin-project/specs-actors/v5/support/ipld"
 	tutil "github.com/filecoin-project/specs-actors/v5/support/testing"
-	vm "github.com/filecoin-project/specs-actors/v5/support/vm"
+	"github.com/filecoin-project/specs-actors/v5/support/vm"
 )
 
 var fakeChainRandomness = []byte("not really random")

--- a/actors/test/market_withdrawal_test.go
+++ b/actors/test/market_withdrawal_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/filecoin-project/specs-actors/v5/actors/builtin"
 	"github.com/filecoin-project/specs-actors/v5/actors/builtin/market"
 	"github.com/filecoin-project/specs-actors/v5/support/ipld"
-	vm "github.com/filecoin-project/specs-actors/v5/support/vm"
+	"github.com/filecoin-project/specs-actors/v5/support/vm"
 )
 
 func TestMarketWithdraw(t *testing.T) {

--- a/actors/test/multisig_delete_self_test.go
+++ b/actors/test/multisig_delete_self_test.go
@@ -15,7 +15,7 @@ import (
 	init_ "github.com/filecoin-project/specs-actors/v5/actors/builtin/init"
 	"github.com/filecoin-project/specs-actors/v5/actors/builtin/multisig"
 	"github.com/filecoin-project/specs-actors/v5/support/ipld"
-	vm "github.com/filecoin-project/specs-actors/v5/support/vm"
+	"github.com/filecoin-project/specs-actors/v5/support/vm"
 )
 
 func TestMultisigDeleteSelf2Of3RemovedIsProposer(t *testing.T) {

--- a/actors/test/power_scenario_test.go
+++ b/actors/test/power_scenario_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/filecoin-project/specs-actors/v5/actors/builtin/power"
 	"github.com/filecoin-project/specs-actors/v5/support/ipld"
 	tutil "github.com/filecoin-project/specs-actors/v5/support/testing"
-	vm "github.com/filecoin-project/specs-actors/v5/support/vm"
+	"github.com/filecoin-project/specs-actors/v5/support/vm"
 )
 
 func TestCreateMiner(t *testing.T) {

--- a/actors/test/terminate_sectors_scenario_test.go
+++ b/actors/test/terminate_sectors_scenario_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/filecoin-project/specs-actors/v5/actors/runtime/proof"
 	"github.com/filecoin-project/specs-actors/v5/support/ipld"
 	tutil "github.com/filecoin-project/specs-actors/v5/support/testing"
-	vm "github.com/filecoin-project/specs-actors/v5/support/vm"
+	"github.com/filecoin-project/specs-actors/v5/support/vm"
 )
 
 // This scenario hits all Market Actor methods.

--- a/support/agent/cases_test.go
+++ b/support/agent/cases_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/filecoin-project/specs-actors/v5/actors/states"
 	"github.com/filecoin-project/specs-actors/v5/support/agent"
 	"github.com/filecoin-project/specs-actors/v5/support/ipld"
-	vm_test "github.com/filecoin-project/specs-actors/v5/support/vm"
+	"github.com/filecoin-project/specs-actors/v5/support/vm"
 )
 
 func TestCreate20Miners(t *testing.T) {
@@ -29,7 +29,7 @@ func TestCreate20Miners(t *testing.T) {
 	rnd := rand.New(rand.NewSource(42))
 
 	sim := agent.NewSim(ctx, t, newBlockStore, agent.SimConfig{Seed: rnd.Int63()})
-	accounts := vm_test.CreateAccounts(ctx, t, getV5VM(t, sim), minerCount, initialBalance, rnd.Int63())
+	accounts := vm.CreateAccounts(ctx, t, getV5VM(t, sim), minerCount, initialBalance, rnd.Int63())
 	sim.AddAgent(agent.NewMinerGenerator(
 		accounts,
 		agent.MinerAgentConfig{
@@ -70,7 +70,7 @@ func TestCreate20Miners(t *testing.T) {
 func Test500Epochs(t *testing.T) {
 	ctx := context.Background()
 	initialBalance := big.Mul(big.NewInt(1e8), big.NewInt(1e18))
-	cumulativeStats := make(vm_test.StatsByCall)
+	cumulativeStats := make(vm.StatsByCall)
 	minerCount := 10
 	clientCount := 9
 
@@ -82,7 +82,7 @@ func Test500Epochs(t *testing.T) {
 	})
 
 	// create miners
-	workerAccounts := vm_test.CreateAccounts(ctx, t, getV5VM(t, sim), minerCount, initialBalance, rnd.Int63())
+	workerAccounts := vm.CreateAccounts(ctx, t, getV5VM(t, sim), minerCount, initialBalance, rnd.Int63())
 	sim.AddAgent(agent.NewMinerGenerator(
 		workerAccounts,
 		agent.MinerAgentConfig{
@@ -99,7 +99,7 @@ func Test500Epochs(t *testing.T) {
 		rnd.Int63(),
 	))
 
-	clientAccounts := vm_test.CreateAccounts(ctx, t, getV5VM(t, sim), clientCount, initialBalance, rnd.Int63())
+	clientAccounts := vm.CreateAccounts(ctx, t, getV5VM(t, sim), clientCount, initialBalance, rnd.Int63())
 	dealAgents := agent.AddDealClientsForAccounts(sim, clientAccounts, rnd.Int63(), agent.DealClientConfig{
 		DealRate:         .05,
 		MinPieceSize:     1 << 29,
@@ -155,7 +155,7 @@ func TestCommitPowerAndCheckInvariants(t *testing.T) {
 
 	rnd := rand.New(rand.NewSource(42))
 	sim := agent.NewSim(ctx, t, newBlockStore, agent.SimConfig{Seed: rnd.Int63()})
-	accounts := vm_test.CreateAccounts(ctx, t, getV5VM(t, sim), minerCount, initialBalance, rnd.Int63())
+	accounts := vm.CreateAccounts(ctx, t, getV5VM(t, sim), minerCount, initialBalance, rnd.Int63())
 	sim.AddAgent(agent.NewMinerGenerator(
 		accounts,
 		agent.MinerAgentConfig{
@@ -203,7 +203,7 @@ func TestCommitAndCheckReadWriteStats(t *testing.T) {
 	t.Skip("this is slow")
 	ctx := context.Background()
 	initialBalance := big.Mul(big.NewInt(1e8), big.NewInt(1e18))
-	cumulativeStats := make(vm_test.StatsByCall)
+	cumulativeStats := make(vm.StatsByCall)
 	minerCount := 10
 	clientCount := 9
 
@@ -215,7 +215,7 @@ func TestCommitAndCheckReadWriteStats(t *testing.T) {
 	})
 
 	// create miners
-	workerAccounts := vm_test.CreateAccounts(ctx, t, getV5VM(t, sim), minerCount, initialBalance, rnd.Int63())
+	workerAccounts := vm.CreateAccounts(ctx, t, getV5VM(t, sim), minerCount, initialBalance, rnd.Int63())
 	sim.AddAgent(agent.NewMinerGenerator(
 		workerAccounts,
 		agent.MinerAgentConfig{
@@ -232,7 +232,7 @@ func TestCommitAndCheckReadWriteStats(t *testing.T) {
 		rnd.Int63(),
 	))
 
-	clientAccounts := vm_test.CreateAccounts(ctx, t, getV5VM(t, sim), clientCount, initialBalance, rnd.Int63())
+	clientAccounts := vm.CreateAccounts(ctx, t, getV5VM(t, sim), clientCount, initialBalance, rnd.Int63())
 	dealAgents := agent.AddDealClientsForAccounts(sim, clientAccounts, rnd.Int63(), agent.DealClientConfig{
 		DealRate:         .05,
 		MinPieceSize:     1 << 29,
@@ -272,7 +272,7 @@ func TestCommitAndCheckReadWriteStats(t *testing.T) {
 			for method, stats := range cumulativeStats {
 				printCallStats(method, stats, "")
 			}
-			cumulativeStats = make(vm_test.StatsByCall)
+			cumulativeStats = make(vm.StatsByCall)
 		}
 	}
 }
@@ -289,7 +289,7 @@ func TestCreateDeals(t *testing.T) {
 	sim := agent.NewSim(ctx, t, newBlockStore, agent.SimConfig{Seed: rnd.Int63()})
 
 	// create miners
-	workerAccounts := vm_test.CreateAccounts(ctx, t, getV5VM(t, sim), minerCount, initialBalance, rnd.Int63())
+	workerAccounts := vm.CreateAccounts(ctx, t, getV5VM(t, sim), minerCount, initialBalance, rnd.Int63())
 	sim.AddAgent(agent.NewMinerGenerator(
 		workerAccounts,
 		agent.MinerAgentConfig{
@@ -305,7 +305,7 @@ func TestCreateDeals(t *testing.T) {
 		rnd.Int63(),
 	))
 
-	clientAccounts := vm_test.CreateAccounts(ctx, t, getV5VM(t, sim), clientCount, initialBalance, rnd.Int63())
+	clientAccounts := vm.CreateAccounts(ctx, t, getV5VM(t, sim), clientCount, initialBalance, rnd.Int63())
 	dealAgents := agent.AddDealClientsForAccounts(sim, clientAccounts, rnd.Int63(), agent.DealClientConfig{
 		DealRate:         .01,
 		MinPieceSize:     1 << 29,
@@ -362,7 +362,7 @@ func TestCCUpgrades(t *testing.T) {
 	sim := agent.NewSim(ctx, t, newBlockStore, agent.SimConfig{Seed: rnd.Int63()})
 
 	// create miners
-	workerAccounts := vm_test.CreateAccounts(ctx, t, getV5VM(t, sim), minerCount, initialBalance, rnd.Int63())
+	workerAccounts := vm.CreateAccounts(ctx, t, getV5VM(t, sim), minerCount, initialBalance, rnd.Int63())
 	sim.AddAgent(agent.NewMinerGenerator(
 		workerAccounts,
 		agent.MinerAgentConfig{
@@ -379,7 +379,7 @@ func TestCCUpgrades(t *testing.T) {
 		rnd.Int63(),
 	))
 
-	clientAccounts := vm_test.CreateAccounts(ctx, t, getV5VM(t, sim), clientCount, initialBalance, rnd.Int63())
+	clientAccounts := vm.CreateAccounts(ctx, t, getV5VM(t, sim), clientCount, initialBalance, rnd.Int63())
 	agent.AddDealClientsForAccounts(sim, clientAccounts, rnd.Int63(), agent.DealClientConfig{
 		DealRate:         .01,
 		MinPieceSize:     1 << 29,
@@ -436,7 +436,7 @@ func newBlockStore() cbor.IpldBlockstore {
 	return ipld.NewBlockStoreInMemory()
 }
 
-func printCallStats(method vm_test.MethodKey, stats *vm_test.CallStats, indent string) { // nolint:unused
+func printCallStats(method vm.MethodKey, stats *vm.CallStats, indent string) { // nolint:unused
 	fmt.Printf("%s%v:%d: calls: %d  gets: %d  puts: %d  read: %d  written: %d  avg gets: %.2f, avg puts: %.2f\n",
 		indent, builtin.ActorNameByCode(method.Code), method.Method, stats.Calls, stats.Reads, stats.Writes,
 		stats.ReadBytes, stats.WriteBytes, float32(stats.Reads)/float32(stats.Calls),
@@ -451,8 +451,8 @@ func printCallStats(method vm_test.MethodKey, stats *vm_test.CallStats, indent s
 	}
 }
 
-func getV5VM(t *testing.T, sim *agent.Sim) *vm_test.VM {
-	vm, ok := sim.GetVM().(*vm_test.VM)
+func getV5VM(t *testing.T, sim *agent.Sim) *vm.VM {
+	vm, ok := sim.GetVM().(*vm.VM)
 	require.True(t, ok)
 	return vm
 }

--- a/support/agent/sim.go
+++ b/support/agent/sim.go
@@ -29,7 +29,7 @@ import (
 	"github.com/filecoin-project/specs-actors/v5/actors/states"
 	"github.com/filecoin-project/specs-actors/v5/actors/util/adt"
 	"github.com/filecoin-project/specs-actors/v5/support/ipld"
-	vm "github.com/filecoin-project/specs-actors/v5/support/vm"
+	"github.com/filecoin-project/specs-actors/v5/support/vm"
 )
 
 // Sim is a simulation framework to exercise actor code in a network-like environment.

--- a/support/vm/invocation_context.go
+++ b/support/vm/invocation_context.go
@@ -1,4 +1,4 @@
-package vm_test
+package vm
 
 import (
 	"bytes"

--- a/support/vm/stats.go
+++ b/support/vm/stats.go
@@ -1,4 +1,4 @@
-package vm_test
+package vm
 
 import (
 	vm2 "github.com/filecoin-project/specs-actors/v2/support/vm"

--- a/support/vm/testing.go
+++ b/support/vm/testing.go
@@ -1,4 +1,4 @@
-package vm_test
+package vm
 
 import (
 	"bytes"

--- a/support/vm/vm.go
+++ b/support/vm/vm.go
@@ -1,4 +1,4 @@
-package vm_test
+package vm
 
 import (
 	"context"


### PR DESCRIPTION
Now the vm_test package is free for tests *of* the VM.

Inspired by the oddity of the cbor-gen setup in #1408.