### PR TITLE
FIP 0027 Migration

### DIFF
--- a/actors/builtin/market/market_actor.go
+++ b/actors/builtin/market/market_actor.go
@@ -454,8 +454,8 @@ func (a Actor) ActivateDeals(rt Runtime, params *ActivateDealsParams) *abi.Empty
 
 			err = msm.dealStates.Set(dealID, &DealState{
 				SectorStartEpoch: currEpoch,
-				LastUpdatedEpoch: epochUndefined,
-				SlashEpoch:       epochUndefined,
+				LastUpdatedEpoch: EpochUndefined,
+				SlashEpoch:       EpochUndefined,
 			})
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to set deal state %d", dealID)
 		}
@@ -557,7 +557,7 @@ func (a Actor) OnMinerSectorsTerminate(rt Runtime, params *OnMinerSectorsTermina
 			}
 
 			// if a deal is already slashed, we don't need to do anything here.
-			if state.SlashEpoch != epochUndefined {
+			if state.SlashEpoch != EpochUndefined {
 				rt.Log(rtt.INFO, "deal %d already slashed", dealID)
 				continue
 			}
@@ -626,7 +626,7 @@ func (a Actor) CronTick(rt Runtime, _ *abi.EmptyValue) *abi.EmptyValue {
 				}
 
 				// if this is the first cron tick for the deal, it should be in the pending state.
-				if state.LastUpdatedEpoch == epochUndefined {
+				if state.LastUpdatedEpoch == EpochUndefined {
 					pdErr := msm.pendingDeals.Delete(abi.CidKey(dcid))
 					builtin.RequireNoErr(rt, pdErr, exitcode.ErrIllegalState, "failed to delete pending proposal %v", dcid)
 				}
@@ -635,7 +635,7 @@ func (a Actor) CronTick(rt Runtime, _ *abi.EmptyValue) *abi.EmptyValue {
 				builtin.RequireState(rt, slashAmount.GreaterThanEqual(big.Zero()), "computed negative slash amount %v for deal %d", slashAmount, dealID)
 
 				if removeDeal {
-					builtin.RequireState(rt, nextEpoch == epochUndefined, "removed deal %d should have no scheduled epoch (got %d)", dealID, nextEpoch)
+					builtin.RequireState(rt, nextEpoch == EpochUndefined, "removed deal %d should have no scheduled epoch (got %d)", dealID, nextEpoch)
 					amountSlashed = big.Add(amountSlashed, slashAmount)
 
 					// Delete proposal and state simultaneously.

--- a/actors/builtin/market/market_state.go
+++ b/actors/builtin/market/market_state.go
@@ -13,7 +13,7 @@ import (
 	"github.com/filecoin-project/specs-actors/v8/actors/util/adt"
 )
 
-const epochUndefined = abi.ChainEpoch(-1)
+const EpochUndefined = abi.ChainEpoch(-1)
 
 // BalanceLockingReason is the reason behind locking an amount.
 type BalanceLockingReason int
@@ -108,15 +108,15 @@ func ConstructState(store adt.Store) (*State, error) {
 func (m *marketStateMutation) updatePendingDealState(rt Runtime, state *DealState, deal *DealProposal, epoch abi.ChainEpoch) (amountSlashed abi.TokenAmount, nextEpoch abi.ChainEpoch, removeDeal bool) {
 	amountSlashed = abi.NewTokenAmount(0)
 
-	everUpdated := state.LastUpdatedEpoch != epochUndefined
-	everSlashed := state.SlashEpoch != epochUndefined
+	everUpdated := state.LastUpdatedEpoch != EpochUndefined
+	everSlashed := state.SlashEpoch != EpochUndefined
 
 	builtin.RequireState(rt, !everUpdated || (state.LastUpdatedEpoch <= epoch), "deal updated at future epoch %d", state.LastUpdatedEpoch)
 
 	// This would be the case that the first callback somehow triggers before it is scheduled to
 	// This is expected not to be able to happen
 	if deal.StartEpoch > epoch {
-		return amountSlashed, epochUndefined, false
+		return amountSlashed, EpochUndefined, false
 	}
 
 	paymentEndEpoch := deal.EndEpoch
@@ -164,12 +164,12 @@ func (m *marketStateMutation) updatePendingDealState(rt Runtime, state *DealStat
 		amountSlashed = deal.ProviderCollateral
 		err = m.slashBalance(deal.Provider, amountSlashed, ProviderCollateral)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "slashing balance")
-		return amountSlashed, epochUndefined, true
+		return amountSlashed, EpochUndefined, true
 	}
 
 	if epoch >= deal.EndEpoch {
 		m.processDealExpired(rt, deal, state)
-		return amountSlashed, epochUndefined, true
+		return amountSlashed, EpochUndefined, true
 	}
 
 	// We're explicitly not inspecting the end epoch and may process a deal's expiration late, in order to prevent an outsider
@@ -206,7 +206,7 @@ func (m *marketStateMutation) processDealInitTimedOut(rt Runtime, deal *DealProp
 
 // Normal expiration. Unlock collaterals for both provider and client.
 func (m *marketStateMutation) processDealExpired(rt Runtime, deal *DealProposal, state *DealState) {
-	builtin.RequireState(rt, state.SectorStartEpoch != epochUndefined, "sector start epoch undefined")
+	builtin.RequireState(rt, state.SectorStartEpoch != EpochUndefined, "sector start epoch undefined")
 
 	// Note: payment has already been completed at this point (_rtProcessDealPaymentEpochsElapsed)
 	err := m.unlockBalance(deal.Provider, deal.ProviderCollateral, ProviderCollateral)

--- a/actors/builtin/market/testing.go
+++ b/actors/builtin/market/testing.go
@@ -115,19 +115,19 @@ func CheckStateInvariants(st *State, store adt.Store, balance abi.TokenAmount, c
 				"deal %d state start epoch undefined: %v", dealID, dealState)
 
 			acc.Require(
-				dealState.LastUpdatedEpoch == epochUndefined || dealState.LastUpdatedEpoch >= dealState.SectorStartEpoch,
+				dealState.LastUpdatedEpoch == EpochUndefined || dealState.LastUpdatedEpoch >= dealState.SectorStartEpoch,
 				"deal %d state last updated before sector start: %v", dealID, dealState)
 
 			acc.Require(
-				dealState.LastUpdatedEpoch == epochUndefined || dealState.LastUpdatedEpoch <= currEpoch,
+				dealState.LastUpdatedEpoch == EpochUndefined || dealState.LastUpdatedEpoch <= currEpoch,
 				"deal %d last updated epoch %d after current %d", dealID, dealState.LastUpdatedEpoch, currEpoch)
 
 			acc.Require(
-				dealState.SlashEpoch == epochUndefined || dealState.SlashEpoch >= dealState.SectorStartEpoch,
+				dealState.SlashEpoch == EpochUndefined || dealState.SlashEpoch >= dealState.SectorStartEpoch,
 				"deal %d state slashed before sector start: %v", dealID, dealState)
 
 			acc.Require(
-				dealState.SlashEpoch == epochUndefined || dealState.SlashEpoch <= currEpoch,
+				dealState.SlashEpoch == EpochUndefined || dealState.SlashEpoch <= currEpoch,
 				"deal %d state slashed after current epoch %d: %v", dealID, currEpoch, dealState)
 
 			stats, found := proposalStats[abi.DealID(dealID)]

--- a/actors/builtin/market/types.go
+++ b/actors/builtin/market/types.go
@@ -78,9 +78,9 @@ func (t *DealMetaArray) Get(id abi.DealID) (*DealState, bool, error) {
 	}
 	if !found {
 		return &DealState{
-			SectorStartEpoch: epochUndefined,
-			LastUpdatedEpoch: epochUndefined,
-			SlashEpoch:       epochUndefined,
+			SectorStartEpoch: EpochUndefined,
+			LastUpdatedEpoch: EpochUndefined,
+			SlashEpoch:       EpochUndefined,
 		}, false, nil
 	}
 	return &value, true, nil

--- a/actors/migration/nv16/market.go
+++ b/actors/migration/nv16/market.go
@@ -140,9 +140,9 @@ func MapProposals(ctx context.Context, store adt.Store, proposalsRoot cid.Cid) (
 	return newProposalsCid, changedProposalCIDs, nil
 }
 
-// This rebuilds pendingproposals after all the CIDs have changed because the labels are of a different type in dealProposal
-// a proposal in Proposals is pending if its dealID is not a member of States, or if the LastUpdatedEpoch field is market.EpochUndefined.
-// Precondition proposalsRoot is new proposals as computed in MapProposals
+// This rebuilds pendingproposals after all the CIDs have changed when the labels are of a different type in dealProposal.
+// A proposal in Proposals is pending if its dealID is not a member of States, or if the LastUpdatedEpoch field is market.EpochUndefined.
+// Precondition: proposalsRoot is new proposals as computed in MapProposals
 func CreateNewPendingProposals(ctx context.Context, store adt.Store, changedProposalCIDs map[int64]cidSwap, proposalsRoot cid.Cid, statesRoot cid.Cid, pendingProposalsRoot cid.Cid) (cid.Cid, error) {
 	proposals, err := adt.AsArray(store, proposalsRoot, market7.ProposalsAmtBitwidth)
 	if err != nil {
@@ -159,8 +159,7 @@ func CreateNewPendingProposals(ctx context.Context, store adt.Store, changedProp
 		return cid.Undef, err
 	}
 
-	var dealprop market.DealProposal
-	err = proposals.ForEach(&dealprop, func(key int64) error {
+	err = proposals.ForEach(nil, func(key int64) error {
 		// only process deals whose serialization has changed
 		swap, ok := changedProposalCIDs[key]
 		if !ok {

--- a/actors/migration/nv16/market.go
+++ b/actors/migration/nv16/market.go
@@ -1,0 +1,177 @@
+package nv16
+
+import (
+	"context"
+	"unicode/utf8"
+
+	cid "github.com/ipfs/go-cid"
+	cbor "github.com/ipfs/go-ipld-cbor"
+
+	"github.com/filecoin-project/go-state-types/abi"
+
+	market7 "github.com/filecoin-project/specs-actors/v7/actors/builtin/market"
+
+	"github.com/filecoin-project/specs-actors/v8/actors/builtin"
+	"github.com/filecoin-project/specs-actors/v8/actors/builtin/market"
+	"github.com/filecoin-project/specs-actors/v8/actors/util/adt"
+)
+
+type marketMigrator struct{}
+
+func (m marketMigrator) migratedCodeCID() cid.Cid {
+	return builtin.StorageMarketActorCodeID
+}
+
+func (m marketMigrator) migrateState(ctx context.Context, store cbor.IpldStore, in actorMigrationInput) (*actorMigrationResult, error) {
+	var inState market7.State
+	if err := store.Get(ctx, in.head, &inState); err != nil {
+		return nil, err
+	}
+	wrappedStore := adt.WrapStore(ctx, store)
+
+	proposalsCidOut, changedDealIDs, err := MapProposals(ctx, wrappedStore, inState.Proposals)
+	if err != nil {
+		return nil, err
+	}
+
+	pendingProposalsCidOut, err := CreateNewPendingProposals(ctx, wrappedStore, changedDealIDs, proposalsCidOut, inState.States)
+	if err != nil {
+		return nil, err
+	}
+
+	outState := market.State{
+		Proposals:                     proposalsCidOut,
+		States:                        inState.States,
+		PendingProposals:              pendingProposalsCidOut,
+		EscrowTable:                   inState.EscrowTable,
+		LockedTable:                   inState.LockedTable,
+		NextID:                        inState.NextID,
+		DealOpsByEpoch:                inState.DealOpsByEpoch,
+		LastCron:                      inState.LastCron,
+		TotalClientLockedCollateral:   inState.TotalClientLockedCollateral,
+		TotalProviderLockedCollateral: inState.TotalProviderLockedCollateral,
+		TotalClientStorageFee:         inState.TotalClientStorageFee,
+	}
+
+	newHead, err := store.Put(ctx, &outState)
+	return &actorMigrationResult{
+		newCodeCID: m.migratedCodeCID(),
+		newHead:    newHead,
+	}, err
+}
+
+// MapProposals converts proposals with invalid i.e. non-utf8 string label serializations into proposals with
+// byte label serializations.  It returns the new cid of Proposals and the set of changed dealIDs
+func MapProposals(ctx context.Context, store adt.Store, proposalsRoot cid.Cid) (cid.Cid, map[int64]struct{}, error) {
+	changedDealIDs := make(map[int64]struct{})
+	oldProposals, err := adt.AsArray(store, proposalsRoot, market7.ProposalsAmtBitwidth)
+	if err != nil {
+		return cid.Undef, nil, err
+	}
+
+	newProposals, err := adt.MakeEmptyArray(store, market.ProposalsAmtBitwidth)
+	if err != nil {
+		return cid.Undef, nil, err
+	}
+
+	var dealprop7 market7.DealProposal
+
+	err = oldProposals.ForEach(&dealprop7, func(key int64) error {
+
+		if utf8.ValidString(dealprop7.Label) {
+			return nil // valid utf8 labels keep their serialization unchanged
+		}
+		changedDealIDs[key] = struct{}{}
+		newLabel, err := market.NewLabelFromBytes([]byte(dealprop7.Label))
+		if err != nil {
+			return err
+		}
+
+		dealprop8 := market.DealProposal{
+			PieceCID:             dealprop7.PieceCID,
+			PieceSize:            dealprop7.PieceSize,
+			VerifiedDeal:         dealprop7.VerifiedDeal,
+			Client:               dealprop7.Client,
+			Provider:             dealprop7.Provider,
+			Label:                newLabel,
+			StartEpoch:           dealprop7.StartEpoch,
+			EndEpoch:             dealprop7.EndEpoch,
+			StoragePricePerEpoch: dealprop7.StoragePricePerEpoch,
+			ProviderCollateral:   dealprop7.ProviderCollateral,
+			ClientCollateral:     dealprop7.ClientCollateral,
+		}
+		return newProposals.Set(uint64(key), &dealprop8)
+	})
+	if err != nil {
+		return cid.Undef, nil, err
+	}
+
+	newProposalsCid, err := newProposals.Root()
+	if err != nil {
+		return cid.Undef, nil, err
+	}
+
+	return newProposalsCid, changedDealIDs, nil
+}
+
+// This rebuilds pendingproposals after all the CIDs have changed because the labels are of a different type in dealProposal
+// a proposal in Proposals is pending if its dealID is not a member of States, or if the LastUpdatedEpoch field is market.EpochUndefined.
+// Precondition proposalsRoot is new proposals as computed in MapProposals
+func CreateNewPendingProposals(ctx context.Context, store adt.Store, changedDealIDs map[int64]struct{}, proposalsRoot cid.Cid, statesRoot cid.Cid) (cid.Cid, error) {
+	proposals, err := adt.AsArray(store, proposalsRoot, market7.ProposalsAmtBitwidth)
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	states, err := adt.AsArray(store, statesRoot, market7.StatesAmtBitwidth)
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	pendingProposals, err := adt.MakeEmptySet(store, builtin.DefaultHamtBitwidth)
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	var dealprop market.DealProposal
+	err = proposals.ForEach(&dealprop, func(key int64) error {
+		if _, changed := changedDealIDs[key]; !changed {
+			// proposal's serialization has not changed so its cid has not changed
+			return nil
+
+		}
+		var dealstate market.DealState
+		has, err := states.Get(uint64(key), &dealstate)
+		if err != nil {
+			return err
+		}
+
+		if (has && dealstate.LastUpdatedEpoch == market.EpochUndefined) || !has {
+			// Cid of this proposal is currently kept in pending proposals to filter duplicates.
+			// Recalculate to get the correct value of the cid given the new serialization.
+			dealpropCid, err := dealprop.Cid()
+			if err != nil {
+				return err
+			}
+			return pendingProposals.Put(abi.CidKey(dealpropCid))
+		}
+		return nil
+	})
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	pendingProposalsCid, err := pendingProposals.Root()
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	return pendingProposalsCid, nil
+}
+
+// An adt.Map key that just preserves the underlying string.
+type StringKey string
+
+func (k StringKey) Key() string {
+	return string(k)
+}

--- a/actors/migration/nv16/market.go
+++ b/actors/migration/nv16/market.go
@@ -149,7 +149,7 @@ func UpdatePendingProposals(ctx context.Context, store adt.Store, changedProposa
 		return cid.Undef, err
 	}
 
-	for _, swap := range changedProposalCIDs {
+	for _, swap := range changedProposalCIDs { //nolint:nomaprange
 		if err := pendingProposals.Delete(abi.CidKey(swap.old)); err != nil {
 			return cid.Undef, err
 		}

--- a/actors/migration/nv16/test/deal_label_migration_test.go
+++ b/actors/migration/nv16/test/deal_label_migration_test.go
@@ -1,0 +1,295 @@
+package test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/crypto"
+	"github.com/filecoin-project/go-state-types/exitcode"
+	"github.com/filecoin-project/go-state-types/rt"
+	"github.com/ipfs/go-cid"
+	cbor "github.com/ipfs/go-ipld-cbor"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
+
+	ipld2 "github.com/filecoin-project/specs-actors/v2/support/ipld"
+	market7 "github.com/filecoin-project/specs-actors/v7/actors/builtin/market"
+	power7 "github.com/filecoin-project/specs-actors/v7/actors/builtin/power"
+
+	vm7 "github.com/filecoin-project/specs-actors/v7/support/vm"
+
+	"github.com/filecoin-project/specs-actors/v8/actors/builtin"
+	"github.com/filecoin-project/specs-actors/v8/actors/builtin/exported"
+	"github.com/filecoin-project/specs-actors/v8/actors/builtin/market"
+	"github.com/filecoin-project/specs-actors/v8/actors/builtin/miner"
+	"github.com/filecoin-project/specs-actors/v8/actors/builtin/power"
+	"github.com/filecoin-project/specs-actors/v8/actors/migration/nv16"
+	"github.com/filecoin-project/specs-actors/v8/actors/util/adt"
+
+	tutil "github.com/filecoin-project/specs-actors/v8/support/testing"
+	"github.com/filecoin-project/specs-actors/v8/support/vm"
+
+	addr "github.com/filecoin-project/go-address"
+)
+
+func TestDealLabelMigration(t *testing.T) {
+	ctx := context.Background()
+	log := nv16.TestLogger{TB: t}
+	bs := ipld2.NewSyncBlockStoreInMemory()
+	v := vm7.NewVMWithSingletons(ctx, t, bs)
+
+	addrs := vm7.CreateAccounts(ctx, t, v, 2, big.Mul(big.NewInt(10_000), vm.FIL), 93837778)
+	worker, client := addrs[0], addrs[1]
+
+	minerBalance := big.Mul(big.NewInt(1_000), vm.FIL)
+	sealProof := abi.RegisteredSealProof_StackedDrg32GiBV1_1
+
+	// create miner
+	params := power7.CreateMinerParams{
+		Owner:               worker,
+		Worker:              worker,
+		WindowPoStProofType: abi.RegisteredPoStProof_StackedDrgWindow32GiBV1,
+		Peer:                abi.PeerID("not really a peer id"),
+	}
+	ret := vm7.ApplyOk(t, v, addrs[0], builtin.StoragePowerActorAddr, minerBalance, builtin.MethodsPower.CreateMiner, &params)
+
+	minerAddrs, ok := ret.(*power.CreateMinerReturn)
+	require.True(t, ok)
+
+	//
+	// publish deals
+	//
+
+	// add market collateral for clients and miner
+	collateral := big.Mul(big.NewInt(64), vm.FIL)
+	vm7.ApplyOk(t, v, client, builtin.StorageMarketActorAddr, collateral, builtin.MethodsMarket.AddBalance, &client)
+	vm7.ApplyOk(t, v, worker, builtin.StorageMarketActorAddr, collateral, builtin.MethodsMarket.AddBalance, &minerAddrs.IDAddress)
+
+	// create 3 deals
+	dealIDs := []abi.DealID{}
+	dealStart := v.GetEpoch() + miner.MaxProveCommitDuration[sealProof]
+	deals := publishDealv7(t, v, worker, client, minerAddrs.IDAddress, "deal1-activatedcronned", 1<<30, false, dealStart, 365*builtin.EpochsInDay)
+	dealIDs = append(dealIDs, deals.IDs...)
+	deals = publishDealv7(t, v, worker, client, minerAddrs.IDAddress, "deal2-activateduncronned", 1<<30, false, dealStart, 365*builtin.EpochsInDay)
+	dealIDs = append(dealIDs, deals.IDs...)
+	deals = publishDealv7(t, v, worker, client, minerAddrs.IDAddress, "deal3-unactivated", 1<<30, false, dealStart, 365*builtin.EpochsInDay)
+	dealIDs = append(dealIDs, deals.IDs...)
+
+	deal1ID := dealIDs[0]
+	deal2ID := dealIDs[1]
+	deal3ID := dealIDs[2]
+
+	deal1CronTime := market.GenRandNextEpoch(dealStart, deal1ID)
+	deal2CronTime := market.GenRandNextEpoch(dealStart, deal2ID)
+	deal3CronTime := market.GenRandNextEpoch(dealStart, deal3ID)
+	require.True(t, deal1CronTime < deal2CronTime && deal2CronTime < deal3CronTime)
+	require.True(t, v.GetEpoch() < dealStart && dealStart < deal1CronTime)
+
+	// precommit sector with deals
+	sectorNumber := abi.SectorNumber(100)
+	sealedCid := tutil.MakeCID("100", &miner.SealedCIDPrefix)
+	preCommitParams := miner.PreCommitSectorParams{
+		SealProof:     sealProof,
+		SectorNumber:  sectorNumber,
+		SealedCID:     sealedCid,
+		SealRandEpoch: v.GetEpoch() - 1,
+		DealIDs:       dealIDs[:2],
+		Expiration:    v.GetEpoch() + 400*builtin.EpochsInDay,
+	}
+	vm7.ApplyOk(t, v, addrs[0], minerAddrs.RobustAddress, big.Zero(), builtin.MethodsMiner.PreCommitSector, &preCommitParams)
+
+	// advance time to max seal duration
+	proveTime := v.GetEpoch() + miner.MaxProveCommitDuration[sealProof]
+	v, _ = vm7.AdvanceByDeadlineTillEpoch(t, v, minerAddrs.IDAddress, proveTime)
+
+	// Prove commit sector after max seal duration- deal1 and deal2 get activated here
+	v, err := v.WithEpoch(proveTime)
+	require.NoError(t, err)
+	proveCommitParams := miner.ProveCommitSectorParams{
+		SectorNumber: sectorNumber,
+	}
+	vm7.ApplyOk(t, v, worker, minerAddrs.RobustAddress, big.Zero(), builtin.MethodsMiner.ProveCommitSector, &proveCommitParams)
+
+	// In the same epoch, trigger cron to validate prove commit
+	vm7.ApplyOk(t, v, builtin.SystemActorAddr, builtin.CronActorAddr, big.Zero(), builtin.MethodsCron.EpochTick, nil)
+
+	// advance time to when deal1 will be cronned
+	v, err = v.WithEpoch(deal1CronTime)
+	require.NoError(t, err)
+	// run market cron to cron deal1, but not deal2 yet
+	vm7.ApplyOk(t, v, builtin.SystemActorAddr, builtin.CronActorAddr, big.Zero(), builtin.MethodsCron.EpochTick, nil)
+
+	// now do some assertions about what's in pendingproposals/proposals
+	// getting various AMTs out of things
+	adtStore := adt.WrapStore(ctx, cbor.NewCborStore(bs))
+	var market7State market7.State
+	require.NoError(t, v.GetState(builtin.StorageMarketActorAddr, &market7State))
+	oldProposals, err := adt.AsArray(adtStore, market7State.Proposals, market7.ProposalsAmtBitwidth)
+	require.NoError(t, err)
+	oldStates, err := adt.AsArray(adtStore, market7State.States, market7.StatesAmtBitwidth)
+	require.NoError(t, err)
+	oldPendingProposals, err := adt.AsSet(adtStore, market7State.PendingProposals, builtin.DefaultHamtBitwidth)
+	require.NoError(t, err)
+	// deal1 will just be in states and proposals and not pendingproposals
+	checkMarketProposalsEtcState(t, oldProposals, oldStates, oldPendingProposals, deal1ID, true, true, false, false)
+	// deal2 will be in proposals pendingproposals and in states
+	checkMarketProposalsEtcState(t, oldProposals, oldStates, oldPendingProposals, deal2ID, true, true, true, false)
+	// deal3 will be in proposals and pendingproposals but not in states
+	checkMarketProposalsEtcState(t, oldProposals, oldStates, oldPendingProposals, deal3ID, true, false, true, false)
+
+	oldMarketActor, found, err := v.GetActor(builtin.StorageMarketActorAddr)
+	require.NoError(t, err)
+	require.True(t, found)
+
+	startRoot := v.StateRoot()
+	manifestCid := makeTestManifest(t, adtStore)
+	nextRoot, err := nv16.MigrateStateTree(ctx, adtStore, manifestCid, startRoot, abi.ChainEpoch(0), nv16.Config{MaxWorkers: 1}, log, nv16.NewMemMigrationCache())
+	require.NoError(t, err)
+
+	lookup := map[cid.Cid]rt.VMActor{}
+	for _, ba := range exported.BuiltinActors() {
+		lookup[ba.Code()] = ba
+	}
+
+	v6, err := vm.NewVMAtEpoch(ctx, lookup, v.Store(), nextRoot, v.GetEpoch()+1)
+	require.NoError(t, err)
+
+	// now do the assertions again about what's in pendingproposals/proposals
+	// getting various AMTs out of things
+	var marketState market.State
+	require.NoError(t, v6.GetState(builtin.StorageMarketActorAddr, &marketState))
+	proposals, err := adt.AsArray(adtStore, marketState.Proposals, market.ProposalsAmtBitwidth)
+	require.NoError(t, err)
+	states, err := adt.AsArray(adtStore, marketState.States, market.StatesAmtBitwidth)
+	require.NoError(t, err)
+	pendingProposals, err := adt.AsSet(adtStore, marketState.PendingProposals, builtin.DefaultHamtBitwidth)
+	require.NoError(t, err)
+	// deal1 will just be in states and proposals and not pendingproposals
+	checkMarketProposalsEtcState(t, proposals, states, pendingProposals, deal1ID, true, true, false, true)
+	// deal2 will be in proposals pendingproposals and in states
+	checkMarketProposalsEtcState(t, proposals, states, pendingProposals, deal2ID, true, true, true, true)
+	// deal3 will be in proposals and pendingproposals but not in states
+	checkMarketProposalsEtcState(t, proposals, states, pendingProposals, deal3ID, true, false, true, true)
+
+	// check that all three's labels are the same, just with changed types, before and after.
+	require.NoError(t, checkSameLabel(oldProposals, proposals, deal1ID))
+	require.NoError(t, checkSameLabel(oldProposals, proposals, deal2ID))
+	require.NoError(t, checkSameLabel(oldProposals, proposals, deal3ID))
+
+	var market6State market.State
+	require.NoError(t, v6.GetState(builtin.StorageMarketActorAddr, &market6State))
+	market.CheckStateInvariants(&market6State, v6.Store(), oldMarketActor.Balance, v.GetEpoch()+1)
+
+}
+
+func publishDealv7(t *testing.T, v *vm7.VM, provider, dealClient, minerID addr.Address, dealLabel string,
+	pieceSize abi.PaddedPieceSize, verifiedDeal bool, dealStart abi.ChainEpoch, dealLifetime abi.ChainEpoch,
+) *market7.PublishStorageDealsReturn {
+	deal := market7.DealProposal{
+		PieceCID:             tutil.MakeCID(dealLabel, &market.PieceCIDPrefix),
+		PieceSize:            pieceSize,
+		VerifiedDeal:         verifiedDeal,
+		Client:               dealClient,
+		Provider:             minerID,
+		Label:                dealLabel,
+		StartEpoch:           dealStart,
+		EndEpoch:             dealStart + dealLifetime,
+		StoragePricePerEpoch: abi.NewTokenAmount(1 << 20),
+		ProviderCollateral:   big.Mul(big.NewInt(2), vm.FIL),
+		ClientCollateral:     big.Mul(big.NewInt(1), vm.FIL),
+	}
+
+	publishDealParams := market7.PublishStorageDealsParams{
+		Deals: []market7.ClientDealProposal{{
+			Proposal: deal,
+			ClientSignature: crypto.Signature{
+				Type: crypto.SigTypeBLS,
+			},
+		}},
+	}
+	result := vm7.RequireApplyMessage(t, v, provider, builtin.StorageMarketActorAddr, big.Zero(), builtin.MethodsMarket.PublishStorageDeals, &publishDealParams, t.Name())
+	require.Equal(t, exitcode.Ok, result.Code)
+
+	expectedPublishSubinvocations := []vm7.ExpectInvocation{
+		{To: minerID, Method: builtin.MethodsMiner.ControlAddresses, SubInvocations: []vm7.ExpectInvocation{}},
+		{To: builtin.RewardActorAddr, Method: builtin.MethodsReward.ThisEpochReward, SubInvocations: []vm7.ExpectInvocation{}},
+		{To: builtin.StoragePowerActorAddr, Method: builtin.MethodsPower.CurrentTotalPower, SubInvocations: []vm7.ExpectInvocation{}},
+	}
+
+	if verifiedDeal {
+		expectedPublishSubinvocations = append(expectedPublishSubinvocations, vm7.ExpectInvocation{
+			To:             builtin.VerifiedRegistryActorAddr,
+			Method:         builtin.MethodsVerifiedRegistry.UseBytes,
+			SubInvocations: []vm7.ExpectInvocation{},
+		})
+	}
+
+	vm7.ExpectInvocation{
+		To:             builtin.StorageMarketActorAddr,
+		Method:         builtin.MethodsMarket.PublishStorageDeals,
+		SubInvocations: expectedPublishSubinvocations,
+	}.Matches(t, v.LastInvocation())
+
+	return result.Ret.(*market7.PublishStorageDealsReturn)
+}
+
+func checkMarketProposalsEtcState(t *testing.T, proposals *adt.Array, states *adt.Array, pendingProposals *adt.Set,
+	dealID abi.DealID, inProposals bool, inStates bool, inPendingProposals bool, isv6 bool) {
+	var dealprop6 market.DealProposal
+	var dealprop5 market7.DealProposal
+	var found bool
+	var err error
+	if isv6 {
+		found, err = proposals.Get(uint64(dealID), &dealprop6)
+	} else {
+		found, err = proposals.Get(uint64(dealID), &dealprop5)
+	}
+	require.NoError(t, err)
+	require.Equal(t, found, inProposals)
+	found, err = states.Get(uint64(dealID), nil)
+	require.NoError(t, err)
+	require.Equal(t, found, inStates)
+	var dealpropcid cid.Cid
+	if isv6 {
+		dealpropcid, err = dealprop6.Cid()
+	} else {
+		dealpropcid, err = dealprop5.Cid()
+	}
+	require.NoError(t, err)
+	found, err = pendingProposals.Has(abi.CidKey(dealpropcid))
+	require.NoError(t, err)
+	require.Equal(t, found, inPendingProposals)
+}
+
+func checkSameLabel(v7Proposals *adt.Array, v8Proposals *adt.Array, dealID abi.DealID) error {
+	var dealprop7 market7.DealProposal
+	var dealprop8 market.DealProposal
+	found, err := v7Proposals.Get(uint64(dealID), &dealprop7)
+	if !found || err != nil {
+		return xerrors.Errorf("failed to look up dealID %v in validating deal label", dealID)
+	}
+	found, err = v8Proposals.Get(uint64(dealID), &dealprop8)
+	if !found || err != nil {
+		return xerrors.Errorf("failed to look up dealID %v in validating deal label", dealID)
+	}
+	var prop8LabelString string
+	if dealprop8.Label.IsString() {
+		prop8LabelString, err = dealprop8.Label.ToString()
+		if err != nil {
+			return err
+		}
+	} else { // dealprop8.Label.IsBytes()
+		bs, err := dealprop8.Label.ToBytes()
+		if err != nil {
+			return err
+		}
+		prop8LabelString = string(bs)
+	}
+
+	if dealprop7.Label != prop8LabelString {
+		return xerrors.Errorf("deal labels were not the same, modulo types, after migration.")
+	}
+	return nil
+}

--- a/actors/migration/nv16/top.go
+++ b/actors/migration/nv16/top.go
@@ -98,7 +98,6 @@ func MigrateStateTree(ctx context.Context, store cbor.IpldStore, actorsManifest 
 		"account":          builtin7.AccountActorCodeID,
 		"storagepower":     builtin7.StoragePowerActorCodeID,
 		"storageminer":     builtin7.StorageMinerActorCodeID,
-		"storagemarket":    builtin7.StorageMarketActorCodeID,
 		"paymentchannel":   builtin7.PaymentChannelActorCodeID,
 		"multisig":         builtin7.MultisigActorCodeID,
 		"reward":           builtin7.RewardActorCodeID,
@@ -120,6 +119,11 @@ func MigrateStateTree(ctx context.Context, store cbor.IpldStore, actorsManifest 
 		return cid.Undef, xerrors.Errorf("code cid for system actor not found in manifet")
 	}
 	migrations[builtin7.SystemActorCodeID] = systemActorMigrator{system8Cid, manifest.Data}
+	market8Cid, ok := manifest.Get("storagemarket")
+	if !ok {
+		return cid.Undef, xerrors.Errorf("code cid for market actor not found in manifest")
+	}
+	migrations[builtin7.StorageMarketActorCodeID] = marketMigrator{market8Cid}
 
 	if len(migrations)+len(deferredCodeIDs) != 11 {
 		panic(fmt.Sprintf("incomplete migration specification with %d code CIDs", len(migrations)))


### PR DESCRIPTION
- Copy over reverted nv14 change
- Fix up migration to only change non utf8 string labels to bytes
- Try to make things faster under the assumption that very few (probably no) labels will need to be migrated 
- change test to cover both utf8 and non-utf8 labels 