### PR TITLE
Prototype implementation of FIL+ explicity subsidy

### DIFF
--- a/actors/builtin/cbor_gen.go
+++ b/actors/builtin/cbor_gen.go
@@ -158,8 +158,8 @@ func (t *ConfirmSectorProofsParams) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.QualityAdjPowerSmoothed (smoothing.FilterEstimate) (struct)
-	if err := t.QualityAdjPowerSmoothed.MarshalCBOR(w); err != nil {
+	// t.RawBytePowerSmoothed (smoothing.FilterEstimate) (struct)
+	if err := t.RawBytePowerSmoothed.MarshalCBOR(w); err != nil {
 		return err
 	}
 	return nil
@@ -234,12 +234,12 @@ func (t *ConfirmSectorProofsParams) UnmarshalCBOR(r io.Reader) error {
 		}
 
 	}
-	// t.QualityAdjPowerSmoothed (smoothing.FilterEstimate) (struct)
+	// t.RawBytePowerSmoothed (smoothing.FilterEstimate) (struct)
 
 	{
 
-		if err := t.QualityAdjPowerSmoothed.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.QualityAdjPowerSmoothed: %w", err)
+		if err := t.RawBytePowerSmoothed.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.RawBytePowerSmoothed: %w", err)
 		}
 
 	}
@@ -277,8 +277,8 @@ func (t *DeferredCronEventParams) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.QualityAdjPowerSmoothed (smoothing.FilterEstimate) (struct)
-	if err := t.QualityAdjPowerSmoothed.MarshalCBOR(w); err != nil {
+	// t.RawBytePowerSmoothed (smoothing.FilterEstimate) (struct)
+	if err := t.RawBytePowerSmoothed.MarshalCBOR(w); err != nil {
 		return err
 	}
 	return nil
@@ -332,12 +332,12 @@ func (t *DeferredCronEventParams) UnmarshalCBOR(r io.Reader) error {
 		}
 
 	}
-	// t.QualityAdjPowerSmoothed (smoothing.FilterEstimate) (struct)
+	// t.RawBytePowerSmoothed (smoothing.FilterEstimate) (struct)
 
 	{
 
-		if err := t.QualityAdjPowerSmoothed.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.QualityAdjPowerSmoothed: %w", err)
+		if err := t.RawBytePowerSmoothed.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.RawBytePowerSmoothed: %w", err)
 		}
 
 	}

--- a/actors/builtin/market/market_actor.go
+++ b/actors/builtin/market/market_actor.go
@@ -889,5 +889,5 @@ func requestCurrentNetworkPower(rt Runtime) (rawPower, qaPower abi.StoragePower)
 	var pwr power.CurrentTotalPowerReturn
 	code := rt.Send(builtin.StoragePowerActorAddr, builtin.MethodsPower.CurrentTotalPower, nil, big.Zero(), &pwr)
 	builtin.RequireSuccess(rt, code, "failed to check current power")
-	return pwr.RawBytePower, pwr.QualityAdjPower
+	return pwr.RawBytePower, big.Zero()
 }

--- a/actors/builtin/market/types.go
+++ b/actors/builtin/market/types.go
@@ -1,11 +1,18 @@
 package market
 
 import (
+	"io"
+
+	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
 	. "github.com/filecoin-project/specs-actors/v8/actors/util/adt"
+	"golang.org/x/xerrors"
 
 	"github.com/ipfs/go-cid"
 )
+
+///// Deal proposal array /////
 
 // A specialization of a array to deals.
 // It is an error to query for a key that doesn't exist.
@@ -41,6 +48,8 @@ func (t *DealArray) Set(k abi.DealID, value *DealProposal) error {
 func (t *DealArray) Delete(id abi.DealID) error {
 	return t.Array.Delete(uint64(id))
 }
+
+///// Deal state array /////
 
 // A specialization of a array to deals.
 // It is an error to query for a key that doesn't exist.
@@ -92,4 +101,177 @@ func (t *DealMetaArray) Set(k abi.DealID, value *DealState) error {
 
 func (t *DealMetaArray) Delete(id abi.DealID) error {
 	return t.Array.Delete(uint64(id))
+}
+
+///// Provider verified claims map /////
+
+// A specialization of a map to provider verified claims.
+// It is an error to query for a key that doesn't exist.
+type ProviderVerifiedClaims struct {
+	*Map
+}
+
+type ProviderVerifiedClaim struct {
+	// The epoch until which rewards were last processed for the provider.
+	LastClaimEpoch abi.ChainEpoch
+	// The provider's active verified deal space at the end of LastClaimEpoch.
+	VerifiedDealSpace abi.StoragePower
+	// Events since LastClaimEpoch, keyed by epoch.
+	DeltaQueue cid.Cid // AMT[epoch]big.Int
+}
+
+// Interprets a store as a provider verified claims map with root `r`.
+func AsProviderVerifiedClaims(s Store, r cid.Cid) (*ProviderVerifiedClaims, error) {
+	pvc, err := AsMap(s, r, ProviderVerifiedClaimsHamtBitwidth)
+	if err != nil {
+		return nil, err
+	}
+	return &ProviderVerifiedClaims{pvc}, nil
+}
+
+func (pvc *ProviderVerifiedClaims) Add(s Store, provider address.Address, epoch abi.ChainEpoch, size abi.StoragePower) error {
+	var providerClaim ProviderVerifiedClaim
+	if found, err := pvc.Get(abi.AddrKey(provider), &providerClaim); err != nil {
+		return err
+	} else if !found {
+		return xerrors.Errorf("no verified claim entry for %v", provider)
+	}
+	deltaQueue, err := AsStoragePowerDeltaQueue(s, providerClaim.DeltaQueue)
+	if err != nil {
+		return err
+	}
+
+	if err = deltaQueue.Add(epoch, size); err != nil {
+		return err
+	}
+	if providerClaim.DeltaQueue, err = deltaQueue.Root(); err != nil {
+		return err
+	}
+	if err = pvc.Put(abi.AddrKey(provider), &providerClaim); err != nil {
+		return err
+	}
+	return nil
+}
+
+///// Provider event queue array /////
+
+// A provider event queue is an ordered collection of events keyed by epoch, implemented as an AMT with
+// array values (supporting multiple events at one epoch).
+// An array value will be efficient while the number of events per epoch is small, or written in batch.
+type ProviderEventQueue struct {
+	*Array
+}
+
+//type ProviderEventQueueEntry struct {
+//	Events []VerifiedDealEvent
+//}
+//
+//type VerifiedDealEvent struct {
+//	EventType     VerifiedDealEventType
+//	VerifiedSpace abi.StoragePower
+//}
+//
+//// Interprets a store as a provider event queue with root `r`.
+//func AsProviderEventQueue(s Store, r cid.Cid) (*ProviderEventQueue, error) {
+//	array, err := AsArray(s, r, ProviderEventQueueAmtBitwidth)
+//	if err != nil {
+//		return nil, err
+//	}
+//	return &ProviderEventQueue{array}, nil
+//}
+//
+//func (q *ProviderEventQueue) Enqueue(epoch abi.ChainEpoch, eventType VerifiedDealEventType, size abi.StoragePower) error {
+//	var queueEntry ProviderEventQueueEntry
+//	_, err := q.Get(uint64(epoch), &queueEntry)
+//	if err != nil {
+//		return err
+//	}
+//
+//	queueEntry.Events = append(queueEntry.Events, VerifiedDealEvent{
+//		EventType:     eventType,
+//		VerifiedSpace: size,
+//	})
+//
+//	if err := q.Set(uint64(epoch), &queueEntry); err != nil {
+//		return err
+//	}
+//	return nil
+//}
+
+///// Storage power delta queue array /////
+
+type StoragePowerDeltaQueue struct {
+	*Array
+}
+
+// Interprets a store as a queue with root `r`.
+func AsStoragePowerDeltaQueue(s Store, r cid.Cid) (*StoragePowerDeltaQueue, error) {
+	array, err := AsArray(s, r, StoragePowerDeltaQueueAmtBitwidth)
+	if err != nil {
+		return nil, err
+	}
+	return &StoragePowerDeltaQueue{array}, nil
+}
+
+// Adds `size` to the entry at `epoch`. The entry is taken to be zero if absent.
+func (q *StoragePowerDeltaQueue) Add(epoch abi.ChainEpoch, size abi.StoragePower) error {
+	queueEntry := big.Zero()
+	_, err := q.Get(uint64(epoch), &queueEntry)
+	if err != nil {
+		return err
+	}
+
+	queueEntry = big.Add(queueEntry, size)
+
+	if err := q.Set(uint64(epoch), &queueEntry); err != nil {
+		return err
+	}
+	return nil
+}
+
+///// Verified reward history array ///
+
+type VerifiedRewardHistory struct {
+	*Array
+}
+
+type VerifiedRewardHistoryEntry struct {
+	TotalVerifiedSpace abi.StoragePower
+	TotalReward        abi.TokenAmount
+}
+
+func AsVerifiedRewardHistory(s Store, r cid.Cid) (*VerifiedRewardHistory, error) {
+	array, err := AsArray(s, r, VerifiedRewardsHistoryAmtBitwidth)
+	if err != nil {
+		return nil, err
+	}
+	return &VerifiedRewardHistory{array}, nil
+}
+
+func (a *VerifiedRewardHistory) Set(epoch abi.ChainEpoch, totalVerifiedSpace abi.StoragePower, totalReward abi.TokenAmount) error {
+	value := VerifiedRewardHistoryEntry{
+		TotalVerifiedSpace: totalVerifiedSpace,
+		TotalReward:        totalReward,
+	}
+	return a.Array.Set(uint64(epoch), &value)
+}
+
+//func (p ProviderEventQueueEntry) MarshalCBOR(w io.Writer) error {
+//	panic("implement me") // FIXME
+//}
+//
+//func (p ProviderEventQueueEntry) UnmarshalCBOR(r io.Reader) error {
+//	panic("implement me") // FIXME
+//}
+
+func (p ProviderVerifiedClaim) UnmarshalCBOR(r io.Reader) error {
+	panic("implement me") // FIXME
+}
+
+func (p ProviderVerifiedClaim) MarshalCBOR(w io.Writer) error {
+	panic("implement me") // FIXME
+}
+
+func (v VerifiedRewardHistoryEntry) MarshalCBOR(w io.Writer) error {
+	panic("implement me") // FIXME
 }

--- a/actors/builtin/methods.go
+++ b/actors/builtin/methods.go
@@ -26,11 +26,12 @@ var MethodsCron = struct {
 }{MethodConstructor, 2}
 
 var MethodsReward = struct {
-	Constructor      abi.MethodNum
-	AwardBlockReward abi.MethodNum
-	ThisEpochReward  abi.MethodNum
-	UpdateNetworkKPI abi.MethodNum
-}{MethodConstructor, 2, 3, 4}
+	Constructor             abi.MethodNum
+	AwardBlockReward        abi.MethodNum
+	ThisEpochReward         abi.MethodNum
+	UpdateNetworkKPI        abi.MethodNum
+	ClaimVerifiedDealReward abi.MethodNum
+}{MethodConstructor, 2, 3, 4, 5}
 
 var MethodsMultisig = struct {
 	Constructor                 abi.MethodNum
@@ -52,15 +53,15 @@ var MethodsPaych = struct {
 }{MethodConstructor, 2, 3, 4}
 
 var MethodsMarket = struct {
-	Constructor              abi.MethodNum
-	AddBalance               abi.MethodNum
-	WithdrawBalance          abi.MethodNum
-	PublishStorageDeals      abi.MethodNum
-	VerifyDealsForActivation abi.MethodNum
-	ActivateDeals            abi.MethodNum
-	OnMinerSectorsTerminate  abi.MethodNum
-	ComputeDataCommitment    abi.MethodNum
-	CronTick                 abi.MethodNum
+	Constructor             abi.MethodNum
+	AddBalance              abi.MethodNum
+	WithdrawBalance         abi.MethodNum
+	PublishStorageDeals     abi.MethodNum
+	Deprecated1             abi.MethodNum
+	ActivateDeals           abi.MethodNum
+	OnMinerSectorsTerminate abi.MethodNum
+	ComputeDataCommitment   abi.MethodNum
+	CronTick                abi.MethodNum
 }{MethodConstructor, 2, 3, 4, 5, 6, 7, 8, 9}
 
 var MethodsPower = struct {

--- a/actors/builtin/miner/cbor_gen.go
+++ b/actors/builtin/miner/cbor_gen.go
@@ -824,8 +824,9 @@ func (t *Deadline) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.FaultyPower (miner.PowerPair) (struct)
-	if err := t.FaultyPower.MarshalCBOR(w); err != nil {
+	// t.FaultySectors (uint64) (uint64)
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.FaultySectors)); err != nil {
 		return err
 	}
 
@@ -944,13 +945,18 @@ func (t *Deadline) UnmarshalCBOR(r io.Reader) error {
 		t.TotalSectors = uint64(extra)
 
 	}
-	// t.FaultyPower (miner.PowerPair) (struct)
+	// t.FaultySectors (uint64) (uint64)
 
 	{
 
-		if err := t.FaultyPower.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.FaultyPower: %w", err)
+		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+		if err != nil {
+			return err
 		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.FaultySectors = uint64(extra)
 
 	}
 	// t.OptimisticPoStSubmissions (cid.Cid) (struct)
@@ -1004,7 +1010,7 @@ func (t *Deadline) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
-var lengthBufPartition = []byte{139}
+var lengthBufPartition = []byte{135}
 
 func (t *Partition) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -1054,25 +1060,6 @@ func (t *Partition) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("failed to write cid field t.EarlyTerminated: %w", err)
 	}
 
-	// t.LivePower (miner.PowerPair) (struct)
-	if err := t.LivePower.MarshalCBOR(w); err != nil {
-		return err
-	}
-
-	// t.UnprovenPower (miner.PowerPair) (struct)
-	if err := t.UnprovenPower.MarshalCBOR(w); err != nil {
-		return err
-	}
-
-	// t.FaultyPower (miner.PowerPair) (struct)
-	if err := t.FaultyPower.MarshalCBOR(w); err != nil {
-		return err
-	}
-
-	// t.RecoveringPower (miner.PowerPair) (struct)
-	if err := t.RecoveringPower.MarshalCBOR(w); err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -1090,7 +1077,7 @@ func (t *Partition) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 11 {
+	if extra != 7 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -1163,42 +1150,6 @@ func (t *Partition) UnmarshalCBOR(r io.Reader) error {
 		t.EarlyTerminated = c
 
 	}
-	// t.LivePower (miner.PowerPair) (struct)
-
-	{
-
-		if err := t.LivePower.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.LivePower: %w", err)
-		}
-
-	}
-	// t.UnprovenPower (miner.PowerPair) (struct)
-
-	{
-
-		if err := t.UnprovenPower.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.UnprovenPower: %w", err)
-		}
-
-	}
-	// t.FaultyPower (miner.PowerPair) (struct)
-
-	{
-
-		if err := t.FaultyPower.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.FaultyPower: %w", err)
-		}
-
-	}
-	// t.RecoveringPower (miner.PowerPair) (struct)
-
-	{
-
-		if err := t.RecoveringPower.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.RecoveringPower: %w", err)
-		}
-
-	}
 	return nil
 }
 
@@ -1212,6 +1163,8 @@ func (t *ExpirationSet) MarshalCBOR(w io.Writer) error {
 	if _, err := w.Write(lengthBufExpirationSet); err != nil {
 		return err
 	}
+
+	scratch := make([]byte, 9)
 
 	// t.OnTimeSectors (bitfield.BitField) (struct)
 	if err := t.OnTimeSectors.MarshalCBOR(w); err != nil {
@@ -1228,15 +1181,18 @@ func (t *ExpirationSet) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.ActivePower (miner.PowerPair) (struct)
-	if err := t.ActivePower.MarshalCBOR(w); err != nil {
+	// t.ActiveCount (uint64) (uint64)
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.ActiveCount)); err != nil {
 		return err
 	}
 
-	// t.FaultyPower (miner.PowerPair) (struct)
-	if err := t.FaultyPower.MarshalCBOR(w); err != nil {
+	// t.FaultyCount (uint64) (uint64)
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.FaultyCount)); err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -1285,22 +1241,32 @@ func (t *ExpirationSet) UnmarshalCBOR(r io.Reader) error {
 		}
 
 	}
-	// t.ActivePower (miner.PowerPair) (struct)
+	// t.ActiveCount (uint64) (uint64)
 
 	{
 
-		if err := t.ActivePower.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.ActivePower: %w", err)
+		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+		if err != nil {
+			return err
 		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.ActiveCount = uint64(extra)
 
 	}
-	// t.FaultyPower (miner.PowerPair) (struct)
+	// t.FaultyCount (uint64) (uint64)
 
 	{
 
-		if err := t.FaultyPower.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.FaultyPower: %w", err)
+		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+		if err != nil {
+			return err
 		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.FaultyCount = uint64(extra)
 
 	}
 	return nil
@@ -1368,7 +1334,7 @@ func (t *PowerPair) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
-var lengthBufSectorPreCommitOnChainInfo = []byte{133}
+var lengthBufSectorPreCommitOnChainInfo = []byte{131}
 
 func (t *SectorPreCommitOnChainInfo) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -1401,16 +1367,6 @@ func (t *SectorPreCommitOnChainInfo) MarshalCBOR(w io.Writer) error {
 			return err
 		}
 	}
-
-	// t.DealWeight (big.Int) (struct)
-	if err := t.DealWeight.MarshalCBOR(w); err != nil {
-		return err
-	}
-
-	// t.VerifiedDealWeight (big.Int) (struct)
-	if err := t.VerifiedDealWeight.MarshalCBOR(w); err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -1428,7 +1384,7 @@ func (t *SectorPreCommitOnChainInfo) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 5 {
+	if extra != 3 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -1475,28 +1431,10 @@ func (t *SectorPreCommitOnChainInfo) UnmarshalCBOR(r io.Reader) error {
 
 		t.PreCommitEpoch = abi.ChainEpoch(extraI)
 	}
-	// t.DealWeight (big.Int) (struct)
-
-	{
-
-		if err := t.DealWeight.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.DealWeight: %w", err)
-		}
-
-	}
-	// t.VerifiedDealWeight (big.Int) (struct)
-
-	{
-
-		if err := t.VerifiedDealWeight.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.VerifiedDealWeight: %w", err)
-		}
-
-	}
 	return nil
 }
 
-var lengthBufSectorPreCommitInfo = []byte{138}
+var lengthBufSectorPreCommitInfo = []byte{134}
 
 func (t *SectorPreCommitInfo) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -1567,30 +1505,6 @@ func (t *SectorPreCommitInfo) MarshalCBOR(w io.Writer) error {
 			return err
 		}
 	}
-
-	// t.ReplaceCapacity (bool) (bool)
-	if err := cbg.WriteBool(w, t.ReplaceCapacity); err != nil {
-		return err
-	}
-
-	// t.ReplaceSectorDeadline (uint64) (uint64)
-
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.ReplaceSectorDeadline)); err != nil {
-		return err
-	}
-
-	// t.ReplaceSectorPartition (uint64) (uint64)
-
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.ReplaceSectorPartition)); err != nil {
-		return err
-	}
-
-	// t.ReplaceSectorNumber (abi.SectorNumber) (uint64)
-
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.ReplaceSectorNumber)); err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -1608,7 +1522,7 @@ func (t *SectorPreCommitInfo) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 10 {
+	if extra != 6 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -1746,69 +1660,10 @@ func (t *SectorPreCommitInfo) UnmarshalCBOR(r io.Reader) error {
 
 		t.Expiration = abi.ChainEpoch(extraI)
 	}
-	// t.ReplaceCapacity (bool) (bool)
-
-	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-	if err != nil {
-		return err
-	}
-	if maj != cbg.MajOther {
-		return fmt.Errorf("booleans must be major type 7")
-	}
-	switch extra {
-	case 20:
-		t.ReplaceCapacity = false
-	case 21:
-		t.ReplaceCapacity = true
-	default:
-		return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
-	}
-	// t.ReplaceSectorDeadline (uint64) (uint64)
-
-	{
-
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.ReplaceSectorDeadline = uint64(extra)
-
-	}
-	// t.ReplaceSectorPartition (uint64) (uint64)
-
-	{
-
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.ReplaceSectorPartition = uint64(extra)
-
-	}
-	// t.ReplaceSectorNumber (abi.SectorNumber) (uint64)
-
-	{
-
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.ReplaceSectorNumber = abi.SectorNumber(extra)
-
-	}
 	return nil
 }
 
-var lengthBufSectorOnChainInfo = []byte{142}
+var lengthBufSectorOnChainInfo = []byte{140}
 
 func (t *SectorOnChainInfo) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -1880,16 +1735,6 @@ func (t *SectorOnChainInfo) MarshalCBOR(w io.Writer) error {
 		}
 	}
 
-	// t.DealWeight (big.Int) (struct)
-	if err := t.DealWeight.MarshalCBOR(w); err != nil {
-		return err
-	}
-
-	// t.VerifiedDealWeight (big.Int) (struct)
-	if err := t.VerifiedDealWeight.MarshalCBOR(w); err != nil {
-		return err
-	}
-
 	// t.InitialPledge (big.Int) (struct)
 	if err := t.InitialPledge.MarshalCBOR(w); err != nil {
 		return err
@@ -1950,7 +1795,7 @@ func (t *SectorOnChainInfo) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 14 {
+	if extra != 12 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -2087,24 +1932,6 @@ func (t *SectorOnChainInfo) UnmarshalCBOR(r io.Reader) error {
 		}
 
 		t.Expiration = abi.ChainEpoch(extraI)
-	}
-	// t.DealWeight (big.Int) (struct)
-
-	{
-
-		if err := t.DealWeight.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.DealWeight: %w", err)
-		}
-
-	}
-	// t.VerifiedDealWeight (big.Int) (struct)
-
-	{
-
-		if err := t.VerifiedDealWeight.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.VerifiedDealWeight: %w", err)
-		}
-
 	}
 	// t.InitialPledge (big.Int) (struct)
 

--- a/actors/builtin/miner/expiration_queue_internal_test.go
+++ b/actors/builtin/miner/expiration_queue_internal_test.go
@@ -18,16 +18,14 @@ func TestExpirations(t *testing.T) {
 		testSector(14, 3, 0, 0, 0),
 		testSector(13, 4, 0, 0, 0),
 	}
-	result := groupNewSectorsByDeclaredExpiration(2048, sectors, quant)
+	result := groupNewSectorsByDeclaredExpiration(sectors, quant)
 	expected := []*sectorEpochSet{{
 		epoch:   13,
 		sectors: []uint64{1, 2, 4},
-		power:   NewPowerPair(big.NewIntUnsigned(2048*3), big.NewIntUnsigned(2048*3)),
 		pledge:  big.Zero(),
 	}, {
 		epoch:   23,
 		sectors: []uint64{3},
-		power:   NewPowerPair(big.NewIntUnsigned(2048), big.NewIntUnsigned(2048)),
 		pledge:  big.Zero(),
 	}}
 	require.Equal(t, len(expected), len(result))
@@ -38,7 +36,7 @@ func TestExpirations(t *testing.T) {
 
 func TestExpirationsEmpty(t *testing.T) {
 	sectors := []*SectorOnChainInfo{}
-	result := groupNewSectorsByDeclaredExpiration(2048, sectors, builtin.NoQuantization)
+	result := groupNewSectorsByDeclaredExpiration(sectors, builtin.NoQuantization)
 	expected := []sectorEpochSet{}
 	require.Equal(t, expected, result)
 }
@@ -46,7 +44,6 @@ func TestExpirationsEmpty(t *testing.T) {
 func assertSectorSet(t *testing.T, expected, actual *sectorEpochSet) {
 	assert.Equal(t, expected.epoch, actual.epoch)
 	assert.Equal(t, expected.sectors, actual.sectors)
-	assert.True(t, expected.power.Equals(actual.power), "expected %v, actual %v", expected.power, actual.power)
 	assert.True(t, expected.pledge.Equals(actual.pledge), "expected %v, actual %v", expected.pledge, actual.pledge)
 }
 
@@ -54,8 +51,6 @@ func testSector(expiration, number, weight, vweight, pledge int64) *SectorOnChai
 	return &SectorOnChainInfo{
 		Expiration:         abi.ChainEpoch(expiration),
 		SectorNumber:       abi.SectorNumber(number),
-		DealWeight:         big.NewInt(weight),
-		VerifiedDealWeight: big.NewInt(vweight),
 		InitialPledge:      abi.NewTokenAmount(pledge),
 	}
 }

--- a/actors/builtin/miner/miner_state_test.go
+++ b/actors/builtin/miner/miner_state_test.go
@@ -687,8 +687,7 @@ func TestSectorAssignment(t *testing.T) {
 	t.Run("assign sectors to deadlines", func(t *testing.T) {
 		harness := constructStateHarness(t, abi.ChainEpoch(0))
 
-		err := harness.s.AssignSectorsToDeadlines(harness.store, 0, sectorInfos,
-			partitionSectors, sectorSize)
+		err := harness.s.AssignSectorsToDeadlines(harness.store, 0, sectorInfos, partitionSectors)
 		require.NoError(t, err)
 
 		sectorArr := sectorsArr(t, harness.store, sectorInfos)
@@ -730,14 +729,14 @@ func TestSectorAssignment(t *testing.T) {
 			result, err := dl.RecordProvenSectors(harness.store, sectorArr, sectorSize, quantSpec, 0, postPartitions)
 			require.NoError(t, err)
 
-			expectedPowerDelta := miner.PowerForSectors(sectorSize, selectSectors(t, sectorInfos, allSectorBf))
+			expectedPowerDelta := miner.SectorsPower(sectorSize, len(allSectorNos))
 
 			assertBitfieldsEqual(t, allSectorBf, result.Sectors)
 			assertBitfieldEmpty(t, result.IgnoredSectors)
-			assert.True(t, result.NewFaultyPower.Equals(miner.NewPowerPairZero()))
-			assert.True(t, result.PowerDelta.Equals(expectedPowerDelta))
-			assert.True(t, result.RecoveredPower.Equals(miner.NewPowerPairZero()))
-			assert.True(t, result.RetractedRecoveryPower.Equals(miner.NewPowerPairZero()))
+			assert.True(t, result.NewFaultyCount.Equals(miner.NewPowerPairZero()))
+			assert.True(t, result.ActiveCountDelta.Equals(expectedPowerDelta))
+			assert.True(t, result.RecoveredCount.Equals(miner.NewPowerPairZero()))
+			assert.True(t, result.RetractedRecoveryCount.Equals(miner.NewPowerPairZero()))
 			return nil
 		}))
 
@@ -1011,8 +1010,6 @@ func newPreCommitOnChain(sectorNo abi.SectorNumber, sealed cid.Cid, deposit abi.
 		Info:               *info,
 		PreCommitDeposit:   deposit,
 		PreCommitEpoch:     epoch,
-		DealWeight:         big.Zero(),
-		VerifiedDealWeight: big.Zero(),
 	}
 }
 
@@ -1025,8 +1022,6 @@ func newSectorOnChainInfo(sectorNo abi.SectorNumber, sealed cid.Cid, weight big.
 		DealIDs:               nil,
 		Activation:            activation,
 		Expiration:            abi.ChainEpoch(1),
-		DealWeight:            weight,
-		VerifiedDealWeight:    weight,
 		InitialPledge:         abi.NewTokenAmount(0),
 		ExpectedDayReward:     abi.NewTokenAmount(0),
 		ExpectedStoragePledge: abi.NewTokenAmount(0),

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -3927,7 +3927,7 @@ func (h *actorHarness) preCommitSector(rt *mock.Runtime, params *miner.PreCommit
 				VerifiedDealWeight: conf.verifiedDealWeight,
 			}},
 		}
-		rt.ExpectSend(builtin.StorageMarketActorAddr, builtin.MethodsMarket.VerifyDealsForActivation, &vdParams, big.Zero(), &vdReturn, exitcode.Ok)
+		rt.ExpectSend(builtin.StorageMarketActorAddr, builtin.MethodsMarket.Deprecated1, &vdParams, big.Zero(), &vdReturn, exitcode.Ok)
 	} else {
 		// Ensure the deal IDs and configured deal weight returns are consistent.
 		require.Equal(h.t, abi.SectorSize(0), conf.dealSpace, "no deals but positive deal space configured")
@@ -3996,7 +3996,7 @@ func (h *actorHarness) preCommitSectorBatch(rt *mock.Runtime, params *miner.PreC
 		vdReturn := market.VerifyDealsForActivationReturn{
 			Sectors: sectorWeights,
 		}
-		rt.ExpectSend(builtin.StorageMarketActorAddr, builtin.MethodsMarket.VerifyDealsForActivation, &vdParams, big.Zero(), &vdReturn, exitcode.Ok)
+		rt.ExpectSend(builtin.StorageMarketActorAddr, builtin.MethodsMarket.Deprecated1, &vdParams, big.Zero(), &vdReturn, exitcode.Ok)
 	}
 	st := getState(rt)
 	// burn networkFee

--- a/actors/builtin/miner/policy_test.go
+++ b/actors/builtin/miner/policy_test.go
@@ -135,7 +135,7 @@ func TestPower(t *testing.T) {
 }
 
 func weight(size abi.SectorSize, duration abi.ChainEpoch) big.Int {
-	return big.Mul(big.NewIntUnsigned(uint64(size)), big.NewInt(int64(duration)))
+	return big.Mul(miner.SectorPower(size), big.NewInt(int64(duration)))
 }
 
 func assertEqual(t *testing.T, a, b big.Int) {

--- a/actors/builtin/network.go
+++ b/actors/builtin/network.go
@@ -48,15 +48,15 @@ var TokenPrecision = big.NewIntUnsigned(1_000_000_000_000_000_000)
 var TotalFilecoin = big.Mul(big.NewIntUnsigned(2_000_000_000), TokenPrecision)
 
 // Quality multiplier for committed capacity (no deals) in a sector
-var QualityBaseMultiplier = big.NewInt(10)
+//var QualityBaseMultiplier = big.NewInt(10)
 
 // Quality multiplier for unverified deals in a sector
-var DealWeightMultiplier = big.NewInt(10)
+//var DealWeightMultiplier = big.NewInt(10)
 
 // Quality multiplier for verified deals in a sector
-var VerifiedDealWeightMultiplier = big.NewInt(100)
+//var VerifiedDealWeightMultiplier = big.NewInt(100)
 
-// Precision used for making QA power calculations
+// Precision used for making power calculations
 const SectorQualityPrecision = 20
 
 // 1 NanoFIL

--- a/actors/builtin/power/cbor_gen.go
+++ b/actors/builtin/power/cbor_gen.go
@@ -14,7 +14,7 @@ import (
 
 var _ = xerrors.Errorf
 
-var lengthBufState = []byte{143}
+var lengthBufState = []byte{140}
 
 func (t *State) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -37,16 +37,6 @@ func (t *State) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.TotalQualityAdjPower (big.Int) (struct)
-	if err := t.TotalQualityAdjPower.MarshalCBOR(w); err != nil {
-		return err
-	}
-
-	// t.TotalQABytesCommitted (big.Int) (struct)
-	if err := t.TotalQABytesCommitted.MarshalCBOR(w); err != nil {
-		return err
-	}
-
 	// t.TotalPledgeCollateral (big.Int) (struct)
 	if err := t.TotalPledgeCollateral.MarshalCBOR(w); err != nil {
 		return err
@@ -57,18 +47,13 @@ func (t *State) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.ThisEpochQualityAdjPower (big.Int) (struct)
-	if err := t.ThisEpochQualityAdjPower.MarshalCBOR(w); err != nil {
-		return err
-	}
-
 	// t.ThisEpochPledgeCollateral (big.Int) (struct)
 	if err := t.ThisEpochPledgeCollateral.MarshalCBOR(w); err != nil {
 		return err
 	}
 
-	// t.ThisEpochQAPowerSmoothed (smoothing.FilterEstimate) (struct)
-	if err := t.ThisEpochQAPowerSmoothed.MarshalCBOR(w); err != nil {
+	// t.ThisEpochRawBytePowerSmoothed (smoothing.FilterEstimate) (struct)
+	if err := t.ThisEpochRawBytePowerSmoothed.MarshalCBOR(w); err != nil {
 		return err
 	}
 
@@ -146,7 +131,7 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 15 {
+	if extra != 12 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -168,24 +153,6 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 		}
 
 	}
-	// t.TotalQualityAdjPower (big.Int) (struct)
-
-	{
-
-		if err := t.TotalQualityAdjPower.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.TotalQualityAdjPower: %w", err)
-		}
-
-	}
-	// t.TotalQABytesCommitted (big.Int) (struct)
-
-	{
-
-		if err := t.TotalQABytesCommitted.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.TotalQABytesCommitted: %w", err)
-		}
-
-	}
 	// t.TotalPledgeCollateral (big.Int) (struct)
 
 	{
@@ -204,15 +171,6 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 		}
 
 	}
-	// t.ThisEpochQualityAdjPower (big.Int) (struct)
-
-	{
-
-		if err := t.ThisEpochQualityAdjPower.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.ThisEpochQualityAdjPower: %w", err)
-		}
-
-	}
 	// t.ThisEpochPledgeCollateral (big.Int) (struct)
 
 	{
@@ -222,12 +180,12 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 		}
 
 	}
-	// t.ThisEpochQAPowerSmoothed (smoothing.FilterEstimate) (struct)
+	// t.ThisEpochRawBytePowerSmoothed (smoothing.FilterEstimate) (struct)
 
 	{
 
-		if err := t.ThisEpochQAPowerSmoothed.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.ThisEpochQAPowerSmoothed: %w", err)
+		if err := t.ThisEpochRawBytePowerSmoothed.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.ThisEpochRawBytePowerSmoothed: %w", err)
 		}
 
 	}
@@ -355,7 +313,7 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
-var lengthBufClaim = []byte{131}
+var lengthBufClaim = []byte{130}
 
 func (t *Claim) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -383,11 +341,6 @@ func (t *Claim) MarshalCBOR(w io.Writer) error {
 	if err := t.RawBytePower.MarshalCBOR(w); err != nil {
 		return err
 	}
-
-	// t.QualityAdjPower (big.Int) (struct)
-	if err := t.QualityAdjPower.MarshalCBOR(w); err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -405,7 +358,7 @@ func (t *Claim) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 3 {
+	if extra != 2 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -440,15 +393,6 @@ func (t *Claim) UnmarshalCBOR(r io.Reader) error {
 
 		if err := t.RawBytePower.UnmarshalCBOR(br); err != nil {
 			return xerrors.Errorf("unmarshaling t.RawBytePower: %w", err)
-		}
-
-	}
-	// t.QualityAdjPower (big.Int) (struct)
-
-	{
-
-		if err := t.QualityAdjPower.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.QualityAdjPower: %w", err)
 		}
 
 	}
@@ -742,7 +686,55 @@ func (t *CreateMinerParams) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
-var lengthBufCurrentTotalPowerReturn = []byte{132}
+var lengthBufUpdateClaimedPowerParams = []byte{129}
+
+func (t *UpdateClaimedPowerParams) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write(lengthBufUpdateClaimedPowerParams); err != nil {
+		return err
+	}
+
+	// t.RawByteDelta (big.Int) (struct)
+	if err := t.RawByteDelta.MarshalCBOR(w); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *UpdateClaimedPowerParams) UnmarshalCBOR(r io.Reader) error {
+	*t = UpdateClaimedPowerParams{}
+
+	br := cbg.GetPeeker(r)
+	scratch := make([]byte, 8)
+
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 1 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.RawByteDelta (big.Int) (struct)
+
+	{
+
+		if err := t.RawByteDelta.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.RawByteDelta: %w", err)
+		}
+
+	}
+	return nil
+}
+
+var lengthBufCurrentTotalPowerReturn = []byte{131}
 
 func (t *CurrentTotalPowerReturn) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -758,18 +750,13 @@ func (t *CurrentTotalPowerReturn) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.QualityAdjPower (big.Int) (struct)
-	if err := t.QualityAdjPower.MarshalCBOR(w); err != nil {
-		return err
-	}
-
 	// t.PledgeCollateral (big.Int) (struct)
 	if err := t.PledgeCollateral.MarshalCBOR(w); err != nil {
 		return err
 	}
 
-	// t.QualityAdjPowerSmoothed (smoothing.FilterEstimate) (struct)
-	if err := t.QualityAdjPowerSmoothed.MarshalCBOR(w); err != nil {
+	// t.RawBytePowerSmoothed (smoothing.FilterEstimate) (struct)
+	if err := t.RawBytePowerSmoothed.MarshalCBOR(w); err != nil {
 		return err
 	}
 	return nil
@@ -789,7 +776,7 @@ func (t *CurrentTotalPowerReturn) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 4 {
+	if extra != 3 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -802,15 +789,6 @@ func (t *CurrentTotalPowerReturn) UnmarshalCBOR(r io.Reader) error {
 		}
 
 	}
-	// t.QualityAdjPower (big.Int) (struct)
-
-	{
-
-		if err := t.QualityAdjPower.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.QualityAdjPower: %w", err)
-		}
-
-	}
 	// t.PledgeCollateral (big.Int) (struct)
 
 	{
@@ -820,12 +798,12 @@ func (t *CurrentTotalPowerReturn) UnmarshalCBOR(r io.Reader) error {
 		}
 
 	}
-	// t.QualityAdjPowerSmoothed (smoothing.FilterEstimate) (struct)
+	// t.RawBytePowerSmoothed (smoothing.FilterEstimate) (struct)
 
 	{
 
-		if err := t.QualityAdjPowerSmoothed.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.QualityAdjPowerSmoothed: %w", err)
+		if err := t.RawBytePowerSmoothed.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.RawBytePowerSmoothed: %w", err)
 		}
 
 	}

--- a/actors/builtin/reward/reward_actor.go
+++ b/actors/builtin/reward/reward_actor.go
@@ -25,6 +25,7 @@ func (a Actor) Exports() []interface{} {
 		2:                         a.AwardBlockReward,
 		3:                         a.ThisEpochReward,
 		4:                         a.UpdateNetworkKPI,
+		5:                         a.ClaimVerifiedDealReward,
 	}
 }
 
@@ -175,6 +176,21 @@ func (a Actor) UpdateNetworkKPI(rt runtime.Runtime, currRealizedPower *abi.Stora
 		st.updateToNextEpochWithReward(*currRealizedPower)
 		// only update smoothed estimates after updating reward and epoch
 		st.updateSmoothedEstimates(st.Epoch - prev)
+	})
+	return nil
+}
+
+func (a Actor) ClaimVerifiedDealReward(rt runtime.Runtime, currTotalVerifiedSpace *abi.StoragePower) *abi.TokenAmount {
+	// Note: this should be opened up to a whitelist after the FVM supports alternative markets.
+	rt.ValidateImmediateCallerIs(builtin.StorageMarketActorAddr)
+	if currTotalVerifiedSpace == nil {
+		rt.Abortf(exitcode.ErrIllegalArgument, "argument should not be nil")
+	}
+
+	var st State
+	rt.StateTransaction(&st, func() {
+		// FIXME send the verified deal reward for the elapsed epoch and record the current total verified space
+		// for calculation of the next one
 	})
 	return nil
 }

--- a/actors/builtin/shared.go
+++ b/actors/builtin/shared.go
@@ -96,19 +96,21 @@ type MinerAddrs struct {
 	ControlAddrs []addr.Address
 }
 
+// Changed in v8:
+// - Replaced QualityAdjPowerSmoothed with RawBytePowerSmoothed
 type DeferredCronEventParams struct {
-	EventPayload            []byte
-	RewardSmoothed          smoothing.FilterEstimate
-	QualityAdjPowerSmoothed smoothing.FilterEstimate
+	EventPayload         []byte
+	RewardSmoothed       smoothing.FilterEstimate
+	RawBytePowerSmoothed smoothing.FilterEstimate
 }
 
-// Note: we could move this alias back to the mutually-importing packages that use it, now that they
-// can instead both alias the v2 version.
+// Changed in v8:
+// - Replaced QualityAdjPowerSmoothed with RawBytePowerSmoothed
 type ConfirmSectorProofsParams struct {
-	Sectors                 []abi.SectorNumber
-	RewardSmoothed          smoothing.FilterEstimate
-	RewardBaselinePower     abi.StoragePower
-	QualityAdjPowerSmoothed smoothing.FilterEstimate
+	Sectors              []abi.SectorNumber
+	RewardSmoothed       smoothing.FilterEstimate
+	RewardBaselinePower  abi.StoragePower
+	RawBytePowerSmoothed smoothing.FilterEstimate
 }
 
 // ResolveToIDAddr resolves the given address to it's ID address form.

--- a/actors/states/check.go
+++ b/actors/states/check.go
@@ -163,9 +163,10 @@ func CheckMinersAgainstPower(acc *builtin.MessageAccumulator, minerSummaries map
 		claim, ok := powerSummary.Claims[addr]
 		acc.Require(ok, "miner %v has no power claim", addr)
 		if ok {
-			claimPower := miner.NewPowerPair(claim.RawBytePower, claim.QualityAdjPower)
-			acc.Require(minerSummary.ActivePower.Equals(claimPower),
-				"miner %v computed active power %v does not match claim %v", addr, minerSummary.ActivePower, claimPower)
+			claimPower := claim.RawBytePower
+			minerPower := big.Mul(big.NewIntUnsigned(uint64(minerSummary.SectorSize)), big.NewIntUnsigned(minerSummary.ActiveCount))
+			acc.Require(minerPower.Equals(claimPower),
+				"miner %v computed active power %v does not match claim %v", addr, minerSummary.ActiveCount, claimPower)
 			acc.Require(minerSummary.WindowPoStProofType == claim.WindowPoStProofType,
 				"miner seal proof type %d does not match claim proof type %d", minerSummary.WindowPoStProofType, claim.WindowPoStProofType)
 		}

--- a/actors/states/election.go
+++ b/actors/states/election.go
@@ -22,7 +22,7 @@ func MinerEligibleForElection(store adt.Store, mstate *miner.State, pstate *powe
 		return false, err
 	} else if !found {
 		return false, err
-	} else if claim.QualityAdjPower.LessThanEqual(big.Zero()) {
+	} else if claim.RawBytePower.LessThanEqual(big.Zero()) {
 		return false, err
 	}
 

--- a/actors/test/commit_post_test.go
+++ b/actors/test/commit_post_test.go
@@ -172,7 +172,7 @@ func TestCommitPoStFlow(t *testing.T) {
 			Index:   pIdx,
 			Skipped: bitfield.New(),
 		}}
-		sectorPower := miner.PowerForSector(sectorSize, sector)
+		sectorPower := miner.SectorPower(sectorSize)
 		submitWindowPoSt(t, tv, worker, minerAddrs.IDAddress, dlInfo, partitions, sectorPower)
 
 		// miner still has initial pledge
@@ -525,7 +525,7 @@ func TestBatchOnboarding(t *testing.T) {
 		Index:   pIdx,
 		Skipped: bitfield.New(),
 	}}
-	newPower := miner.PowerForSector(sectorSize, sector).Mul(big.NewInt(int64(provenCount)))
+	newPower := miner.SectorsPower(sectorSize, provenCount)
 	submitWindowPoSt(t, v, worker, minerAddrs.IDAddress, dlInfo, partitions, newPower)
 
 	// Miner has initial pledge

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -37,8 +37,8 @@ func main() {
 
 	if err := gen.WriteTupleEncodersToFile("./actors/builtin/cbor_gen.go", "builtin",
 		builtin.MinerAddrs{},
-		builtin.ConfirmSectorProofsParams{},
-		builtin.DeferredCronEventParams{},
+		builtin.ConfirmSectorProofsParams{}, // Changed in v8
+		builtin.DeferredCronEventParams{}, // Changed in v8
 		// builtin.ApplyRewardParams{}, // Aliased from v2
 	); err != nil {
 		panic(err)
@@ -140,7 +140,7 @@ func main() {
 		power.CreateMinerParams{},
 		//power.CreateMinerReturn{}, // Aliased from v0
 		//power.EnrollCronEventParams{}, // Aliased from v0
-		//power.UpdateClaimedPowerParams{}, // Aliased from v0
+		power.UpdateClaimedPowerParams{}, // Changed in v8
 		power.CurrentTotalPowerReturn{},
 		// other types
 		power.MinerConstructorParams{},

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -156,8 +156,6 @@ func main() {
 		// market.PublishStorageDealsParams{}, // Aliased from v0
 		market.PublishStorageDealsReturn{},
 		//market.ActivateDealsParams{}, // Aliased from v0
-		market.VerifyDealsForActivationParams{},
-		market.VerifyDealsForActivationReturn{},
 		market.SectorDataSpec{},
 		market.ComputeDataCommitmentParams{},
 		market.ComputeDataCommitmentReturn{},
@@ -165,8 +163,6 @@ func main() {
 		// other types
 		//market.DealProposal{}, // Aliased from v0
 		//market.ClientDealProposal{},
-		market.SectorDeals{},
-		market.SectorWeights{},
 		market.DealState{},
 	); err != nil {
 		panic(err)

--- a/support/vm/testing.go
+++ b/support/vm/testing.go
@@ -476,7 +476,7 @@ func GetMinerBalances(t *testing.T, vm *VM, minerIdAddr address.Address) MinerBa
 	}
 }
 
-func PowerForMinerSector(t *testing.T, vm *VM, minerIdAddr address.Address, sectorNumber abi.SectorNumber) miner.PowerPair {
+func PowerForMinerSector(t *testing.T, vm *VM, minerIdAddr address.Address, sectorNumber abi.SectorNumber) abi.StoragePower {
 	var state miner.State
 	err := vm.GetState(minerIdAddr, &state)
 	require.NoError(t, err)
@@ -487,7 +487,7 @@ func PowerForMinerSector(t *testing.T, vm *VM, minerIdAddr address.Address, sect
 
 	sectorSize, err := sector.SealProof.SectorSize()
 	require.NoError(t, err)
-	return miner.PowerForSector(sectorSize, sector)
+	return miner.SectorPower(sectorSize)
 }
 
 func MinerPower(t *testing.T, vm *VM, minerIdAddr address.Address) miner.PowerPair {
@@ -499,7 +499,7 @@ func MinerPower(t *testing.T, vm *VM, minerIdAddr address.Address) miner.PowerPa
 	require.NoError(t, err)
 	require.True(t, found)
 
-	return miner.NewPowerPair(claim.RawBytePower, claim.QualityAdjPower)
+	return miner.NewPowerPair(claim.RawBytePower, big.Zero())
 }
 
 type NetworkStats struct {
@@ -539,11 +539,11 @@ func GetNetworkStats(t *testing.T, vm *VM) NetworkStats {
 	return NetworkStats{
 		TotalRawBytePower:             powerState.TotalRawBytePower,
 		TotalBytesCommitted:           powerState.TotalBytesCommitted,
-		TotalQualityAdjPower:          powerState.TotalQualityAdjPower,
-		TotalQABytesCommitted:         powerState.TotalQABytesCommitted,
+		TotalQualityAdjPower:          big.Zero(),
+		TotalQABytesCommitted:         big.Zero(),
 		TotalPledgeCollateral:         powerState.TotalPledgeCollateral,
 		ThisEpochRawBytePower:         powerState.ThisEpochRawBytePower,
-		ThisEpochQualityAdjPower:      powerState.ThisEpochQualityAdjPower,
+		ThisEpochQualityAdjPower:      big.Zero(),
 		ThisEpochPledgeCollateral:     powerState.ThisEpochPledgeCollateral,
 		MinerCount:                    powerState.MinerCount,
 		MinerAboveMinPowerCount:       powerState.MinerAboveMinPowerCount,


### PR DESCRIPTION
This is an implementation sketch of the FIL+ explicit subsidy, in support of the FIP ([discussion](https://github.com/filecoin-project/FIPs/discussions/243)). The goal is to flesh out enough of the implementation to discover all the key challenges, and be able to test some of the assumptions and mechanisms.

This PR will probably never land, because we expect to migrate to Rust actors running in the FVM before it does. This PR can thus guide implementation over there after the FIP is accepted.

- [x] Remove QA power from miner and power actors
- [x] Account for verified space in market actor
- [ ] Implement reward split and claim/payment of verified space rewards
- [ ] Implement fault notification and handling by market actor
- [ ] Implement deal pledge in the market actor
- [ ] Implement fault penalties in market actor
- [ ] (Maybe) update all the tests
