### PR TITLE
FIP-0027: Add JSON un/marshaler for DealLabel

### DIFF
--- a/actors/builtin/market/deal.go
+++ b/actors/builtin/market/deal.go
@@ -2,6 +2,7 @@ package market
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"unicode/utf8"
@@ -149,6 +150,30 @@ func (label *DealLabel) UnmarshalCBOR(br io.Reader) error {
 		return fmt.Errorf("label string not valid utf8")
 	}
 
+	return nil
+}
+
+func (label *DealLabel) MarshalJSON() ([]byte, error) {
+	str, err := label.ToString()
+	if err != nil {
+		return nil, xerrors.Errorf("can only marshal strings: %w", err)
+	}
+
+	return json.Marshal(str)
+}
+
+func (label *DealLabel) UnmarshalJSON(b []byte) error {
+	var str string
+	if err := json.Unmarshal(b, &str); err != nil {
+		return xerrors.Errorf("failed to unmarshal string: %w", err)
+	}
+
+	newLabel, err := NewLabelFromString(str)
+	if err != nil {
+		return xerrors.Errorf("failed to create label from string: %w", err)
+	}
+
+	*label = newLabel
 	return nil
 }
 

--- a/actors/builtin/market/deal_test.go
+++ b/actors/builtin/market/deal_test.go
@@ -2,7 +2,12 @@ package market_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"testing"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/ipfs/go-cid"
 
 	"github.com/filecoin-project/specs-actors/v8/actors/builtin/market"
 	tutil "github.com/filecoin-project/specs-actors/v8/support/testing"
@@ -73,6 +78,77 @@ func TestDealLabel(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot unmarshal into nil pointer")
 
+}
+func TestDealLabelJSON(t *testing.T) {
+
+	// Non-empty string
+	label1, err := market.NewLabelFromString("i am a label, json me correctly plz")
+	require.NoError(t, err, "failed to create label from string")
+	label1JSON, err := json.Marshal(&label1)
+	require.NoError(t, err, "failed to JSON marshal string label")
+	label2 := &market.DealLabel{}
+	require.NoError(t, label2.UnmarshalJSON(label1JSON))
+	assert.True(t, label2.IsString())
+	assert.False(t, label2.IsBytes())
+	str, err := label2.ToString()
+	assert.NoError(t, err)
+	assert.Equal(t, "i am a label, json me correctly plz", str)
+
+	dp := &market.DealProposal{
+		PieceCID:             cid.Undef,
+		PieceSize:            0,
+		VerifiedDeal:         false,
+		Client:               address.Undef,
+		Provider:             address.Undef,
+		Label:                label1,
+		StoragePricePerEpoch: big.Zero(),
+		ProviderCollateral:   big.Zero(),
+		ClientCollateral:     big.Zero(),
+	}
+
+	dpJSON, err := json.Marshal(dp)
+	require.NoError(t, err, "failed to JSON marshal deal proposal")
+	dp2 := market.DealProposal{}
+	require.NoError(t, json.Unmarshal(dpJSON, &dp2))
+	assert.True(t, dp2.Label.IsString())
+	assert.False(t, dp2.Label.IsBytes())
+	str, err = dp2.Label.ToString()
+	assert.NoError(t, err)
+	assert.Equal(t, "i am a label, json me correctly plz", str)
+
+	label1, err = market.NewLabelFromString("")
+	require.NoError(t, err, "failed to create label from string")
+	label1JSON, err = json.Marshal(&label1)
+	require.NoError(t, err, "failed to JSON marshal string label")
+	label2 = &market.DealLabel{}
+	require.NoError(t, label2.UnmarshalJSON(label1JSON))
+	assert.True(t, label2.IsString())
+	assert.False(t, label2.IsBytes())
+	str, err = label2.ToString()
+	assert.NoError(t, err)
+	assert.Equal(t, "", str)
+
+	dp = &market.DealProposal{
+		PieceCID:             cid.Undef,
+		PieceSize:            0,
+		VerifiedDeal:         false,
+		Client:               address.Undef,
+		Provider:             address.Undef,
+		Label:                label1,
+		StoragePricePerEpoch: big.Zero(),
+		ProviderCollateral:   big.Zero(),
+		ClientCollateral:     big.Zero(),
+	}
+
+	dpJSON, err = json.Marshal(dp)
+	require.NoError(t, err, "failed to JSON marshal deal proposal")
+	dp2 = market.DealProposal{}
+	require.NoError(t, json.Unmarshal(dpJSON, &dp2))
+	assert.True(t, dp2.Label.IsString())
+	assert.False(t, dp2.Label.IsBytes())
+	str, err = dp2.Label.ToString()
+	assert.NoError(t, err)
+	assert.Equal(t, "", str)
 }
 
 func TestDealLabelFromCBOR(t *testing.T) {


### PR DESCRIPTION
We only marshal DealLabels that are of type string -- we can add support for byte types later.