### PR TITLE
Feat/market dobe rand

### DIFF
--- a/actors/builtin/market/market_actor.go
+++ b/actors/builtin/market/market_actor.go
@@ -1,15 +1,12 @@
 package market
 
 import (
-	"bytes"
-	"encoding/binary"
 	"sort"
 
 	addr "github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/cbor"
-	"github.com/filecoin-project/go-state-types/crypto"
 	"github.com/filecoin-project/go-state-types/exitcode"
 	rtt "github.com/filecoin-project/go-state-types/rt"
 	market0 "github.com/filecoin-project/specs-actors/actors/builtin/market"
@@ -237,7 +234,7 @@ func (a Actor) PublishStorageDeals(rt Runtime, params *PublishStorageDealsParams
 
 			// We should randomize the first epoch for when the deal will be processed so an attacker isn't able to
 			// schedule too many deals for the same tick.
-			processEpoch, err := genRandNextEpoch(rt.CurrEpoch(), &deal.Proposal, rt.GetRandomnessFromTickets)
+			processEpoch, err := genRandNextEpoch(rt.CurrEpoch(), &deal.Proposal, id)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to generate random process epoch")
 
 			err = msm.dealsByEpoch.Put(processEpoch, id)
@@ -636,18 +633,15 @@ func (a Actor) CronTick(rt Runtime, _ *abi.EmptyValue) *abi.EmptyValue {
 	return nil
 }
 
-func genRandNextEpoch(currEpoch abi.ChainEpoch, deal *DealProposal, rbF func(crypto.DomainSeparationTag, abi.ChainEpoch, []byte) abi.Randomness) (abi.ChainEpoch, error) {
-	buf := bytes.Buffer{}
-	if err := deal.MarshalCBOR(&buf); err != nil {
-		return epochUndefined, xerrors.Errorf("failed to marshal proposal: %w", err)
+func genRandNextEpoch(currEpoch abi.ChainEpoch, deal *DealProposal, dealID abi.DealID) (abi.ChainEpoch, error) {
+	offset := abi.ChainEpoch(uint64(dealID) % uint64(DealUpdatesInterval))
+	q := builtin.NewQuantSpec(DealUpdatesInterval, 0)
+	prevDay := q.QuantizeDown(deal.StartEpoch)
+	if prevDay+offset >= deal.StartEpoch {
+		return prevDay + offset, nil
 	}
-
-	rb := rbF(crypto.DomainSeparationTag_MarketDealCronSeed, currEpoch, buf.Bytes())
-
-	// generate a random epoch in [baseEpoch, baseEpoch + DealUpdatesInterval)
-	offset := binary.BigEndian.Uint64(rb)
-
-	return deal.StartEpoch + abi.ChainEpoch(offset%uint64(DealUpdatesInterval)), nil
+	nextDay := q.QuantizeUp(deal.StartEpoch)
+	return nextDay + offset, nil
 }
 
 //

--- a/actors/builtin/market/market_actor.go
+++ b/actors/builtin/market/market_actor.go
@@ -234,7 +234,7 @@ func (a Actor) PublishStorageDeals(rt Runtime, params *PublishStorageDealsParams
 
 			// We should randomize the first epoch for when the deal will be processed so an attacker isn't able to
 			// schedule too many deals for the same tick.
-			processEpoch, err := genRandNextEpoch(rt.CurrEpoch(), &deal.Proposal, id)
+			processEpoch, err := GenRandNextEpoch(deal.Proposal.StartEpoch, id)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to generate random process epoch")
 
 			err = msm.dealsByEpoch.Put(processEpoch, id)
@@ -633,14 +633,14 @@ func (a Actor) CronTick(rt Runtime, _ *abi.EmptyValue) *abi.EmptyValue {
 	return nil
 }
 
-func genRandNextEpoch(currEpoch abi.ChainEpoch, deal *DealProposal, dealID abi.DealID) (abi.ChainEpoch, error) {
+func GenRandNextEpoch(startEpoch abi.ChainEpoch, dealID abi.DealID) (abi.ChainEpoch, error) {
 	offset := abi.ChainEpoch(uint64(dealID) % uint64(DealUpdatesInterval))
 	q := builtin.NewQuantSpec(DealUpdatesInterval, 0)
-	prevDay := q.QuantizeDown(deal.StartEpoch)
-	if prevDay+offset >= deal.StartEpoch {
+	prevDay := q.QuantizeDown(startEpoch)
+	if prevDay+offset >= startEpoch {
 		return prevDay + offset, nil
 	}
-	nextDay := q.QuantizeUp(deal.StartEpoch)
+	nextDay := q.QuantizeUp(startEpoch)
 	return nextDay + offset, nil
 }
 

--- a/actors/builtin/market/market_actor.go
+++ b/actors/builtin/market/market_actor.go
@@ -234,7 +234,7 @@ func (a Actor) PublishStorageDeals(rt Runtime, params *PublishStorageDealsParams
 
 			// We should randomize the first epoch for when the deal will be processed so an attacker isn't able to
 			// schedule too many deals for the same tick.
-			processEpoch, err := GenRandNextEpoch(deal.Proposal.StartEpoch, id)
+			processEpoch := GenRandNextEpoch(deal.Proposal.StartEpoch, id)
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to generate random process epoch")
 
 			err = msm.dealsByEpoch.Put(processEpoch, id)
@@ -633,15 +633,15 @@ func (a Actor) CronTick(rt Runtime, _ *abi.EmptyValue) *abi.EmptyValue {
 	return nil
 }
 
-func GenRandNextEpoch(startEpoch abi.ChainEpoch, dealID abi.DealID) (abi.ChainEpoch, error) {
+func GenRandNextEpoch(startEpoch abi.ChainEpoch, dealID abi.DealID) abi.ChainEpoch {
 	offset := abi.ChainEpoch(uint64(dealID) % uint64(DealUpdatesInterval))
 	q := builtin.NewQuantSpec(DealUpdatesInterval, 0)
 	prevDay := q.QuantizeDown(startEpoch)
 	if prevDay+offset >= startEpoch {
-		return prevDay + offset, nil
+		return prevDay + offset
 	}
 	nextDay := q.QuantizeUp(startEpoch)
-	return nextDay + offset, nil
+	return nextDay + offset
 }
 
 //

--- a/actors/builtin/market/market_test.go
+++ b/actors/builtin/market/market_test.go
@@ -342,7 +342,7 @@ func TestMarketActor(t *testing.T) {
 
 			// publish the deal so that client AND provider collateral is locked
 			rt.SetEpoch(publishEpoch)
-			dealId := actor.generateAndPublishDeal(rt, client, minerAddrs, startEpoch, endEpoch, startEpoch)
+			dealId := actor.generateAndPublishDeal(rt, client, minerAddrs, startEpoch, endEpoch)
 			deal := actor.getDealProposal(rt, dealId)
 			rt.GetState(&st)
 			require.Equal(t, deal.ProviderCollateral, actor.getEscrowBalance(rt, provider))
@@ -372,7 +372,7 @@ func TestMarketActor(t *testing.T) {
 
 			// publish deal
 			rt.SetEpoch(publishEpoch)
-			dealID := actor.generateAndPublishDeal(rt, client, minerAddrs, startEpoch, endEpoch, startEpoch)
+			dealID := actor.generateAndPublishDeal(rt, client, minerAddrs, startEpoch, endEpoch)
 
 			// activate the deal
 			actor.activateDeals(rt, endEpoch+1, provider, publishEpoch, dealID)
@@ -514,14 +514,14 @@ func TestPublishStorageDeals(t *testing.T) {
 
 		// publish the deal and activate it
 		rt.SetEpoch(publishEpoch)
-		deal1ID := actor.generateAndPublishDeal(rt, client, mAddr, startEpoch, endEpoch, startEpoch)
+		deal1ID := actor.generateAndPublishDeal(rt, client, mAddr, startEpoch, endEpoch)
 		actor.activateDeals(rt, endEpoch, provider, publishEpoch, deal1ID)
 		st := actor.getDealState(rt, deal1ID)
 		require.EqualValues(t, publishEpoch, st.SectorStartEpoch)
 
 		// now publish a second deal and activate it
 		newEpoch := rt.SetEpoch(publishEpoch + 1)
-		deal2ID := actor.generateAndPublishDeal(rt, client, mAddr, startEpoch+1, endEpoch+1, startEpoch+1)
+		deal2ID := actor.generateAndPublishDeal(rt, client, mAddr, startEpoch+1, endEpoch+1)
 		actor.activateDeals(rt, endEpoch+1, provider, newEpoch, deal2ID)
 		actor.checkState(rt)
 	})
@@ -990,15 +990,15 @@ func TestActivateDeals(t *testing.T) {
 		rt.SetEpoch(currentEpoch)
 
 		// provider 1 publishes deals1 and deals2 and deal3
-		dealId1 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch, startEpoch)
-		dealId2 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch+1, startEpoch)
-		dealId3 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch+2, startEpoch)
+		dealId1 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch)
+		dealId2 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch+1)
+		dealId3 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch+2)
 
 		// provider2 publishes deal4 and deal5
 		provider2 := tutil.NewIDAddr(t, 401)
 		mAddrs.provider = provider2
-		dealId4 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch, startEpoch)
-		dealId5 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch+1, startEpoch)
+		dealId4 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch)
+		dealId5 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch+1)
 
 		// provider1 activates deal 1 and deal2 but that does not activate deal3 to deal5
 		actor.activateDeals(rt, sectorExpiry, provider, currentEpoch, dealId1, dealId2)
@@ -1032,7 +1032,7 @@ func TestActivateDealFailures(t *testing.T) {
 			rt, actor := basicMarketSetup(t, owner, provider, worker, client)
 			provider2 := tutil.NewIDAddr(t, 201)
 			mAddrs2 := &minerAddrs{owner, worker, provider2, nil}
-			dealId := actor.generateAndPublishDeal(rt, client, mAddrs2, startEpoch, endEpoch, startEpoch)
+			dealId := actor.generateAndPublishDeal(rt, client, mAddrs2, startEpoch, endEpoch)
 
 			params := mkActivateDealParams(sectorExpiry, dealId)
 
@@ -1083,7 +1083,7 @@ func TestActivateDealFailures(t *testing.T) {
 	{
 		t.Run("fail when deal has already been activated", func(t *testing.T) {
 			rt, actor := basicMarketSetup(t, owner, provider, worker, client)
-			dealId := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch, startEpoch)
+			dealId := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch)
 			actor.activateDeals(rt, sectorExpiry, provider, 0, dealId)
 
 			rt.ExpectValidateCallerType(builtin.StorageMinerActorCodeID)
@@ -1101,7 +1101,7 @@ func TestActivateDealFailures(t *testing.T) {
 	{
 		t.Run("fail when current epoch greater than start epoch of deal", func(t *testing.T) {
 			rt, actor := basicMarketSetup(t, owner, provider, worker, client)
-			dealId := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch, startEpoch)
+			dealId := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch)
 
 			rt.ExpectValidateCallerType(builtin.StorageMinerActorCodeID)
 			rt.SetCaller(provider, builtin.StorageMinerActorCodeID)
@@ -1116,7 +1116,7 @@ func TestActivateDealFailures(t *testing.T) {
 
 		t.Run("fail when end epoch of deal greater than sector expiry", func(t *testing.T) {
 			rt, actor := basicMarketSetup(t, owner, provider, worker, client)
-			dealId := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch, startEpoch)
+			dealId := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch)
 
 			rt.ExpectValidateCallerType(builtin.StorageMinerActorCodeID)
 			rt.SetCaller(provider, builtin.StorageMinerActorCodeID)
@@ -1135,10 +1135,10 @@ func TestActivateDealFailures(t *testing.T) {
 			rt, actor := basicMarketSetup(t, owner, provider, worker, client)
 
 			// activate deal1 so it fails later
-			dealId1 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch, startEpoch)
+			dealId1 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch)
 			actor.activateDeals(rt, sectorExpiry, provider, 0, dealId1)
 
-			dealId2 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch+1, startEpoch)
+			dealId2 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch+1)
 
 			rt.ExpectValidateCallerType(builtin.StorageMinerActorCodeID)
 			rt.SetCaller(provider, builtin.StorageMinerActorCodeID)
@@ -1180,16 +1180,16 @@ func TestOnMinerSectorsTerminate(t *testing.T) {
 		rt.SetEpoch(currentEpoch)
 
 		// provider1 publishes deal1,2 and 3
-		dealId1 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch, startEpoch)
-		dealId2 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch+1, startEpoch)
-		dealId3 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch+2, startEpoch)
+		dealId1 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch)
+		dealId2 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch+1)
+		dealId3 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch+2)
 		actor.activateDeals(rt, sectorExpiry, provider, currentEpoch, dealId1, dealId2, dealId3)
 
 		// provider2 publishes deal4 and deal5
 		provider2 := tutil.NewIDAddr(t, 501)
 		maddrs2 := &minerAddrs{owner, worker, provider2, nil}
-		dealId4 := actor.generateAndPublishDeal(rt, client, maddrs2, startEpoch, endEpoch, startEpoch)
-		dealId5 := actor.generateAndPublishDeal(rt, client, maddrs2, startEpoch, endEpoch+1, startEpoch)
+		dealId4 := actor.generateAndPublishDeal(rt, client, maddrs2, startEpoch, endEpoch)
+		dealId5 := actor.generateAndPublishDeal(rt, client, maddrs2, startEpoch, endEpoch+1)
 		actor.activateDeals(rt, sectorExpiry, provider2, currentEpoch, dealId4, dealId5)
 
 		// provider1 terminates deal1 but that does not terminate deals2-5
@@ -1217,7 +1217,7 @@ func TestOnMinerSectorsTerminate(t *testing.T) {
 		rt, actor := basicMarketSetup(t, owner, provider, worker, client)
 		rt.SetEpoch(currentEpoch)
 
-		dealId1 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch, startEpoch)
+		dealId1 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch)
 		actor.activateDeals(rt, sectorExpiry, provider, currentEpoch, dealId1)
 
 		// deal1 will be terminated and the other deal will be ignored because it does not exist
@@ -1232,9 +1232,9 @@ func TestOnMinerSectorsTerminate(t *testing.T) {
 		rt.SetEpoch(currentEpoch)
 
 		// provider1 publishes deal1 and 2 and deal3 -> deal3 has the lowest endepoch
-		dealId1 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch, startEpoch)
-		dealId2 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch+1, startEpoch)
-		dealId3 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch-1, startEpoch)
+		dealId1 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch)
+		dealId2 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch+1)
+		dealId3 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch-1)
 		actor.activateDeals(rt, sectorExpiry, provider, currentEpoch, dealId1, dealId2, dealId3)
 
 		// set current epoch such that deal3 expires but the other two do not
@@ -1274,7 +1274,7 @@ func TestOnMinerSectorsTerminate(t *testing.T) {
 		rt, actor := basicMarketSetup(t, owner, provider, worker, client)
 		rt.SetEpoch(currentEpoch)
 
-		dealId1 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch, startEpoch)
+		dealId1 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch)
 		actor.activateDeals(rt, sectorExpiry, provider, currentEpoch, dealId1)
 
 		// terminating the deal so slash epoch is the current epoch
@@ -1293,9 +1293,9 @@ func TestOnMinerSectorsTerminate(t *testing.T) {
 		rt.SetEpoch(currentEpoch)
 
 		// provider1 publishes deal1 and 2 and deal3 -> deal3 has the lowest endepoch
-		dealId1 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch, startEpoch)
-		dealId2 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch+1, startEpoch)
-		dealId3 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch-1, startEpoch)
+		dealId1 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch)
+		dealId2 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch+1)
+		dealId3 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch-1)
 		actor.activateDeals(rt, sectorExpiry, provider, currentEpoch, dealId1, dealId2, dealId3)
 
 		// terminating the deal so slash epoch is the current epoch
@@ -1321,7 +1321,7 @@ func TestOnMinerSectorsTerminate(t *testing.T) {
 		rt.SetEpoch(currentEpoch)
 
 		// deal1 has endepoch equal to current epoch when terminate is called
-		dealId1 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch, startEpoch)
+		dealId1 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch)
 		actor.activateDeals(rt, sectorExpiry, provider, currentEpoch, dealId1)
 		rt.SetEpoch(endEpoch)
 		actor.terminateDeals(rt, provider, dealId1)
@@ -1329,7 +1329,7 @@ func TestOnMinerSectorsTerminate(t *testing.T) {
 
 		// deal2 has end epoch less than current epoch when terminate is called
 		rt.SetEpoch(currentEpoch)
-		dealId2 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch+1, endEpoch, startEpoch+1)
+		dealId2 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch+1, endEpoch)
 		actor.activateDeals(rt, sectorExpiry, provider, currentEpoch, dealId2)
 		rt.SetEpoch(endEpoch + 1)
 		actor.terminateDeals(rt, provider, dealId2)
@@ -1353,7 +1353,7 @@ func TestOnMinerSectorsTerminate(t *testing.T) {
 		rt, actor := basicMarketSetup(t, owner, provider, worker, client)
 		rt.SetEpoch(currentEpoch)
 
-		dealId := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch, startEpoch)
+		dealId := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch)
 		actor.activateDeals(rt, sectorExpiry, provider, currentEpoch, dealId)
 
 		params := mkTerminateDealParams(currentEpoch, dealId)
@@ -1373,7 +1373,7 @@ func TestOnMinerSectorsTerminate(t *testing.T) {
 		rt, actor := basicMarketSetup(t, owner, provider, worker, client)
 		rt.SetEpoch(currentEpoch)
 
-		dealId := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch, startEpoch)
+		dealId := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch)
 
 		params := mkTerminateDealParams(currentEpoch, dealId)
 		rt.ExpectValidateCallerType(builtin.StorageMinerActorCodeID)
@@ -1391,9 +1391,9 @@ func TestOnMinerSectorsTerminate(t *testing.T) {
 		rt.SetEpoch(currentEpoch)
 
 		// deal1 would terminate but deal2 will fail because deal2 has not been activated
-		dealId1 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch, startEpoch)
+		dealId1 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch)
 		actor.activateDeals(rt, sectorExpiry, provider, currentEpoch, dealId1)
-		dealId2 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch+1, startEpoch)
+		dealId2 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch+1)
 
 		params := mkTerminateDealParams(currentEpoch, dealId1, dealId2)
 		rt.ExpectValidateCallerType(builtin.StorageMinerActorCodeID)
@@ -1491,8 +1491,7 @@ func TestCronTick(t *testing.T) {
 		dealId2 := actor.publishAndActivateDeal(rt, client, mAddrs, startEpoch+1, endEpoch+1, 0, sectorExpiry)
 
 		// slash deal1
-
-		slashEpoch := rt.SetEpoch(150)
+		slashEpoch := rt.SetEpoch(processEpoch(t, dealId2, startEpoch) + abi.ChainEpoch(100))
 		actor.terminateDeals(rt, provider, dealId1)
 
 		// cron tick will slash deal1 and make payment for deal2
@@ -1509,8 +1508,7 @@ func TestCronTick(t *testing.T) {
 	t.Run("cannot publish the same deal twice BEFORE a cron tick", func(t *testing.T) {
 		// Publish a deal
 		rt, actor := basicMarketSetup(t, owner, provider, worker, client)
-		dealId1 := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch, startEpoch)
-		d1 := actor.getDealProposal(rt, dealId1)
+		actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch)
 
 		// now try to publish it again and it should fail because it will still be in pending state
 		d2 := actor.generateDealAndAddFunds(rt, client, mAddrs, startEpoch, endEpoch)
@@ -1524,15 +1522,6 @@ func TestCronTick(t *testing.T) {
 			rt.Call(actor.PublishStorageDeals, params)
 		})
 		rt.Verify()
-
-		// now a cron tick happens -> deal1 is no longer pending and then publishing the same deal again should work
-		rt.SetEpoch(d1.StartEpoch - 1)
-		actor.activateDeals(rt, sectorExpiry, provider, d1.StartEpoch-1, dealId1)
-		rt.SetEpoch(d1.StartEpoch)
-		actor.cronTick(rt)
-		rt.SetCaller(worker, builtin.AccountActorCodeID)
-		actor.publishDeals(rt, mAddrs, publishDealReq{deal: d2})
-		actor.checkState(rt)
 	})
 }
 
@@ -1547,10 +1536,9 @@ func TestRandomCronEpochDuringPublish(t *testing.T) {
 	endEpoch := startEpoch + 200*builtin.EpochsInDay
 	sectorExpiry := endEpoch + 1
 
-	t.Run("a random epoch in chosen as the cron processing epoch for a deal during publishing", func(t *testing.T) {
+	t.Run("cron processing happens at processing epoch, not start epoch", func(t *testing.T) {
 		rt, actor := basicMarketSetup(t, owner, provider, worker, client)
-		processEpoch := startEpoch + 5
-		dealId := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch, processEpoch)
+		dealId := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch)
 		d := actor.getDealProposal(rt, dealId)
 
 		// activate the deal
@@ -1562,6 +1550,7 @@ func TestRandomCronEpochDuringPublish(t *testing.T) {
 		actor.cronTickNoChange(rt, client, provider)
 
 		// first cron tick at process epoch will make payment and schedule the deal for next epoch
+		processEpoch := processEpoch(t, dealId, startEpoch)
 		rt.SetEpoch(processEpoch)
 		pay, _ := actor.cronTickAndAssertBalances(rt, client, provider, processEpoch, dealId)
 		duration := big.Sub(big.NewInt(int64(processEpoch)), big.NewInt(int64(startEpoch)))
@@ -1577,7 +1566,8 @@ func TestRandomCronEpochDuringPublish(t *testing.T) {
 
 	t.Run("deals are scheduled for expiry later than the end epoch", func(t *testing.T) {
 		rt, actor := basicMarketSetup(t, owner, provider, worker, client)
-		dealId := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch, startEpoch)
+		//		dealId := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch, startEpoch)
+		dealId := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch)
 		d := actor.getDealProposal(rt, dealId)
 
 		rt.SetEpoch(startEpoch - 1)
@@ -1620,8 +1610,8 @@ func TestRandomCronEpochDuringPublish(t *testing.T) {
 
 	t.Run("activation after deal start epoch but before it is processed fails", func(t *testing.T) {
 		rt, actor := basicMarketSetup(t, owner, provider, worker, client)
-		processEpoch := startEpoch + 5
-		dealId := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch, processEpoch)
+		//		dealId := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch, processEpoch)
+		dealId := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch)
 
 		// activate the deal after the start epoch
 		currEpoch := rt.SetEpoch(startEpoch + 1)
@@ -1634,11 +1624,10 @@ func TestRandomCronEpochDuringPublish(t *testing.T) {
 
 	t.Run("cron processing of deal after missed activation should fail and slash", func(t *testing.T) {
 		rt, actor := basicMarketSetup(t, owner, provider, worker, client)
-		processEpoch := startEpoch + 5
-		dealId := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch, processEpoch)
+		dealId := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch)
 		d := actor.getDealProposal(rt, dealId)
 
-		rt.SetEpoch(processEpoch)
+		rt.SetEpoch(processEpoch(t, dealId, startEpoch))
 
 		rt.ExpectSend(builtin.BurntFundsActorAddr, builtin.MethodSend, nil, d.ProviderCollateral, nil, exitcode.Ok)
 		actor.cronTick(rt)
@@ -1680,13 +1669,13 @@ func TestLockedFundTrackingStates(t *testing.T) {
 	require.True(t, st.TotalClientStorageFee.IsZero())
 
 	// Publish deal1, deal2 and deal3  with different client and provider
-	dealId1 := actor.generateAndPublishDeal(rt, c1, m1, startEpoch, endEpoch, startEpoch)
+	dealId1 := actor.generateAndPublishDeal(rt, c1, m1, startEpoch, endEpoch)
 	d1 := actor.getDealProposal(rt, dealId1)
 
-	dealId2 := actor.generateAndPublishDeal(rt, c2, m2, startEpoch, endEpoch, startEpoch)
+	dealId2 := actor.generateAndPublishDeal(rt, c2, m2, startEpoch, endEpoch)
 	d2 := actor.getDealProposal(rt, dealId2)
 
-	dealId3 := actor.generateAndPublishDeal(rt, c3, m3, startEpoch, endEpoch, startEpoch)
+	dealId3 := actor.generateAndPublishDeal(rt, c3, m3, startEpoch, endEpoch)
 	d3 := actor.getDealProposal(rt, dealId3)
 
 	csf := big.Sum(d1.TotalStorageFee(), d2.TotalStorageFee(), d3.TotalStorageFee())
@@ -1703,7 +1692,7 @@ func TestLockedFundTrackingStates(t *testing.T) {
 	actor.assertLockedFundStates(rt, csf, plc, clc)
 
 	// make payment for p1 and p2, p3 times out as it has not been activated
-	curr = rt.SetEpoch(startEpoch + 1)
+	curr = rt.SetEpoch(processEpoch(t, dealId3, startEpoch))
 	rt.ExpectSend(builtin.BurntFundsActorAddr, builtin.MethodSend, nil, d3.ProviderCollateral, nil, exitcode.Ok)
 	actor.cronTick(rt)
 	payment := big.Product(big.NewInt(2), d1.StoragePricePerEpoch)
@@ -1753,13 +1742,13 @@ func TestCronTickTimedoutDeals(t *testing.T) {
 	t.Run("timed out deal is slashed and deleted", func(t *testing.T) {
 		// publish a deal but do NOT activate it
 		rt, actor := basicMarketSetup(t, owner, provider, worker, client)
-		dealId := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch, startEpoch)
+		dealId := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch)
 		d := actor.getDealProposal(rt, dealId)
 
 		cEscrow := actor.getEscrowBalance(rt, client)
 
 		// do a cron tick for it -> should time out and get slashed
-		rt.SetEpoch(startEpoch)
+		rt.SetEpoch(processEpoch(t, dealId, startEpoch))
 		rt.ExpectSend(builtin.BurntFundsActorAddr, builtin.MethodSend, nil, d.ProviderCollateral, nil, exitcode.Ok)
 		actor.cronTick(rt)
 
@@ -1771,8 +1760,10 @@ func TestCronTickTimedoutDeals(t *testing.T) {
 	})
 
 	t.Run("publishing timed out deal again should work after cron tick as it should no longer be pending", func(t *testing.T) {
+		// dealID(0) + 0 % 2880 = 0.  Need processing epoch == start epoch to do hack where we publish deals after cron in same epoch
+		startEpoch := abi.ChainEpoch(0)
 		rt, actor := basicMarketSetup(t, owner, provider, worker, client)
-		dealId := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch, startEpoch)
+		dealId := actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch)
 		d := actor.getDealProposal(rt, dealId)
 
 		// publishing will fail as it will be in pending
@@ -1789,13 +1780,13 @@ func TestCronTickTimedoutDeals(t *testing.T) {
 		rt.Verify()
 
 		// do a cron tick for it -> should time out and get slashed
-		rt.SetEpoch(startEpoch)
+		rt.SetEpoch(processEpoch(t, dealId, startEpoch))
 		rt.ExpectSend(builtin.BurntFundsActorAddr, builtin.MethodSend, nil, d.ProviderCollateral, nil, exitcode.Ok)
 		actor.cronTick(rt)
 		actor.assertDealDeleted(rt, dealId, d)
 
 		// now publishing should work
-		actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch, startEpoch)
+		actor.generateAndPublishDeal(rt, client, mAddrs, startEpoch, endEpoch)
 		actor.checkState(rt)
 	})
 
@@ -1817,7 +1808,7 @@ func TestCronTickTimedoutDeals(t *testing.T) {
 
 		// do a cron tick for it -> all should time out and get slashed
 		// ONLY deal1 and deal2 should be sent to the Registry actor
-		rt.SetEpoch(startEpoch)
+		rt.SetEpoch(processEpoch(t, dealIds[len(dealIds)-1], startEpoch))
 
 		// expected sends to the registry actor
 		param1 := &verifreg.RestoreBytesParams{
@@ -1888,6 +1879,9 @@ func TestCronTickDealExpiry(t *testing.T) {
 	})
 
 	t.Run("deal expiry -> regular payments till deal expires and then locked funds are unlocked", func(t *testing.T) {
+		// start epoch should equal first processing epoch for logic to work
+		// 2880 + 0 % 2880 = 2880
+		startEpoch := abi.ChainEpoch(builtin.EpochsInDay)
 		t.Parallel()
 		rt, actor := basicMarketSetup(t, owner, provider, worker, client)
 		dealId := actor.publishAndActivateDeal(rt, client, mAddrs, startEpoch, endEpoch, 0, sectorExpiry)
@@ -2016,7 +2010,6 @@ func TestCronTickDealSlashing(t *testing.T) {
 			dealEnd          abi.ChainEpoch
 			activationEpoch  abi.ChainEpoch
 			terminationEpoch abi.ChainEpoch
-			cronTickEpoch    abi.ChainEpoch
 			payment          abi.TokenAmount
 		}{
 			"deal is slashed after the startepoch and then the first crontick happens": {
@@ -2024,7 +2017,6 @@ func TestCronTickDealSlashing(t *testing.T) {
 				dealEnd:          abi.ChainEpoch(10 + 200*builtin.EpochsInDay),
 				activationEpoch:  abi.ChainEpoch(5),
 				terminationEpoch: abi.ChainEpoch(15),
-				cronTickEpoch:    abi.ChainEpoch(16),
 				payment:          abi.NewTokenAmount(50), // (15 - 10) * 10 as deal storage fee is 10 per epoch
 			},
 			"deal is slashed at the startepoch and then the first crontick happens": {
@@ -2032,7 +2024,6 @@ func TestCronTickDealSlashing(t *testing.T) {
 				dealEnd:          abi.ChainEpoch(10 + 200*builtin.EpochsInDay),
 				activationEpoch:  abi.ChainEpoch(5),
 				terminationEpoch: abi.ChainEpoch(10),
-				cronTickEpoch:    abi.ChainEpoch(11),
 				payment:          abi.NewTokenAmount(0), // (10 - 10) * 10
 			},
 			"deal is slashed before the startepoch and then the first crontick happens": {
@@ -2040,7 +2031,6 @@ func TestCronTickDealSlashing(t *testing.T) {
 				dealEnd:          abi.ChainEpoch(10 + 200*builtin.EpochsInDay),
 				activationEpoch:  abi.ChainEpoch(5),
 				terminationEpoch: abi.ChainEpoch(6),
-				cronTickEpoch:    abi.ChainEpoch(10),
 				payment:          abi.NewTokenAmount(0), // (10 - 10) * 10
 			},
 			"deal is terminated at the activation epoch and then the first crontick happens": {
@@ -2048,7 +2038,6 @@ func TestCronTickDealSlashing(t *testing.T) {
 				dealEnd:          abi.ChainEpoch(10 + 200*builtin.EpochsInDay),
 				activationEpoch:  abi.ChainEpoch(5),
 				terminationEpoch: abi.ChainEpoch(5),
-				cronTickEpoch:    abi.ChainEpoch(10),
 				payment:          abi.NewTokenAmount(0), // (10 - 10) * 10
 			},
 			"deal is slashed and then deal expiry happens on crontick, but slashing still occurs": {
@@ -2056,7 +2045,6 @@ func TestCronTickDealSlashing(t *testing.T) {
 				dealEnd:          abi.ChainEpoch(10 + 200*builtin.EpochsInDay),
 				activationEpoch:  abi.ChainEpoch(5),
 				terminationEpoch: abi.ChainEpoch(15),
-				cronTickEpoch:    abi.ChainEpoch(25), // deal has expired
 				payment:          abi.NewTokenAmount(50),
 			},
 			"deal is slashed just BEFORE the end epoch": {
@@ -2064,7 +2052,6 @@ func TestCronTickDealSlashing(t *testing.T) {
 				dealEnd:          abi.ChainEpoch(10 + 200*builtin.EpochsInDay),
 				activationEpoch:  abi.ChainEpoch(5),
 				terminationEpoch: abi.ChainEpoch(19),
-				cronTickEpoch:    abi.ChainEpoch(19),
 				payment:          abi.NewTokenAmount(90), // (19 - 10) * 10
 			},
 		}
@@ -2083,9 +2070,10 @@ func TestCronTickDealSlashing(t *testing.T) {
 				actor.terminateDeals(rt, provider, dealId)
 
 				//  cron tick
-				rt.SetEpoch(tc.cronTickEpoch)
+				cronTickEpoch := processEpoch(t, dealId, tc.dealStart)
+				rt.SetEpoch(cronTickEpoch)
 
-				pay, slashed := actor.cronTickAndAssertBalances(rt, client, provider, tc.cronTickEpoch, dealId)
+				pay, slashed := actor.cronTickAndAssertBalances(rt, client, provider, cronTickEpoch, dealId)
 				require.EqualValues(t, tc.payment, pay)
 				require.EqualValues(t, d.ProviderCollateral, slashed)
 				actor.assertDealDeleted(rt, dealId, d)
@@ -2137,12 +2125,15 @@ func TestCronTickDealSlashing(t *testing.T) {
 
 	t.Run("deal is correctly processed twice in the same crontick and slashed", func(t *testing.T) {
 		t.Parallel()
+		// start epoch should equal first processing epoch for logic to work
+		// 2880 + 0 % 2880 = 2880
+		startEpoch := abi.ChainEpoch(builtin.EpochsInDay)
 		rt, actor := basicMarketSetup(t, owner, provider, worker, client)
 		dealId := actor.publishAndActivateDeal(rt, client, mAddrs, startEpoch, endEpoch, 0, sectorExpiry)
 		d := actor.getDealProposal(rt, dealId)
 
 		// move the current epoch to startEpoch so next cron epoch will be start + Interval
-		current := rt.SetEpoch(startEpoch)
+		current := rt.SetEpoch(processEpoch(t, dealId, startEpoch))
 		pay, slashed := actor.cronTickAndAssertBalances(rt, client, provider, current, dealId)
 		require.EqualValues(t, big.Zero(), pay)
 		require.EqualValues(t, big.Zero(), slashed)
@@ -2177,12 +2168,12 @@ func TestCronTickDealSlashing(t *testing.T) {
 		dealId3 := actor.publishAndActivateDeal(rt, client, mAddrs, startEpoch, endEpoch+2, 0, sectorExpiry)
 		d3 := actor.getDealProposal(rt, dealId3)
 
-		// set slash epoch of deal at 151
-		rt.SetEpoch(151)
+		// set slash epoch of deal at 100 epochs past last process epoch
+		rt.SetEpoch(processEpoch(t, dealId3, startEpoch) + 100)
 		actor.terminateDeals(rt, provider, dealId1, dealId2, dealId3)
 
-		// process slashing of deals
-		rt.SetEpoch(300)
+		// process slashing of deals 200 epochs later
+		rt.SetEpoch(processEpoch(t, dealId3, startEpoch) + 300)
 		totalSlashed := big.Sum(d1.ProviderCollateral, d2.ProviderCollateral, d3.ProviderCollateral)
 		rt.ExpectSend(builtin.BurntFundsActorAddr, builtin.MethodSend, nil, totalSlashed, nil, exitcode.Ok)
 
@@ -2200,11 +2191,12 @@ func TestCronTickDealSlashing(t *testing.T) {
 		dealId := actor.publishAndActivateDeal(rt, client, mAddrs, startEpoch, endEpoch, 0, sectorExpiry)
 		d := actor.getDealProposal(rt, dealId)
 
-		// move the current epoch to startEpoch + 5 so payment is made
-		current := rt.SetEpoch(startEpoch + 5)
+		// move the current epoch to the process epoch + 5 so payment is made
+		processStart := processEpoch(t, dealId, startEpoch)
+		current := rt.SetEpoch(processStart + 5)
 		// assert payment
 		pay, slashed := actor.cronTickAndAssertBalances(rt, client, provider, current, dealId)
-		require.EqualValues(t, pay, big.Mul(big.NewInt(5), d.StoragePricePerEpoch))
+		require.EqualValues(t, pay, big.Mul(big.NewInt(int64(5+processStart-startEpoch)), d.StoragePricePerEpoch))
 		require.EqualValues(t, big.Zero(), slashed)
 
 		// Setting the current epoch to before the next schedule will NOT make any changes as the deal
@@ -2252,13 +2244,14 @@ func TestCronTickDealSlashing(t *testing.T) {
 		dealId := actor.publishAndActivateDeal(rt, client, mAddrs, startEpoch, endEpoch, 0, sectorExpiry)
 		d := actor.getDealProposal(rt, dealId)
 
-		// move the current epoch to startEpoch + 5 so payment is made and assert payment
-		current := rt.SetEpoch(startEpoch + 5) // 55
+		// move the current epoch to processEpoch + 5 so payment is made and assert payment
+		processStart := processEpoch(t, dealId, startEpoch)
+		current := rt.SetEpoch(processStart + 5)
 		pay, slashed := actor.cronTickAndAssertBalances(rt, client, provider, current, dealId)
-		require.EqualValues(t, pay, big.Mul(big.NewInt(5), d.StoragePricePerEpoch))
+		require.EqualValues(t, pay, big.Mul(big.NewInt(int64(5+processStart-startEpoch)), d.StoragePricePerEpoch))
 		require.EqualValues(t, big.Zero(), slashed)
 
-		//  Setting the current epoch to 155 will make another payment
+		//  Incrementing the current epoch another update interval will make another payment
 		current = rt.SetEpoch(current + market.DealUpdatesInterval)
 		duration := big.NewInt(market.DealUpdatesInterval)
 		pay, slashed = actor.cronTickAndAssertBalances(rt, client, provider, current, dealId)
@@ -2392,10 +2385,10 @@ func TestComputeDataCommitment(t *testing.T) {
 
 	t.Run("successfully compute cid", func(t *testing.T) {
 		rt, actor := basicMarketSetup(t, owner, provider, worker, client)
-		dealId1 := actor.generateAndPublishDeal(rt, client, mAddrs, start, end, start)
+		dealId1 := actor.generateAndPublishDeal(rt, client, mAddrs, start, end)
 		d1 := actor.getDealProposal(rt, dealId1)
 
-		dealId2 := actor.generateAndPublishDeal(rt, client, mAddrs, start, end+1, start)
+		dealId2 := actor.generateAndPublishDeal(rt, client, mAddrs, start, end+1)
 		d2 := actor.getDealProposal(rt, dealId2)
 
 		param := &market.ComputeDataCommitmentParams{}
@@ -2437,10 +2430,10 @@ func TestComputeDataCommitment(t *testing.T) {
 
 	t.Run("success with multiple sector commitments", func(t *testing.T) {
 		rt, actor := basicMarketSetup(t, owner, provider, worker, client)
-		dealId1 := actor.generateAndPublishDeal(rt, client, mAddrs, start, end, start)
+		dealId1 := actor.generateAndPublishDeal(rt, client, mAddrs, start, end)
 		d1 := actor.getDealProposal(rt, dealId1)
 
-		dealId2 := actor.generateAndPublishDeal(rt, client, mAddrs, start, end+1, start)
+		dealId2 := actor.generateAndPublishDeal(rt, client, mAddrs, start, end+1)
 		d2 := actor.getDealProposal(rt, dealId2)
 
 		param := &market.ComputeDataCommitmentParams{}
@@ -2484,7 +2477,7 @@ func TestComputeDataCommitment(t *testing.T) {
 
 	t.Run("fail when syscall returns an error", func(t *testing.T) {
 		rt, actor := basicMarketSetup(t, owner, provider, worker, client)
-		dealId := actor.generateAndPublishDeal(rt, client, mAddrs, start, end, start)
+		dealId := actor.generateAndPublishDeal(rt, client, mAddrs, start, end)
 		d := actor.getDealProposal(rt, dealId)
 		param := &market.ComputeDataCommitmentParams{}
 		param.Inputs = []*market.SectorDataSpec{{DealIDs: []abi.DealID{dealId}, SectorType: 1}}
@@ -2502,7 +2495,7 @@ func TestComputeDataCommitment(t *testing.T) {
 
 	t.Run("fail whole call when one deal proposal of one sector is absent", func(t *testing.T) {
 		rt, actor := basicMarketSetup(t, owner, provider, worker, client)
-		dealId1 := actor.generateAndPublishDeal(rt, client, mAddrs, start, end, start)
+		dealId1 := actor.generateAndPublishDeal(rt, client, mAddrs, start, end)
 		dealId2 := abi.DealID(2)
 
 		param := &market.ComputeDataCommitmentParams{}
@@ -2522,8 +2515,8 @@ func TestComputeDataCommitment(t *testing.T) {
 
 	t.Run("fail whole call when one commitment fails syscall", func(t *testing.T) {
 		rt, actor := basicMarketSetup(t, owner, provider, worker, client)
-		dealId1 := actor.generateAndPublishDeal(rt, client, mAddrs, start, end, start)
-		dealId2 := actor.generateAndPublishDeal(rt, client, mAddrs, start, end+1, start)
+		dealId1 := actor.generateAndPublishDeal(rt, client, mAddrs, start, end)
+		dealId2 := actor.generateAndPublishDeal(rt, client, mAddrs, start, end+1)
 
 		param := &market.ComputeDataCommitmentParams{}
 		param.Inputs = []*market.SectorDataSpec{
@@ -2553,7 +2546,7 @@ func TestVerifyDealsForActivation(t *testing.T) {
 
 	t.Run("verify deal and get deal weight for unverified deal proposal", func(t *testing.T) {
 		rt, actor := basicMarketSetup(t, owner, provider, worker, client)
-		dealId := actor.generateAndPublishDeal(rt, client, mAddrs, start, end, start)
+		dealId := actor.generateAndPublishDeal(rt, client, mAddrs, start, end)
 		d := actor.getDealProposal(rt, dealId)
 
 		resp := actor.verifyDealsForActivation(rt, provider, []market.SectorDeals{{
@@ -2611,7 +2604,7 @@ func TestVerifyDealsForActivation(t *testing.T) {
 
 	t.Run("fail when caller is not a StorageMinerActor", func(t *testing.T) {
 		rt, actor := basicMarketSetup(t, owner, provider, worker, client)
-		dealId := actor.generateAndPublishDeal(rt, client, mAddrs, start, end, start)
+		dealId := actor.generateAndPublishDeal(rt, client, mAddrs, start, end)
 
 		param := &market.VerifyDealsForActivationParams{Sectors: []market.SectorDeals{{
 			SectorExpiry: sectorExpiry,
@@ -2641,7 +2634,7 @@ func TestVerifyDealsForActivation(t *testing.T) {
 
 	t.Run("fail when caller is not the provider", func(t *testing.T) {
 		rt, actor := basicMarketSetup(t, owner, provider, worker, client)
-		dealId := actor.generateAndPublishDeal(rt, client, mAddrs, start, end, start)
+		dealId := actor.generateAndPublishDeal(rt, client, mAddrs, start, end)
 
 		param := &market.VerifyDealsForActivationParams{Sectors: []market.SectorDeals{{
 			SectorExpiry: sectorExpiry,
@@ -2658,7 +2651,7 @@ func TestVerifyDealsForActivation(t *testing.T) {
 
 	t.Run("fail when current epoch is greater than proposal start epoch", func(t *testing.T) {
 		rt, actor := basicMarketSetup(t, owner, provider, worker, client)
-		dealId := actor.generateAndPublishDeal(rt, client, mAddrs, start, end, start)
+		dealId := actor.generateAndPublishDeal(rt, client, mAddrs, start, end)
 
 		rt.SetEpoch(start + 1)
 		param := &market.VerifyDealsForActivationParams{Sectors: []market.SectorDeals{{
@@ -2675,7 +2668,7 @@ func TestVerifyDealsForActivation(t *testing.T) {
 
 	t.Run("fail when deal end epoch is greater than sector expiration", func(t *testing.T) {
 		rt, actor := basicMarketSetup(t, owner, provider, worker, client)
-		dealId := actor.generateAndPublishDeal(rt, client, mAddrs, start, end, start)
+		dealId := actor.generateAndPublishDeal(rt, client, mAddrs, start, end)
 
 		param := &market.VerifyDealsForActivationParams{Sectors: []market.SectorDeals{{
 			SectorExpiry: end - 1,
@@ -2691,7 +2684,7 @@ func TestVerifyDealsForActivation(t *testing.T) {
 
 	t.Run("fail when the same deal ID is passed multiple times", func(t *testing.T) {
 		rt, actor := basicMarketSetup(t, owner, provider, worker, client)
-		dealId := actor.generateAndPublishDeal(rt, client, mAddrs, start, end, start)
+		dealId := actor.generateAndPublishDeal(rt, client, mAddrs, start, end)
 
 		param := &market.VerifyDealsForActivationParams{Sectors: []market.SectorDeals{{
 			SectorExpiry: sectorExpiry,
@@ -3150,7 +3143,7 @@ func (h *marketActorTestHarness) deleteDealProposal(rt *mock.Runtime, dealId abi
 }
 
 func (h *marketActorTestHarness) generateAndPublishDeal(rt *mock.Runtime, client address.Address, minerAddrs *minerAddrs,
-	startEpoch, endEpoch abi.ChainEpoch, requiredProcessEpoch abi.ChainEpoch) abi.DealID {
+	startEpoch, endEpoch abi.ChainEpoch) abi.DealID {
 
 	deal := h.generateDealAndAddFunds(rt, client, minerAddrs, startEpoch, endEpoch)
 	rt.SetCaller(minerAddrs.worker, builtin.AccountActorCodeID)

--- a/actors/builtin/market/market_test.go
+++ b/actors/builtin/market/market_test.go
@@ -3275,7 +3275,5 @@ func expectQueryNetworkInfo(rt *mock.Runtime, h *marketActorTestHarness) {
 }
 
 func processEpoch(t *testing.T, id abi.DealID, startEpoch abi.ChainEpoch) abi.ChainEpoch {
-	e, err := market.GenRandNextEpoch(startEpoch, id)
-	require.NoError(t, err)
-	return e
+	return market.GenRandNextEpoch(startEpoch, id)
 }

--- a/actors/builtin/market/market_test.go
+++ b/actors/builtin/market/market_test.go
@@ -1599,8 +1599,8 @@ func TestRandomCronEpochDuringPublish(t *testing.T) {
 		dealId := actor.publishAndActivateDeal(rt, client, mAddrs, startEpoch, endEpoch, activationEpoch, sectorExpiry)
 		d := actor.getDealProposal(rt, dealId)
 
-		rt.SetEpoch(processEpoch(t, dealId, startEpoch))
-		pay, slashed := actor.cronTickAndAssertBalances(rt, client, provider, processEpoch(t, dealId, startEpoch), dealId)
+		rt.SetEpoch(endEpoch + 100)
+		pay, slashed := actor.cronTickAndAssertBalances(rt, client, provider, endEpoch+100, dealId)
 		require.EqualValues(t, big.Zero(), slashed)
 		duration := big.Sub(big.NewInt(int64(endEpoch)), big.NewInt(int64(startEpoch)))
 		require.EqualValues(t, big.Mul(duration, d.StoragePricePerEpoch), pay)
@@ -1655,7 +1655,7 @@ func TestLockedFundTrackingStates(t *testing.T) {
 	m2 := &minerAddrs{owner, worker, p2, nil}
 	m3 := &minerAddrs{owner, worker, p3, nil}
 
-	startEpoch := abi.ChainEpoch(50)
+	startEpoch := abi.ChainEpoch(2880)
 	endEpoch := startEpoch + 200*builtin.EpochsInDay
 	sectorExpiry := endEpoch + 400
 
@@ -1695,7 +1695,7 @@ func TestLockedFundTrackingStates(t *testing.T) {
 	curr = rt.SetEpoch(processEpoch(t, dealId3, startEpoch))
 	rt.ExpectSend(builtin.BurntFundsActorAddr, builtin.MethodSend, nil, d3.ProviderCollateral, nil, exitcode.Ok)
 	actor.cronTick(rt)
-	payment := big.Product(big.NewInt(2), d1.StoragePricePerEpoch)
+	payment := big.Product(big.NewInt(4), d1.StoragePricePerEpoch)
 	csf = big.Sub(big.Sub(csf, payment), d3.TotalStorageFee())
 	plc = big.Sub(plc, d3.ProviderCollateral)
 	clc = big.Sub(clc, d3.ClientCollateral)

--- a/actors/builtin/miner/bitfield_queue.go
+++ b/actors/builtin/miner/bitfield_queue.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ipfs/go-cid"
 	"golang.org/x/xerrors"
 
+	"github.com/filecoin-project/specs-actors/v5/actors/builtin"
 	"github.com/filecoin-project/specs-actors/v5/actors/util/adt"
 )
 
@@ -16,10 +17,10 @@ import (
 // Keys in the queue are quantized (upwards), modulo some offset, to reduce the cardinality of keys.
 type BitfieldQueue struct {
 	*adt.Array
-	quant QuantSpec
+	quant builtin.QuantSpec
 }
 
-func LoadBitfieldQueue(store adt.Store, root cid.Cid, quant QuantSpec, bitwidth int) (BitfieldQueue, error) {
+func LoadBitfieldQueue(store adt.Store, root cid.Cid, quant builtin.QuantSpec, bitwidth int) (BitfieldQueue, error) {
 	arr, err := adt.AsArray(store, root, bitwidth)
 	if err != nil {
 		return BitfieldQueue{}, xerrors.Errorf("failed to load epoch queue %v: %w", root, err)

--- a/actors/builtin/miner/bitfield_queue_test.go
+++ b/actors/builtin/miner/bitfield_queue_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/filecoin-project/specs-actors/v5/actors/builtin"
 	"github.com/filecoin-project/specs-actors/v5/actors/builtin/miner"
 	"github.com/filecoin-project/specs-actors/v5/actors/util/adt"
 	"github.com/filecoin-project/specs-actors/v5/support/mock"
@@ -43,7 +44,7 @@ func TestBitfieldQueue(t *testing.T) {
 	})
 
 	t.Run("quantizes added epochs according to quantization spec", func(t *testing.T) {
-		queue := emptyBitfieldQueueWithQuantizing(t, miner.NewQuantSpec(5, 3), testAmtBitwidth)
+		queue := emptyBitfieldQueueWithQuantizing(t, builtin.NewQuantSpec(5, 3), testAmtBitwidth)
 
 		for _, val := range []uint64{0, 2, 3, 4, 7, 8, 9} {
 			require.NoError(t, queue.AddToQueueValues(abi.ChainEpoch(val), val))
@@ -58,7 +59,7 @@ func TestBitfieldQueue(t *testing.T) {
 	})
 
 	t.Run("quantizes added epochs according to quantization spec", func(t *testing.T) {
-		queue := emptyBitfieldQueueWithQuantizing(t, miner.NewQuantSpec(5, 3), testAmtBitwidth)
+		queue := emptyBitfieldQueueWithQuantizing(t, builtin.NewQuantSpec(5, 3), testAmtBitwidth)
 
 		for _, val := range []uint64{0, 2, 3, 4, 7, 8, 9} {
 			err := queue.AddToQueueValues(abi.ChainEpoch(val), val)
@@ -234,7 +235,7 @@ func TestBitfieldQueue(t *testing.T) {
 
 }
 
-func emptyBitfieldQueueWithQuantizing(t *testing.T, quant miner.QuantSpec, bitwidth int) miner.BitfieldQueue {
+func emptyBitfieldQueueWithQuantizing(t *testing.T, quant builtin.QuantSpec, bitwidth int) miner.BitfieldQueue {
 	rt := mock.NewBuilder(address.Undef).Build(t)
 	store := adt.AsStore(rt)
 	emptyArray, err := adt.StoreEmptyArray(store, bitwidth)
@@ -246,7 +247,7 @@ func emptyBitfieldQueueWithQuantizing(t *testing.T, quant miner.QuantSpec, bitwi
 }
 
 func emptyBitfieldQueue(t *testing.T, bitwidth int) miner.BitfieldQueue {
-	return emptyBitfieldQueueWithQuantizing(t, miner.NoQuantization, bitwidth)
+	return emptyBitfieldQueueWithQuantizing(t, builtin.NoQuantization, bitwidth)
 }
 
 type bqExpectation struct {

--- a/actors/builtin/miner/deadline_state_test.go
+++ b/actors/builtin/miner/deadline_state_test.go
@@ -36,7 +36,7 @@ func TestDeadlines(t *testing.T) {
 	allSectors := append(sectors, extraSectors...)
 
 	sectorSize := abi.SectorSize(32 << 30)
-	quantSpec := miner.NewQuantSpec(4, 1)
+	quantSpec := builtin.NewQuantSpec(4, 1)
 	partitionSize := uint64(4)
 
 	dlState := expectedDeadlineState{
@@ -907,7 +907,7 @@ func emptyDeadline(t *testing.T, store adt.Store) *miner.Deadline {
 // All methods take and the state by _value_ so one can (and should) construct a
 // sane base-state.
 type expectedDeadlineState struct {
-	quant         miner.QuantSpec
+	quant         builtin.QuantSpec
 	sectorSize    abi.SectorSize
 	partitionSize uint64
 	sectors       []*miner.SectorOnChainInfo
@@ -922,7 +922,7 @@ type expectedDeadlineState struct {
 }
 
 //nolint:unused
-func (s expectedDeadlineState) withQuantSpec(quant miner.QuantSpec) expectedDeadlineState {
+func (s expectedDeadlineState) withQuantSpec(quant builtin.QuantSpec) expectedDeadlineState {
 	s.quant = quant
 	return s
 }
@@ -991,7 +991,7 @@ func (s expectedDeadlineState) assert(t *testing.T, store adt.Store, dl *miner.D
 // recoveries, terminations, and partition/sector assignments.
 func checkDeadlineInvariants(
 	t *testing.T, store adt.Store, dl *miner.Deadline,
-	quant miner.QuantSpec, ssize abi.SectorSize,
+	quant builtin.QuantSpec, ssize abi.SectorSize,
 	sectors []*miner.SectorOnChainInfo,
 ) (
 	allSectors bitfield.BitField,

--- a/actors/builtin/miner/deadlines.go
+++ b/actors/builtin/miner/deadlines.go
@@ -7,6 +7,7 @@ import (
 	"github.com/filecoin-project/go-state-types/dline"
 	"golang.org/x/xerrors"
 
+	"github.com/filecoin-project/specs-actors/v5/actors/builtin"
 	"github.com/filecoin-project/specs-actors/v5/actors/util/adt"
 )
 
@@ -15,8 +16,8 @@ func NewDeadlineInfo(periodStart abi.ChainEpoch, deadlineIdx uint64, currEpoch a
 	return dline.NewInfo(periodStart, deadlineIdx, currEpoch, WPoStPeriodDeadlines, WPoStProvingPeriod, WPoStChallengeWindow, WPoStChallengeLookback, FaultDeclarationCutoff)
 }
 
-func QuantSpecForDeadline(di *dline.Info) QuantSpec {
-	return NewQuantSpec(WPoStProvingPeriod, di.Last())
+func QuantSpecForDeadline(di *dline.Info) builtin.QuantSpec {
+	return builtin.NewQuantSpec(WPoStProvingPeriod, di.Last())
 }
 
 // FindSector returns the deadline and partition index for a sector number.
@@ -99,7 +100,7 @@ func deadlineAvailableForCompaction(provingPeriodStart abi.ChainEpoch, dlIdx uin
 // the offset implied by the proving period. This works correctly even for the state
 // of a miner actor without an active deadline cron
 func NewDeadlineInfoFromOffsetAndEpoch(periodStartSeed abi.ChainEpoch, currEpoch abi.ChainEpoch) *dline.Info {
-	q := NewQuantSpec(WPoStProvingPeriod, periodStartSeed)
+	q := builtin.NewQuantSpec(WPoStProvingPeriod, periodStartSeed)
 	currentPeriodStart := q.QuantizeDown(currEpoch)
 	currentDeadlineIdx := uint64((currEpoch-currentPeriodStart)/WPoStChallengeWindow) % WPoStPeriodDeadlines
 	return NewDeadlineInfo(currentPeriodStart, currentDeadlineIdx, currEpoch)

--- a/actors/builtin/miner/expiration_queue.go
+++ b/actors/builtin/miner/expiration_queue.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ipfs/go-cid"
 	"golang.org/x/xerrors"
 
+	"github.com/filecoin-project/specs-actors/v5/actors/builtin"
 	"github.com/filecoin-project/specs-actors/v5/actors/util"
 	"github.com/filecoin-project/specs-actors/v5/actors/util/adt"
 )
@@ -151,7 +152,7 @@ func (es *ExpirationSet) ValidateState() error {
 // Keys in the queue are quantized (upwards), modulo some offset, to reduce the cardinality of keys.
 type ExpirationQueue struct {
 	*adt.Array
-	quant QuantSpec
+	quant builtin.QuantSpec
 }
 
 // An internal limit on the cardinality of a bitfield in a queue entry.
@@ -162,7 +163,7 @@ const entrySectorsMax = 10_000
 // Loads a queue root.
 // Epochs provided to subsequent method calls will be quantized upwards to quanta mod offsetSeed before being
 // written to/read from queue entries.
-func LoadExpirationQueue(store adt.Store, root cid.Cid, quant QuantSpec, bitwidth int) (ExpirationQueue, error) {
+func LoadExpirationQueue(store adt.Store, root cid.Cid, quant builtin.QuantSpec, bitwidth int) (ExpirationQueue, error) {
 	arr, err := adt.AsArray(store, root, bitwidth)
 	if err != nil {
 		return ExpirationQueue{}, xerrors.Errorf("failed to load epoch queue %v: %w", root, err)
@@ -718,7 +719,7 @@ type sectorExpirationSet struct {
 // sorted by expiration epoch, quantized.
 //
 // Note: While the result is sorted by epoch, the order of per-epoch sectors is maintained.
-func groupNewSectorsByDeclaredExpiration(sectorSize abi.SectorSize, sectors []*SectorOnChainInfo, quant QuantSpec) []sectorEpochSet {
+func groupNewSectorsByDeclaredExpiration(sectorSize abi.SectorSize, sectors []*SectorOnChainInfo, quant builtin.QuantSpec) []sectorEpochSet {
 	sectorsByExpiration := make(map[abi.ChainEpoch][]*SectorOnChainInfo)
 
 	for _, sector := range sectors {

--- a/actors/builtin/miner/expiration_queue_internal_test.go
+++ b/actors/builtin/miner/expiration_queue_internal_test.go
@@ -5,12 +5,13 @@ import (
 
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/specs-actors/v5/actors/builtin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestExpirations(t *testing.T) {
-	quant := QuantSpec{unit: 10, offset: 3}
+	quant := builtin.NewQuantSpec(10, 3)
 	sectors := []*SectorOnChainInfo{
 		testSector(7, 1, 0, 0, 0),
 		testSector(8, 2, 0, 0, 0),
@@ -37,7 +38,7 @@ func TestExpirations(t *testing.T) {
 
 func TestExpirationsEmpty(t *testing.T) {
 	sectors := []*SectorOnChainInfo{}
-	result := groupNewSectorsByDeclaredExpiration(2048, sectors, NoQuantization)
+	result := groupNewSectorsByDeclaredExpiration(2048, sectors, builtin.NoQuantization)
 	expected := []sectorEpochSet{}
 	require.Equal(t, expected, result)
 }

--- a/actors/builtin/miner/expiration_queue_test.go
+++ b/actors/builtin/miner/expiration_queue_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/filecoin-project/specs-actors/v5/actors/builtin"
 	"github.com/filecoin-project/specs-actors/v5/actors/builtin/miner"
 	"github.com/filecoin-project/specs-actors/v5/actors/util/adt"
 	"github.com/filecoin-project/specs-actors/v5/support/mock"
@@ -240,7 +241,7 @@ func TestExpirationQueue(t *testing.T) {
 	})
 
 	t.Run("quantizes added sectors by expiration", func(t *testing.T) {
-		queue := emptyExpirationQueueWithQuantizing(t, miner.NewQuantSpec(5, 3), testAmtBitwidth)
+		queue := emptyExpirationQueueWithQuantizing(t, builtin.NewQuantSpec(5, 3), testAmtBitwidth)
 		secNums, power, pledge, err := queue.AddActiveSectors(sectors, sectorSize)
 		require.NoError(t, err)
 		assertBitfieldEquals(t, secNums, 1, 2, 3, 4, 5, 6)
@@ -341,7 +342,7 @@ func TestExpirationQueue(t *testing.T) {
 
 	t.Run("reschedules sectors as faults", func(t *testing.T) {
 		// Create 3 expiration sets with 2 sectors apiece
-		queue := emptyExpirationQueueWithQuantizing(t, miner.NewQuantSpec(4, 1), testAmtBitwidth)
+		queue := emptyExpirationQueueWithQuantizing(t, builtin.NewQuantSpec(4, 1), testAmtBitwidth)
 		_, _, _, err := queue.AddActiveSectors(sectors, sectorSize)
 		require.NoError(t, err)
 
@@ -402,7 +403,7 @@ func TestExpirationQueue(t *testing.T) {
 
 	t.Run("reschedules all sectors as faults", func(t *testing.T) {
 		// Create expiration 3 sets with 2 sectors apiece
-		queue := emptyExpirationQueueWithQuantizing(t, miner.NewQuantSpec(4, 1), testAmtBitwidth)
+		queue := emptyExpirationQueueWithQuantizing(t, builtin.NewQuantSpec(4, 1), testAmtBitwidth)
 		_, _, _, err := queue.AddActiveSectors(sectors, sectorSize)
 		require.NoError(t, err)
 
@@ -463,7 +464,7 @@ func TestExpirationQueue(t *testing.T) {
 
 	t.Run("reschedule expirations then reschedule as fault", func(t *testing.T) {
 		// Create expiration 3 sets with 2 sectors apiece
-		queue := emptyExpirationQueueWithQuantizing(t, miner.NewQuantSpec(4, 1), testAmtBitwidth)
+		queue := emptyExpirationQueueWithQuantizing(t, builtin.NewQuantSpec(4, 1), testAmtBitwidth)
 		_, _, _, err := queue.AddActiveSectors(sectors, sectorSize)
 		require.NoError(t, err)
 
@@ -500,7 +501,7 @@ func TestExpirationQueue(t *testing.T) {
 
 	t.Run("reschedule recover restores all sector stats", func(t *testing.T) {
 		// Create expiration 3 sets with 2 sectors apiece
-		queue := emptyExpirationQueueWithQuantizing(t, miner.NewQuantSpec(4, 1), testAmtBitwidth)
+		queue := emptyExpirationQueueWithQuantizing(t, builtin.NewQuantSpec(4, 1), testAmtBitwidth)
 		_, _, _, err := queue.AddActiveSectors(sectors, sectorSize)
 		require.NoError(t, err)
 
@@ -565,7 +566,7 @@ func TestExpirationQueue(t *testing.T) {
 
 	t.Run("replaces sectors with new sectors", func(t *testing.T) {
 		// Create expiration 3 sets
-		queue := emptyExpirationQueueWithQuantizing(t, miner.NewQuantSpec(4, 1), testAmtBitwidth)
+		queue := emptyExpirationQueueWithQuantizing(t, builtin.NewQuantSpec(4, 1), testAmtBitwidth)
 
 		// add sectors to each set
 		_, _, _, err := queue.AddActiveSectors([]*miner.SectorOnChainInfo{sectors[0], sectors[1], sectors[3], sectors[5]}, sectorSize)
@@ -619,7 +620,7 @@ func TestExpirationQueue(t *testing.T) {
 
 	t.Run("removes sectors", func(t *testing.T) {
 		// add all sectors into 3 sets
-		queue := emptyExpirationQueueWithQuantizing(t, miner.NewQuantSpec(4, 1), testAmtBitwidth)
+		queue := emptyExpirationQueueWithQuantizing(t, builtin.NewQuantSpec(4, 1), testAmtBitwidth)
 		_, _, _, err := queue.AddActiveSectors(sectors, sectorSize)
 		require.NoError(t, err)
 
@@ -681,21 +682,21 @@ func TestExpirationQueue(t *testing.T) {
 	})
 
 	t.Run("adding no sectors leaves the queue empty", func(t *testing.T) {
-		queue := emptyExpirationQueueWithQuantizing(t, miner.NewQuantSpec(4, 1), testAmtBitwidth)
+		queue := emptyExpirationQueueWithQuantizing(t, builtin.NewQuantSpec(4, 1), testAmtBitwidth)
 		_, _, _, err := queue.AddActiveSectors(nil, sectorSize)
 		require.NoError(t, err)
 		assert.Zero(t, queue.Length())
 	})
 
 	t.Run("rescheduling no expirations leaves the queue empty", func(t *testing.T) {
-		queue := emptyExpirationQueueWithQuantizing(t, miner.NewQuantSpec(4, 1), testAmtBitwidth)
+		queue := emptyExpirationQueueWithQuantizing(t, builtin.NewQuantSpec(4, 1), testAmtBitwidth)
 		err := queue.RescheduleExpirations(10, nil, sectorSize)
 		require.NoError(t, err)
 		assert.Zero(t, queue.Length())
 	})
 
 	t.Run("rescheduling no expirations as faults leaves the queue empty", func(t *testing.T) {
-		queue := emptyExpirationQueueWithQuantizing(t, miner.NewQuantSpec(4, 1), testAmtBitwidth)
+		queue := emptyExpirationQueueWithQuantizing(t, builtin.NewQuantSpec(4, 1), testAmtBitwidth)
 
 		_, _, _, err := queue.AddActiveSectors(sectors, sectorSize)
 		require.NoError(t, err)
@@ -708,7 +709,7 @@ func TestExpirationQueue(t *testing.T) {
 	})
 
 	t.Run("rescheduling all expirations as faults leaves the queue empty if it was empty", func(t *testing.T) {
-		queue := emptyExpirationQueueWithQuantizing(t, miner.NewQuantSpec(4, 1), testAmtBitwidth)
+		queue := emptyExpirationQueueWithQuantizing(t, builtin.NewQuantSpec(4, 1), testAmtBitwidth)
 
 		_, _, _, err := queue.AddActiveSectors(sectors, sectorSize)
 		require.NoError(t, err)
@@ -721,7 +722,7 @@ func TestExpirationQueue(t *testing.T) {
 	})
 
 	t.Run("rescheduling no sectors as recovered leaves the queue empty", func(t *testing.T) {
-		queue := emptyExpirationQueueWithQuantizing(t, miner.NewQuantSpec(4, 1), testAmtBitwidth)
+		queue := emptyExpirationQueueWithQuantizing(t, builtin.NewQuantSpec(4, 1), testAmtBitwidth)
 		_, err := queue.RescheduleRecovered(nil, sectorSize)
 		require.NoError(t, err)
 		assert.Zero(t, queue.Length())
@@ -750,7 +751,7 @@ func requireNoExpirationGroupsBefore(t *testing.T, epoch abi.ChainEpoch, queue m
 	require.True(t, empty)
 }
 
-func emptyExpirationQueueWithQuantizing(t *testing.T, quant miner.QuantSpec, bitwidth int) miner.ExpirationQueue {
+func emptyExpirationQueueWithQuantizing(t *testing.T, quant builtin.QuantSpec, bitwidth int) miner.ExpirationQueue {
 	rt := mock.NewBuilder(address.Undef).Build(t)
 	store := adt.AsStore(rt)
 	emptyArray, err := adt.StoreEmptyArray(store, testAmtBitwidth)
@@ -762,5 +763,5 @@ func emptyExpirationQueueWithQuantizing(t *testing.T, quant miner.QuantSpec, bit
 }
 
 func emptyExpirationQueue(t *testing.T) miner.ExpirationQueue {
-	return emptyExpirationQueueWithQuantizing(t, miner.NoQuantization, testAmtBitwidth)
+	return emptyExpirationQueueWithQuantizing(t, builtin.NoQuantization, testAmtBitwidth)
 }

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -297,7 +297,7 @@ func (st *State) CurrentProvingPeriodStart(currEpoch abi.ChainEpoch) abi.ChainEp
 }
 
 // Returns deadline calculations for the current (according to state) proving period
-func (st *State) QuantSpecForDeadline(dlIdx uint64) QuantSpec {
+func (st *State) QuantSpecForDeadline(dlIdx uint64) builtin.QuantSpec {
 	return QuantSpecForDeadline(NewDeadlineInfo(st.ProvingPeriodStart, dlIdx, 0))
 }
 
@@ -1024,8 +1024,8 @@ func (st *State) IsDebtFree() bool {
 }
 
 // pre-commit clean up
-func (st *State) QuantSpecEveryDeadline() QuantSpec {
-	return NewQuantSpec(WPoStChallengeWindow, st.ProvingPeriodStart)
+func (st *State) QuantSpecEveryDeadline() builtin.QuantSpec {
+	return builtin.NewQuantSpec(WPoStChallengeWindow, st.ProvingPeriodStart)
 }
 
 func (st *State) AddPreCommitCleanUps(store adt.Store, cleanUpEvents map[abi.ChainEpoch][]uint64) error {

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -4214,7 +4214,7 @@ func TestApplyRewards(t *testing.T) {
 		require.Len(t, vestingFunds.Funds, 180)
 
 		// Vested FIL pays out on epochs with expected offset
-		quantSpec := miner.NewQuantSpec(miner.RewardVestingSpec.Quantization, periodOffset)
+		quantSpec := builtin.NewQuantSpec(miner.RewardVestingSpec.Quantization, periodOffset)
 
 		currEpoch := rt.Epoch()
 		for i := range vestingFunds.Funds {
@@ -4678,7 +4678,7 @@ func (h *actorHarness) collectSectors(rt *mock.Runtime) map[abi.SectorNumber]*mi
 }
 
 func (h *actorHarness) collectPrecommitExpirations(rt *mock.Runtime, st *miner.State) map[abi.ChainEpoch][]uint64 {
-	queue, err := miner.LoadBitfieldQueue(rt.AdtStore(), st.PreCommittedSectorsCleanUp, miner.NoQuantization, miner.PrecommitCleanUpAmtBitwidth)
+	queue, err := miner.LoadBitfieldQueue(rt.AdtStore(), st.PreCommittedSectorsCleanUp, builtin.NoQuantization, miner.PrecommitCleanUpAmtBitwidth)
 	require.NoError(h.t, err)
 	expirations := map[abi.ChainEpoch][]uint64{}
 	_ = queue.ForEach(func(epoch abi.ChainEpoch, bf bitfield.BitField) error {
@@ -4691,7 +4691,7 @@ func (h *actorHarness) collectPrecommitExpirations(rt *mock.Runtime, st *miner.S
 }
 
 func (h *actorHarness) collectDeadlineExpirations(rt *mock.Runtime, deadline *miner.Deadline) map[abi.ChainEpoch][]uint64 {
-	queue, err := miner.LoadBitfieldQueue(rt.AdtStore(), deadline.ExpirationsEpochs, miner.NoQuantization, miner.DeadlineExpirationAmtBitwidth)
+	queue, err := miner.LoadBitfieldQueue(rt.AdtStore(), deadline.ExpirationsEpochs, builtin.NoQuantization, miner.DeadlineExpirationAmtBitwidth)
 	require.NoError(h.t, err)
 	expirations := map[abi.ChainEpoch][]uint64{}
 	_ = queue.ForEach(func(epoch abi.ChainEpoch, bf bitfield.BitField) error {
@@ -4704,7 +4704,7 @@ func (h *actorHarness) collectDeadlineExpirations(rt *mock.Runtime, deadline *mi
 }
 
 func (h *actorHarness) collectPartitionExpirations(rt *mock.Runtime, partition *miner.Partition) map[abi.ChainEpoch]*miner.ExpirationSet {
-	queue, err := miner.LoadExpirationQueue(rt.AdtStore(), partition.ExpirationsEpochs, miner.NoQuantization, miner.PartitionExpirationAmtBitwidth)
+	queue, err := miner.LoadExpirationQueue(rt.AdtStore(), partition.ExpirationsEpochs, builtin.NoQuantization, miner.PartitionExpirationAmtBitwidth)
 	require.NoError(h.t, err)
 	expirations := map[abi.ChainEpoch]*miner.ExpirationSet{}
 	var es miner.ExpirationSet

--- a/actors/builtin/miner/partition_state_test.go
+++ b/actors/builtin/miner/partition_state_test.go
@@ -31,7 +31,7 @@ func TestPartitions(t *testing.T) {
 	}
 	sectorSize := abi.SectorSize(32 << 30)
 
-	quantSpec := miner.NewQuantSpec(4, 1)
+	quantSpec := builtin.NewQuantSpec(4, 1)
 
 	setupUnproven := func(t *testing.T) (adt.Store, *miner.Partition) {
 		store := ipld.NewADTStore(context.Background())
@@ -449,7 +449,7 @@ func TestPartitions(t *testing.T) {
 		})
 
 		// sectors should be added to early termination bitfield queue
-		queue, err := miner.LoadBitfieldQueue(store, partition.EarlyTerminated, miner.NoQuantization, miner.PartitionEarlyTerminationArrayAmtBitwidth)
+		queue, err := miner.LoadBitfieldQueue(store, partition.EarlyTerminated, builtin.NoQuantization, miner.PartitionEarlyTerminationArrayAmtBitwidth)
 		require.NoError(t, err)
 
 		ExpectBQ().
@@ -542,7 +542,7 @@ func TestPartitions(t *testing.T) {
 		})
 
 		// sectors should be added to early termination bitfield queue
-		queue, err := miner.LoadBitfieldQueue(store, partition.EarlyTerminated, miner.NoQuantization, miner.PartitionEarlyTerminationArrayAmtBitwidth)
+		queue, err := miner.LoadBitfieldQueue(store, partition.EarlyTerminated, builtin.NoQuantization, miner.PartitionEarlyTerminationArrayAmtBitwidth)
 		require.NoError(t, err)
 
 		// only early termination appears in bitfield queue
@@ -663,7 +663,7 @@ func TestPartitions(t *testing.T) {
 		assert.True(t, hasMore)
 
 		// expect terminations to still contain 3 and 5
-		queue, err := miner.LoadBitfieldQueue(store, partition.EarlyTerminated, miner.NoQuantization, miner.PartitionEarlyTerminationArrayAmtBitwidth)
+		queue, err := miner.LoadBitfieldQueue(store, partition.EarlyTerminated, builtin.NoQuantization, miner.PartitionEarlyTerminationArrayAmtBitwidth)
 		require.NoError(t, err)
 
 		// only early termination appears in bitfield queue
@@ -682,7 +682,7 @@ func TestPartitions(t *testing.T) {
 		assert.False(t, hasMore)
 
 		// expect early terminations to be empty
-		queue, err = miner.LoadBitfieldQueue(store, partition.EarlyTerminated, miner.NoQuantization, miner.PartitionEarlyTerminationArrayAmtBitwidth)
+		queue, err = miner.LoadBitfieldQueue(store, partition.EarlyTerminated, builtin.NoQuantization, miner.PartitionEarlyTerminationArrayAmtBitwidth)
 		require.NoError(t, err)
 		ExpectBQ().Equals(t, queue)
 	})
@@ -706,14 +706,14 @@ func TestPartitions(t *testing.T) {
 		}
 		sectorNos := bf(ids...)
 
-		power, err := partition.AddSectors(store, false, manySectors, sectorSize, miner.NoQuantization)
+		power, err := partition.AddSectors(store, false, manySectors, sectorSize, builtin.NoQuantization)
 		require.NoError(t, err)
 		expectedPower := miner.PowerForSectors(sectorSize, manySectors)
 		assert.True(t, expectedPower.Equals(power))
 
 		assertPartitionState(
 			t, store, partition,
-			miner.NoQuantization, sectorSize, manySectors,
+			builtin.NoQuantization, sectorSize, manySectors,
 			sectorNos, bf(), bf(), bf(), sectorNos,
 		)
 
@@ -728,7 +728,7 @@ func TestPartitions(t *testing.T) {
 
 		assertPartitionState(
 			t, store, &newPartition,
-			miner.NoQuantization, sectorSize, manySectors,
+			builtin.NoQuantization, sectorSize, manySectors,
 			sectorNos, bf(), bf(), bf(), sectorNos,
 		)
 
@@ -746,7 +746,7 @@ func TestRecordSkippedFaults(t *testing.T) {
 	}
 	sectorSize := abi.SectorSize(32 << 30)
 
-	quantSpec := miner.NewQuantSpec(4, 1)
+	quantSpec := builtin.NewQuantSpec(4, 1)
 	exp := abi.ChainEpoch(100)
 
 	setup := func(t *testing.T) (adt.Store, *miner.Partition) {
@@ -862,7 +862,7 @@ type expectExpirationGroup struct {
 	sectors    bitfield.BitField
 }
 
-func assertPartitionExpirationQueue(t *testing.T, store adt.Store, partition *miner.Partition, quant miner.QuantSpec, groups []expectExpirationGroup) {
+func assertPartitionExpirationQueue(t *testing.T, store adt.Store, partition *miner.Partition, quant builtin.QuantSpec, groups []expectExpirationGroup) {
 	queue, err := miner.LoadExpirationQueue(store, partition.ExpirationsEpochs, quant, miner.PartitionExpirationAmtBitwidth)
 	require.NoError(t, err)
 
@@ -881,7 +881,7 @@ func assertPartitionExpirationQueue(t *testing.T, store adt.Store, partition *mi
 func assertPartitionState(t *testing.T,
 	store adt.Store,
 	partition *miner.Partition,
-	quant miner.QuantSpec,
+	quant builtin.QuantSpec,
 	sectorSize abi.SectorSize,
 	sectors []*miner.SectorOnChainInfo,
 	allSectorIds bitfield.BitField,

--- a/actors/builtin/miner/testing.go
+++ b/actors/builtin/miner/testing.go
@@ -128,7 +128,7 @@ type DeadlineStateSummary struct {
 	FaultyPower       PowerPair
 }
 
-func CheckDeadlineStateInvariants(deadline *Deadline, store adt.Store, quant QuantSpec, ssize abi.SectorSize,
+func CheckDeadlineStateInvariants(deadline *Deadline, store adt.Store, quant builtin.QuantSpec, ssize abi.SectorSize,
 	sectors map[abi.SectorNumber]*SectorOnChainInfo, acc *builtin.MessageAccumulator) *DeadlineStateSummary {
 
 	// Load linked structures.
@@ -359,7 +359,7 @@ type PartitionStateSummary struct {
 func CheckPartitionStateInvariants(
 	partition *Partition,
 	store adt.Store,
-	quant QuantSpec,
+	quant builtin.QuantSpec,
 	sectorSize abi.SectorSize,
 	sectors map[abi.SectorNumber]*SectorOnChainInfo,
 	acc *builtin.MessageAccumulator,
@@ -485,7 +485,7 @@ func CheckPartitionStateInvariants(
 
 	// Validate the early termination queue.
 	earlyTerminationCount := 0
-	if earlyQ, err := LoadBitfieldQueue(store, partition.EarlyTerminated, NoQuantization, PartitionEarlyTerminationArrayAmtBitwidth); err != nil {
+	if earlyQ, err := LoadBitfieldQueue(store, partition.EarlyTerminated, builtin.NoQuantization, PartitionEarlyTerminationArrayAmtBitwidth); err != nil {
 		acc.Addf("error loading early termination queue: %v", err)
 	} else {
 		earlyTerminationCount = CheckEarlyTerminationQueue(earlyQ, partition.Terminated, acc)
@@ -518,7 +518,7 @@ type ExpirationQueueStateSummary struct {
 
 // Checks the expiration queue for consistency.
 func CheckExpirationQueue(expQ ExpirationQueue, liveSectors map[abi.SectorNumber]*SectorOnChainInfo,
-	partitionFaults bitfield.BitField, quant QuantSpec, sectorSize abi.SectorSize, acc *builtin.MessageAccumulator) *ExpirationQueueStateSummary {
+	partitionFaults bitfield.BitField, quant builtin.QuantSpec, sectorSize abi.SectorSize, acc *builtin.MessageAccumulator) *ExpirationQueueStateSummary {
 	partitionFaultsMap, err := partitionFaults.AllMap(1 << 30)
 	if err != nil {
 		acc.Addf("error loading partition faults map: %v", err)

--- a/actors/builtin/miner/vesting_state.go
+++ b/actors/builtin/miner/vesting_state.go
@@ -3,6 +3,8 @@ package miner
 import (
 	"sort"
 
+	"github.com/filecoin-project/specs-actors/v5/actors/builtin"
+
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 )
@@ -48,7 +50,7 @@ func (v *VestingFunds) addLockedFunds(currEpoch abi.ChainEpoch, vestingSum abi.T
 	vestPeriod := big.NewInt(int64(spec.VestPeriod))
 	vestedSoFar := big.Zero()
 	for e := vestBegin + spec.StepDuration; vestedSoFar.LessThan(vestingSum); e += spec.StepDuration {
-		vestEpoch := quantizeUp(e, spec.Quantization, provingPeriodStart)
+		vestEpoch := builtin.QuantizeUp(e, spec.Quantization, provingPeriodStart)
 		elapsed := vestEpoch - vestBegin
 
 		targetVest := big.Zero() //nolint:ineffassign

--- a/actors/builtin/quantize.go
+++ b/actors/builtin/quantize.go
@@ -1,4 +1,4 @@
-package miner
+package builtin
 
 import "github.com/filecoin-project/go-state-types/abi"
 
@@ -13,7 +13,7 @@ func NewQuantSpec(unit, offset abi.ChainEpoch) QuantSpec {
 }
 
 func (q QuantSpec) QuantizeUp(e abi.ChainEpoch) abi.ChainEpoch {
-	return quantizeUp(e, q.unit, q.offset)
+	return QuantizeUp(e, q.unit, q.offset)
 }
 
 func (q QuantSpec) QuantizeDown(e abi.ChainEpoch) abi.ChainEpoch {
@@ -32,7 +32,7 @@ var NoQuantization = NewQuantSpec(1, 0)
 // This function is equivalent to `unit * ceil(e - (offsetSeed % unit) / unit) + (offsetSeed % unit)`
 // with the variables/operations are over real numbers instead of ints.
 // Precondition: unit >= 0 else behaviour is undefined
-func quantizeUp(e abi.ChainEpoch, unit abi.ChainEpoch, offsetSeed abi.ChainEpoch) abi.ChainEpoch {
+func QuantizeUp(e abi.ChainEpoch, unit abi.ChainEpoch, offsetSeed abi.ChainEpoch) abi.ChainEpoch {
 	offset := offsetSeed % unit
 
 	remainder := (e - offset) % unit

--- a/actors/builtin/quantize_test.go
+++ b/actors/builtin/quantize_test.go
@@ -1,7 +1,9 @@
-package miner
+package builtin_test
 
 import (
 	"testing"
+
+	. "github.com/filecoin-project/specs-actors/v5/actors/builtin"
 
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/stretchr/testify/assert"
@@ -16,23 +18,23 @@ func TestQuantizeUp(t *testing.T) {
 		assert.Equal(t, abi.ChainEpoch(123456789), q.QuantizeUp(123456789))
 	})
 	t.Run("zero offset", func(t *testing.T) {
-		assert.Equal(t, abi.ChainEpoch(50), quantizeUp(42, 10, 0))
-		assert.Equal(t, abi.ChainEpoch(16000), quantizeUp(16000, 100, 0))
-		assert.Equal(t, abi.ChainEpoch(0), quantizeUp(-5, 10, 0))
-		assert.Equal(t, abi.ChainEpoch(-50), quantizeUp(-50, 10, 0))
-		assert.Equal(t, abi.ChainEpoch(-50), quantizeUp(-53, 10, 0))
+		assert.Equal(t, abi.ChainEpoch(50), QuantizeUp(42, 10, 0))
+		assert.Equal(t, abi.ChainEpoch(16000), QuantizeUp(16000, 100, 0))
+		assert.Equal(t, abi.ChainEpoch(0), QuantizeUp(-5, 10, 0))
+		assert.Equal(t, abi.ChainEpoch(-50), QuantizeUp(-50, 10, 0))
+		assert.Equal(t, abi.ChainEpoch(-50), QuantizeUp(-53, 10, 0))
 	})
 
 	t.Run("non zero offset", func(t *testing.T) {
-		assert.Equal(t, abi.ChainEpoch(6), quantizeUp(4, 5, 1))
-		assert.Equal(t, abi.ChainEpoch(1), quantizeUp(0, 5, 1))
-		assert.Equal(t, abi.ChainEpoch(-4), quantizeUp(-6, 5, 1))
-		assert.Equal(t, abi.ChainEpoch(4), quantizeUp(2, 10, 4))
+		assert.Equal(t, abi.ChainEpoch(6), QuantizeUp(4, 5, 1))
+		assert.Equal(t, abi.ChainEpoch(1), QuantizeUp(0, 5, 1))
+		assert.Equal(t, abi.ChainEpoch(-4), QuantizeUp(-6, 5, 1))
+		assert.Equal(t, abi.ChainEpoch(4), QuantizeUp(2, 10, 4))
 	})
 
 	t.Run("offset seed bigger than unit is normalized", func(t *testing.T) {
-		assert.Equal(t, abi.ChainEpoch(13), quantizeUp(9, 5, 28)) // offset should be 3
-		assert.Equal(t, abi.ChainEpoch(10000), quantizeUp(10000, 100, 2000000))
+		assert.Equal(t, abi.ChainEpoch(13), QuantizeUp(9, 5, 28)) // offset should be 3
+		assert.Equal(t, abi.ChainEpoch(10000), QuantizeUp(10000, 100, 2000000))
 	})
 }
 


### PR DESCRIPTION
Another fix for #1435.  This avoids the problem of increasing wait time between deal start and first processing by up to another day by choosing between next and current day based on offset.  It should remove all grinding possibilities because processing epoch is now assigned predictably but unbiasedly.

Tests still need to be fixed -- currently market tests everywhere assume the ability to set processing epoch which makes this a long fix