### PR TITLE
Set ConsensusMinerMinPower to 10 TiB

### DIFF
--- a/actors/builtin/power/power_test.go
+++ b/actors/builtin/power/power_test.go
@@ -333,7 +333,7 @@ func TestPowerAndPledgeAccounting(t *testing.T) {
 			expectedMiners int64
 		}{{
 			version:        network.Version6,
-			proof:          abi.RegisteredSealProof_StackedDrg2KiBV1, // 2K sectors have zero consensus minimum
+			proof:          abi.RegisteredSealProof_StackedDrg2KiBV1,
 			expectedMiners: 0,
 		}, {
 			version:        network.Version6,
@@ -341,8 +341,8 @@ func TestPowerAndPledgeAccounting(t *testing.T) {
 			expectedMiners: 0,
 		}, {
 			version:        network.Version7,
-			proof:          abi.RegisteredSealProof_StackedDrg2KiBV1, // 2K sectors have zero consensus minimum
-			expectedMiners: 1,
+			proof:          abi.RegisteredSealProof_StackedDrg2KiBV1,
+			expectedMiners: 0,
 		}, {
 			version:        network.Version7,
 			proof:          abi.RegisteredSealProof_StackedDrg32GiBV1,
@@ -449,15 +449,16 @@ func TestPowerAndPledgeAccounting(t *testing.T) {
 
 		power64Unit, err := builtin.ConsensusMinerMinPower(abi.RegisteredSealProof_StackedDrg64GiBV1_1)
 		require.NoError(t, err)
-		assert.True(t, power64Unit.GreaterThan(powerUnit))
+
+		belowLimitUnit := big.Div(powerUnit, big.NewInt(2))
 
 		// below limit actors power is not added
-		actor.updateClaimedPower(rt, miner5, powerUnit, powerUnit)
+		actor.updateClaimedPower(rt, miner5, belowLimitUnit, belowLimitUnit)
 		actor.expectMinersAboveMinPower(rt, 4)
 		actor.expectTotalPowerEager(rt, expectedTotal, expectedTotal)
 
 		// just below limit
-		delta := big.Subtract(power64Unit, powerUnit, big.NewInt(1))
+		delta := big.Subtract(power64Unit, belowLimitUnit, big.NewInt(1))
 		actor.updateClaimedPower(rt, miner5, delta, delta)
 		actor.expectMinersAboveMinPower(rt, 4)
 		actor.expectTotalPowerEager(rt, expectedTotal, expectedTotal)

--- a/actors/builtin/sector.go
+++ b/actors/builtin/sector.go
@@ -17,15 +17,15 @@ const EpochsInFiveYears = stabi.ChainEpoch(5 * EpochsInYear)
 var SealProofPolicies = map[stabi.RegisteredSealProof]*SealProofPolicy{
 	stabi.RegisteredSealProof_StackedDrg2KiBV1: {
 		SectorMaxLifetime:      EpochsInFiveYears,
-		ConsensusMinerMinPower: stabi.NewStoragePower(0),
+		ConsensusMinerMinPower: stabi.NewStoragePower(10 << 40),
 	},
 	stabi.RegisteredSealProof_StackedDrg8MiBV1: {
 		SectorMaxLifetime:      EpochsInFiveYears,
-		ConsensusMinerMinPower: stabi.NewStoragePower(16 << 20),
+		ConsensusMinerMinPower: stabi.NewStoragePower(10 << 40),
 	},
 	stabi.RegisteredSealProof_StackedDrg512MiBV1: {
 		SectorMaxLifetime:      EpochsInFiveYears,
-		ConsensusMinerMinPower: stabi.NewStoragePower(1 << 30),
+		ConsensusMinerMinPower: stabi.NewStoragePower(10 << 40),
 	},
 	stabi.RegisteredSealProof_StackedDrg32GiBV1: {
 		SectorMaxLifetime:      EpochsInFiveYears,
@@ -33,20 +33,20 @@ var SealProofPolicies = map[stabi.RegisteredSealProof]*SealProofPolicy{
 	},
 	stabi.RegisteredSealProof_StackedDrg64GiBV1: {
 		SectorMaxLifetime:      EpochsInFiveYears,
-		ConsensusMinerMinPower: stabi.NewStoragePower(20 << 40),
+		ConsensusMinerMinPower: stabi.NewStoragePower(10 << 40),
 	},
 
 	stabi.RegisteredSealProof_StackedDrg2KiBV1_1: {
 		SectorMaxLifetime:      EpochsInFiveYears,
-		ConsensusMinerMinPower: stabi.NewStoragePower(0),
+		ConsensusMinerMinPower: stabi.NewStoragePower(10 << 40),
 	},
 	stabi.RegisteredSealProof_StackedDrg8MiBV1_1: {
 		SectorMaxLifetime:      EpochsInFiveYears,
-		ConsensusMinerMinPower: stabi.NewStoragePower(16 << 20),
+		ConsensusMinerMinPower: stabi.NewStoragePower(10 << 40),
 	},
 	stabi.RegisteredSealProof_StackedDrg512MiBV1_1: {
 		SectorMaxLifetime:      EpochsInFiveYears,
-		ConsensusMinerMinPower: stabi.NewStoragePower(1 << 30),
+		ConsensusMinerMinPower: stabi.NewStoragePower(10 << 40),
 	},
 	stabi.RegisteredSealProof_StackedDrg32GiBV1_1: {
 		SectorMaxLifetime:      EpochsInFiveYears,
@@ -54,7 +54,7 @@ var SealProofPolicies = map[stabi.RegisteredSealProof]*SealProofPolicy{
 	},
 	stabi.RegisteredSealProof_StackedDrg64GiBV1_1: {
 		SectorMaxLifetime:      EpochsInFiveYears,
-		ConsensusMinerMinPower: stabi.NewStoragePower(20 << 40),
+		ConsensusMinerMinPower: stabi.NewStoragePower(10 << 40),
 	},
 }
 

--- a/actors/states/election_test.go
+++ b/actors/states/election_test.go
@@ -122,12 +122,6 @@ func TestMinerEligibleAtLookback(t *testing.T) {
 			// bigger sector size requires higher minimum
 			consensusMiners: power.ConsensusMinerMinMiners,
 			minerProof:      abi.RegisteredSealProof_StackedDrg64GiBV1_1,
-			power:           pow32GiBMin,
-			eligible:        false,
-		}, {
-			// bigger sector size requires higher minimum
-			consensusMiners: power.ConsensusMinerMinMiners,
-			minerProof:      abi.RegisteredSealProof_StackedDrg64GiBV1_1,
 			power:           pow64GiBMin,
 			eligible:        true,
 		}} {

--- a/support/agent/miner_agent.go
+++ b/support/agent/miner_agent.go
@@ -74,6 +74,40 @@ type MinerAgent struct {
 	rnd *rand.Rand
 }
 
+type MinerAgentExport struct {
+	Config        MinerAgentConfig
+	Owner         address.Address
+	Worker        address.Address
+	IDAddress     address.Address
+	RobustAddress address.Address
+
+	UpgradedSectors uint64
+
+	LiveSectors   []uint64
+	FaultySectors []uint64
+	CCSectors     []uint64
+
+	PendingDeals          []market.ClientDealProposal
+	DealsPendingInclusion []pendingDeal
+
+	// priority queue used to trigger actions at future epochs
+	operationSchedule *opQueue
+	// which sector belongs to which deadline/partition
+	deadlines [miner.WPoStPeriodDeadlines][]partition
+	// iterator to time PreCommit events according to rate
+	preCommitEvents *RateIterator
+	// iterator to time faults events according to rate
+	faultEvents *RateIterator
+	// iterator to time recoveries according to rate
+	recoveryEvents *RateIterator
+	// tracks which sector number to use next
+	nextSectorNumber abi.SectorNumber
+	// tracks funds expected to be locked for miner deal collateral
+	expectedMarketBalance abi.TokenAmount
+	// random numnber generator provided by sim
+	rnd *rand.Rand
+}
+
 func NewMinerAgent(owner address.Address, worker address.Address, idAddress address.Address, robustAddress address.Address,
 	rndSeed int64, config MinerAgentConfig,
 ) *MinerAgent {

--- a/support/agent/miner_agent.go
+++ b/support/agent/miner_agent.go
@@ -74,40 +74,6 @@ type MinerAgent struct {
 	rnd *rand.Rand
 }
 
-type MinerAgentExport struct {
-	Config        MinerAgentConfig
-	Owner         address.Address
-	Worker        address.Address
-	IDAddress     address.Address
-	RobustAddress address.Address
-
-	UpgradedSectors uint64
-
-	LiveSectors   []uint64
-	FaultySectors []uint64
-	CCSectors     []uint64
-
-	PendingDeals          []market.ClientDealProposal
-	DealsPendingInclusion []pendingDeal
-
-	// priority queue used to trigger actions at future epochs
-	operationSchedule *opQueue
-	// which sector belongs to which deadline/partition
-	deadlines [miner.WPoStPeriodDeadlines][]partition
-	// iterator to time PreCommit events according to rate
-	preCommitEvents *RateIterator
-	// iterator to time faults events according to rate
-	faultEvents *RateIterator
-	// iterator to time recoveries according to rate
-	recoveryEvents *RateIterator
-	// tracks which sector number to use next
-	nextSectorNumber abi.SectorNumber
-	// tracks funds expected to be locked for miner deal collateral
-	expectedMarketBalance abi.TokenAmount
-	// random numnber generator provided by sim
-	rnd *rand.Rand
-}
-
 func NewMinerAgent(owner address.Address, worker address.Address, idAddress address.Address, robustAddress address.Address,
 	rndSeed int64, config MinerAgentConfig,
 ) *MinerAgent {

--- a/support/vm/vm.go
+++ b/support/vm/vm.go
@@ -354,6 +354,11 @@ func (vm *VM) ApplyMessage(from, to address.Address, value abi.TokenAmount, meth
 		if err := vm.rollback(priorRoot); err != nil {
 			panic(err)
 		}
+	} else {
+		// persist changes from final invocation if call is ok
+		if _, err := vm.checkpoint(); err != nil {
+			panic(err)
+		}
 	}
 
 	return ret.inner, exitCode
@@ -423,6 +428,10 @@ func (vm *VM) GetCirculatingSupply() abi.TokenAmount {
 	return vm.circSupply
 }
 
+func (vm *VM) GetActorImpls() map[cid.Cid]rt.VMActor {
+	return vm.ActorImpls
+}
+
 // transfer debits money from one account and credits it to another.
 // avoid calling this method with a zero amount else it will perform unnecessary actor loading.
 //
@@ -488,6 +497,10 @@ func (vm *VM) getActorImpl(code cid.Cid) runtime.VMActor {
 
 func (vm *VM) SetStatsSource(s StatsSource) {
 	vm.statsSource = s
+}
+
+func (vm *VM) GetStatsSource() StatsSource {
+	return vm.statsSource
 }
 
 func (vm *VM) StoreReads() uint64 {


### PR DESCRIPTION
**Note: This introduces 3 other commits into the release branch, since Lotus has been pointing to `5b58b773f4fb`** 

Lotus has been unintentionally overwriting this value to 10 TiB for all proof types since mainnet. We might as well reflect this behaviour in the actors code.