### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Reference
+# https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners
+
+# Global owners
+# Ensure maintainers team is a requested reviewer for non-draft PRs
+*                       @filecoin-project/actors-maintainers


### PR DESCRIPTION
Per updated CR policies for this repo, we want non-draft PRs to be assigned to the filecoin-project/actors-maintainers team.