### PR TITLE
update go-ipld-format to remove globals, and use go-ipld-cbor explicitly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/ipfs/go-block-format v0.0.3
 	github.com/ipfs/go-cid v0.0.7
 	github.com/ipfs/go-ipld-cbor v0.0.5
-	github.com/ipfs/go-ipld-format v0.0.2
+	github.com/ipfs/go-ipld-format v0.4.1-0.20230530195241-c3da01c74a06
 	github.com/ipld/go-car v0.1.0
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1
 	github.com/minio/sha256-simd v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -155,8 +155,9 @@ github.com/ipfs/go-ipld-cbor v0.0.4/go.mod h1:BkCduEx3XBCO6t2Sfo5BaHzuok7hbhdMm9
 github.com/ipfs/go-ipld-cbor v0.0.5 h1:ovz4CHKogtG2KB/h1zUp5U0c/IzZrL435rCh5+K/5G8=
 github.com/ipfs/go-ipld-cbor v0.0.5/go.mod h1:BkCduEx3XBCO6t2Sfo5BaHzuok7hbhdMm9Oh8B2Ftq4=
 github.com/ipfs/go-ipld-format v0.0.1/go.mod h1:kyJtbkDALmFHv3QR6et67i35QzO3S0dCDnkOJhcZkms=
-github.com/ipfs/go-ipld-format v0.0.2 h1:OVAGlyYT6JPZ0pEfGntFPS40lfrDmaDbQwNHEY2G9Zs=
 github.com/ipfs/go-ipld-format v0.0.2/go.mod h1:4B6+FM2u9OJ9zCV+kSbgFAZlOrv1Hqbf0INGQgiKf9k=
+github.com/ipfs/go-ipld-format v0.4.1-0.20230530195241-c3da01c74a06 h1:veXief2ep+niDh2HuhDrOk0+W2iqn4QdIcmI+8MD9bc=
+github.com/ipfs/go-ipld-format v0.4.1-0.20230530195241-c3da01c74a06/go.mod h1:ImdZqJQaEouMjCvqCe0ORUS+uoBmf7Hf+EO/jh+nk3M=
 github.com/ipfs/go-log v0.0.1/go.mod h1:kL1d2/hzSpI0thNYjiKfjanbVNU+IIGA/WnNESY9leM=
 github.com/ipfs/go-log v1.0.4 h1:6nLQdX4W8P9yZZFH7mO+X/PzjN8Laozm/lMJ6esdgzY=
 github.com/ipfs/go-log v1.0.4/go.mod h1:oDCg2FkjogeFOhqqb+N39l2RpTNPL6F/StPkB3kPgcs=

--- a/support/vm/vector.go
+++ b/support/vm/vector.go
@@ -17,6 +17,7 @@ import (
 	blocks "github.com/ipfs/go-block-format"
 
 	"github.com/ipfs/go-cid"
+	ipldcbor "github.com/ipfs/go-ipld-cbor"
 	format "github.com/ipfs/go-ipld-format"
 	"github.com/ipld/go-car"
 	cbg "github.com/whyrusleeping/cbor-gen"
@@ -334,7 +335,7 @@ func (a *adtNodeGetter) Get(ctx context.Context, c cid.Cid) (format.Node, error)
 	if err != nil {
 		return nil, err
 	}
-	return format.Decode(b)
+	return format.Decode(b, ipldcbor.DecodeBlock)
 }
 
 func (a *adtNodeGetter) GetMany(ctx context.Context, cids []cid.Cid) <-chan *format.NodeOption {


### PR DESCRIPTION
Coming along the same set of changes as https://github.com/filecoin-project/lotus/pull/10921.

The change to go-ipld-format hasn't been merged + released yet but should soon so please let me know if there's a problem