### PR TITLE
Suppress echoing of command when comparing test vector digest.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ determinism-check:
 	SPECS_ACTORS_DETERMINISM="$(TEST_VECTOR_PATH)/determinism" $(GO_BIN) test ./actors/test -count=1
 	$(GO_BIN) build ./test-vectors/tools/digest
 
-	if [ "`./digest ./test-vectors/determinism`" != "`cat ./test-vectors/determinism-check`" ]; then \
+	@if [ "`./digest ./test-vectors/determinism`" != "`cat ./test-vectors/determinism-check`" ]; then \
 		echo "test-vectors don't match expected";\
 		exit 1;\
 	fi


### PR DESCRIPTION
The echoing of the 'if' block can be confusing because the body contains 'exit 1', which looks like a failure, even though the exit is not executed.

Clean build output now looks like:
```
go test -race ./actors/migration/nv15/test
ok  	github.com/filecoin-project/specs-actors/v7/actors/migration/nv15/test	(cached)
go mod tidy
rm -rf test-vectors/determinism
SPECS_ACTORS_DETERMINISM="../../test-vectors/determinism" go test ./actors/test -count=1
ok  	github.com/filecoin-project/specs-actors/v7/actors/test	110.041s
go build ./test-vectors/tools/digest
```