### PR TITLE
Change miner cron event types to not just be raw bytes.

### DIFF
--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -5854,7 +5854,7 @@ func (h *actorHarness) onDeadlineCron(rt *mock.Runtime, config *cronConfig) {
 
 	rt.SetCaller(builtin.StoragePowerActorAddr, builtin.StoragePowerActorCodeID)
 	rt.Call(h.a.OnDeferredCronEvent, &miner.CronEventPayload{
-		EventType: miner.CronEventProvingDeadline,
+		EventType: builtin.CronEventProvingDeadline,
 	})
 	rt.Verify()
 }
@@ -6138,14 +6138,14 @@ func getState(rt *mock.Runtime) *miner.State {
 }
 
 func makeDeadlineCronEventParams(t testing.TB, epoch abi.ChainEpoch) *power.EnrollCronEventParams {
-	eventPayload := miner.CronEventPayload{EventType: miner.CronEventProvingDeadline}
+	eventPayload := miner.CronEventPayload{EventType: builtin.CronEventProvingDeadline}
 	buf := bytes.Buffer{}
 	err := eventPayload.MarshalCBOR(&buf)
 	require.NoError(t, err)
 
 	params := &power.EnrollCronEventParams{
-		EventEpoch: epoch,
-		Payload:    buf.Bytes(),
+		EventEpoch:   epoch,
+		EventPayload: eventPayload,
 	}
 	return params
 }

--- a/actors/builtin/power/power_state.go
+++ b/actors/builtin/power/power_state.go
@@ -8,13 +8,12 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/exitcode"
-	cid "github.com/ipfs/go-cid"
-	errors "github.com/pkg/errors"
-	"golang.org/x/xerrors"
-
 	"github.com/filecoin-project/specs-actors/v6/actors/builtin"
 	"github.com/filecoin-project/specs-actors/v6/actors/util/adt"
 	"github.com/filecoin-project/specs-actors/v6/actors/util/smoothing"
+	cid "github.com/ipfs/go-cid"
+	errors "github.com/pkg/errors"
+	"golang.org/x/xerrors"
 )
 
 // genesis power in bytes = 750,000 GiB
@@ -80,8 +79,8 @@ type Claim struct {
 }
 
 type CronEvent struct {
-	MinerAddr       addr.Address
-	CallbackPayload []byte
+	MinerAddr    addr.Address
+	EventPayload builtin.CronEventPayload
 }
 
 func ConstructState(store adt.Store) (*State, error) {

--- a/actors/builtin/power/testing.go
+++ b/actors/builtin/power/testing.go
@@ -11,8 +11,8 @@ import (
 )
 
 type MinerCronEvent struct {
-	Epoch   abi.ChainEpoch
-	Payload []byte
+	Epoch       abi.ChainEpoch
+	CronPayload builtin.CronEventPayload
 }
 
 type CronEventsByAddress map[address.Address][]MinerCronEvent
@@ -77,8 +77,8 @@ func CheckCronInvariants(st *State, store adt.Store, acc *builtin.MessageAccumul
 		var event CronEvent
 		return arr.ForEach(&event, func(i int64) error {
 			byAddress[event.MinerAddr] = append(byAddress[event.MinerAddr], MinerCronEvent{
-				Epoch:   abi.ChainEpoch(epoch),
-				Payload: event.CallbackPayload,
+				Epoch:       abi.ChainEpoch(epoch),
+				CronPayload: event.EventPayload,
 			})
 
 			return nil

--- a/actors/builtin/shared.go
+++ b/actors/builtin/shared.go
@@ -21,6 +21,20 @@ import (
 // This value has been empirically chosen, but the optimal value for maps with different mutation profiles may differ.
 const DefaultHamtBitwidth = 5
 
+//type CronEventPayload struct {
+//	EventType CronEventType
+//}
+type CronEventPayload struct {
+	EventType CronEventType
+}
+
+type CronEventType = int64
+
+const (
+	CronEventProvingDeadline          CronEventType = 1
+	CronEventProcessEarlyTerminations CronEventType = 2
+)
+
 type BigFrac struct {
 	Numerator   big.Int
 	Denominator big.Int

--- a/actors/states/check.go
+++ b/actors/states/check.go
@@ -1,8 +1,6 @@
 package states
 
 import (
-	"bytes"
-
 	addr "github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
@@ -179,13 +177,14 @@ func CheckMinersAgainstPower(acc *builtin.MessageAccumulator, minerSummaries map
 		var payload miner.CronEventPayload
 		var provingPeriodCron *power.MinerCronEvent
 		for _, event := range crons {
-			err := payload.UnmarshalCBOR(bytes.NewReader(event.Payload))
-			acc.Require(err == nil, "miner %v registered cron at epoch %d with wrong or corrupt payload",
-				addr, event.Epoch)
-			acc.Require(payload.EventType == miner.CronEventProcessEarlyTerminations || payload.EventType == miner.CronEventProvingDeadline,
+			// this should be impossible now- types are constrained.
+			// err := payload.UnmarshalCBOR(bytes.NewReader(event.CronPayload))
+			// acc.Require(err == nil, "miner %v registered cron at epoch %d with wrong or corrupt payload",
+			// 	addr, event.Epoch)
+			acc.Require(payload.EventType == builtin.CronEventProcessEarlyTerminations || payload.EventType == builtin.CronEventProvingDeadline,
 				"miner %v has unexpected cron event type %v", addr, payload.EventType)
 
-			if payload.EventType == miner.CronEventProvingDeadline {
+			if payload.EventType == builtin.CronEventProvingDeadline {
 				if provingPeriodCron != nil {
 					acc.Require(false, "miner %v has duplicate proving period crons at epoch %d and %d",
 						addr, provingPeriodCron.Epoch, event.Epoch)

--- a/actors/test/power_scenario_test.go
+++ b/actors/test/power_scenario_test.go
@@ -145,7 +145,7 @@ func TestCronTick(t *testing.T) {
 				Method: builtin.MethodsMiner.OnDeferredCronEvent,
 				From:   builtin.StoragePowerActorAddr,
 				Value:  vm.ExpectAttoFil(big.Zero()),
-				Params: vm.ExpectBytes(cronConfig.Payload),
+				Params: vm.ExpectObject(cronConfig.EventPayload),
 			},
 			{
 				// expect call to reward to update kpi


### PR DESCRIPTION
This will constrain payloads more than just being bytes. Future cron event types can extend the types I wrote here eventually. Broken with CBOR-gen issues, I don't know why those confuse me so much still.