### PR TITLE
Feat/aggregate porep less harsh error

### DIFF
--- a/actors/builtin/miner/cbor_gen.go
+++ b/actors/builtin/miner/cbor_gen.go
@@ -68,10 +68,10 @@ func (t *State) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("failed to write cid field t.PreCommittedSectors: %w", err)
 	}
 
-	// t.PreCommittedSectorsExpiry (cid.Cid) (struct)
+	// t.PreCommittedSectorsCleanUp (cid.Cid) (struct)
 
-	if err := cbg.WriteCidBuf(scratch, w, t.PreCommittedSectorsExpiry); err != nil {
-		return xerrors.Errorf("failed to write cid field t.PreCommittedSectorsExpiry: %w", err)
+	if err := cbg.WriteCidBuf(scratch, w, t.PreCommittedSectorsCleanUp); err != nil {
+		return xerrors.Errorf("failed to write cid field t.PreCommittedSectorsCleanUp: %w", err)
 	}
 
 	// t.AllocatedSectors (cid.Cid) (struct)
@@ -211,16 +211,16 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 		t.PreCommittedSectors = c
 
 	}
-	// t.PreCommittedSectorsExpiry (cid.Cid) (struct)
+	// t.PreCommittedSectorsCleanUp (cid.Cid) (struct)
 
 	{
 
 		c, err := cbg.ReadCid(br)
 		if err != nil {
-			return xerrors.Errorf("failed to read cid field t.PreCommittedSectorsExpiry: %w", err)
+			return xerrors.Errorf("failed to read cid field t.PreCommittedSectorsCleanUp: %w", err)
 		}
 
-		t.PreCommittedSectorsExpiry = c
+		t.PreCommittedSectorsCleanUp = c
 
 	}
 	// t.AllocatedSectors (cid.Cid) (struct)

--- a/actors/builtin/miner/miner_commitment_test.go
+++ b/actors/builtin/miner/miner_commitment_test.go
@@ -110,7 +110,7 @@ func TestCommitments(t *testing.T) {
 			assert.Equal(t, expectedDeposit, st.PreCommitDeposits)
 
 			expirations := actor.collectPrecommitExpirations(rt, st)
-			expectedPrecommitExpiration := st.QuantSpecEveryDeadline().QuantizeUp(precommitEpoch + miner.MaxProveCommitDuration[actor.sealProofType] + miner.PreCommitExpiryDelay)
+			expectedPrecommitExpiration := st.QuantSpecEveryDeadline().QuantizeUp(precommitEpoch + miner.MaxProveCommitDuration[actor.sealProofType] + miner.ExpiredPreCommitCleanUpDelay)
 			assert.Equal(t, map[abi.ChainEpoch][]uint64{expectedPrecommitExpiration: {uint64(test.sectorNo)}}, expirations)
 		})
 	}
@@ -583,7 +583,7 @@ func TestPreCommitBatch(t *testing.T) {
 			assert.Equal(t, totalDeposit, st.PreCommitDeposits)
 
 			expirations := actor.collectPrecommitExpirations(rt, st)
-			expectedPrecommitExpiration := st.QuantSpecEveryDeadline().QuantizeUp(precommitEpoch + miner.MaxProveCommitDuration[actor.sealProofType] + miner.PreCommitExpiryDelay)
+			expectedPrecommitExpiration := st.QuantSpecEveryDeadline().QuantizeUp(precommitEpoch + miner.MaxProveCommitDuration[actor.sealProofType] + miner.ExpiredPreCommitCleanUpDelay)
 			assert.Equal(t, map[abi.ChainEpoch][]uint64{expectedPrecommitExpiration: sectorNoAsUints}, expirations)
 		})
 	}

--- a/actors/builtin/miner/miner_commitment_test.go
+++ b/actors/builtin/miner/miner_commitment_test.go
@@ -110,7 +110,7 @@ func TestCommitments(t *testing.T) {
 			assert.Equal(t, expectedDeposit, st.PreCommitDeposits)
 
 			expirations := actor.collectPrecommitExpirations(rt, st)
-			expectedPrecommitExpiration := st.QuantSpecEveryDeadline().QuantizeUp(precommitEpoch + miner.MaxProveCommitDuration[actor.sealProofType] + 1)
+			expectedPrecommitExpiration := st.QuantSpecEveryDeadline().QuantizeUp(precommitEpoch + miner.MaxProveCommitDuration[actor.sealProofType] + miner.PreCommitExpiryDelay)
 			assert.Equal(t, map[abi.ChainEpoch][]uint64{expectedPrecommitExpiration: {uint64(test.sectorNo)}}, expirations)
 		})
 	}
@@ -583,7 +583,7 @@ func TestPreCommitBatch(t *testing.T) {
 			assert.Equal(t, totalDeposit, st.PreCommitDeposits)
 
 			expirations := actor.collectPrecommitExpirations(rt, st)
-			expectedPrecommitExpiration := st.QuantSpecEveryDeadline().QuantizeUp(precommitEpoch + miner.MaxProveCommitDuration[actor.sealProofType] + 1)
+			expectedPrecommitExpiration := st.QuantSpecEveryDeadline().QuantizeUp(precommitEpoch + miner.MaxProveCommitDuration[actor.sealProofType] + miner.PreCommitExpiryDelay)
 			assert.Equal(t, map[abi.ChainEpoch][]uint64{expectedPrecommitExpiration: sectorNoAsUints}, expirations)
 		})
 	}

--- a/actors/builtin/miner/miner_state_test.go
+++ b/actors/builtin/miner/miner_state_test.go
@@ -608,33 +608,33 @@ func TestVestingFunds_UnvestedFunds(t *testing.T) {
 }
 
 func TestAddPreCommitExpiry(t *testing.T) {
-	t.Run("simple pre-commit expiry", func(t *testing.T) {
+	t.Run("simple pre-commit expiry and cleanup", func(t *testing.T) {
 		harness := constructStateHarness(t, 0)
-		err := harness.s.AddPreCommitExpirations(harness.store, map[abi.ChainEpoch][]uint64{100: {1}})
+		err := harness.s.AddPreCommitCleanUps(harness.store, map[abi.ChainEpoch][]uint64{100: {1}})
 		require.NoError(t, err)
 
 		quant := harness.s.QuantSpecEveryDeadline()
 		ExpectBQ().
 			Add(quant.QuantizeUp(100), 1).
-			Equals(t, harness.loadPreCommitExpiries())
+			Equals(t, harness.loadPreCommitCleanUps())
 
-		err = harness.s.AddPreCommitExpirations(harness.store, map[abi.ChainEpoch][]uint64{100: {2}})
+		err = harness.s.AddPreCommitCleanUps(harness.store, map[abi.ChainEpoch][]uint64{100: {2}})
 		require.NoError(t, err)
 		ExpectBQ().
 			Add(quant.QuantizeUp(100), 1, 2).
-			Equals(t, harness.loadPreCommitExpiries())
+			Equals(t, harness.loadPreCommitCleanUps())
 
-		err = harness.s.AddPreCommitExpirations(harness.store, map[abi.ChainEpoch][]uint64{200: {3}})
+		err = harness.s.AddPreCommitCleanUps(harness.store, map[abi.ChainEpoch][]uint64{200: {3}})
 		require.NoError(t, err)
 		ExpectBQ().
 			Add(quant.QuantizeUp(100), 1, 2).
 			Add(quant.QuantizeUp(200), 3).
-			Equals(t, harness.loadPreCommitExpiries())
+			Equals(t, harness.loadPreCommitCleanUps())
 	})
 
 	t.Run("batch pre-commit expiry", func(t *testing.T) {
 		harness := constructStateHarness(t, abi.ChainEpoch(0))
-		err := harness.s.AddPreCommitExpirations(harness.store, map[abi.ChainEpoch][]uint64{
+		err := harness.s.AddPreCommitCleanUps(harness.store, map[abi.ChainEpoch][]uint64{
 			100: {1},
 			200: {2, 3},
 			300: {},
@@ -645,9 +645,9 @@ func TestAddPreCommitExpiry(t *testing.T) {
 		ExpectBQ().
 			Add(quant.QuantizeUp(100), 1).
 			Add(quant.QuantizeUp(200), 2, 3).
-			Equals(t, harness.loadPreCommitExpiries())
+			Equals(t, harness.loadPreCommitCleanUps())
 
-		err = harness.s.AddPreCommitExpirations(harness.store, map[abi.ChainEpoch][]uint64{
+		err = harness.s.AddPreCommitCleanUps(harness.store, map[abi.ChainEpoch][]uint64{
 			100: {1}, // Redundant
 			200: {4},
 			300: {5, 6},
@@ -657,7 +657,7 @@ func TestAddPreCommitExpiry(t *testing.T) {
 			Add(quant.QuantizeUp(100), 1).
 			Add(quant.QuantizeUp(200), 2, 3, 4).
 			Add(quant.QuantizeUp(300), 5, 6).
-			Equals(t, harness.loadPreCommitExpiries())
+			Equals(t, harness.loadPreCommitCleanUps())
 	})
 }
 
@@ -955,8 +955,8 @@ func (h *stateHarness) deletePreCommit(sectorNo abi.SectorNumber) {
 	require.NoError(h.t, err)
 }
 
-func (h *stateHarness) loadPreCommitExpiries() miner.BitfieldQueue {
-	queue, err := miner.LoadBitfieldQueue(h.store, h.s.PreCommittedSectorsExpiry, h.s.QuantSpecEveryDeadline(), miner.PrecommitExpiryAmtBitwidth)
+func (h *stateHarness) loadPreCommitCleanUps() miner.BitfieldQueue {
+	queue, err := miner.LoadBitfieldQueue(h.store, h.s.PreCommittedSectorsCleanUp, h.s.QuantSpecEveryDeadline(), miner.PrecommitCleanUpAmtBitwidth)
 	require.NoError(h.t, err)
 	return queue
 }

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -2123,7 +2123,7 @@ func (h *cronControl) preCommitToStartCron(t *testing.T, preCommitEpoch abi.Chai
 	// PCD != 0 so cron must be active
 	h.requireCronActive(t)
 
-	expiryEpoch := preCommitEpoch + miner.MaxProveCommitDuration[h.actor.sealProofType] + abi.ChainEpoch(1)
+	expiryEpoch := preCommitEpoch + miner.MaxProveCommitDuration[h.actor.sealProofType] + miner.PreCommitExpiryDelay
 	return expiryEpoch
 }
 

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -314,3 +314,4 @@ func RewardForDisputedWindowPoSt(proofType abi.RegisteredPoStProof, disputedPowe
 const MaxAggregatedSectors = 819
 const MinAggregatedSectors = 1
 const MaxAggregateProofSize = 192000
+const PreCommitExpiryDelay = 8 * builtin.EpochsInHour

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -314,4 +314,8 @@ func RewardForDisputedWindowPoSt(proofType abi.RegisteredPoStProof, disputedPowe
 const MaxAggregatedSectors = 819
 const MinAggregatedSectors = 1
 const MaxAggregateProofSize = 192000
-const PreCommitExpiryDelay = 8 * builtin.EpochsInHour
+
+// The delay between pre commit expiration and clean up from state. This enforces that expired pre-commits
+// stay in state for a period of time creating a grace period during which a late-running aggregated prove-commit
+// can still prove its non-expired precommits without resubmitting a message
+const ExpiredPreCommitCleanUpDelay = 8 * builtin.EpochsInHour

--- a/actors/builtin/miner/testing.go
+++ b/actors/builtin/miner/testing.go
@@ -757,23 +757,23 @@ func CheckMinerBalances(st *State, store adt.Store, balance abi.TokenAmount, acc
 func CheckPreCommits(st *State, store adt.Store, allocatedSectors map[uint64]bool, acc *builtin.MessageAccumulator) {
 	quant := st.QuantSpecEveryDeadline()
 
-	// invert pre-commit expiry queue into a lookup by sector number
-	expireEpochs := make(map[uint64]abi.ChainEpoch)
-	if expiryQ, err := LoadBitfieldQueue(store, st.PreCommittedSectorsExpiry, st.QuantSpecEveryDeadline(), PrecommitExpiryAmtBitwidth); err != nil {
-		acc.Addf("error loading pre-commit expiry queue: %v", err)
+	// invert pre-commit clean up queue into a lookup by sector number
+	cleanUpEpochs := make(map[uint64]abi.ChainEpoch)
+	if cleanUpQ, err := LoadBitfieldQueue(store, st.PreCommittedSectorsCleanUp, st.QuantSpecEveryDeadline(), PrecommitCleanUpAmtBitwidth); err != nil {
+		acc.Addf("error loading pre-commit clean up queue: %v", err)
 	} else {
-		err = expiryQ.ForEach(func(epoch abi.ChainEpoch, bf bitfield.BitField) error {
+		err = cleanUpQ.ForEach(func(epoch abi.ChainEpoch, bf bitfield.BitField) error {
 			quantized := quant.QuantizeUp(epoch)
 			acc.Require(quantized == epoch, "precommit expiration %d is not quantized", epoch)
 			if err = bf.ForEach(func(secNum uint64) error {
-				expireEpochs[secNum] = epoch
+				cleanUpEpochs[secNum] = epoch
 				return nil
 			}); err != nil {
 				acc.Addf("error iteration pre-commit expiration bitfield: %v", err)
 			}
 			return nil
 		})
-		acc.RequireNoError(err, "error iterating pre-commit expiry queue")
+		acc.RequireNoError(err, "error iterating pre-commit clean up queue")
 	}
 
 	precommitTotal := big.Zero()
@@ -790,8 +790,8 @@ func CheckPreCommits(st *State, store adt.Store, allocatedSectors map[uint64]boo
 
 			acc.Require(allocatedSectors[secNum], "pre-committed sector number has not been allocated %d", secNum)
 
-			_, found := expireEpochs[secNum]
-			acc.Require(found, "no expiry epoch for pre-commit at %d", precommit.PreCommitEpoch)
+			_, found := cleanUpEpochs[secNum]
+			acc.Require(found, "no clean up epoch for pre-commit at %d", precommit.PreCommitEpoch)
 
 			precommitTotal = big.Add(precommitTotal, precommit.PreCommitDeposit)
 			return nil


### PR DESCRIPTION
1. AggregateProveCommit does not fail if a subset of precommits exist on chain but are out of date (prove commit epoch greater than epoch due).  Instead all inputs are provided to the proof, but only the sectors not out of date are added to the state through confirmSectorsProofsValid.
2. PreCommitExpiries are now scheduled an additional 8 hours after the corresponding prove commit epoch is due. This provides much more time (8 hours vs 0-30 minutes) for aggregates including expired precommits to make it on chain.  This is a somewhat arbitrary choice, feedback on this would be great

TODO:
- [ ] land #1381 and rebase this on top before merging