### PR TITLE
Adding MustGet method to adt.Array in order to simplify code

### DIFF
--- a/actors/builtin/miner/bitfield_queue.go
+++ b/actors/builtin/miner/bitfield_queue.go
@@ -38,6 +38,7 @@ func (q BitfieldQueue) AddToQueue(rawEpoch abi.ChainEpoch, values bitfield.BitFi
 	}
 	epoch := q.quant.QuantizeUp(rawEpoch)
 	var bf bitfield.BitField
+	// is this a bug?
 	if _, err := q.Array.Get(uint64(epoch), &bf); err != nil {
 		return xerrors.Errorf("failed to lookup queue epoch %v: %w", epoch, err)
 	}

--- a/actors/builtin/miner/deadline_state.go
+++ b/actors/builtin/miner/deadline_state.go
@@ -295,10 +295,8 @@ func (dl *Deadline) PopExpiredSectors(store adt.Store, until abi.ChainEpoch, qua
 	// For each partition with an expiry, remove and collect expirations from the partition queue.
 	if err = expiredPartitions.ForEach(func(partIdx uint64) error {
 		var partition Partition
-		if found, err := partitions.Get(partIdx, &partition); err != nil {
-			return err
-		} else if !found {
-			return xerrors.Errorf("missing expected partition %d", partIdx)
+		if err := partitions.MustGet(partIdx, &partition); err != nil {
+			return xerrors.Errorf("failed to lookup partition %d: %w", partIdx, err)
 		}
 
 		partExpiration, err := partition.PopExpiredSectors(store, until, quant)
@@ -897,12 +895,8 @@ func (dl *Deadline) ProcessDeadlineEnd(store adt.Store, quant builtin.QuantSpec,
 		}
 
 		var partition Partition
-		found, err := partitions.Get(partIdx, &partition)
-		if err != nil {
-			return powerDelta, penalizedPower, xerrors.Errorf("failed to load partition %d: %w", partIdx, err)
-		}
-		if !found {
-			return powerDelta, penalizedPower, xerrors.Errorf("no partition %d", partIdx)
+		if err := partitions.MustGet(partIdx, &partition); err != nil {
+			return powerDelta, penalizedPower, xerrors.Errorf("failed to lookup partition %d: %w", partIdx, err)
 		}
 
 		// If we have no recovering power/sectors, and all power is faulty, skip
@@ -1243,10 +1237,8 @@ func (dl *Deadline) LoadPartitionsForDispute(store adt.Store, partitions bitfiel
 	disputedPower := NewPowerPairZero()
 	err = partitions.ForEach(func(partIdx uint64) error {
 		var partitionSnapshot Partition
-		if found, err := partitionsSnapshot.Get(partIdx, &partitionSnapshot); err != nil {
-			return err
-		} else if !found {
-			return xerrors.Errorf("failed to find partition %d", partIdx)
+		if err := partitionsSnapshot.MustGet(partIdx, &partitionSnapshot); err != nil {
+			return xerrors.Errorf("failed to lookup partition %d: %w", partIdx, err)
 		}
 
 		// Record sectors for proof verification

--- a/actors/builtin/miner/deadline_state_test.go
+++ b/actors/builtin/miner/deadline_state_test.go
@@ -980,9 +980,8 @@ func (s expectedDeadlineState) assert(t *testing.T, store adt.Store, dl *miner.D
 	require.Equal(t, uint64(len(s.partitionSectors)), partitions.Length(), "unexpected number of partitions")
 	for i, partSectors := range s.partitionSectors {
 		var partition miner.Partition
-		found, err := partitions.Get(uint64(i), &partition)
+		err := partitions.MustGet(uint64(i), &partition)
 		require.NoError(t, err)
-		require.True(t, found)
 		assertBitfieldsEqual(t, partSectors, partition.Sectors)
 	}
 }

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -578,8 +578,7 @@ func TestCCUpgrade(t *testing.T) {
 			partitions, err := deadline.PartitionsArray(rt.AdtStore())
 			require.NoError(t, err)
 			var partition miner.Partition
-			found, err := partitions.Get(partIdx, &partition)
-			require.True(t, found)
+			err = partitions.MustGet(partIdx, &partition)
 			require.NoError(t, err)
 			sectorArr, err := miner.LoadSectors(rt.AdtStore(), st.Sectors)
 			require.NoError(t, err)
@@ -614,8 +613,7 @@ func TestCCUpgrade(t *testing.T) {
 			partitions, err := deadline.PartitionsArray(rt.AdtStore())
 			require.NoError(t, err)
 			var partition miner.Partition
-			found, err := partitions.Get(partIdx, &partition)
-			require.True(t, found)
+			err = partitions.MustGet(partIdx, &partition)
 			require.NoError(t, err)
 			sectorArr, err := miner.LoadSectors(rt.AdtStore(), st.Sectors)
 			require.NoError(t, err)
@@ -1277,9 +1275,8 @@ func TestWindowPost(t *testing.T) {
 		require.NoError(t, err)
 		require.EqualValues(t, posts.Length(), 1)
 		var post miner.WindowedPoSt
-		found, err := posts.Get(0, &post)
+		err = posts.MustGet(0, &post)
 		require.NoError(t, err)
-		require.True(t, found)
 		assertBitfieldEquals(t, post.Partitions, pIdx)
 
 		// Advance to end-of-deadline cron to verify no penalties.
@@ -4638,9 +4635,8 @@ func (h *actorHarness) getSubmittedProof(rt *mock.Runtime, deadline *miner.Deadl
 	proofs, err := adt.AsArray(rt.AdtStore(), deadline.OptimisticPoStSubmissionsSnapshot, miner.DeadlineOptimisticPoStSubmissionsAmtBitwidth)
 	require.NoError(h.t, err)
 	var post miner.WindowedPoSt
-	found, err := proofs.Get(idx, &post)
+	err = proofs.MustGet(idx, &post)
 	require.NoError(h.t, err)
-	require.True(h.t, found)
 	return &post
 }
 

--- a/actors/builtin/paych/paych_test.go
+++ b/actors/builtin/paych/paych_test.go
@@ -273,8 +273,7 @@ func TestPaymentChannelActor_CreateLane(t *testing.T) {
 				assert.Equal(t, uint64(1), lstates.Length())
 
 				var ls LaneState
-				found, err := lstates.Get(sv.Lane, &ls)
-				assert.True(t, found)
+				err = lstates.MustGet(sv.Lane, &ls)
 				assert.NoError(t, err)
 
 				assert.Equal(t, sv.Amount, ls.Redeemed)
@@ -319,9 +318,8 @@ func getLaneState(t *testing.T, rt *mock.Runtime, rcid cid.Cid, lane uint64) *La
 	assert.NoError(t, err)
 
 	var out LaneState
-	found, err := arr.Get(lane, &out)
+	err = arr.MustGet(lane, &out)
 	assert.NoError(t, err)
-	assert.True(t, found)
 
 	return &out
 }

--- a/actors/builtin/power/power_test.go
+++ b/actors/builtin/power/power_test.go
@@ -823,9 +823,8 @@ func TestSubmitPoRepForBulkVerify(t *testing.T) {
 		require.True(t, found)
 		assert.Equal(t, uint64(1), arr.Length())
 		var storedSealInfo proof.SealVerifyInfo
-		found, err = arr.Get(0, &storedSealInfo)
+		err = arr.MustGet(0, &storedSealInfo)
 		require.NoError(t, err)
-		require.True(t, found)
 		assert.Equal(t, commR, storedSealInfo.SealedCID)
 		actor.checkState(rt)
 	})

--- a/actors/util/adt/array.go
+++ b/actors/util/adt/array.go
@@ -134,6 +134,17 @@ func (a *Array) Get(k uint64, out cbor.Unmarshaler) (bool, error) {
 	}
 }
 
+// MustGet retrieves array element into the 'out' unmarshaler, returning an error if it 
+//  failed to get the element or if it did not find the element in the array.
+func (a *Array) MustGet(k uint64, out cbor.Unmarshaler) error {
+	if found, err := a.root.Get(a.store.Context(), k, out); err != nil {
+		return xerrors.Errorf("failed to get index %v in root %v: %w", k, a.root, err)
+	} else if !found{
+		return xerrors.Errorf("did not find index %v in root %v.", k, a.root)
+	}
+	return nil
+}
+
 // Retrieves an array value into the 'out' unmarshaler (if non-nil), and removes the entry.
 // Returns a boolean indicating whether the element was previously in the array.
 func (a *Array) Pop(k uint64, out cbor.Unmarshaler) (bool, error) {

--- a/actors/util/adt/array.go
+++ b/actors/util/adt/array.go
@@ -128,19 +128,19 @@ func (a *Array) Length() uint64 {
 //  indicating whether the element was found in the array
 func (a *Array) Get(k uint64, out cbor.Unmarshaler) (bool, error) {
 	if found, err := a.root.Get(a.store.Context(), k, out); err != nil {
-		return false, xerrors.Errorf("failed to get index %v in root %v: %w", k, a.root, err)
+		return false, xerrors.Errorf("failed to get index %d in root %v: %w", k, a.root, err)
 	} else {
 		return found, nil
 	}
 }
 
-// MustGet retrieves array element into the 'out' unmarshaler, returning an error if it 
+// MustGet retrieves array element into the 'out' unmarshaler, returning an error if it
 //  failed to get the element or if it did not find the element in the array.
 func (a *Array) MustGet(k uint64, out cbor.Unmarshaler) error {
 	if found, err := a.root.Get(a.store.Context(), k, out); err != nil {
-		return xerrors.Errorf("failed to get index %v in root %v: %w", k, a.root, err)
-	} else if !found{
-		return xerrors.Errorf("did not find index %v in root %v.", k, a.root)
+		return xerrors.Errorf("failed to get index %d in root %v: %w", k, a.root, err)
+	} else if !found {
+		return xerrors.Errorf("did not find index %d in root %v.", k, a.root)
 	}
 	return nil
 }


### PR DESCRIPTION
#677 
Add a mustget function so that we don’t have to do things like say `if err != nil {error out} if !found {error out}`

This is a draft because i want to work the new pattern into the code in at least a few places before we merge it :)