### PR TITLE
Divide once when calculating qa power

### DIFF
--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -242,7 +242,7 @@ func QualityForWeight(size abi.SectorSize, duration abi.ChainEpoch, dealWeight, 
 	scaledUpWeightedSumSpaceTime := big.Lsh(weightedSumSpaceTime, builtin.SectorQualityPrecision)
 
 	// Average of weighted space time: (scaledUpWeightedSumSpaceTime / sectorSpaceTime * 10)
-	return big.Div(big.Div(scaledUpWeightedSumSpaceTime, sectorSpaceTime), builtin.QualityBaseMultiplier)
+	return big.Div(scaledUpWeightedSumSpaceTime, big.Mul(builtin.QualityBaseMultiplier, sectorSpaceTime))
 }
 
 // The power for a sector size, committed duration, and weight.


### PR DESCRIPTION
Fixes #1250

This is already well tested in miner/policy_test.go `TestQuality`.  The high value of SectorQualityPrecision seems to have kept any error from creeping in to the computation, at least in test cases.