### PR TITLE
PreCommitDeposit is now independent of the verified status

### DIFF
--- a/actors/builtin/market/cbor_gen.go
+++ b/actors/builtin/market/cbor_gen.go
@@ -398,3 +398,386 @@ func (t *DealState) UnmarshalCBOR(r io.Reader) error {
 	}
 	return nil
 }
+
+var lengthBufActivateDealsParams = []byte{129}
+
+func (t *ActivateDealsParams) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write(lengthBufActivateDealsParams); err != nil {
+		return err
+	}
+
+	scratch := make([]byte, 9)
+
+	// t.Sectors ([]market.ActivateDealsParamsInner) (slice)
+	if len(t.Sectors) > cbg.MaxLength {
+		return xerrors.Errorf("Slice value in field t.Sectors was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.Sectors))); err != nil {
+		return err
+	}
+	for _, v := range t.Sectors {
+		if err := v.MarshalCBOR(w); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *ActivateDealsParams) UnmarshalCBOR(r io.Reader) error {
+	*t = ActivateDealsParams{}
+
+	br := cbg.GetPeeker(r)
+	scratch := make([]byte, 8)
+
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 1 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.Sectors ([]market.ActivateDealsParamsInner) (slice)
+
+	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("t.Sectors: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.Sectors = make([]ActivateDealsParamsInner, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+
+		var v ActivateDealsParamsInner
+		if err := v.UnmarshalCBOR(br); err != nil {
+			return err
+		}
+
+		t.Sectors[i] = v
+	}
+
+	return nil
+}
+
+var lengthBufActivateDealsParamsInner = []byte{130}
+
+func (t *ActivateDealsParamsInner) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write(lengthBufActivateDealsParamsInner); err != nil {
+		return err
+	}
+
+	scratch := make([]byte, 9)
+
+	// t.DealIDs ([]abi.DealID) (slice)
+	if len(t.DealIDs) > cbg.MaxLength {
+		return xerrors.Errorf("Slice value in field t.DealIDs was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.DealIDs))); err != nil {
+		return err
+	}
+	for _, v := range t.DealIDs {
+		if err := cbg.CborWriteHeader(w, cbg.MajUnsignedInt, uint64(v)); err != nil {
+			return err
+		}
+	}
+
+	// t.SectorExpiry (abi.ChainEpoch) (int64)
+	if t.SectorExpiry >= 0 {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.SectorExpiry)); err != nil {
+			return err
+		}
+	} else {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.SectorExpiry-1)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *ActivateDealsParamsInner) UnmarshalCBOR(r io.Reader) error {
+	*t = ActivateDealsParamsInner{}
+
+	br := cbg.GetPeeker(r)
+	scratch := make([]byte, 8)
+
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 2 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.DealIDs ([]abi.DealID) (slice)
+
+	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("t.DealIDs: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.DealIDs = make([]abi.DealID, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+
+		maj, val, err := cbg.CborReadHeaderBuf(br, scratch)
+		if err != nil {
+			return xerrors.Errorf("failed to read uint64 for t.DealIDs slice: %w", err)
+		}
+
+		if maj != cbg.MajUnsignedInt {
+			return xerrors.Errorf("value read for array t.DealIDs was not a uint, instead got %d", maj)
+		}
+
+		t.DealIDs[i] = abi.DealID(val)
+	}
+
+	// t.SectorExpiry (abi.ChainEpoch) (int64)
+	{
+		maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+		var extraI int64
+		if err != nil {
+			return err
+		}
+		switch maj {
+		case cbg.MajUnsignedInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 positive overflow")
+			}
+		case cbg.MajNegativeInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 negative oveflow")
+			}
+			extraI = -1 - extraI
+		default:
+			return fmt.Errorf("wrong type for int64 field: %d", maj)
+		}
+
+		t.SectorExpiry = abi.ChainEpoch(extraI)
+	}
+	return nil
+}
+
+var lengthBufActivateDealsReturn = []byte{129}
+
+func (t *ActivateDealsReturn) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write(lengthBufActivateDealsReturn); err != nil {
+		return err
+	}
+
+	scratch := make([]byte, 9)
+
+	// t.Sectors ([]market.ActivateDealsReturnInner) (slice)
+	if len(t.Sectors) > cbg.MaxLength {
+		return xerrors.Errorf("Slice value in field t.Sectors was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.Sectors))); err != nil {
+		return err
+	}
+	for _, v := range t.Sectors {
+		if err := v.MarshalCBOR(w); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *ActivateDealsReturn) UnmarshalCBOR(r io.Reader) error {
+	*t = ActivateDealsReturn{}
+
+	br := cbg.GetPeeker(r)
+	scratch := make([]byte, 8)
+
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 1 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.Sectors ([]market.ActivateDealsReturnInner) (slice)
+
+	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("t.Sectors: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.Sectors = make([]ActivateDealsReturnInner, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+
+		var v ActivateDealsReturnInner
+		if err := v.UnmarshalCBOR(br); err != nil {
+			return err
+		}
+
+		t.Sectors[i] = v
+	}
+
+	return nil
+}
+
+var lengthBufActivateDealsReturnInner = []byte{132}
+
+func (t *ActivateDealsReturnInner) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write(lengthBufActivateDealsReturnInner); err != nil {
+		return err
+	}
+
+	scratch := make([]byte, 9)
+
+	// t.Success (bool) (bool)
+	if err := cbg.WriteBool(w, t.Success); err != nil {
+		return err
+	}
+
+	// t.DealSpace (uint64) (uint64)
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.DealSpace)); err != nil {
+		return err
+	}
+
+	// t.DealWeight (big.Int) (struct)
+	if err := t.DealWeight.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.VerifiedDealWeight (big.Int) (struct)
+	if err := t.VerifiedDealWeight.MarshalCBOR(w); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *ActivateDealsReturnInner) UnmarshalCBOR(r io.Reader) error {
+	*t = ActivateDealsReturnInner{}
+
+	br := cbg.GetPeeker(r)
+	scratch := make([]byte, 8)
+
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 4 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.Success (bool) (bool)
+
+	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajOther {
+		return fmt.Errorf("booleans must be major type 7")
+	}
+	switch extra {
+	case 20:
+		t.Success = false
+	case 21:
+		t.Success = true
+	default:
+		return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
+	}
+	// t.DealSpace (uint64) (uint64)
+
+	{
+
+		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.DealSpace = uint64(extra)
+
+	}
+	// t.DealWeight (big.Int) (struct)
+
+	{
+
+		if err := t.DealWeight.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.DealWeight: %w", err)
+		}
+
+	}
+	// t.VerifiedDealWeight (big.Int) (struct)
+
+	{
+
+		if err := t.VerifiedDealWeight.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.VerifiedDealWeight: %w", err)
+		}
+
+	}
+	return nil
+}

--- a/actors/builtin/methods.go
+++ b/actors/builtin/methods.go
@@ -103,7 +103,8 @@ var MethodsMiner = struct {
 	PreCommitSectorBatch     abi.MethodNum
 	ProveCommitAggregate     abi.MethodNum
 	ProveReplicaUpdates      abi.MethodNum
-}{MethodConstructor, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27}
+	PreCommitSectorBatch2    abi.MethodNum
+}{MethodConstructor, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28}
 
 var MethodsVerifiedRegistry = struct {
 	Constructor                 abi.MethodNum

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -791,11 +791,8 @@ func (a Actor) PreCommitSectorBatch(rt Runtime, params *PreCommitSectorBatchPara
 				rt.Abortf(exitcode.ErrIllegalArgument, "deals too large to fit in sector %d > %d", dealWeight.DealSpace, info.SectorSize)
 			}
 
-			// Estimate the sector weight using the current epoch as an estimate for activation,
-			// and compute the pre-commit deposit using that weight.
-			// The sector's power will be recalculated when it's proven.
-			duration := precommit.Expiration - currEpoch
-			sectorWeight := QAPowerForWeight(info.SectorSize, duration, dealWeight.DealWeight, dealWeight.VerifiedDealWeight)
+			// For PreCommitDeposit we estimate maximum possible power of the sector
+			sectorWeight := QAPowerMax(info.SectorSize)
 			depositReq := PreCommitDepositForPower(rewardStats.ThisEpochRewardSmoothed, pwrTotal.QualityAdjPowerSmoothed, sectorWeight)
 
 			// Build on-chain record.

--- a/actors/builtin/miner/miner_commitment_test.go
+++ b/actors/builtin/miner/miner_commitment_test.go
@@ -91,8 +91,6 @@ func TestCommitments(t *testing.T) {
 
 			// Check precommit expectations.
 			assert.Equal(t, precommitEpoch, precommit.PreCommitEpoch)
-			assert.Equal(t, dealWeight, precommit.DealWeight)
-			assert.Equal(t, verifiedDealWeight, precommit.VerifiedDealWeight)
 
 			assert.Equal(t, test.sectorNo, precommit.Info.SectorNumber)
 			assert.Equal(t, precommitParams.SealProof, precommit.Info.SealProof)
@@ -573,8 +571,6 @@ func TestPreCommitBatch(t *testing.T) {
 			st := getState(rt)
 			for i := 0; i < batchSize; i++ {
 				assert.Equal(t, precommitEpoch, precommits[i].PreCommitEpoch)
-				assert.Equal(t, conf.sectorWeights[i].DealWeight, precommits[i].DealWeight)
-				assert.Equal(t, conf.sectorWeights[i].VerifiedDealWeight, precommits[i].VerifiedDealWeight)
 
 				assert.Equal(t, sectorNos[i], precommits[i].Info.SectorNumber)
 				assert.Equal(t, sectors[i].SealProof, precommits[i].Info.SealProof)
@@ -675,10 +671,6 @@ func TestProveCommit(t *testing.T) {
 		}, true)
 
 		// Check precommit
-		// deal weights must be set in precommit onchain info
-		assert.Equal(t, dealWeight, precommit.DealWeight)
-		assert.Equal(t, verifiedDealWeight, precommit.VerifiedDealWeight)
-
 		expectedDeposit := miner.PreCommitDepositForPower(actor.epochRewardSmooth, actor.epochQAPowerSmooth, miner.QAPowerMax(actor.sectorSize))
 		assert.Equal(t, expectedDeposit, precommit.PreCommitDeposit)
 
@@ -696,8 +688,6 @@ func TestProveCommit(t *testing.T) {
 		assert.Equal(t, precommit.Info.DealIDs, sector.DealIDs)
 		assert.Equal(t, rt.Epoch(), sector.Activation)
 		assert.Equal(t, precommit.Info.Expiration, sector.Expiration)
-		assert.Equal(t, precommit.DealWeight, sector.DealWeight)
-		assert.Equal(t, precommit.VerifiedDealWeight, sector.VerifiedDealWeight)
 
 		// expect precommit to have been removed
 		st = getState(rt)
@@ -710,13 +700,9 @@ func TestProveCommit(t *testing.T) {
 
 		// The sector is exactly full with verified deals, so expect fully verified power.
 		expectedPower := big.Mul(big.NewInt(int64(actor.sectorSize)), big.Div(builtin.VerifiedDealWeightMultiplier, builtin.QualityBaseMultiplier))
-		qaPower := miner.QAPowerForWeight(actor.sectorSize, precommit.Info.Expiration-rt.Epoch(), precommit.DealWeight, precommit.VerifiedDealWeight)
+		qaPower := miner.QAPowerForWeight(actor.sectorSize, precommit.Info.Expiration-rt.Epoch(), sector.DealWeight, sector.VerifiedDealWeight)
 		assert.Equal(t, expectedPower, qaPower)
 		sectorPower := miner.NewPowerPair(big.NewIntUnsigned(uint64(actor.sectorSize)), qaPower)
-
-		// expect deal weights to be transferred to on chain info
-		assert.Equal(t, precommit.DealWeight, sector.DealWeight)
-		assert.Equal(t, precommit.VerifiedDealWeight, sector.VerifiedDealWeight)
 
 		// expect initial plege of sector to be set, and be total pledge requirement
 		expectedInitialPledge := miner.InitialPledgeForPower(qaPower, actor.baselinePower, actor.epochRewardSmooth, actor.epochQAPowerSmooth, rt.TotalFilCircSupply())

--- a/actors/builtin/miner/miner_commitment_test.go
+++ b/actors/builtin/miner/miner_commitment_test.go
@@ -133,6 +133,7 @@ func TestCommitments(t *testing.T) {
 	})
 
 	t.Run("deal space exceeds sector space", func(t *testing.T) {
+		t.Skip("TODO needs to be moved to ProveCommit") //TODO
 		actor := newHarness(t, periodOffset)
 		rt := builderForHarness(actor).
 			WithBalance(bigBalance, big.Zero()).

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -133,28 +133,29 @@ type WorkerKeyChange struct {
 	EffectiveAt abi.ChainEpoch
 }
 
+// possible states
+// (DealIDs > 0, UnsealedCID != nil) => CommD provided by SP, needs to be checked
+// (DealIDs > 0, UnsealedCID == nil) => Old method or migration, DealIDs checked at PreCommit (Depracated)
+// (DealIDs == 0, UnsealedCID == nil) => NoDeals, CommD of empty sector
+// (DealIDs == 0, UnsealedCID != 0) future approach, fail for now
 // Information provided by a miner when pre-committing a sector.
 type SectorPreCommitInfo struct {
-	SealProof       abi.RegisteredSealProof
-	SectorNumber    abi.SectorNumber
-	SealedCID       cid.Cid `checked:"true"` // CommR
-	SealRandEpoch   abi.ChainEpoch
-	DealIDs         []abi.DealID
-	Expiration      abi.ChainEpoch
-	ReplaceCapacity bool // Whether to replace a "committed capacity" no-deal sector (requires non-empty DealIDs)
-	// The committed capacity sector to replace, and it's deadline/partition location
-	ReplaceSectorDeadline  uint64
-	ReplaceSectorPartition uint64
-	ReplaceSectorNumber    abi.SectorNumber
+	SealProof     abi.RegisteredSealProof
+	SectorNumber  abi.SectorNumber
+	SealedCID     cid.Cid `checked:"true"` // CommR
+	SealRandEpoch abi.ChainEpoch
+	DealIDs       []abi.DealID
+	Expiration    abi.ChainEpoch
+	UnsealedCID   *cid.Cid `checked:"true"`
 }
 
 // Information stored on-chain for a pre-committed sector.
 type SectorPreCommitOnChainInfo struct {
-	Info               SectorPreCommitInfo
-	PreCommitDeposit   abi.TokenAmount
-	PreCommitEpoch     abi.ChainEpoch
-	DealWeight         abi.DealWeight // Integral of active deals over sector lifetime
-	VerifiedDealWeight abi.DealWeight // Integral of active verified deals over sector lifetime
+	Info             SectorPreCommitInfo
+	PreCommitDeposit abi.TokenAmount
+	PreCommitEpoch   abi.ChainEpoch
+	//DealWeight         abi.DealWeight // Integral of active deals over sector lifetime
+	//VerifiedDealWeight abi.DealWeight // Integral of active verified deals over sector lifetime
 }
 
 // Information stored on-chain for a proven sector.

--- a/actors/builtin/miner/miner_state_test.go
+++ b/actors/builtin/miner/miner_state_test.go
@@ -1008,11 +1008,9 @@ func constructStateHarness(t *testing.T, periodBoundary abi.ChainEpoch) *stateHa
 func newPreCommitOnChain(sectorNo abi.SectorNumber, sealed cid.Cid, deposit abi.TokenAmount, epoch abi.ChainEpoch) *miner.SectorPreCommitOnChainInfo {
 	info := newSectorPreCommitInfo(sectorNo, sealed)
 	return &miner.SectorPreCommitOnChainInfo{
-		Info:               *info,
-		PreCommitDeposit:   deposit,
-		PreCommitEpoch:     epoch,
-		DealWeight:         big.Zero(),
-		VerifiedDealWeight: big.Zero(),
+		Info:             *info,
+		PreCommitDeposit: deposit,
+		PreCommitEpoch:   epoch,
 	}
 }
 

--- a/actors/builtin/miner/monies.go
+++ b/actors/builtin/miner/monies.go
@@ -4,7 +4,6 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/exitcode"
-	rtt "github.com/filecoin-project/go-state-types/rt"
 
 	"github.com/filecoin-project/specs-actors/v7/actors/builtin"
 	"github.com/filecoin-project/specs-actors/v7/actors/util/math"
@@ -192,7 +191,6 @@ func RepayDebtsOrAbort(rt Runtime, st *State) abi.TokenAmount {
 	currBalance := rt.CurrentBalance()
 	toBurn, err := st.repayDebts(currBalance)
 	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "unlocked balance can not repay fee debt")
-	rt.Log(rtt.DEBUG, "RepayDebtsOrAbort was called and succeeded")
 	return toBurn
 }
 

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -249,6 +249,13 @@ func QualityForWeight(size abi.SectorSize, duration abi.ChainEpoch, dealWeight, 
 	return big.Div(big.Div(scaledUpWeightedSumSpaceTime, sectorSpaceTime), builtin.QualityBaseMultiplier)
 }
 
+func QAPowerMax(size abi.SectorSize) abi.StoragePower {
+	// return (size * VerifiedDealWeightMultiplier) / QualityBaseMultiplier
+	// order of operation to preserve maximum precision
+	// for efficiency we could change definition of VerifiedDealWeightMultiplier to be more efficient
+	return big.Div(big.Mul(big.NewIntUnsigned(uint64(size)), builtin.VerifiedDealWeightMultiplier), builtin.QualityBaseMultiplier)
+}
+
 // The power for a sector size, committed duration, and weight.
 func QAPowerForWeight(size abi.SectorSize, duration abi.ChainEpoch, dealWeight, verifiedWeight abi.DealWeight) abi.StoragePower {
 	quality := QualityForWeight(size, duration, dealWeight, verifiedWeight)

--- a/actors/test/commit_post_test.go
+++ b/actors/test/commit_post_test.go
@@ -282,7 +282,7 @@ func TestMeasurePreCommitGas(t *testing.T) {
 	require.NoError(t, err)
 	addrs := vm.CreateAccounts(ctx, t, v, 1, big.Mul(big.NewInt(100_000), builtin.TokenPrecision), 93837778)
 	owner, worker := addrs[0], addrs[0]
-	minerAddrs := createMiner(t, v, owner, worker, wPoStProof, big.Mul(big.NewInt(10_000), vm.FIL))
+	minerAddrs := createMiner(t, v, owner, worker, wPoStProof, big.Mul(big.NewInt(100_000), vm.FIL))
 
 	// Advance vm so we can have seal randomness epoch in the past
 	v, err = v.WithEpoch(abi.ChainEpoch(200))
@@ -327,9 +327,9 @@ func TestMeasurePoRepGas(t *testing.T) {
 	wPoStProof, err := sealProof.RegisteredWindowPoStProof()
 	require.NoError(t, err)
 
-	addrs := vm.CreateAccounts(ctx, t, v, 1, big.Mul(big.NewInt(10_000), builtin.TokenPrecision), 93837778)
+	addrs := vm.CreateAccounts(ctx, t, v, 1, big.Mul(big.NewInt(100_000), builtin.TokenPrecision), 93837778)
 	owner, worker := addrs[0], addrs[0]
-	minerAddrs := createMiner(t, v, owner, worker, wPoStProof, big.Mul(big.NewInt(10_000), vm.FIL))
+	minerAddrs := createMiner(t, v, owner, worker, wPoStProof, big.Mul(big.NewInt(100_000), vm.FIL))
 
 	// advance vm so we can have seal randomness epoch in the past
 	v, err = v.WithEpoch(abi.ChainEpoch(200))
@@ -620,14 +620,14 @@ func TestAggregateSizeLimits(t *testing.T) {
 	ctx := context.Background()
 	blkStore := ipld.NewBlockStoreInMemory()
 	v := vm.NewVMWithSingletons(ctx, t, blkStore)
-	addrs := vm.CreateAccounts(ctx, t, v, 1, big.Mul(big.NewInt(10_000), big.NewInt(1e18)), 93837778)
+	addrs := vm.CreateAccounts(ctx, t, v, 1, big.Mul(big.NewInt(100_000), big.NewInt(1e18)), 93837778)
 
 	// create miner
 	sealProof := abi.RegisteredSealProof_StackedDrg32GiBV1_1
 	wPoStProof, err := sealProof.RegisteredWindowPoStProof()
 	require.NoError(t, err)
 	owner, worker := addrs[0], addrs[0]
-	minerAddrs := createMiner(t, v, owner, worker, wPoStProof, big.Mul(big.NewInt(10_000), vm.FIL))
+	minerAddrs := createMiner(t, v, owner, worker, wPoStProof, big.Mul(big.NewInt(100_000), vm.FIL))
 
 	// advance vm so we can have seal randomness epoch in the past
 	v, err = v.WithEpoch(abi.ChainEpoch(200))
@@ -780,9 +780,9 @@ func TestMeasureAggregatePorepGas(t *testing.T) {
 	sealProof := abi.RegisteredSealProof_StackedDrg32GiBV1_1
 	wPoStProof, err := sealProof.RegisteredWindowPoStProof()
 	require.NoError(t, err)
-	addrs := vm.CreateAccounts(ctx, t, v, 1, big.Mul(big.NewInt(10_000), builtin.TokenPrecision), 93837778)
+	addrs := vm.CreateAccounts(ctx, t, v, 1, big.Mul(big.NewInt(100_000), builtin.TokenPrecision), 93837778)
 	owner, worker := addrs[0], addrs[0]
-	minerAddrs := createMiner(t, v, owner, worker, wPoStProof, big.Mul(big.NewInt(10_000), vm.FIL))
+	minerAddrs := createMiner(t, v, owner, worker, wPoStProof, big.Mul(big.NewInt(100_000), vm.FIL))
 
 	// advance vm so we can have seal randomness epoch in the past
 	v, err = v.WithEpoch(abi.ChainEpoch(200))

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -119,7 +119,7 @@ func main() {
 		// method params and returns
 		//paych.ConstructorParams{}, // Aliased from v0
 		paych.UpdateChannelStateParams{}, // Changed in v7
-		paych.SignedVoucher{}, // Changed in v7
+		paych.SignedVoucher{},            // Changed in v7
 		//paych.ModVerifyParams{}, // Aliased from v0
 		// other types
 		//paych.Merge{}, // Aliased from v0
@@ -152,7 +152,10 @@ func main() {
 		//market.WithdrawBalanceParams{}, // Aliased from v0
 		// market.PublishStorageDealsParams{}, // Aliased from v0
 		//market.PublishStorageDealsReturn{}, // Aliased from v6
-		//market.ActivateDealsParams{}, // Aliased from v0
+		market.ActivateDealsParams{},
+		market.ActivateDealsParamsInner{},
+		market.ActivateDealsReturn{},
+		market.ActivateDealsReturnInner{},
 		//market.VerifyDealsForActivationParams{}, // Aliased from v3
 		//market.VerifyDealsForActivationReturn{}, // Aliased from v3
 		//market.ComputeDataCommitmentParams{}, // Aliased from v5
@@ -230,9 +233,9 @@ func main() {
 		verifreg.RemoveDataCapParams{}, // New in v7
 		verifreg.RemoveDataCapReturn{}, // New in v7
 		// other types
-		verifreg.RemoveDataCapRequest{}, // New in v7
+		verifreg.RemoveDataCapRequest{},  // New in v7
 		verifreg.RemoveDataCapProposal{}, // New in v7
-		verifreg.RmDcProposalID{}, // New in v7
+		verifreg.RmDcProposalID{},        // New in v7
 	); err != nil {
 		panic(err)
 	}

--- a/support/agent/cases_test.go
+++ b/support/agent/cases_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestCreate20Miners(t *testing.T) {
 	ctx := context.Background()
-	initialBalance := big.Mul(big.NewInt(1000), big.NewInt(1e18))
+	initialBalance := big.Mul(big.NewInt(10000), big.NewInt(1e18))
 	minerCount := 20
 
 	rnd := rand.New(rand.NewSource(42))


### PR DESCRIPTION
Deal data is still fetched to check if deals don't occupy more space than
the room in the sector. This check can be delayed to ProveCommit.