### PR TITLE
Raise AddressedSectorsMax from 10,000 to 25,000.

### DIFF
--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -1352,12 +1352,9 @@ func TestWindowPost(t *testing.T) {
 
 		// Too many partitions.
 		rt.ExpectAbortContainsMessage(exitcode.ErrIllegalArgument, "too many partitions", func() {
-			partitions := []miner.PoStPartition{
-				{Index: pIdx, Skipped: bf()},
-				{Index: pIdx + 1, Skipped: bf()},
-				{Index: pIdx + 2, Skipped: bf()},
-				{Index: pIdx + 3, Skipped: bf()},
-				{Index: pIdx + 4, Skipped: bf()},
+			partitions := make([]miner.PoStPartition, 11)
+			for i, p := range partitions {
+				p.Index = pIdx + uint64(i)
 			}
 			params := miner.SubmitWindowedPoStParams{
 				Deadline:         dlInfo.Index,

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -81,7 +81,7 @@ const DeclarationsMax = AddressedPartitionsMax
 
 // The maximum number of sector infos that can be loaded in a single invocation.
 // This limits the amount of state to be read in a single message execution.
-const AddressedSectorsMax = 10_000 // PARAM_SPEC
+const AddressedSectorsMax = 25_000 // PARAM_SPEC
 
 // Libp2p peer info limits.
 const (


### PR DESCRIPTION
This number bounds the amount of memory used or state loaded in a number of operations
such as declaring faults. A critical need is to limit the number of sectors that may
be addressed by a single WindowPoSt sumbission to ensure it can be safely disputed
later if fraudulent.

25000 sectors permits submitting (and disputing) up to 10 partitions at once
for both 32GiB (25,000/2,349 ~= 10.6) and 64GiB (25,000/2,300 ~= 10.8) sectors.

Empirically, disputing 10 partitions fits within the block gas limit >= 3 times over.

Closes #1415 