### PR TITLE
Common types don't need cbor marshalling

### DIFF
--- a/gen/gen.go
+++ b/gen/gen.go
@@ -20,16 +20,6 @@ import (
 )
 
 func main() {
-	// Common types
-	//if err := gen.WriteTupleEncodersToFile("./actors/runtime/proof/cbor_gen.go", "proof",
-	//proof.SectorInfo{}, // Aliased from v0
-	//proof.SealVerifyInfo{}, // Aliased from v0
-	//proof.PoStProof{}, // Aliased from v0
-	//proof.WindowPoStVerifyInfo{}, // Aliased from v0
-	//proof.WinningPoStVerifyInfo{}, // Aliased from v0
-	//); err != nil {
-	//	panic(err)
-	//}
 
 	if err := gen.WriteTupleEncodersToFile("./actors/builtin/cbor_gen.go", "builtin",
 		builtin.MinerAddrs{},


### PR DESCRIPTION
@arajasek question for you: will lotus be sad if specs-actors does not generate cbor marshal/unmarshal methods for the common proof and syscall types?  I realized that we never added the new aggregate syscall types to cbor gen and everything worked fine.  This makes me think lotus doesn't care about these things doing cbor stuff in which case we should do this cleanup.