### PR TITLE
Set ConsensusMinerMinPower to 10 TiB for all PoStProofPolicies

### DIFF
--- a/actors/builtin/sector.go
+++ b/actors/builtin/sector.go
@@ -98,15 +98,15 @@ type PoStProofPolicy struct {
 var PoStProofPolicies = map[stabi.RegisteredPoStProof]*PoStProofPolicy{
 	stabi.RegisteredPoStProof_StackedDrgWindow2KiBV1: {
 		WindowPoStPartitionSectors: 2,
-		ConsensusMinerMinPower:     stabi.NewStoragePower(0),
+		ConsensusMinerMinPower:     stabi.NewStoragePower(10 << 40),
 	},
 	stabi.RegisteredPoStProof_StackedDrgWindow8MiBV1: {
 		WindowPoStPartitionSectors: 2,
-		ConsensusMinerMinPower:     stabi.NewStoragePower(16 << 20),
+		ConsensusMinerMinPower:     stabi.NewStoragePower(10 << 40),
 	},
 	stabi.RegisteredPoStProof_StackedDrgWindow512MiBV1: {
 		WindowPoStPartitionSectors: 2,
-		ConsensusMinerMinPower:     stabi.NewStoragePower(1 << 30),
+		ConsensusMinerMinPower:     stabi.NewStoragePower(10 << 40),
 	},
 	stabi.RegisteredPoStProof_StackedDrgWindow32GiBV1: {
 		WindowPoStPartitionSectors: 2349,
@@ -114,7 +114,7 @@ var PoStProofPolicies = map[stabi.RegisteredPoStProof]*PoStProofPolicy{
 	},
 	stabi.RegisteredPoStProof_StackedDrgWindow64GiBV1: {
 		WindowPoStPartitionSectors: 2300,
-		ConsensusMinerMinPower:     stabi.NewStoragePower(20 << 40),
+		ConsensusMinerMinPower:     stabi.NewStoragePower(10 << 40),
 	},
 	// Winning PoSt proof types omitted.
 }

--- a/actors/states/election_test.go
+++ b/actors/states/election_test.go
@@ -118,13 +118,6 @@ func TestMinerEligibleAtLookback(t *testing.T) {
 			power:           pow32GiBMin,
 			eligible:        true,
 		}, {
-			// bigger sector size requires higher minimum
-			consensusMiners: power.ConsensusMinerMinMiners,
-			minerProof:      abi.RegisteredPoStProof_StackedDrgWindow64GiBV1,
-			power:           pow32GiBMin,
-			eligible:        false,
-		}, {
-			// bigger sector size requires higher minimum
 			consensusMiners: power.ConsensusMinerMinMiners,
 			minerProof:      abi.RegisteredPoStProof_StackedDrgWindow64GiBV1,
 			power:           pow64GiBMin,


### PR DESCRIPTION
Lotus has been unintentionally overwriting this value to 10 TiB for all proof types since mainnet. We might as well reflect this behaviour in the actors code.