### PR TITLE
Defensive programming: harden power actor against seal verify failures

### DIFF
--- a/actors/builtin/power/power_actor.go
+++ b/actors/builtin/power/power_actor.go
@@ -404,7 +404,7 @@ func (a Actor) processBatchProofVerifies(rt Runtime, rewret reward.ThisEpochRewa
 		})
 		// Do not return immediately, all runs that get this far should wipe the ProofValidationBatchQueue.
 		// If we leave the validation batch then in the case of a repeating state error the queue
-		// will quickly fill up and repeated traversls will start ballooning cron execution time.
+		// will quickly fill up and repeated traversals will start ballooning cron execution time.
 		if err != nil {
 			stErr = xerrors.Errorf("failed to iterate proof batch: %w", err)
 		}

--- a/actors/builtin/power/power_test.go
+++ b/actors/builtin/power/power_test.go
@@ -1093,7 +1093,7 @@ func TestCronBatchProofVerifies(t *testing.T) {
 		ac.checkState(rt)
 	})
 
-	t.Run("fails if batch verify seals fails", func(t *testing.T) {
+	t.Run("cron tick does not fail if batch verify seals fails", func(t *testing.T) {
 		rt, ac := basicPowerSetup(t)
 		ac.createMinerBasic(rt, owner, owner, miner1)
 
@@ -1106,15 +1106,17 @@ func TestCronBatchProofVerifies(t *testing.T) {
 		rt.ExpectBatchVerifySeals(infos, batchVerifyDefaultOutput(infos), fmt.Errorf("fail"))
 		rt.ExpectValidateCallerAddr(builtin.CronActorAddr)
 
+		power := big.Zero()
+		//expect power sends to reward actor
+		rt.ExpectSend(builtin.RewardActorAddr, builtin.MethodsReward.UpdateNetworkKPI, &power, abi.NewTokenAmount(0), nil, 0)
 		rt.SetEpoch(abi.ChainEpoch(0))
 		rt.SetCaller(builtin.CronActorAddr, builtin.CronActorCodeID)
 
 		expectQueryNetworkInfo(rt, ac)
 
-		rt.ExpectAbort(exitcode.ErrIllegalState, func() {
-			rt.Call(ac.Actor.OnEpochTickEnd, nil)
-		})
+		rt.Call(ac.Actor.OnEpochTickEnd, nil)
 		rt.Verify()
+		ac.checkState(rt)
 	})
 }
 

--- a/actors/builtin/power/power_test.go
+++ b/actors/builtin/power/power_test.go
@@ -1103,6 +1103,7 @@ func TestCronBatchProofVerifies(t *testing.T) {
 
 		infos := map[addr.Address][]proof.SealVerifyInfo{miner1: {*info1, *info2, *info3}}
 
+		expectQueryNetworkInfo(rt, ac)
 		rt.ExpectBatchVerifySeals(infos, batchVerifyDefaultOutput(infos), fmt.Errorf("fail"))
 		rt.ExpectValidateCallerAddr(builtin.CronActorAddr)
 
@@ -1111,8 +1112,6 @@ func TestCronBatchProofVerifies(t *testing.T) {
 		rt.ExpectSend(builtin.RewardActorAddr, builtin.MethodsReward.UpdateNetworkKPI, &power, abi.NewTokenAmount(0), nil, 0)
 		rt.SetEpoch(abi.ChainEpoch(0))
 		rt.SetCaller(builtin.CronActorAddr, builtin.CronActorCodeID)
-
-		expectQueryNetworkInfo(rt, ac)
 
 		rt.Call(ac.Actor.OnEpochTickEnd, nil)
 		rt.Verify()


### PR DESCRIPTION
While aborts from processBatchProofVerifies are all believed to be the result of programmer error or individual validator system error aborting from this code presents unnecessary risk if this is wrong.  This PR changes these aborts to errors which are then logged and ignored from top level power cron.

The impact is that now in case of programmer error a batch of seal proofs will fail to validate and propagate power to storage providers instead of aborting power cron and either halting the chain or taking out 1/60th of sps from deadline cron.

In the worst case where programmer error is global all prove commits (not prove commit aggregates) would be dropped until programmer error fixed.  In a more plausible state where programmer error is related to contents of the validation batch prove commits for one epoch would be dropped and then processing would continue as normal.

Reiterating that programmer error is not expected to exist but now defense against it is better.